### PR TITLE
feat: add get_dependency_changes tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,74 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+MCP server for Maven dependency intelligence. Provides tools to query artifact versions from Maven repositories (Maven Central, Google Maven, custom repos). Distributed as npm package, runs via `npx maven-central-mcp`.
+
+**Stack:** TypeScript, Node.js, `@modelcontextprotocol/sdk`, `zod/v4`, `vitest`
+
+## Commands
+
+```bash
+npm run build          # TypeScript compilation (tsc)
+npm run test           # Run all tests (vitest run)
+npx vitest run src/tools/__tests__/get-latest-version.test.ts  # Single test file
+npm run dev            # Watch mode (tsc --watch)
+```
+
+## Architecture
+
+```
+src/
+  index.ts              # Entry point: MCP server setup, tool registration, repository wiring
+  maven/
+    repository.ts       # MavenRepository interface + HttpMavenRepository (works with any Maven repo)
+    resolver.ts         # resolveFirst (sequential) / resolveAll (parallel + merge) strategies
+    types.ts            # MavenMetadata, MavenSearchResponse
+  discovery/
+    discover.ts         # Orchestrator: scans project build files, returns RepositoryConfig[]
+    gradle-parser.ts    # Regex-based parser for build.gradle[.kts] / settings.gradle[.kts]
+    maven-parser.ts     # Regex-based parser for pom.xml <repositories>
+    types.ts            # RepositoryConfig, DiscoveryResult
+  project/
+    find-project-root.ts  # Walks up from cwd to find build file markers
+  tools/                # MCP tool handlers (one file per tool)
+  github/
+    pom-scm.ts          # POM SCM parser → GitHub owner/repo extraction
+    guess-repo.ts        # Fallback: guess GitHub repo from groupId
+    github-client.ts     # GitHub REST API client (releases, changelog, repo check)
+    changelog-parser.ts  # Parse CHANGELOG.md sections by version
+    tag-matcher.ts       # Match GitHub release tags to Maven versions
+    discover-repo.ts     # Orchestrator: POM → guess → validate
+  cache/
+    file-cache.ts        # Persistent JSON file cache (~/.cache/maven-central-mcp/)
+  version/
+    classify.ts         # classifyVersion() + findLatestVersion() — stability detection
+    compare.ts          # getUpgradeType() — major/minor/patch comparison
+    range.ts            # filterVersionRange() — extract versions between two bounds
+    types.ts            # StabilityType, StabilityFilter, UpgradeType
+```
+
+**Key data flow:** Tool call -> `getRepositories()` (lazy, cached) -> `findProjectRoot()` -> `discoverRepositories()` -> parser extracts repos from build files -> `HttpMavenRepository[]` built with Maven Central as fallback -> resolver strategy (`resolveAll`/`resolveFirst`) fetches `maven-metadata.xml` from repos -> tool handler processes versions.
+
+**Repository resolution strategies per tool:**
+- `get_latest_version`, `check_multiple_dependencies`, `compare_dependency_versions` -> `resolveAll` (parallel, merged versions)
+- `check_version_exists` -> sequential iteration, checks each repo for the specific version
+- `get_dependency_changes` -> `resolveAll` (versions) + POM fetch → GitHub API → releases/changelog
+
+**Deduplication responsibility:** Parsers return raw results; `discoverRepositories()` in `discover.ts` handles URL deduplication.
+
+**Well-known repo constants** are defined once in `repository.ts` (`MAVEN_CENTRAL`, `GOOGLE_MAVEN`, `GRADLE_PLUGIN_PORTAL`) and referenced from `gradle-parser.ts`.
+
+## Conventions
+
+- ESM (`"type": "module"` in package.json), all imports use `.js` extension
+- Tests colocated in `__tests__/` directories next to source
+- No XML parser dependency — all XML parsing is regex-based
+- Tool handlers accept `MavenRepository[]` as first argument (not a single client)
+- `findLatestVersion()` in `version/classify.ts` is the single source of truth for stable version selection logic
+
+## Worktrees
+
+Worktree directory: `.worktrees/` (gitignored). Clean up stale worktrees after merging feature branches.

--- a/src/cache/__tests__/file-cache.test.ts
+++ b/src/cache/__tests__/file-cache.test.ts
@@ -79,12 +79,25 @@ describe("FileCache", () => {
 
       await cache.set("my-key", { name: "test" });
 
-      expect(mockedFs.mkdirSync).toHaveBeenCalledWith(baseDir, {
+      expect(mockedFs.mkdirSync).toHaveBeenCalledWith("/tmp/test-cache", {
         recursive: true,
       });
       expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
         "/tmp/test-cache/my-key.json",
         JSON.stringify({ data: { name: "test" }, timestamp: 1700000000000 })
+      );
+    });
+    it("creates nested directories for keys with path separators", async () => {
+      vi.spyOn(Date, "now").mockReturnValue(1700000000000);
+
+      await cache.set("scm/io.ktor/ktor-core", { owner: "ktorio", repo: "ktor" });
+
+      expect(mockedFs.mkdirSync).toHaveBeenCalledWith("/tmp/test-cache/scm/io.ktor", {
+        recursive: true,
+      });
+      expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
+        "/tmp/test-cache/scm/io.ktor/ktor-core.json",
+        expect.any(String),
       );
     });
   });

--- a/src/cache/__tests__/file-cache.test.ts
+++ b/src/cache/__tests__/file-cache.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import * as fs from "node:fs";
+import { FileCache } from "../file-cache.js";
+
+vi.mock("node:fs");
+
+const mockedFs = vi.mocked(fs);
+
+describe("FileCache", () => {
+  const baseDir = "/tmp/test-cache";
+  let cache: FileCache;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    cache = new FileCache(baseDir);
+  });
+
+  describe("get", () => {
+    it("returns undefined when file does not exist", async () => {
+      mockedFs.existsSync.mockReturnValue(false);
+
+      const result = await cache.get("some-key");
+
+      expect(result).toBeUndefined();
+      expect(mockedFs.existsSync).toHaveBeenCalledWith(
+        "/tmp/test-cache/some-key.json"
+      );
+    });
+
+    it("returns cached data when file exists and no TTL", async () => {
+      const entry = { data: { version: "1.0.0" }, timestamp: Date.now() };
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.readFileSync.mockReturnValue(JSON.stringify(entry));
+
+      const result = await cache.get<{ version: string }>("my-key");
+
+      expect(result).toEqual({ version: "1.0.0" });
+      expect(mockedFs.readFileSync).toHaveBeenCalledWith(
+        "/tmp/test-cache/my-key.json",
+        "utf-8"
+      );
+    });
+
+    it("returns cached data when TTL has not expired", async () => {
+      const entry = { data: "hello", timestamp: Date.now() - 1000 };
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.readFileSync.mockReturnValue(JSON.stringify(entry));
+
+      const result = await cache.get<string>("key", 5000);
+
+      expect(result).toBe("hello");
+    });
+
+    it("returns undefined when TTL has expired", async () => {
+      const entry = { data: "hello", timestamp: Date.now() - 10000 };
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.readFileSync.mockReturnValue(JSON.stringify(entry));
+
+      const result = await cache.get<string>("key", 5000);
+
+      expect(result).toBeUndefined();
+    });
+
+    it("returns undefined when file read throws", async () => {
+      mockedFs.existsSync.mockReturnValue(true);
+      mockedFs.readFileSync.mockImplementation(() => {
+        throw new Error("read error");
+      });
+
+      const result = await cache.get("key");
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("set", () => {
+    it("creates directories and writes cache entry", async () => {
+      vi.spyOn(Date, "now").mockReturnValue(1700000000000);
+
+      await cache.set("my-key", { name: "test" });
+
+      expect(mockedFs.mkdirSync).toHaveBeenCalledWith(baseDir, {
+        recursive: true,
+      });
+      expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
+        "/tmp/test-cache/my-key.json",
+        JSON.stringify({ data: { name: "test" }, timestamp: 1700000000000 })
+      );
+    });
+  });
+});

--- a/src/cache/file-cache.ts
+++ b/src/cache/file-cache.ts
@@ -1,0 +1,43 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+interface CacheEntry<T> {
+  data: T;
+  timestamp: number;
+}
+
+export class FileCache {
+  constructor(private readonly baseDir: string) {}
+
+  async get<T>(key: string, ttlMs?: number): Promise<T | undefined> {
+    const filePath = this.filePath(key);
+
+    if (!fs.existsSync(filePath)) {
+      return undefined;
+    }
+
+    try {
+      const raw = fs.readFileSync(filePath, "utf-8");
+      const entry: CacheEntry<T> = JSON.parse(raw);
+
+      if (ttlMs !== undefined && Date.now() - entry.timestamp > ttlMs) {
+        return undefined;
+      }
+
+      return entry.data;
+    } catch {
+      return undefined;
+    }
+  }
+
+  async set<T>(key: string, data: T): Promise<void> {
+    fs.mkdirSync(this.baseDir, { recursive: true });
+
+    const entry: CacheEntry<T> = { data, timestamp: Date.now() };
+    fs.writeFileSync(this.filePath(key), JSON.stringify(entry));
+  }
+
+  private filePath(key: string): string {
+    return path.join(this.baseDir, `${key}.json`);
+  }
+}

--- a/src/cache/file-cache.ts
+++ b/src/cache/file-cache.ts
@@ -1,5 +1,8 @@
 import * as fs from "node:fs";
+import * as os from "node:os";
 import * as path from "node:path";
+
+const DEFAULT_CACHE_DIR = path.join(os.homedir(), ".cache", "maven-central-mcp");
 
 interface CacheEntry<T> {
   data: T;
@@ -7,7 +10,7 @@ interface CacheEntry<T> {
 }
 
 export class FileCache {
-  constructor(private readonly baseDir: string) {}
+  constructor(private readonly baseDir: string = DEFAULT_CACHE_DIR) {}
 
   async get<T>(key: string, ttlMs?: number): Promise<T | undefined> {
     const filePath = this.filePath(key);
@@ -31,10 +34,11 @@ export class FileCache {
   }
 
   async set<T>(key: string, data: T): Promise<void> {
-    fs.mkdirSync(this.baseDir, { recursive: true });
+    const filePath = this.filePath(key);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
 
     const entry: CacheEntry<T> = { data, timestamp: Date.now() };
-    fs.writeFileSync(this.filePath(key), JSON.stringify(entry));
+    fs.writeFileSync(filePath, JSON.stringify(entry));
   }
 
   private filePath(key: string): string {

--- a/src/github/__tests__/changelog-parser.test.ts
+++ b/src/github/__tests__/changelog-parser.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { parseChangelogSections } from "../changelog-parser.js";
+
+describe("parseChangelogSections", () => {
+  it("parses heading with brackets and date", () => {
+    const content = `# Changelog
+
+## [2.0.0] - 2024-01-15
+
+### Breaking Changes
+- Removed deprecated API
+
+### Features
+- New plugin system
+
+## [1.0.0] - 2023-06-01
+
+- Initial release
+`;
+    const result = parseChangelogSections(content);
+    expect(result.size).toBe(2);
+    expect(result.has("2.0.0")).toBe(true);
+    expect(result.has("1.0.0")).toBe(true);
+    expect(result.get("2.0.0")).toContain("Removed deprecated API");
+    expect(result.get("2.0.0")).toContain("New plugin system");
+    expect(result.get("1.0.0")).toContain("Initial release");
+  });
+
+  it("parses heading without brackets", () => {
+    const content = `## 1.5.0
+
+- Bug fixes
+
+## 1.4.0
+
+- Performance improvements
+`;
+    const result = parseChangelogSections(content);
+    expect(result.size).toBe(2);
+    expect(result.has("1.5.0")).toBe(true);
+    expect(result.has("1.4.0")).toBe(true);
+    expect(result.get("1.5.0")).toContain("Bug fixes");
+    expect(result.get("1.4.0")).toContain("Performance improvements");
+  });
+
+  it("strips v prefix from version numbers", () => {
+    const content = `## v3.0.0
+
+- Major update
+
+## v2.0.0
+
+- Previous major
+`;
+    const result = parseChangelogSections(content);
+    expect(result.size).toBe(2);
+    expect(result.has("3.0.0")).toBe(true);
+    expect(result.has("2.0.0")).toBe(true);
+    expect(result.get("3.0.0")).toContain("Major update");
+  });
+
+  it("handles brackets with v prefix", () => {
+    const content = `## [v1.2.3] - 2024-03-01
+
+- Some change
+`;
+    const result = parseChangelogSections(content);
+    expect(result.size).toBe(1);
+    expect(result.has("1.2.3")).toBe(true);
+    expect(result.get("1.2.3")).toContain("Some change");
+  });
+
+  it("returns empty Map for non-changelog content", () => {
+    const content = `# README
+
+This is a project readme.
+
+## Installation
+
+Run npm install.
+
+## Usage
+
+Import the module.
+`;
+    const result = parseChangelogSections(content);
+    expect(result.size).toBe(0);
+  });
+
+  it("returns empty Map for empty string", () => {
+    const result = parseChangelogSections("");
+    expect(result.size).toBe(0);
+  });
+
+  it("handles pre-release version numbers", () => {
+    const content = `## [2.0.0-beta.1] - 2024-01-10
+
+- Beta feature
+
+## [1.0.0-rc.1] - 2023-12-01
+
+- Release candidate
+`;
+    const result = parseChangelogSections(content);
+    expect(result.size).toBe(2);
+    expect(result.has("2.0.0-beta.1")).toBe(true);
+    expect(result.has("1.0.0-rc.1")).toBe(true);
+  });
+
+  it("trims body whitespace", () => {
+    const content = `## 1.0.0
+
+- A change
+
+`;
+    const result = parseChangelogSections(content);
+    const body = result.get("1.0.0")!;
+    expect(body).not.toMatch(/^\n/);
+    expect(body).not.toMatch(/\n$/);
+  });
+});

--- a/src/github/__tests__/discover-repo.test.ts
+++ b/src/github/__tests__/discover-repo.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { discoverGitHubRepo } from "../discover-repo.js";
+import type { MavenRepository } from "../../maven/repository.js";
+import { GitHubClient } from "../github-client.js";
+
+function makeMockRepo(name: string, url: string): MavenRepository {
+  return {
+    name,
+    url,
+    fetchMetadata: vi.fn(),
+  };
+}
+
+const POM_WITH_SCM = `<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>com.squareup.okhttp3</groupId>
+  <artifactId>okhttp</artifactId>
+  <version>4.12.0</version>
+  <scm>
+    <url>https://github.com/square/okhttp</url>
+  </scm>
+</project>`;
+
+const POM_WITHOUT_SCM = `<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>com.example</groupId>
+  <artifactId>lib</artifactId>
+  <version>1.0.0</version>
+</project>`;
+
+describe("discoverGitHubRepo", () => {
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+  });
+
+  it("returns GitHub repo from POM SCM", async () => {
+    const repo = makeMockRepo("Maven Central", "https://repo1.maven.org/maven2");
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: async () => POM_WITH_SCM,
+    });
+
+    const result = await discoverGitHubRepo(
+      [repo],
+      "com.squareup.okhttp3",
+      "okhttp",
+      "4.12.0",
+    );
+
+    expect(result).toEqual({ owner: "square", repo: "okhttp" });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://repo1.maven.org/maven2/com/squareup/okhttp3/okhttp/4.12.0/okhttp-4.12.0.pom",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("tries multiple repos and returns first POM with GitHub SCM", async () => {
+    const repo1 = makeMockRepo("Custom", "https://custom.repo.com/maven2");
+    const repo2 = makeMockRepo("Maven Central", "https://repo1.maven.org/maven2");
+
+    // First repo POM fetch fails
+    mockFetch.mockResolvedValueOnce({ ok: false });
+    // Second repo returns POM with SCM
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: async () => POM_WITH_SCM,
+    });
+
+    const result = await discoverGitHubRepo(
+      [repo1, repo2],
+      "com.squareup.okhttp3",
+      "okhttp",
+      "4.12.0",
+    );
+
+    expect(result).toEqual({ owner: "square", repo: "okhttp" });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to guess when POM has no GitHub SCM", async () => {
+    const repo = makeMockRepo("Maven Central", "https://repo1.maven.org/maven2");
+
+    // POM without SCM
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: async () => POM_WITHOUT_SCM,
+    });
+
+    // repoExists check for guessed repo
+    mockFetch.mockResolvedValueOnce({ ok: true });
+
+    const result = await discoverGitHubRepo(
+      [repo],
+      "io.github.javalin",
+      "javalin",
+      "5.0.0",
+    );
+
+    expect(result).toEqual({ owner: "javalin", repo: "javalin" });
+  });
+
+  it("returns null when guess repo does not exist on GitHub", async () => {
+    const repo = makeMockRepo("Maven Central", "https://repo1.maven.org/maven2");
+
+    // POM without SCM
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: async () => POM_WITHOUT_SCM,
+    });
+
+    // repoExists returns false
+    mockFetch.mockResolvedValueOnce({ ok: false });
+
+    const result = await discoverGitHubRepo(
+      [repo],
+      "io.github.someuser",
+      "nonexistent-lib",
+      "1.0.0",
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no POM found and groupId is not guessable", async () => {
+    const repo = makeMockRepo("Maven Central", "https://repo1.maven.org/maven2");
+
+    // POM fetch fails
+    mockFetch.mockResolvedValueOnce({ ok: false });
+
+    const result = await discoverGitHubRepo(
+      [repo],
+      "org.apache.commons",
+      "commons-lang3",
+      "3.14.0",
+    );
+
+    expect(result).toBeNull();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles fetch errors gracefully during POM retrieval", async () => {
+    const repo = makeMockRepo("Maven Central", "https://repo1.maven.org/maven2");
+
+    // POM fetch throws
+    mockFetch.mockRejectedValueOnce(new Error("Network error"));
+
+    const result = await discoverGitHubRepo(
+      [repo],
+      "org.example",
+      "lib",
+      "1.0.0",
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("uses provided githubClient for repoExists check", async () => {
+    const repo = makeMockRepo("Maven Central", "https://repo1.maven.org/maven2");
+
+    // POM without SCM
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: async () => POM_WITHOUT_SCM,
+    });
+
+    const client = new GitHubClient("test-token");
+    const repoExistsSpy = vi.spyOn(client, "repoExists").mockResolvedValue(true);
+
+    const result = await discoverGitHubRepo(
+      [repo],
+      "com.github.myuser",
+      "mylib",
+      "1.0.0",
+      client,
+    );
+
+    expect(result).toEqual({ owner: "myuser", repo: "mylib" });
+    expect(repoExistsSpy).toHaveBeenCalledWith("myuser", "mylib");
+  });
+
+  it("skips POM without GitHub info and tries next repo", async () => {
+    const repo1 = makeMockRepo("Repo1", "https://repo1.example.com");
+    const repo2 = makeMockRepo("Repo2", "https://repo2.example.com");
+
+    // First repo returns POM without GitHub SCM
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: async () => POM_WITHOUT_SCM,
+    });
+
+    // Second repo returns POM with GitHub SCM
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: async () => POM_WITH_SCM,
+    });
+
+    const result = await discoverGitHubRepo(
+      [repo1, repo2],
+      "com.squareup.okhttp3",
+      "okhttp",
+      "4.12.0",
+    );
+
+    expect(result).toEqual({ owner: "square", repo: "okhttp" });
+  });
+});

--- a/src/github/__tests__/github-client.test.ts
+++ b/src/github/__tests__/github-client.test.ts
@@ -147,13 +147,14 @@ describe("GitHubClient", () => {
       expect(fetch).toHaveBeenCalledTimes(3);
     });
 
-    it("returns null on fetch error", async () => {
+    it("returns null on fetch error and tries all filenames", async () => {
       mockFetch(async () => { throw new Error("Network error"); });
 
       const client = new GitHubClient();
       const result = await client.fetchChangelog("owner", "repo");
 
       expect(result).toBeNull();
+      expect(fetch).toHaveBeenCalledTimes(3);
     });
   });
 

--- a/src/github/__tests__/github-client.test.ts
+++ b/src/github/__tests__/github-client.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { GitHubClient } from "../github-client.js";
+
+describe("GitHubClient", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    globalThis.fetch = originalFetch;
+  });
+
+  function mockFetch(handler: (url: string, init?: RequestInit) => Promise<Response>) {
+    vi.stubGlobal("fetch", vi.fn(handler));
+  }
+
+  describe("fetchReleases", () => {
+    it("returns releases on success", async () => {
+      const releases = [
+        { tag_name: "v1.0.0", body: "First release", html_url: "https://github.com/owner/repo/releases/tag/v1.0.0" },
+        { tag_name: "v2.0.0", body: "Second release", html_url: "https://github.com/owner/repo/releases/tag/v2.0.0" },
+      ];
+      mockFetch(async () => new Response(JSON.stringify(releases), { status: 200 }));
+
+      const client = new GitHubClient();
+      const result = await client.fetchReleases("owner", "repo");
+
+      expect(result).toEqual(releases);
+      expect(fetch).toHaveBeenCalledOnce();
+      const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe("https://api.github.com/repos/owner/repo/releases?per_page=100");
+      expect(init.headers["Accept"]).toBe("application/vnd.github.v3+json");
+      expect(init.headers["User-Agent"]).toBe("maven-central-mcp");
+    });
+
+    it("returns empty array on non-ok response", async () => {
+      mockFetch(async () => new Response("Not Found", { status: 404 }));
+
+      const client = new GitHubClient();
+      const result = await client.fetchReleases("owner", "repo");
+
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array on fetch error", async () => {
+      mockFetch(async () => { throw new Error("Network error"); });
+
+      const client = new GitHubClient();
+      const result = await client.fetchReleases("owner", "repo");
+
+      expect(result).toEqual([]);
+    });
+
+    it("sends Authorization header when token is provided", async () => {
+      mockFetch(async () => new Response(JSON.stringify([]), { status: 200 }));
+
+      const client = new GitHubClient("my-token");
+      await client.fetchReleases("owner", "repo");
+
+      const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(init.headers["Authorization"]).toBe("Bearer my-token");
+    });
+
+    it("does not send Authorization header when no token", async () => {
+      mockFetch(async () => new Response(JSON.stringify([]), { status: 200 }));
+
+      const client = new GitHubClient();
+      await client.fetchReleases("owner", "repo");
+
+      const [, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(init.headers["Authorization"]).toBeUndefined();
+    });
+
+    it("uses 15s timeout via AbortSignal", async () => {
+      mockFetch(async (_url: string, init?: RequestInit) => {
+        expect(init?.signal).toBeDefined();
+        return new Response(JSON.stringify([]), { status: 200 });
+      });
+
+      const client = new GitHubClient();
+      await client.fetchReleases("owner", "repo");
+    });
+  });
+
+  describe("fetchChangelog", () => {
+    it("returns decoded content for CHANGELOG.md", async () => {
+      const content = "# Changelog\n\n## v1.0.0\n- Initial release";
+      const base64Content = Buffer.from(content).toString("base64");
+      mockFetch(async () => new Response(JSON.stringify({ content: base64Content }), { status: 200 }));
+
+      const client = new GitHubClient();
+      const result = await client.fetchChangelog("owner", "repo");
+
+      expect(result).toBe(content);
+      const [url] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe("https://api.github.com/repos/owner/repo/contents/CHANGELOG.md");
+    });
+
+    it("tries changelog.md if CHANGELOG.md returns 404", async () => {
+      const content = "# Changes";
+      const base64Content = Buffer.from(content).toString("base64");
+      let callCount = 0;
+      mockFetch(async () => {
+        callCount++;
+        if (callCount === 1) return new Response("Not Found", { status: 404 });
+        return new Response(JSON.stringify({ content: base64Content }), { status: 200 });
+      });
+
+      const client = new GitHubClient();
+      const result = await client.fetchChangelog("owner", "repo");
+
+      expect(result).toBe(content);
+      expect(fetch).toHaveBeenCalledTimes(2);
+      const [url2] = (fetch as ReturnType<typeof vi.fn>).mock.calls[1];
+      expect(url2).toBe("https://api.github.com/repos/owner/repo/contents/changelog.md");
+    });
+
+    it("tries CHANGES.md if first two return 404", async () => {
+      const content = "# Changes";
+      const base64Content = Buffer.from(content).toString("base64");
+      let callCount = 0;
+      mockFetch(async () => {
+        callCount++;
+        if (callCount <= 2) return new Response("Not Found", { status: 404 });
+        return new Response(JSON.stringify({ content: base64Content }), { status: 200 });
+      });
+
+      const client = new GitHubClient();
+      const result = await client.fetchChangelog("owner", "repo");
+
+      expect(result).toBe(content);
+      expect(fetch).toHaveBeenCalledTimes(3);
+      const [url3] = (fetch as ReturnType<typeof vi.fn>).mock.calls[2];
+      expect(url3).toBe("https://api.github.com/repos/owner/repo/contents/CHANGES.md");
+    });
+
+    it("returns null if all changelog files return 404", async () => {
+      mockFetch(async () => new Response("Not Found", { status: 404 }));
+
+      const client = new GitHubClient();
+      const result = await client.fetchChangelog("owner", "repo");
+
+      expect(result).toBeNull();
+      expect(fetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("returns null on fetch error", async () => {
+      mockFetch(async () => { throw new Error("Network error"); });
+
+      const client = new GitHubClient();
+      const result = await client.fetchChangelog("owner", "repo");
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("repoExists", () => {
+    it("returns true when repo exists", async () => {
+      mockFetch(async () => new Response("{}", { status: 200 }));
+
+      const client = new GitHubClient();
+      const result = await client.repoExists("owner", "repo");
+
+      expect(result).toBe(true);
+      const [url] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(url).toBe("https://api.github.com/repos/owner/repo");
+    });
+
+    it("returns false when repo does not exist", async () => {
+      mockFetch(async () => new Response("Not Found", { status: 404 }));
+
+      const client = new GitHubClient();
+      const result = await client.repoExists("owner", "repo");
+
+      expect(result).toBe(false);
+    });
+
+    it("returns false on fetch error", async () => {
+      mockFetch(async () => { throw new Error("Network error"); });
+
+      const client = new GitHubClient();
+      const result = await client.repoExists("owner", "repo");
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/src/github/__tests__/guess-repo.test.ts
+++ b/src/github/__tests__/guess-repo.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { guessGitHubRepo } from "../guess-repo.js";
+
+describe("guessGitHubRepo", () => {
+  it("returns owner and repo for com.github.{owner}", () => {
+    const result = guessGitHubRepo("com.github.johnsmith", "my-library");
+    expect(result).toEqual({ owner: "johnsmith", repo: "my-library" });
+  });
+
+  it("returns owner and repo for io.github.{owner}", () => {
+    const result = guessGitHubRepo("io.github.janedoe", "cool-lib");
+    expect(result).toEqual({ owner: "janedoe", repo: "cool-lib" });
+  });
+
+  it("returns null for non-github groupId", () => {
+    expect(guessGitHubRepo("org.apache.commons", "commons-lang3")).toBeNull();
+  });
+
+  it("returns null for com.google groupId", () => {
+    expect(guessGitHubRepo("com.google.guava", "guava")).toBeNull();
+  });
+
+  it("returns null for groupId that is just com.github without owner", () => {
+    expect(guessGitHubRepo("com.github", "some-lib")).toBeNull();
+  });
+
+  it("returns null for groupId that is just io.github without owner", () => {
+    expect(guessGitHubRepo("io.github", "some-lib")).toBeNull();
+  });
+
+  it("handles nested groupId under com.github.{owner}", () => {
+    const result = guessGitHubRepo("com.github.owner.subpackage", "artifact");
+    expect(result).toEqual({ owner: "owner", repo: "artifact" });
+  });
+
+  it("handles nested groupId under io.github.{owner}", () => {
+    const result = guessGitHubRepo("io.github.owner.sub.deep", "artifact");
+    expect(result).toEqual({ owner: "owner", repo: "artifact" });
+  });
+});

--- a/src/github/__tests__/pom-scm.test.ts
+++ b/src/github/__tests__/pom-scm.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import { buildPomUrl, extractGitHubRepo } from "../pom-scm.js";
+
+describe("buildPomUrl", () => {
+  it("builds URL with dots replaced by slashes in groupId", () => {
+    expect(
+      buildPomUrl(
+        "https://repo1.maven.org/maven2",
+        "com.google.guava",
+        "guava",
+        "31.1-jre",
+      ),
+    ).toBe(
+      "https://repo1.maven.org/maven2/com/google/guava/guava/31.1-jre/guava-31.1-jre.pom",
+    );
+  });
+
+  it("handles single-segment groupId", () => {
+    expect(
+      buildPomUrl("https://repo.example.com", "commons", "commons-lang", "3.0"),
+    ).toBe(
+      "https://repo.example.com/commons/commons-lang/3.0/commons-lang-3.0.pom",
+    );
+  });
+
+  it("strips trailing slash from repo URL", () => {
+    expect(
+      buildPomUrl(
+        "https://repo1.maven.org/maven2/",
+        "org.apache",
+        "commons",
+        "1.0",
+      ),
+    ).toBe(
+      "https://repo1.maven.org/maven2/org/apache/commons/1.0/commons-1.0.pom",
+    );
+  });
+});
+
+describe("extractGitHubRepo", () => {
+  it("extracts from scm url", () => {
+    const pom = `
+      <project>
+        <scm>
+          <url>https://github.com/google/guava</url>
+        </scm>
+      </project>`;
+    expect(extractGitHubRepo(pom)).toEqual({ owner: "google", repo: "guava" });
+  });
+
+  it("extracts from scm connection with git protocol", () => {
+    const pom = `
+      <project>
+        <scm>
+          <connection>scm:git:git://github.com/apache/commons-lang.git</connection>
+        </scm>
+      </project>`;
+    expect(extractGitHubRepo(pom)).toEqual({
+      owner: "apache",
+      repo: "commons-lang",
+    });
+  });
+
+  it("extracts from scm developerConnection with ssh", () => {
+    const pom = `
+      <project>
+        <scm>
+          <developerConnection>scm:git:ssh://git@github.com/square/okhttp.git</developerConnection>
+        </scm>
+      </project>`;
+    expect(extractGitHubRepo(pom)).toEqual({
+      owner: "square",
+      repo: "okhttp",
+    });
+  });
+
+  it("falls back to root url outside scm", () => {
+    const pom = `
+      <project>
+        <url>https://github.com/reactor/reactor-core</url>
+      </project>`;
+    expect(extractGitHubRepo(pom)).toEqual({
+      owner: "reactor",
+      repo: "reactor-core",
+    });
+  });
+
+  it("handles .git suffix", () => {
+    const pom = `
+      <project>
+        <scm>
+          <url>https://github.com/jetbrains/kotlin.git</url>
+        </scm>
+      </project>`;
+    expect(extractGitHubRepo(pom)).toEqual({
+      owner: "jetbrains",
+      repo: "kotlin",
+    });
+  });
+
+  it("handles /tree/main suffix", () => {
+    const pom = `
+      <project>
+        <scm>
+          <url>https://github.com/owner/repo/tree/main</url>
+        </scm>
+      </project>`;
+    expect(extractGitHubRepo(pom)).toEqual({ owner: "owner", repo: "repo" });
+  });
+
+  it("returns null when no GitHub URL found", () => {
+    const pom = `
+      <project>
+        <scm>
+          <url>https://gitlab.com/owner/repo</url>
+        </scm>
+      </project>`;
+    expect(extractGitHubRepo(pom)).toBeNull();
+  });
+
+  it("returns null for empty POM", () => {
+    expect(extractGitHubRepo("")).toBeNull();
+  });
+
+  it("prefers scm url over root url", () => {
+    const pom = `
+      <project>
+        <url>https://github.com/wrong/fallback</url>
+        <scm>
+          <url>https://github.com/correct/repo</url>
+        </scm>
+      </project>`;
+    expect(extractGitHubRepo(pom)).toEqual({
+      owner: "correct",
+      repo: "repo",
+    });
+  });
+
+  it("extracts from https connection string", () => {
+    const pom = `
+      <project>
+        <scm>
+          <connection>scm:git:https://github.com/owner/repo.git</connection>
+        </scm>
+      </project>`;
+    expect(extractGitHubRepo(pom)).toEqual({ owner: "owner", repo: "repo" });
+  });
+});

--- a/src/github/__tests__/tag-matcher.test.ts
+++ b/src/github/__tests__/tag-matcher.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { matchReleaseToVersion } from "../tag-matcher.js";
+import type { GitHubRelease } from "../github-client.js";
+
+function release(tag: string): GitHubRelease {
+  return { tag_name: tag, body: "", html_url: `https://github.com/test/repo/releases/tag/${tag}` };
+}
+
+describe("matchReleaseToVersion", () => {
+  it("returns undefined for empty releases array", () => {
+    expect(matchReleaseToVersion([], "1.0.0")).toBeUndefined();
+  });
+
+  it("matches exact version tag", () => {
+    const releases = [release("1.0.0"), release("2.0.0")];
+    const result = matchReleaseToVersion(releases, "1.0.0");
+    expect(result).toEqual(releases[0]);
+  });
+
+  it("matches v-prefixed tag", () => {
+    const releases = [release("v1.0.0"), release("v2.0.0")];
+    const result = matchReleaseToVersion(releases, "1.0.0");
+    expect(result).toEqual(releases[0]);
+  });
+
+  it("matches tag with dash separator suffix", () => {
+    const releases = [release("release-1.0.0"), release("release-2.0.0")];
+    const result = matchReleaseToVersion(releases, "1.0.0");
+    expect(result).toEqual(releases[0]);
+  });
+
+  it("matches tag with slash separator suffix", () => {
+    const releases = [release("ktor/1.0.0"), release("ktor/2.0.0")];
+    const result = matchReleaseToVersion(releases, "1.0.0");
+    expect(result).toEqual(releases[0]);
+  });
+
+  it("matches ktor-style tag with artifact prefix", () => {
+    const releases = [release("ktor-1.0.0")];
+    const result = matchReleaseToVersion(releases, "1.0.0");
+    expect(result).toEqual(releases[0]);
+  });
+
+  it("prefers exact match over v-prefix", () => {
+    const releases = [release("v1.0.0"), release("1.0.0")];
+    const result = matchReleaseToVersion(releases, "1.0.0");
+    expect(result?.tag_name).toBe("1.0.0");
+  });
+
+  it("prefers v-prefix over suffix match", () => {
+    const releases = [release("release-1.0.0"), release("v1.0.0")];
+    const result = matchReleaseToVersion(releases, "1.0.0");
+    expect(result?.tag_name).toBe("v1.0.0");
+  });
+
+  it("does not match tag where version appears mid-string without separator", () => {
+    const releases = [release("prefix1.0.0")];
+    const result = matchReleaseToVersion(releases, "1.0.0");
+    expect(result).toBeUndefined();
+  });
+
+  it("does not match partial version in longer tag", () => {
+    const releases = [release("1.0.0-beta")];
+    const result = matchReleaseToVersion(releases, "1.0.0");
+    expect(result).toBeUndefined();
+  });
+
+  it("returns undefined when no tag matches", () => {
+    const releases = [release("3.0.0"), release("v2.0.0")];
+    const result = matchReleaseToVersion(releases, "1.0.0");
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/github/changelog-parser.ts
+++ b/src/github/changelog-parser.ts
@@ -1,0 +1,33 @@
+const VERSION_HEADING_RE = /^##\s+\[?v?(\d+[^\]\s]*)\]?/;
+
+/**
+ * Parse markdown changelog content into a map of version -> body text.
+ * Recognizes headings like `## [2.0.0] - 2024-01-15`, `## 1.0.0`, `## v3.0.0`.
+ * Returns empty Map for non-changelog content.
+ */
+export function parseChangelogSections(content: string): Map<string, string> {
+  const sections = new Map<string, string>();
+  const lines = content.split("\n");
+
+  let currentVersion: string | null = null;
+  let currentBody: string[] = [];
+
+  for (const line of lines) {
+    const match = line.match(VERSION_HEADING_RE);
+    if (match) {
+      if (currentVersion !== null) {
+        sections.set(currentVersion, currentBody.join("\n").trim());
+      }
+      currentVersion = match[1];
+      currentBody = [];
+    } else if (currentVersion !== null) {
+      currentBody.push(line);
+    }
+  }
+
+  if (currentVersion !== null) {
+    sections.set(currentVersion, currentBody.join("\n").trim());
+  }
+
+  return sections;
+}

--- a/src/github/discover-repo.ts
+++ b/src/github/discover-repo.ts
@@ -1,0 +1,40 @@
+import type { MavenRepository } from "../maven/repository.js";
+import type { GitHubRepo } from "./pom-scm.js";
+import { buildPomUrl, extractGitHubRepo } from "./pom-scm.js";
+import { guessGitHubRepo } from "./guess-repo.js";
+import { GitHubClient } from "./github-client.js";
+
+export async function discoverGitHubRepo(
+  repos: MavenRepository[],
+  groupId: string,
+  artifactId: string,
+  version: string,
+  githubClient?: GitHubClient,
+): Promise<GitHubRepo | null> {
+  // Step 1: Try each Maven repo's POM for GitHub SCM info
+  for (const repo of repos) {
+    try {
+      const pomUrl = buildPomUrl(repo.url, groupId, artifactId, version);
+      const response = await fetch(pomUrl, {
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!response.ok) continue;
+
+      const pomXml = await response.text();
+      const ghRepo = extractGitHubRepo(pomXml);
+      if (ghRepo) return ghRepo;
+    } catch {
+      // Fetch failed, try next repo
+      continue;
+    }
+  }
+
+  // Step 2: Try guessing from groupId/artifactId
+  const guess = guessGitHubRepo(groupId, artifactId);
+  if (!guess) return null;
+
+  // Step 3: Verify guessed repo exists
+  const client = githubClient ?? new GitHubClient(process.env.GITHUB_TOKEN);
+  const exists = await client.repoExists(guess.owner, guess.repo);
+  return exists ? guess : null;
+}

--- a/src/github/github-client.ts
+++ b/src/github/github-client.ts
@@ -58,7 +58,7 @@ export class GitHubClient {
         const data = (await response.json()) as { content: string };
         return Buffer.from(data.content, "base64").toString("utf-8");
       } catch {
-        return null;
+        continue;
       }
     }
     return null;

--- a/src/github/github-client.ts
+++ b/src/github/github-client.ts
@@ -1,0 +1,81 @@
+export interface GitHubRelease {
+  tag_name: string;
+  body: string;
+  html_url: string;
+}
+
+const GITHUB_API = "https://api.github.com";
+const USER_AGENT = "maven-central-mcp";
+const ACCEPT_HEADER = "application/vnd.github.v3+json";
+
+const CHANGELOG_NAMES = ["CHANGELOG.md", "changelog.md", "CHANGES.md"];
+
+export class GitHubClient {
+  private readonly token?: string;
+
+  constructor(token?: string) {
+    this.token = token;
+  }
+
+  private buildHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      Accept: ACCEPT_HEADER,
+      "User-Agent": USER_AGENT,
+    };
+    if (this.token) {
+      headers["Authorization"] = `Bearer ${this.token}`;
+    }
+    return headers;
+  }
+
+  async fetchReleases(owner: string, repo: string): Promise<GitHubRelease[]> {
+    try {
+      const response = await fetch(
+        `${GITHUB_API}/repos/${owner}/${repo}/releases?per_page=100`,
+        {
+          headers: this.buildHeaders(),
+          signal: AbortSignal.timeout(15_000),
+        }
+      );
+      if (!response.ok) return [];
+      return (await response.json()) as GitHubRelease[];
+    } catch {
+      return [];
+    }
+  }
+
+  async fetchChangelog(owner: string, repo: string): Promise<string | null> {
+    for (const name of CHANGELOG_NAMES) {
+      try {
+        const response = await fetch(
+          `${GITHUB_API}/repos/${owner}/${repo}/contents/${name}`,
+          {
+            headers: this.buildHeaders(),
+            signal: AbortSignal.timeout(10_000),
+          }
+        );
+        if (!response.ok) continue;
+        const data = (await response.json()) as { content: string };
+        return Buffer.from(data.content, "base64").toString("utf-8");
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  async repoExists(owner: string, repo: string): Promise<boolean> {
+    try {
+      const response = await fetch(
+        `${GITHUB_API}/repos/${owner}/${repo}`,
+        {
+          headers: this.buildHeaders(),
+          signal: AbortSignal.timeout(10_000),
+        }
+      );
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/github/guess-repo.ts
+++ b/src/github/guess-repo.ts
@@ -1,0 +1,17 @@
+import type { GitHubRepo } from "./pom-scm.js";
+
+const GITHUB_GROUP_PREFIXES = ["com.github.", "io.github."] as const;
+
+export function guessGitHubRepo(
+  groupId: string,
+  artifactId: string,
+): GitHubRepo | null {
+  for (const prefix of GITHUB_GROUP_PREFIXES) {
+    if (groupId.startsWith(prefix) && groupId.length > prefix.length) {
+      const rest = groupId.slice(prefix.length);
+      const owner = rest.split(".")[0];
+      return { owner, repo: artifactId };
+    }
+  }
+  return null;
+}

--- a/src/github/pom-scm.ts
+++ b/src/github/pom-scm.ts
@@ -1,0 +1,83 @@
+export interface GitHubRepo {
+  owner: string;
+  repo: string;
+}
+
+/**
+ * Builds a Maven POM URL from repository URL and artifact coordinates.
+ */
+export function buildPomUrl(
+  repoUrl: string,
+  groupId: string,
+  artifactId: string,
+  version: string,
+): string {
+  const base = repoUrl.replace(/\/+$/, "");
+  const groupPath = groupId.replace(/\./g, "/");
+  return `${base}/${groupPath}/${artifactId}/${version}/${artifactId}-${version}.pom`;
+}
+
+const GITHUB_REPO_RE =
+  /github\.com[/:]([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)/;
+
+function parseGitHubUrl(url: string): GitHubRepo | null {
+  const m = url.match(GITHUB_REPO_RE);
+  if (!m) return null;
+  const owner = m[1];
+  let repo = m[2];
+  repo = repo.replace(/\.git$/, "");
+  // Strip path suffixes like /tree/main
+  repo = repo.split("/")[0];
+  return { owner, repo };
+}
+
+/**
+ * Extracts GitHub owner/repo from POM XML using regex-based parsing.
+ *
+ * Priority:
+ * 1. <scm><url>
+ * 2. <scm><connection>
+ * 3. <scm><developerConnection>
+ * 4. Root <url> (outside <scm>)
+ */
+export function extractGitHubRepo(pomXml: string): GitHubRepo | null {
+  // Extract <scm> block
+  const scmMatch = pomXml.match(/<scm>([\s\S]*?)<\/scm>/);
+
+  if (scmMatch) {
+    const scmBlock = scmMatch[1];
+
+    // Try <url> inside <scm>
+    const scmUrl = scmBlock.match(/<url>\s*(.*?)\s*<\/url>/);
+    if (scmUrl) {
+      const result = parseGitHubUrl(scmUrl[1]);
+      if (result) return result;
+    }
+
+    // Try <connection>
+    const conn = scmBlock.match(/<connection>\s*(.*?)\s*<\/connection>/);
+    if (conn) {
+      const result = parseGitHubUrl(conn[1]);
+      if (result) return result;
+    }
+
+    // Try <developerConnection>
+    const devConn = scmBlock.match(
+      /<developerConnection>\s*(.*?)\s*<\/developerConnection>/,
+    );
+    if (devConn) {
+      const result = parseGitHubUrl(devConn[1]);
+      if (result) return result;
+    }
+  }
+
+  // Fallback: root <url> outside <scm>
+  // Remove <scm> block first to avoid matching URLs inside it
+  const withoutScm = pomXml.replace(/<scm>[\s\S]*?<\/scm>/, "");
+  const rootUrl = withoutScm.match(/<url>\s*(.*?)\s*<\/url>/);
+  if (rootUrl) {
+    return parseGitHubUrl(rootUrl[1]);
+  }
+
+  return null;
+}

--- a/src/github/tag-matcher.ts
+++ b/src/github/tag-matcher.ts
@@ -1,0 +1,44 @@
+import type { GitHubRelease } from "./github-client.js";
+
+/**
+ * Find the release whose tag matches the given Maven version.
+ *
+ * Match strategies (in priority order):
+ * 1. Exact: tag === version
+ * 2. v-prefix: tag === "v" + version
+ * 3. Suffix after separator: tag ends with version and the preceding char is `-` or `/`
+ */
+export function matchReleaseToVersion(
+  releases: GitHubRelease[],
+  version: string,
+): GitHubRelease | undefined {
+  let vPrefixMatch: GitHubRelease | undefined;
+  let suffixMatch: GitHubRelease | undefined;
+
+  for (const release of releases) {
+    const tag = release.tag_name;
+
+    // Strategy 1: Exact match
+    if (tag === version) {
+      return release;
+    }
+
+    // Strategy 2: v-prefix
+    if (!vPrefixMatch && tag === `v${version}`) {
+      vPrefixMatch = release;
+    }
+
+    // Strategy 3: Suffix after `-` or `/`
+    if (!suffixMatch && tag.endsWith(version)) {
+      const prefixLength = tag.length - version.length;
+      if (prefixLength > 0) {
+        const separator = tag[prefixLength - 1];
+        if (separator === "-" || separator === "/") {
+          suffixMatch = release;
+        }
+      }
+    }
+  }
+
+  return vPrefixMatch ?? suffixMatch;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { getLatestVersionHandler } from "./tools/get-latest-version.js";
 import { checkVersionExistsHandler } from "./tools/check-version-exists.js";
 import { checkMultipleDependenciesHandler } from "./tools/check-multiple-dependencies.js";
 import { compareDependencyVersionsHandler } from "./tools/compare-dependency-versions.js";
+import { getDependencyChangesHandler } from "./tools/get-dependency-changes.js";
 
 const server = new McpServer({
   name: "maven-central-mcp",
@@ -101,6 +102,21 @@ server.tool(
   },
   async (params) => {
     const result = await compareDependencyVersionsHandler(getRepositories(), params);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  },
+);
+
+server.tool(
+  "get_dependency_changes",
+  "Show what changed between two versions of a dependency. Fetches release notes from GitHub and changelog files. Returns raw change descriptions for each intermediate version — summarize the most important changes for the user.",
+  {
+    groupId: z.string().describe("Maven group ID (e.g. io.ktor)"),
+    artifactId: z.string().describe("Maven artifact ID (e.g. ktor-server-core)"),
+    fromVersion: z.string().describe("Current version"),
+    toVersion: z.string().describe("Target version to upgrade to"),
+  },
+  async (params) => {
+    const result = await getDependencyChangesHandler(getRepositories(), params);
     return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
   },
 );

--- a/src/tools/__tests__/get-dependency-changes.test.ts
+++ b/src/tools/__tests__/get-dependency-changes.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getDependencyChangesHandler } from "../get-dependency-changes.js";
+import type { MavenRepository } from "../../maven/repository.js";
+
+// Mock node:fs to prevent FileCache from writing to disk
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn().mockReturnValue(false),
+  readFileSync: vi.fn().mockReturnValue(""),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+function mockRepo(versions: string[]): MavenRepository {
+  return {
+    name: "central",
+    url: "https://repo1.maven.org/maven2",
+    fetchMetadata: vi.fn().mockResolvedValue({
+      groupId: "io.ktor",
+      artifactId: "ktor-core",
+      versions,
+      latest: versions[versions.length - 1],
+      release: versions[versions.length - 1],
+    }),
+  };
+}
+
+const POM_WITH_SCM = `<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>io.ktor</groupId>
+  <artifactId>ktor-core</artifactId>
+  <version>2.3.0</version>
+  <scm>
+    <url>https://github.com/ktorio/ktor</url>
+  </scm>
+</project>`;
+
+const POM_WITHOUT_SCM = `<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>com.example</groupId>
+  <artifactId>no-scm</artifactId>
+  <version>1.0.0</version>
+</project>`;
+
+describe("getDependencyChangesHandler", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("returns changes from GitHub releases", async () => {
+    const repo = mockRepo(["2.1.0", "2.2.0", "2.3.0"]);
+
+    const releases = [
+      { tag_name: "2.2.0", body: "Bug fixes for 2.2.0", html_url: "https://github.com/ktorio/ktor/releases/tag/2.2.0" },
+      { tag_name: "2.3.0", body: "New features in 2.3.0", html_url: "https://github.com/ktorio/ktor/releases/tag/2.3.0" },
+    ];
+
+    globalThis.fetch = vi.fn()
+      // First call: POM fetch (from discoverGitHubRepo)
+      .mockResolvedValueOnce(new Response(POM_WITH_SCM, { status: 200 }))
+      // Second call: GitHub releases
+      .mockResolvedValueOnce(new Response(JSON.stringify(releases), { status: 200 })) as typeof fetch;
+
+    const result = await getDependencyChangesHandler([repo], {
+      groupId: "io.ktor",
+      artifactId: "ktor-core",
+      fromVersion: "2.1.0",
+      toVersion: "2.3.0",
+    });
+
+    expect(result.groupId).toBe("io.ktor");
+    expect(result.artifactId).toBe("ktor-core");
+    expect(result.fromVersion).toBe("2.1.0");
+    expect(result.toVersion).toBe("2.3.0");
+    expect(result.repositoryUrl).toBe("https://github.com/ktorio/ktor");
+    expect(result.repositoryNotFound).toBeUndefined();
+    expect(result.changes).toHaveLength(2);
+    expect(result.changes[0]).toEqual({
+      version: "2.2.0",
+      releaseUrl: "https://github.com/ktorio/ktor/releases/tag/2.2.0",
+      body: "Bug fixes for 2.2.0",
+    });
+    expect(result.changes[1]).toEqual({
+      version: "2.3.0",
+      releaseUrl: "https://github.com/ktorio/ktor/releases/tag/2.3.0",
+      body: "New features in 2.3.0",
+    });
+  });
+
+  it("returns repositoryNotFound when no GitHub repo found", async () => {
+    const repo = mockRepo(["1.0.0", "1.1.0", "1.2.0"]);
+
+    globalThis.fetch = vi.fn()
+      // POM fetch returns no SCM info
+      .mockResolvedValueOnce(new Response(POM_WITHOUT_SCM, { status: 200 }))
+      // repoExists check for guessed repo fails
+      .mockResolvedValueOnce(new Response("", { status: 404 })) as typeof fetch;
+
+    const result = await getDependencyChangesHandler([repo], {
+      groupId: "com.example",
+      artifactId: "no-scm",
+      fromVersion: "1.0.0",
+      toVersion: "1.2.0",
+    });
+
+    expect(result.repositoryNotFound).toBe(true);
+    expect(result.changes).toEqual([]);
+  });
+
+  it("falls back to changelog when releases don't match versions", async () => {
+    const repo = mockRepo(["2.1.0", "2.2.0", "2.3.0"]);
+
+    const changelogContent = Buffer.from(
+      "# Changelog\n\n## [2.3.0] - 2024-03-01\n\nNew stuff\n\n## [2.2.0] - 2024-02-01\n\nOlder stuff\n",
+    ).toString("base64");
+
+    globalThis.fetch = vi.fn()
+      // POM fetch
+      .mockResolvedValueOnce(new Response(POM_WITH_SCM, { status: 200 }))
+      // Releases fetch — empty array, no matches
+      .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }))
+      // Changelog fetch (CHANGELOG.md)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ content: changelogContent }), { status: 200 }),
+      ) as typeof fetch;
+
+    const result = await getDependencyChangesHandler([repo], {
+      groupId: "io.ktor",
+      artifactId: "ktor-core",
+      fromVersion: "2.1.0",
+      toVersion: "2.3.0",
+    });
+
+    expect(result.repositoryNotFound).toBeUndefined();
+    expect(result.changes).toHaveLength(2);
+    expect(result.changes[0].version).toBe("2.2.0");
+    expect(result.changes[0].body).toBe("Older stuff");
+    expect(result.changes[1].version).toBe("2.3.0");
+    expect(result.changes[1].body).toBe("New stuff");
+    expect(result.changelogUrl).toContain("CHANGELOG.md");
+  });
+
+  it("returns error when no versions found between from and to", async () => {
+    const repo = mockRepo(["1.0.0", "3.0.0"]);
+
+    const result = await getDependencyChangesHandler([repo], {
+      groupId: "io.ktor",
+      artifactId: "ktor-core",
+      fromVersion: "2.0.0",
+      toVersion: "2.5.0",
+    });
+
+    expect(result.error).toContain("No versions found between");
+    expect(result.changes).toEqual([]);
+  });
+});

--- a/src/tools/get-dependency-changes.ts
+++ b/src/tools/get-dependency-changes.ts
@@ -36,7 +36,7 @@ export interface DependencyChangesResult {
 
 const TTL_24H = 24 * 60 * 60 * 1000;
 
-const cache = new FileCache(".cache/mcp-maven-central");
+const cache = new FileCache();
 const githubClient = new GitHubClient(process.env.GITHUB_TOKEN);
 
 export async function getDependencyChangesHandler(

--- a/src/tools/get-dependency-changes.ts
+++ b/src/tools/get-dependency-changes.ts
@@ -1,0 +1,158 @@
+import type { MavenRepository } from "../maven/repository.js";
+import { resolveAll } from "../maven/resolver.js";
+import { filterVersionRange } from "../version/range.js";
+import { discoverGitHubRepo } from "../github/discover-repo.js";
+import { GitHubClient } from "../github/github-client.js";
+import type { GitHubRelease } from "../github/github-client.js";
+import { matchReleaseToVersion } from "../github/tag-matcher.js";
+import { parseChangelogSections } from "../github/changelog-parser.js";
+import { FileCache } from "../cache/file-cache.js";
+import type { GitHubRepo } from "../github/pom-scm.js";
+
+export interface DependencyChangesInput {
+  groupId: string;
+  artifactId: string;
+  fromVersion: string;
+  toVersion: string;
+}
+
+export interface VersionChange {
+  version: string;
+  releaseUrl?: string;
+  body?: string;
+}
+
+export interface DependencyChangesResult {
+  groupId: string;
+  artifactId: string;
+  fromVersion: string;
+  toVersion: string;
+  repositoryUrl?: string;
+  changes: VersionChange[];
+  changelogUrl?: string;
+  repositoryNotFound?: boolean;
+  error?: string;
+}
+
+const TTL_24H = 24 * 60 * 60 * 1000;
+
+const cache = new FileCache(".cache/mcp-maven-central");
+const githubClient = new GitHubClient(process.env.GITHUB_TOKEN);
+
+export async function getDependencyChangesHandler(
+  repos: MavenRepository[],
+  input: DependencyChangesInput,
+): Promise<DependencyChangesResult> {
+  const { groupId, artifactId, fromVersion, toVersion } = input;
+
+  const baseResult: DependencyChangesResult = {
+    groupId,
+    artifactId,
+    fromVersion,
+    toVersion,
+    changes: [],
+  };
+
+  // Step 1: Resolve all versions
+  let allVersions: string[];
+  try {
+    const metadata = await resolveAll(repos, groupId, artifactId);
+    allVersions = metadata.versions;
+  } catch (e) {
+    return { ...baseResult, error: String(e) };
+  }
+
+  // Step 2: Filter version range
+  const intermediateVersions = filterVersionRange(allVersions, fromVersion, toVersion);
+  if (intermediateVersions.length === 0) {
+    return {
+      ...baseResult,
+      error: `No versions found between ${fromVersion} and ${toVersion}`,
+    };
+  }
+
+  // Step 3: Discover GitHub repo
+  const scmCacheKey = `scm/${groupId}/${artifactId}`;
+  let ghRepo: GitHubRepo | null | undefined = await cache.get<GitHubRepo>(scmCacheKey);
+
+  if (ghRepo === undefined) {
+    ghRepo = await discoverGitHubRepo(repos, groupId, artifactId, toVersion, githubClient);
+    if (ghRepo) {
+      await cache.set(scmCacheKey, ghRepo);
+    }
+  }
+
+  if (!ghRepo) {
+    return { ...baseResult, repositoryNotFound: true };
+  }
+
+  const { owner, repo } = ghRepo;
+  const repositoryUrl = `https://github.com/${owner}/${repo}`;
+
+  // Step 4: Fetch GitHub releases (with cache)
+  const releasesCacheKey = `releases/${owner}/${repo}`;
+  let releases: GitHubRelease[] | undefined = await cache.get<GitHubRelease[]>(releasesCacheKey, TTL_24H);
+  if (releases === undefined) {
+    releases = await githubClient.fetchReleases(owner, repo);
+    await cache.set(releasesCacheKey, releases);
+  }
+
+  // Step 5: Match releases to versions
+  const changes: VersionChange[] = [];
+  const unmatchedVersions: string[] = [];
+
+  for (const version of intermediateVersions) {
+    const release = matchReleaseToVersion(releases, version);
+    if (release) {
+      changes.push({
+        version,
+        releaseUrl: release.html_url,
+        body: release.body,
+      });
+    } else {
+      unmatchedVersions.push(version);
+    }
+  }
+
+  // Step 6: For unmatched versions, try CHANGELOG.md
+  let changelogUrl: string | undefined;
+  if (unmatchedVersions.length > 0) {
+    const changelogCacheKey = `changelog/${owner}/${repo}`;
+    let changelogContent: string | null | undefined = await cache.get<string | null>(changelogCacheKey, TTL_24H);
+    if (changelogContent === undefined) {
+      changelogContent = await githubClient.fetchChangelog(owner, repo);
+      if (changelogContent !== null) {
+        await cache.set(changelogCacheKey, changelogContent);
+      }
+    }
+
+    if (changelogContent) {
+      changelogUrl = `https://github.com/${owner}/${repo}/blob/main/CHANGELOG.md`;
+      const sections = parseChangelogSections(changelogContent);
+
+      for (const version of unmatchedVersions) {
+        const body = sections.get(version);
+        if (body) {
+          changes.push({ version, body });
+        } else {
+          changes.push({ version });
+        }
+      }
+    } else {
+      for (const version of unmatchedVersions) {
+        changes.push({ version });
+      }
+    }
+  }
+
+  // Step 7: Sort changes by version order (same order as intermediateVersions)
+  const versionOrder = new Map(intermediateVersions.map((v, i) => [v, i]));
+  changes.sort((a, b) => (versionOrder.get(a.version) ?? 0) - (versionOrder.get(b.version) ?? 0));
+
+  return {
+    ...baseResult,
+    repositoryUrl,
+    changes,
+    changelogUrl,
+  };
+}

--- a/src/version/__tests__/range.test.ts
+++ b/src/version/__tests__/range.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { filterVersionRange } from "../range.js";
+
+describe("filterVersionRange", () => {
+  const versions = ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "2.0.0-beta1", "2.0.0"];
+
+  it("returns versions between from (exclusive) and to (inclusive)", () => {
+    expect(filterVersionRange(versions, "1.0.0", "1.3.0")).toEqual([
+      "1.1.0",
+      "1.2.0",
+      "1.3.0",
+    ]);
+  });
+
+  it("includes pre-release versions in range", () => {
+    expect(filterVersionRange(versions, "1.2.0", "2.0.0")).toEqual([
+      "1.3.0",
+      "2.0.0-beta1",
+      "2.0.0",
+    ]);
+  });
+
+  it("returns empty array when from and to are the same", () => {
+    expect(filterVersionRange(versions, "1.0.0", "1.0.0")).toEqual([]);
+  });
+
+  it("returns empty array when fromVersion is not found", () => {
+    expect(filterVersionRange(versions, "0.9.0", "1.3.0")).toEqual([]);
+  });
+
+  it("returns empty array when toVersion is not found", () => {
+    expect(filterVersionRange(versions, "1.0.0", "9.9.9")).toEqual([]);
+  });
+});

--- a/src/version/range.ts
+++ b/src/version/range.ts
@@ -1,0 +1,20 @@
+/**
+ * Filters a versions array to return only versions between fromVersion (exclusive)
+ * and toVersion (inclusive).
+ *
+ * Returns an empty array if either version is not found or fromIndex >= toIndex.
+ */
+export function filterVersionRange(
+  versions: string[],
+  fromVersion: string,
+  toVersion: string,
+): string[] {
+  const fromIndex = versions.indexOf(fromVersion);
+  const toIndex = versions.indexOf(toVersion);
+
+  if (fromIndex === -1 || toIndex === -1 || fromIndex >= toIndex) {
+    return [];
+  }
+
+  return versions.slice(fromIndex + 1, toIndex + 1);
+}


### PR DESCRIPTION
## Summary
- New MCP tool `get_dependency_changes(groupId, artifactId, fromVersion, toVersion)` that shows what changed between dependency versions
- Discovers GitHub repo from POM `<scm>` tags, falls back to guessing from groupId
- Fetches GitHub Releases for each intermediate version, falls back to CHANGELOG.md parsing
- Persistent file cache at `~/.cache/maven-central-mcp/` (SCM mappings immutable, releases/changelog 24h TTL)
- Supports `GITHUB_TOKEN` env for higher GitHub API rate limits (5000 req/h vs 60)

## New modules
- `src/github/` — POM SCM parser, GitHub client, changelog parser, tag matcher, repo discovery
- `src/cache/` — persistent JSON file cache
- `src/version/range.ts` — version range filter

## Test plan
- [x] 154 tests passing (78 new)
- [x] TypeScript build clean
- [ ] Manual test: run MCP server, call `get_dependency_changes` for a real dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)