### PR TITLE
feat: add search_artifacts tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -157,7 +157,7 @@ server.tool(
   "Search Maven Central for artifacts by keyword. Use when looking for libraries by name or functionality.",
   {
     query: z.string().describe("Search query (library name, keyword)"),
-    limit: z.number().optional().describe("Max results (default: 10)"),
+    limit: z.number().int().min(1).max(100).optional().describe("Max results (default: 10, max: 100)"),
   },
   async (params) => {
     const result = await searchArtifactsHandler(params);

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { compareDependencyVersionsHandler } from "./tools/compare-dependency-ver
 import { getDependencyChangesHandler } from "./tools/get-dependency-changes.js";
 import { scanProjectDependenciesHandler } from "./tools/scan-project-dependencies.js";
 import { getDependencyVulnerabilitiesHandler } from "./tools/get-dependency-vulnerabilities.js";
+import { searchArtifactsHandler } from "./tools/search-artifacts.js";
 
 const server = new McpServer({
   name: "maven-central-mcp",
@@ -147,6 +148,19 @@ server.tool(
   },
   async (params) => {
     const result = await getDependencyVulnerabilitiesHandler(params);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  },
+);
+
+server.tool(
+  "search_artifacts",
+  "Search Maven Central for artifacts by keyword. Use when looking for libraries by name or functionality.",
+  {
+    query: z.string().describe("Search query (library name, keyword)"),
+    limit: z.number().optional().describe("Max results (default: 10)"),
+  },
+  async (params) => {
+    const result = await searchArtifactsHandler(params);
     return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
   },
 );

--- a/src/search/__tests__/maven-search.test.ts
+++ b/src/search/__tests__/maven-search.test.ts
@@ -42,4 +42,10 @@ describe("searchMavenCentral", () => {
     const result = await searchMavenCentral("fail");
     expect(result).toEqual([]);
   });
+
+  it("returns empty array when fetch rejects", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network error"));
+    const result = await searchMavenCentral("network-fail");
+    expect(result).toEqual([]);
+  });
 });

--- a/src/search/__tests__/maven-search.test.ts
+++ b/src/search/__tests__/maven-search.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { searchMavenCentral } from "../maven-search.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+describe("searchMavenCentral", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns parsed search results", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        response: {
+          numFound: 2,
+          docs: [
+            { g: "io.ktor", a: "ktor-client-core", latestVersion: "3.1.1", p: "jar", versionCount: 50 },
+            { g: "io.ktor", a: "ktor-server-core", latestVersion: "3.1.1", p: "jar", versionCount: 48 },
+          ],
+        },
+      }),
+    });
+    const result = await searchMavenCentral("ktor");
+    expect(result).toHaveLength(2);
+    expect(result[0].groupId).toBe("io.ktor");
+    expect(result[0].artifactId).toBe("ktor-client-core");
+    expect(result[0].latestVersion).toBe("3.1.1");
+  });
+
+  it("respects limit parameter", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ response: { numFound: 0, docs: [] } }),
+    });
+    await searchMavenCentral("test", 5);
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("rows=5");
+  });
+
+  it("returns empty array on error", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    const result = await searchMavenCentral("fail");
+    expect(result).toEqual([]);
+  });
+});

--- a/src/search/maven-search.ts
+++ b/src/search/maven-search.ts
@@ -1,5 +1,19 @@
 const SEARCH_API = "https://search.maven.org/solrsearch/select";
 
+interface SolrDoc {
+  g: string;
+  a: string;
+  latestVersion: string;
+  versionCount: number;
+}
+
+interface SolrResponse {
+  response: {
+    numFound: number;
+    docs: SolrDoc[];
+  };
+}
+
 export interface SearchArtifact {
   groupId: string;
   artifactId: string;
@@ -15,8 +29,8 @@ export async function searchMavenCentral(
     const url = `${SEARCH_API}?q=${encodeURIComponent(query)}&rows=${limit}&wt=json`;
     const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });
     if (!response.ok) return [];
-    const data = await response.json();
-    return data.response.docs.map((doc: any) => ({
+    const data = (await response.json()) as SolrResponse;
+    return data.response.docs.map((doc) => ({
       groupId: doc.g,
       artifactId: doc.a,
       latestVersion: doc.latestVersion,

--- a/src/search/maven-search.ts
+++ b/src/search/maven-search.ts
@@ -1,0 +1,28 @@
+const SEARCH_API = "https://search.maven.org/solrsearch/select";
+
+export interface SearchArtifact {
+  groupId: string;
+  artifactId: string;
+  latestVersion: string;
+  versionCount: number;
+}
+
+export async function searchMavenCentral(
+  query: string,
+  limit: number = 10,
+): Promise<SearchArtifact[]> {
+  try {
+    const url = `${SEARCH_API}?q=${encodeURIComponent(query)}&rows=${limit}&wt=json`;
+    const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+    if (!response.ok) return [];
+    const data = await response.json();
+    return data.response.docs.map((doc: any) => ({
+      groupId: doc.g,
+      artifactId: doc.a,
+      latestVersion: doc.latestVersion,
+      versionCount: doc.versionCount,
+    }));
+  } catch {
+    return [];
+  }
+}

--- a/src/tools/__tests__/search-artifacts.test.ts
+++ b/src/tools/__tests__/search-artifacts.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { searchArtifactsHandler } from "../search-artifacts.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+describe("searchArtifactsHandler", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns search results", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        response: {
+          numFound: 1,
+          docs: [{ g: "com.google.code.gson", a: "gson", latestVersion: "2.11.0", versionCount: 30 }],
+        },
+      }),
+    });
+    const result = await searchArtifactsHandler({ query: "gson" });
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0].groupId).toBe("com.google.code.gson");
+  });
+});

--- a/src/tools/search-artifacts.ts
+++ b/src/tools/search-artifacts.ts
@@ -1,0 +1,22 @@
+import { searchMavenCentral } from "../search/maven-search.js";
+
+export interface SearchArtifactsInput {
+  query: string;
+  limit?: number;
+}
+
+export interface SearchArtifactsResult {
+  results: {
+    groupId: string;
+    artifactId: string;
+    latestVersion: string;
+    versionCount: number;
+  }[];
+}
+
+export async function searchArtifactsHandler(
+  input: SearchArtifactsInput,
+): Promise<SearchArtifactsResult> {
+  const results = await searchMavenCentral(input.query, input.limit);
+  return { results };
+}

--- a/src/tools/search-artifacts.ts
+++ b/src/tools/search-artifacts.ts
@@ -1,4 +1,4 @@
-import { searchMavenCentral } from "../search/maven-search.js";
+import { searchMavenCentral, type SearchArtifact } from "../search/maven-search.js";
 
 export interface SearchArtifactsInput {
   query: string;
@@ -6,12 +6,7 @@ export interface SearchArtifactsInput {
 }
 
 export interface SearchArtifactsResult {
-  results: {
-    groupId: string;
-    artifactId: string;
-    latestVersion: string;
-    versionCount: number;
-  }[];
+  results: SearchArtifact[];
 }
 
 export async function searchArtifactsHandler(


### PR DESCRIPTION
## Summary
- Add Maven Central Search API client (`src/search/maven-search.ts`)
- Add `search_artifacts` MCP tool for keyword-based artifact search
- Returns groupId, artifactId, latestVersion, versionCount

## Test plan
- [x] Unit tests for search client (3 tests)
- [x] Unit test for tool handler (1 test)
- [x] All 158 tests pass
- [x] TypeScript build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)