### PR TITLE
feat: add scan_project_dependencies tool

### DIFF
--- a/src/dependencies/__tests__/gradle-deps-parser.test.ts
+++ b/src/dependencies/__tests__/gradle-deps-parser.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { parseGradleDependencies } from "../gradle-deps-parser.js";
+
+describe("parseGradleDependencies", () => {
+  it("parses string notation with version", () => {
+    const content = `
+dependencies {
+    implementation("io.ktor:ktor-client-core:3.1.1")
+    testImplementation("org.junit:junit:5.10.0")
+}`;
+    const deps = parseGradleDependencies(content);
+    expect(deps).toContainEqual({
+      groupId: "io.ktor", artifactId: "ktor-client-core", version: "3.1.1",
+      configuration: "implementation", source: "build.gradle.kts",
+    });
+    expect(deps).toContainEqual({
+      groupId: "org.junit", artifactId: "junit", version: "5.10.0",
+      configuration: "testImplementation", source: "build.gradle.kts",
+    });
+  });
+
+  it("parses string notation without version (BOM)", () => {
+    const content = `implementation("io.ktor:ktor-client-core")`;
+    const deps = parseGradleDependencies(content);
+    expect(deps[0].version).toBeNull();
+  });
+
+  it("parses Groovy single-quote notation", () => {
+    const content = `implementation 'io.ktor:ktor-client-core:3.1.1'`;
+    const deps = parseGradleDependencies(content);
+    expect(deps[0].groupId).toBe("io.ktor");
+    expect(deps[0].version).toBe("3.1.1");
+  });
+
+  it("parses version catalog references", () => {
+    const content = `implementation(libs.ktor.client.core)`;
+    const deps = parseGradleDependencies(content);
+    expect(deps[0]).toEqual({
+      groupId: null, artifactId: null, version: null,
+      configuration: "implementation", source: "build.gradle.kts",
+      catalogRef: "ktor.client.core",
+    });
+  });
+
+  it("extracts various configurations", () => {
+    const content = `
+api("com.example:api-lib:1.0")
+compileOnly("com.example:compile-lib:1.0")
+runtimeOnly("com.example:runtime-lib:1.0")
+`;
+    const deps = parseGradleDependencies(content);
+    expect(deps.map(d => d.configuration)).toEqual(["api", "compileOnly", "runtimeOnly"]);
+  });
+
+  it("returns empty for no dependencies", () => {
+    expect(parseGradleDependencies("plugins { }")).toEqual([]);
+  });
+});

--- a/src/dependencies/__tests__/gradle-deps-parser.test.ts
+++ b/src/dependencies/__tests__/gradle-deps-parser.test.ts
@@ -27,9 +27,10 @@ dependencies {
 
   it("parses Groovy single-quote notation", () => {
     const content = `implementation 'io.ktor:ktor-client-core:3.1.1'`;
-    const deps = parseGradleDependencies(content);
+    const deps = parseGradleDependencies(content, "build.gradle");
     expect(deps[0].groupId).toBe("io.ktor");
     expect(deps[0].version).toBe("3.1.1");
+    expect(deps[0].source).toBe("build.gradle");
   });
 
   it("parses version catalog references", () => {

--- a/src/dependencies/__tests__/maven-deps-parser.test.ts
+++ b/src/dependencies/__tests__/maven-deps-parser.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { parseMavenDependencies } from "../maven-deps-parser.js";
+
+describe("parseMavenDependencies", () => {
+  it("parses dependencies with version and scope", () => {
+    const pom = `
+<dependencies>
+  <dependency>
+    <groupId>io.ktor</groupId>
+    <artifactId>ktor-client-core</artifactId>
+    <version>3.1.1</version>
+  </dependency>
+  <dependency>
+    <groupId>junit</groupId>
+    <artifactId>junit</artifactId>
+    <version>4.13.2</version>
+    <scope>test</scope>
+  </dependency>
+</dependencies>`;
+    const deps = parseMavenDependencies(pom);
+    expect(deps).toHaveLength(2);
+    expect(deps[0]).toEqual({
+      groupId: "io.ktor", artifactId: "ktor-client-core", version: "3.1.1",
+      configuration: "implementation", source: "pom.xml",
+    });
+    expect(deps[1].configuration).toBe("testImplementation");
+  });
+
+  it("parses dependencies without version (BOM)", () => {
+    const pom = `
+<dependency>
+  <groupId>io.ktor</groupId>
+  <artifactId>ktor-client-core</artifactId>
+</dependency>`;
+    const deps = parseMavenDependencies(pom);
+    expect(deps[0].version).toBeNull();
+  });
+
+  it("handles property references as null version", () => {
+    const pom = `
+<dependency>
+  <groupId>io.ktor</groupId>
+  <artifactId>ktor-core</artifactId>
+  <version>\${ktor.version}</version>
+</dependency>`;
+    const deps = parseMavenDependencies(pom);
+    expect(deps[0].version).toBeNull();
+  });
+
+  it("returns empty for no dependencies", () => {
+    expect(parseMavenDependencies("<project></project>")).toEqual([]);
+  });
+});

--- a/src/dependencies/__tests__/scan.test.ts
+++ b/src/dependencies/__tests__/scan.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { scanDependencies } from "../scan.js";
+import * as fs from "node:fs";
+
+vi.mock("node:fs");
+const mockedFs = vi.mocked(fs);
+
+describe("scanDependencies", () => {
+  it("scans Gradle project with version catalog", () => {
+    mockedFs.existsSync.mockImplementation((p: any) => {
+      if (p.toString().endsWith("build.gradle.kts")) return true;
+      if (p.toString().endsWith("libs.versions.toml")) return true;
+      return false;
+    });
+    mockedFs.readFileSync.mockImplementation((p: any) => {
+      if (p.toString().endsWith("build.gradle.kts")) {
+        return `
+dependencies {
+    implementation(libs.ktor.core)
+    implementation("com.google.code.gson:gson:2.11.0")
+}`;
+      }
+      if (p.toString().endsWith("libs.versions.toml")) {
+        return `
+[versions]
+ktor = "3.1.1"
+
+[libraries]
+ktor-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+`;
+      }
+      return "";
+    });
+
+    const result = scanDependencies("/project");
+    expect(result.buildSystem).toBe("gradle");
+    expect(result.dependencies).toContainEqual(expect.objectContaining({
+      groupId: "io.ktor", artifactId: "ktor-client-core", version: "3.1.1",
+    }));
+    expect(result.dependencies).toContainEqual(expect.objectContaining({
+      groupId: "com.google.code.gson", artifactId: "gson", version: "2.11.0",
+    }));
+  });
+
+  it("scans Maven project", () => {
+    mockedFs.existsSync.mockImplementation((p: any) => {
+      if (p.toString().endsWith("pom.xml")) return true;
+      return false;
+    });
+    mockedFs.readFileSync.mockImplementation(() => `
+<dependencies>
+  <dependency>
+    <groupId>io.ktor</groupId>
+    <artifactId>ktor-core</artifactId>
+    <version>3.1.1</version>
+  </dependency>
+</dependencies>`);
+
+    const result = scanDependencies("/project");
+    expect(result.buildSystem).toBe("maven");
+    expect(result.dependencies).toHaveLength(1);
+  });
+
+  it("returns empty for unknown project", () => {
+    mockedFs.existsSync.mockReturnValue(false);
+    const result = scanDependencies("/empty");
+    expect(result.buildSystem).toBe("unknown");
+    expect(result.dependencies).toEqual([]);
+  });
+});

--- a/src/dependencies/__tests__/scan.test.ts
+++ b/src/dependencies/__tests__/scan.test.ts
@@ -7,12 +7,12 @@ const mockedFs = vi.mocked(fs);
 
 describe("scanDependencies", () => {
   it("scans Gradle project with version catalog", () => {
-    mockedFs.existsSync.mockImplementation((p: any) => {
+    mockedFs.existsSync.mockImplementation((p: fs.PathLike) => {
       if (p.toString().endsWith("build.gradle.kts")) return true;
       if (p.toString().endsWith("libs.versions.toml")) return true;
       return false;
     });
-    mockedFs.readFileSync.mockImplementation((p: any) => {
+    mockedFs.readFileSync.mockImplementation((p: fs.PathLike) => {
       if (p.toString().endsWith("build.gradle.kts")) {
         return `
 dependencies {
@@ -43,7 +43,7 @@ ktor-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
   });
 
   it("scans Maven project", () => {
-    mockedFs.existsSync.mockImplementation((p: any) => {
+    mockedFs.existsSync.mockImplementation((p: fs.PathLike) => {
       if (p.toString().endsWith("pom.xml")) return true;
       return false;
     });

--- a/src/dependencies/__tests__/toml-parser.test.ts
+++ b/src/dependencies/__tests__/toml-parser.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { parseVersionCatalog } from "../toml-parser.js";
+
+describe("parseVersionCatalog", () => {
+  it("parses libraries with version.ref", () => {
+    const toml = `
+[versions]
+ktor = "3.1.1"
+kotlin = "2.1.0"
+
+[libraries]
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+`;
+    const result = parseVersionCatalog(toml);
+    expect(result.get("ktor-client-core")).toEqual({
+      groupId: "io.ktor", artifactId: "ktor-client-core", version: "3.1.1",
+    });
+    expect(result.get("kotlin-stdlib")).toEqual({
+      groupId: "org.jetbrains.kotlin", artifactId: "kotlin-stdlib", version: "2.1.0",
+    });
+  });
+
+  it("parses libraries with inline version", () => {
+    const toml = `
+[libraries]
+gson = { module = "com.google.code.gson:gson", version = "2.11.0" }
+`;
+    const result = parseVersionCatalog(toml);
+    expect(result.get("gson")).toEqual({
+      groupId: "com.google.code.gson", artifactId: "gson", version: "2.11.0",
+    });
+  });
+
+  it("parses libraries with group/name syntax", () => {
+    const toml = `
+[versions]
+ktor = "3.1.1"
+
+[libraries]
+ktor-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
+`;
+    const result = parseVersionCatalog(toml);
+    expect(result.get("ktor-core")).toEqual({
+      groupId: "io.ktor", artifactId: "ktor-client-core", version: "3.1.1",
+    });
+  });
+
+  it("returns null version for libraries without version", () => {
+    const toml = `
+[libraries]
+bom-lib = { module = "io.ktor:ktor-bom" }
+`;
+    const result = parseVersionCatalog(toml);
+    expect(result.get("bom-lib")).toEqual({
+      groupId: "io.ktor", artifactId: "ktor-bom", version: null,
+    });
+  });
+
+  it("returns empty map for empty content", () => {
+    expect(parseVersionCatalog("").size).toBe(0);
+  });
+});

--- a/src/dependencies/gradle-deps-parser.ts
+++ b/src/dependencies/gradle-deps-parser.ts
@@ -15,7 +15,7 @@ const CONFIGURATIONS = [
 
 const CONFIG_PATTERN = CONFIGURATIONS.join("|");
 
-export function parseGradleDependencies(content: string): GradleDependency[] {
+export function parseGradleDependencies(content: string, source: string = "build.gradle.kts"): GradleDependency[] {
   const deps: GradleDependency[] = [];
 
   const stringRegex = new RegExp(
@@ -29,7 +29,7 @@ export function parseGradleDependencies(content: string): GradleDependency[] {
       artifactId: match[3],
       version: match[4] ?? null,
       configuration: match[1],
-      source: "build.gradle.kts",
+      source,
     });
   }
 
@@ -43,7 +43,7 @@ export function parseGradleDependencies(content: string): GradleDependency[] {
       artifactId: null,
       version: null,
       configuration: match[1],
-      source: "build.gradle.kts",
+      source,
       catalogRef: match[2],
     });
   }

--- a/src/dependencies/gradle-deps-parser.ts
+++ b/src/dependencies/gradle-deps-parser.ts
@@ -1,0 +1,52 @@
+export interface GradleDependency {
+  groupId: string | null;
+  artifactId: string | null;
+  version: string | null;
+  configuration: string;
+  source: string;
+  catalogRef?: string;
+}
+
+const CONFIGURATIONS = [
+  "implementation", "api", "compileOnly", "runtimeOnly",
+  "testImplementation", "testCompileOnly", "testRuntimeOnly",
+  "kapt", "ksp", "annotationProcessor",
+];
+
+const CONFIG_PATTERN = CONFIGURATIONS.join("|");
+
+export function parseGradleDependencies(content: string): GradleDependency[] {
+  const deps: GradleDependency[] = [];
+
+  const stringRegex = new RegExp(
+    `\\b(${CONFIG_PATTERN})\\s*[( ]\\s*["']([^"':]+):([^"':]+)(?::([^"']+))?["']\\s*\\)?`,
+    "g",
+  );
+  let match: RegExpExecArray | null;
+  while ((match = stringRegex.exec(content)) !== null) {
+    deps.push({
+      groupId: match[2],
+      artifactId: match[3],
+      version: match[4] ?? null,
+      configuration: match[1],
+      source: "build.gradle.kts",
+    });
+  }
+
+  const catalogRegex = new RegExp(
+    `\\b(${CONFIG_PATTERN})\\s*\\(\\s*libs\\.([a-zA-Z0-9.]+)\\s*\\)`,
+    "g",
+  );
+  while ((match = catalogRegex.exec(content)) !== null) {
+    deps.push({
+      groupId: null,
+      artifactId: null,
+      version: null,
+      configuration: match[1],
+      source: "build.gradle.kts",
+      catalogRef: match[2],
+    });
+  }
+
+  return deps;
+}

--- a/src/dependencies/maven-deps-parser.ts
+++ b/src/dependencies/maven-deps-parser.ts
@@ -1,0 +1,38 @@
+export interface MavenDependency {
+  groupId: string;
+  artifactId: string;
+  version: string | null;
+  configuration: string;
+  source: string;
+}
+
+const SCOPE_TO_CONFIG: Record<string, string> = {
+  compile: "implementation",
+  runtime: "runtimeOnly",
+  test: "testImplementation",
+  provided: "compileOnly",
+  system: "compileOnly",
+};
+
+export function parseMavenDependencies(content: string): MavenDependency[] {
+  const deps: MavenDependency[] = [];
+  const depRegex = /<dependency>([\s\S]*?)<\/dependency>/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = depRegex.exec(content)) !== null) {
+    const block = match[1];
+    const groupId = block.match(/<groupId>([^<]+)<\/groupId>/)?.[1]?.trim();
+    const artifactId = block.match(/<artifactId>([^<]+)<\/artifactId>/)?.[1]?.trim();
+    if (!groupId || !artifactId) continue;
+
+    let version: string | null = block.match(/<version>([^<]+)<\/version>/)?.[1]?.trim() ?? null;
+    if (version?.startsWith("${")) version = null;
+
+    const scope = block.match(/<scope>([^<]+)<\/scope>/)?.[1]?.trim() ?? "compile";
+    const configuration = SCOPE_TO_CONFIG[scope] ?? "implementation";
+
+    deps.push({ groupId, artifactId, version, configuration, source: "pom.xml" });
+  }
+
+  return deps;
+}

--- a/src/dependencies/scan.ts
+++ b/src/dependencies/scan.ts
@@ -34,7 +34,7 @@ export function scanDependencies(projectRoot: string): ScanResult {
     buildSystem = "gradle";
 
     const content = readFileSync(path, "utf-8");
-    const gradleDeps = parseGradleDependencies(content);
+    const gradleDeps = parseGradleDependencies(content, file);
 
     const catalogPath = join(projectRoot, "gradle", "libs.versions.toml");
     let catalog = new Map<string, CatalogEntry>();

--- a/src/dependencies/scan.ts
+++ b/src/dependencies/scan.ts
@@ -1,0 +1,80 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parseGradleDependencies } from "./gradle-deps-parser.js";
+import { parseMavenDependencies } from "./maven-deps-parser.js";
+import { parseVersionCatalog } from "./toml-parser.js";
+import type { CatalogEntry } from "./toml-parser.js";
+
+export interface ScannedDependency {
+  groupId: string;
+  artifactId: string;
+  version: string | null;
+  configuration: string;
+  source: string;
+}
+
+export interface ScanResult {
+  buildSystem: "gradle" | "maven" | "unknown";
+  dependencies: ScannedDependency[];
+}
+
+function resolveCatalogRef(ref: string, catalog: Map<string, CatalogEntry>): CatalogEntry | undefined {
+  const dashed = ref.replace(/\./g, "-");
+  return catalog.get(dashed) ?? catalog.get(ref);
+}
+
+export function scanDependencies(projectRoot: string): ScanResult {
+  const deps: ScannedDependency[] = [];
+  const gradleFiles = ["build.gradle.kts", "build.gradle"];
+  let buildSystem: ScanResult["buildSystem"] = "unknown";
+
+  for (const file of gradleFiles) {
+    const path = join(projectRoot, file);
+    if (!existsSync(path)) continue;
+    buildSystem = "gradle";
+
+    const content = readFileSync(path, "utf-8");
+    const gradleDeps = parseGradleDependencies(content);
+
+    const catalogPath = join(projectRoot, "gradle", "libs.versions.toml");
+    let catalog = new Map<string, CatalogEntry>();
+    if (existsSync(catalogPath)) {
+      catalog = parseVersionCatalog(readFileSync(catalogPath, "utf-8"));
+    }
+
+    for (const dep of gradleDeps) {
+      if (dep.catalogRef) {
+        const entry = resolveCatalogRef(dep.catalogRef, catalog);
+        if (entry) {
+          deps.push({
+            groupId: entry.groupId,
+            artifactId: entry.artifactId,
+            version: entry.version,
+            configuration: dep.configuration,
+            source: "libs.versions.toml",
+          });
+        }
+      } else if (dep.groupId && dep.artifactId) {
+        deps.push({
+          groupId: dep.groupId,
+          artifactId: dep.artifactId,
+          version: dep.version,
+          configuration: dep.configuration,
+          source: file,
+        });
+      }
+    }
+    break;
+  }
+
+  if (buildSystem === "unknown") {
+    const pomPath = join(projectRoot, "pom.xml");
+    if (existsSync(pomPath)) {
+      buildSystem = "maven";
+      const content = readFileSync(pomPath, "utf-8");
+      deps.push(...parseMavenDependencies(content));
+    }
+  }
+
+  return { buildSystem, dependencies: deps };
+}

--- a/src/dependencies/toml-parser.ts
+++ b/src/dependencies/toml-parser.ts
@@ -46,7 +46,7 @@ export function parseVersionCatalog(content: string): Map<string, CatalogEntry> 
       version = versions.get(versionRef[1]) ?? null;
     }
 
-    const versionInline = props.match(/(?<!\.ref\s*=\s*)version\s*=\s*"([^"]+)"/);
+    const versionInline = props.match(/\bversion\s*=\s*"([^"]+)"/);
     if (versionInline && !versionRef) {
       version = versionInline[1];
     }

--- a/src/dependencies/toml-parser.ts
+++ b/src/dependencies/toml-parser.ts
@@ -1,0 +1,60 @@
+export interface CatalogEntry {
+  groupId: string;
+  artifactId: string;
+  version: string | null;
+}
+
+export function parseVersionCatalog(content: string): Map<string, CatalogEntry> {
+  const entries = new Map<string, CatalogEntry>();
+  const versions = new Map<string, string>();
+
+  const versionsMatch = content.match(/\[versions\]([\s\S]*?)(?=\n\[|$)/);
+  if (versionsMatch) {
+    const versionLines = versionsMatch[1].matchAll(/^(\S+)\s*=\s*"([^"]+)"/gm);
+    for (const m of versionLines) {
+      versions.set(m[1], m[2]);
+    }
+  }
+
+  const librariesMatch = content.match(/\[libraries\]([\s\S]*?)(?=\n\[|$)/);
+  if (!librariesMatch) return entries;
+
+  const libLines = librariesMatch[1].matchAll(/^(\S+)\s*=\s*\{([^}]+)\}/gm);
+  for (const m of libLines) {
+    const alias = m[1];
+    const props = m[2];
+
+    let groupId: string | undefined;
+    let artifactId: string | undefined;
+    let version: string | null = null;
+
+    const moduleMatch = props.match(/module\s*=\s*"([^"]+):([^"]+)"/);
+    if (moduleMatch) {
+      groupId = moduleMatch[1];
+      artifactId = moduleMatch[2];
+    }
+
+    const groupMatch = props.match(/group\s*=\s*"([^"]+)"/);
+    const nameMatch = props.match(/name\s*=\s*"([^"]+)"/);
+    if (groupMatch && nameMatch) {
+      groupId = groupMatch[1];
+      artifactId = nameMatch[1];
+    }
+
+    const versionRef = props.match(/version\.ref\s*=\s*"([^"]+)"/);
+    if (versionRef) {
+      version = versions.get(versionRef[1]) ?? null;
+    }
+
+    const versionInline = props.match(/(?<!\.ref\s*=\s*)version\s*=\s*"([^"]+)"/);
+    if (versionInline && !versionRef) {
+      version = versionInline[1];
+    }
+
+    if (groupId && artifactId) {
+      entries.set(alias, { groupId, artifactId, version });
+    }
+  }
+
+  return entries;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { checkVersionExistsHandler } from "./tools/check-version-exists.js";
 import { checkMultipleDependenciesHandler } from "./tools/check-multiple-dependencies.js";
 import { compareDependencyVersionsHandler } from "./tools/compare-dependency-versions.js";
 import { getDependencyChangesHandler } from "./tools/get-dependency-changes.js";
+import { scanProjectDependenciesHandler } from "./tools/scan-project-dependencies.js";
 
 const server = new McpServer({
   name: "maven-central-mcp",
@@ -117,6 +118,18 @@ server.tool(
   },
   async (params) => {
     const result = await getDependencyChangesHandler(getRepositories(), params);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  },
+);
+
+server.tool(
+  "scan_project_dependencies",
+  "Scan project build files (Gradle, Maven, version catalogs) and extract all declared dependencies with versions.",
+  {
+    projectPath: z.string().optional().describe("Path to project root (default: auto-detect from cwd)"),
+  },
+  async (params) => {
+    const result = scanProjectDependenciesHandler(params);
     return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
   },
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,7 @@ server.tool(
     projectPath: z.string().optional().describe("Path to project root (default: auto-detect from cwd)"),
   },
   async (params) => {
-    const result = scanProjectDependenciesHandler(params);
+    const result = await scanProjectDependenciesHandler(params);
     return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
   },
 );

--- a/src/tools/__tests__/scan-project-dependencies.test.ts
+++ b/src/tools/__tests__/scan-project-dependencies.test.ts
@@ -7,7 +7,7 @@ const mockedFs = vi.mocked(fs);
 
 describe("scanProjectDependenciesHandler", () => {
   it("scans project and returns dependencies", () => {
-    mockedFs.existsSync.mockImplementation((p: any) => {
+    mockedFs.existsSync.mockImplementation((p: fs.PathLike) => {
       if (p.toString().endsWith("build.gradle.kts")) return true;
       return false;
     });

--- a/src/tools/__tests__/scan-project-dependencies.test.ts
+++ b/src/tools/__tests__/scan-project-dependencies.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from "vitest";
+import { scanProjectDependenciesHandler } from "../scan-project-dependencies.js";
+import * as fs from "node:fs";
+
+vi.mock("node:fs");
+const mockedFs = vi.mocked(fs);
+
+describe("scanProjectDependenciesHandler", () => {
+  it("scans project and returns dependencies", () => {
+    mockedFs.existsSync.mockImplementation((p: any) => {
+      if (p.toString().endsWith("build.gradle.kts")) return true;
+      return false;
+    });
+    mockedFs.readFileSync.mockReturnValue(`
+dependencies {
+    implementation("io.ktor:ktor-client-core:3.1.1")
+}`);
+
+    const result = scanProjectDependenciesHandler({ projectPath: "/project" });
+    expect(result.buildSystem).toBe("gradle");
+    expect(result.dependencies).toHaveLength(1);
+  });
+});

--- a/src/tools/scan-project-dependencies.ts
+++ b/src/tools/scan-project-dependencies.ts
@@ -1,0 +1,11 @@
+import { scanDependencies } from "../dependencies/scan.js";
+import { findProjectRoot } from "../project/find-project-root.js";
+
+export interface ScanProjectInput {
+  projectPath?: string;
+}
+
+export function scanProjectDependenciesHandler(input: ScanProjectInput) {
+  const projectRoot = input.projectPath ?? findProjectRoot(process.cwd()) ?? process.cwd();
+  return scanDependencies(projectRoot);
+}


### PR DESCRIPTION
## Summary
- Add TOML version catalog parser (`libs.versions.toml` support)
- Add Gradle dependency parser (string notation, Groovy, catalog refs)
- Add Maven POM dependency parser (scope mapping)
- Add scan orchestrator (auto-detect build system, resolve catalog refs)
- Add `scan_project_dependencies` MCP tool

## Test plan
- [x] TOML parser tests (5 tests)
- [x] Gradle parser tests (6 tests)
- [x] Maven parser tests (4 tests)
- [x] Scan orchestrator tests (3 tests)
- [x] Tool handler test (1 test)
- [x] All 173 tests pass
- [x] TypeScript build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)