### PR TITLE
feat: add audit_project_dependencies tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { getDependencyChangesHandler } from "./tools/get-dependency-changes.js";
 import { scanProjectDependenciesHandler } from "./tools/scan-project-dependencies.js";
 import { getDependencyVulnerabilitiesHandler } from "./tools/get-dependency-vulnerabilities.js";
 import { searchArtifactsHandler } from "./tools/search-artifacts.js";
+import { auditProjectDependenciesHandler } from "./tools/audit-project-dependencies.js";
 
 const server = new McpServer({
   name: "maven-central-mcp",
@@ -161,6 +162,19 @@ server.tool(
   },
   async (params) => {
     const result = await searchArtifactsHandler(params);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  },
+);
+
+server.tool(
+  "audit_project_dependencies",
+  "Full project dependency audit: scans build files, compares versions against latest, checks for vulnerabilities. One-stop tool for dependency health check.",
+  {
+    projectPath: z.string().optional().describe("Path to project root (default: auto-detect)"),
+    includeVulnerabilities: z.boolean().optional().describe("Check for CVEs via OSV (default: true)"),
+  },
+  async (params) => {
+    const result = await auditProjectDependenciesHandler(getRepositories(), params);
     return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
   },
 );

--- a/src/tools/__tests__/audit-project-dependencies.test.ts
+++ b/src/tools/__tests__/audit-project-dependencies.test.ts
@@ -145,4 +145,43 @@ dependencies {
     expect(result.dependencies[0].currentVersion).toBe("3.0.0");
     expect(result.dependencies[1].currentVersion).toBe("3.1.0");
   });
+
+  it("deduplicates OSV queries for same GAV and maps vulns to all entries", async () => {
+    mockGradleProject(`
+dependencies {
+    implementation("io.ktor:ktor-client-core:3.0.0")
+    testImplementation("io.ktor:ktor-client-core:3.0.0")
+}`);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        results: [{
+          vulns: [{
+            id: "GHSA-5678",
+            summary: "test vuln",
+            database_specific: { severity: "MEDIUM" },
+            affected: [],
+            references: [],
+          }],
+        }],
+      }),
+    });
+
+    const repos = [mockRepo(["3.0.0", "3.1.1"])];
+    const result = await auditProjectDependenciesHandler(repos, {
+      projectPath: "/project",
+      includeVulnerabilities: true,
+    });
+
+    // Only one OSV query should be made (deduplicated)
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    // Both entries should have the same vulnerability
+    expect(result.dependencies).toHaveLength(2);
+    expect(result.dependencies[0].vulnerabilities).toHaveLength(1);
+    expect(result.dependencies[0].vulnerabilities![0].id).toBe("GHSA-5678");
+    expect(result.dependencies[1].vulnerabilities).toHaveLength(1);
+    expect(result.dependencies[1].vulnerabilities![0].id).toBe("GHSA-5678");
+    expect(result.summary.vulnerable).toBe(2);
+  });
 });

--- a/src/tools/__tests__/audit-project-dependencies.test.ts
+++ b/src/tools/__tests__/audit-project-dependencies.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { auditProjectDependenciesHandler } from "../audit-project-dependencies.js";
+import * as fs from "node:fs";
+import type { MavenRepository } from "../../maven/repository.js";
+
+vi.mock("node:fs");
+const mockedFs = vi.mocked(fs);
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function mockRepo(versions: string[]): MavenRepository {
+  return {
+    name: "central",
+    url: "https://repo1.maven.org/maven2",
+    fetchMetadata: vi.fn().mockResolvedValue({
+      groupId: "io.ktor", artifactId: "ktor-client-core", versions,
+      latest: versions[versions.length - 1],
+      release: versions[versions.length - 1],
+    }),
+  };
+}
+
+describe("auditProjectDependenciesHandler", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("scans, compares, and checks vulnerabilities", async () => {
+    mockedFs.existsSync.mockImplementation((p: fs.PathLike) => {
+      if (p.toString().endsWith("build.gradle.kts")) return true;
+      return false;
+    });
+    mockedFs.readFileSync.mockReturnValue(`
+dependencies {
+    implementation("io.ktor:ktor-client-core:3.0.0")
+}`);
+
+    // OSV response
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ results: [{ vulns: [] }] }),
+    });
+
+    const repos = [mockRepo(["3.0.0", "3.1.0", "3.1.1"])];
+    const result = await auditProjectDependenciesHandler(repos, {
+      projectPath: "/project",
+      includeVulnerabilities: true,
+    });
+
+    expect(result.summary.total).toBe(1);
+    expect(result.summary.upgradeable).toBe(1);
+    expect(result.dependencies[0].currentVersion).toBe("3.0.0");
+    expect(result.dependencies[0].latestVersion).toBe("3.1.1");
+    expect(result.dependencies[0].upgradeType).toBe("minor");
+  });
+
+  it("skips deps without version", async () => {
+    mockedFs.existsSync.mockImplementation((p: fs.PathLike) => {
+      if (p.toString().endsWith("build.gradle.kts")) return true;
+      return false;
+    });
+    mockedFs.readFileSync.mockReturnValue(`implementation("io.ktor:ktor-bom")`);
+
+    const repos = [mockRepo([])];
+    const result = await auditProjectDependenciesHandler(repos, { projectPath: "/project" });
+
+    expect(result.summary.total).toBe(1);
+    expect(result.dependencies[0].upgradeType).toBeUndefined();
+  });
+});

--- a/src/tools/__tests__/audit-project-dependencies.test.ts
+++ b/src/tools/__tests__/audit-project-dependencies.test.ts
@@ -21,20 +21,23 @@ function mockRepo(versions: string[]): MavenRepository {
   };
 }
 
+function mockGradleProject(content: string) {
+  mockedFs.existsSync.mockImplementation((p: fs.PathLike) => {
+    if (p.toString().endsWith("build.gradle.kts")) return true;
+    return false;
+  });
+  mockedFs.readFileSync.mockReturnValue(content);
+}
+
 describe("auditProjectDependenciesHandler", () => {
-  beforeEach(() => vi.restoreAllMocks());
+  beforeEach(() => vi.clearAllMocks());
 
   it("scans, compares, and checks vulnerabilities", async () => {
-    mockedFs.existsSync.mockImplementation((p: fs.PathLike) => {
-      if (p.toString().endsWith("build.gradle.kts")) return true;
-      return false;
-    });
-    mockedFs.readFileSync.mockReturnValue(`
+    mockGradleProject(`
 dependencies {
     implementation("io.ktor:ktor-client-core:3.0.0")
 }`);
 
-    // OSV response
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve({ results: [{ vulns: [] }] }),
@@ -54,16 +57,74 @@ dependencies {
   });
 
   it("skips deps without version", async () => {
-    mockedFs.existsSync.mockImplementation((p: fs.PathLike) => {
-      if (p.toString().endsWith("build.gradle.kts")) return true;
-      return false;
-    });
-    mockedFs.readFileSync.mockReturnValue(`implementation("io.ktor:ktor-bom")`);
+    mockGradleProject(`implementation("io.ktor:ktor-bom")`);
 
     const repos = [mockRepo([])];
     const result = await auditProjectDependenciesHandler(repos, { projectPath: "/project" });
 
     expect(result.summary.total).toBe(1);
     expect(result.dependencies[0].upgradeType).toBeUndefined();
+  });
+
+  it("skips vulnerability check when includeVulnerabilities is false", async () => {
+    mockGradleProject(`implementation("io.ktor:ktor-client-core:3.0.0")`);
+
+    const repos = [mockRepo(["3.0.0", "3.1.1"])];
+    const result = await auditProjectDependenciesHandler(repos, {
+      projectPath: "/project",
+      includeVulnerabilities: false,
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.dependencies[0].vulnerabilities).toBeUndefined();
+  });
+
+  it("handles resolution failure gracefully", async () => {
+    mockGradleProject(`implementation("io.ktor:ktor-client-core:3.0.0")`);
+
+    const failingRepo: MavenRepository = {
+      name: "central",
+      url: "https://repo1.maven.org/maven2",
+      fetchMetadata: vi.fn().mockResolvedValue(null),
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ results: [{ vulns: [] }] }),
+    });
+
+    const result = await auditProjectDependenciesHandler([failingRepo], {
+      projectPath: "/project",
+    });
+
+    expect(result.summary.total).toBe(1);
+    expect(result.dependencies[0].upgradeType).toBeUndefined();
+    expect(result.dependencies[0].latestVersion).toBeUndefined();
+  });
+
+  it("reports vulnerabilities in summary count", async () => {
+    mockGradleProject(`implementation("io.ktor:ktor-client-core:3.0.0")`);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        results: [{
+          vulns: [{
+            id: "GHSA-1234",
+            summary: "test vuln",
+            database_specific: { severity: "HIGH" },
+            affected: [{ ranges: [{ type: "ECOSYSTEM", events: [{ fixed: "3.1.0" }] }] }],
+            references: [],
+          }],
+        }],
+      }),
+    });
+
+    const repos = [mockRepo(["3.0.0", "3.1.1"])];
+    const result = await auditProjectDependenciesHandler(repos, { projectPath: "/project" });
+
+    expect(result.summary.vulnerable).toBe(1);
+    expect(result.dependencies[0].vulnerabilities).toHaveLength(1);
+    expect(result.dependencies[0].vulnerabilities![0].id).toBe("GHSA-1234");
   });
 });

--- a/src/tools/__tests__/audit-project-dependencies.test.ts
+++ b/src/tools/__tests__/audit-project-dependencies.test.ts
@@ -184,4 +184,49 @@ dependencies {
     expect(result.dependencies[1].vulnerabilities![0].id).toBe("GHSA-5678");
     expect(result.summary.vulnerable).toBe(2);
   });
+
+  it("assigns different vulns to correct versioned entries for same GA", async () => {
+    mockGradleProject(`
+dependencies {
+    implementation("io.ktor:ktor-client-core:3.0.0")
+    testImplementation("io.ktor:ktor-client-core:3.1.0")
+}`);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        results: [
+          {
+            vulns: [{
+              id: "GHSA-OLD",
+              summary: "old vuln",
+              database_specific: { severity: "HIGH" },
+              affected: [{ ranges: [{ type: "ECOSYSTEM", events: [{ fixed: "3.0.1" }] }] }],
+              references: [],
+            }],
+          },
+          {
+            vulns: [],
+          },
+        ],
+      }),
+    });
+
+    const repos = [mockRepo(["3.0.0", "3.1.0", "3.1.1"])];
+    const result = await auditProjectDependenciesHandler(repos, {
+      projectPath: "/project",
+      includeVulnerabilities: true,
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result.dependencies).toHaveLength(2);
+    // 3.0.0 should have the vulnerability
+    expect(result.dependencies[0].currentVersion).toBe("3.0.0");
+    expect(result.dependencies[0].vulnerabilities).toHaveLength(1);
+    expect(result.dependencies[0].vulnerabilities![0].id).toBe("GHSA-OLD");
+    // 3.1.0 should have no vulnerabilities
+    expect(result.dependencies[1].currentVersion).toBe("3.1.0");
+    expect(result.dependencies[1].vulnerabilities).toHaveLength(0);
+    expect(result.summary.vulnerable).toBe(1);
+  });
 });

--- a/src/tools/__tests__/audit-project-dependencies.test.ts
+++ b/src/tools/__tests__/audit-project-dependencies.test.ts
@@ -127,4 +127,22 @@ dependencies {
     expect(result.dependencies[0].vulnerabilities).toHaveLength(1);
     expect(result.dependencies[0].vulnerabilities![0].id).toBe("GHSA-1234");
   });
+
+  it("handles duplicate dependencies with same GA but different versions", async () => {
+    mockGradleProject(`
+dependencies {
+    implementation("io.ktor:ktor-client-core:3.0.0")
+    testImplementation("io.ktor:ktor-client-core:3.1.0")
+}`);
+
+    const repos = [mockRepo(["3.0.0", "3.1.0", "3.1.1"])];
+    const result = await auditProjectDependenciesHandler(repos, {
+      projectPath: "/project",
+      includeVulnerabilities: false,
+    });
+
+    expect(result.dependencies).toHaveLength(2);
+    expect(result.dependencies[0].currentVersion).toBe("3.0.0");
+    expect(result.dependencies[1].currentVersion).toBe("3.1.0");
+  });
 });

--- a/src/tools/audit-project-dependencies.ts
+++ b/src/tools/audit-project-dependencies.ts
@@ -1,4 +1,5 @@
 import type { MavenRepository } from "../maven/repository.js";
+import type { UpgradeType } from "../version/types.js";
 import { scanDependencies } from "../dependencies/scan.js";
 import { findProjectRoot } from "../project/find-project-root.js";
 import { resolveAll } from "../maven/resolver.js";
@@ -16,7 +17,7 @@ export interface AuditDependency {
   artifactId: string;
   currentVersion?: string;
   latestVersion?: string;
-  upgradeType?: string;
+  upgradeType?: UpgradeType;
   vulnerabilities?: { id: string; severity?: string; fixedVersion?: string }[];
 }
 
@@ -52,10 +53,10 @@ export async function auditProjectDependenciesHandler(
       try {
         const metadata = await resolveAll(repos, dep.groupId, dep.artifactId);
         const latest = findLatestVersionForCurrent(metadata.versions, dep.version!);
-        const upgradeType = latest ? getUpgradeType(dep.version!, latest) : "none";
+        const upgradeType = latest ? getUpgradeType(dep.version!, latest) : "none" as const;
         return { dep, latest, upgradeType };
       } catch {
-        return { dep, latest: undefined, upgradeType: "none" as const };
+        return { dep, latest: undefined, upgradeType: undefined };
       }
     }),
   );
@@ -74,17 +75,23 @@ export async function auditProjectDependenciesHandler(
     auditDeps.push({ groupId: dep.groupId, artifactId: dep.artifactId });
   }
 
-  // Vulnerability check
+  // Vulnerability check — correlate by groupId:artifactId key, not positional index
   if (includeVulns && depsWithVersion.length > 0) {
     const vulnResults = await queryOsvBatch(
       depsWithVersion.map((d) => ({
         groupId: d.groupId, artifactId: d.artifactId, version: d.version!,
       })),
     );
-    for (let i = 0; i < vulnResults.length; i++) {
-      auditDeps[i].vulnerabilities = vulnResults[i].vulnerabilities.map((v) => ({
-        id: v.id, severity: v.severity, fixedVersion: v.fixedVersion,
-      }));
+    for (let i = 0; i < depsWithVersion.length; i++) {
+      const dep = depsWithVersion[i];
+      const target = auditDeps.find(
+        (a) => a.groupId === dep.groupId && a.artifactId === dep.artifactId,
+      );
+      if (target) {
+        target.vulnerabilities = vulnResults[i].vulnerabilities.map((v) => ({
+          id: v.id, severity: v.severity, fixedVersion: v.fixedVersion,
+        }));
+      }
     }
   }
 

--- a/src/tools/audit-project-dependencies.ts
+++ b/src/tools/audit-project-dependencies.ts
@@ -1,0 +1,101 @@
+import type { MavenRepository } from "../maven/repository.js";
+import { scanDependencies } from "../dependencies/scan.js";
+import { findProjectRoot } from "../project/find-project-root.js";
+import { resolveAll } from "../maven/resolver.js";
+import { findLatestVersionForCurrent } from "../version/classify.js";
+import { getUpgradeType } from "../version/compare.js";
+import { queryOsvBatch } from "../vulnerabilities/osv-client.js";
+
+export interface AuditInput {
+  projectPath?: string;
+  includeVulnerabilities?: boolean;
+}
+
+export interface AuditDependency {
+  groupId: string;
+  artifactId: string;
+  currentVersion?: string;
+  latestVersion?: string;
+  upgradeType?: string;
+  vulnerabilities?: { id: string; severity?: string; fixedVersion?: string }[];
+}
+
+export interface AuditResult {
+  buildSystem: string;
+  dependencies: AuditDependency[];
+  summary: {
+    total: number;
+    upgradeable: number;
+    vulnerable: number;
+    major: number;
+    minor: number;
+    patch: number;
+  };
+}
+
+export async function auditProjectDependenciesHandler(
+  repos: MavenRepository[],
+  input: AuditInput,
+): Promise<AuditResult> {
+  const projectRoot = input.projectPath ?? findProjectRoot(process.cwd()) ?? process.cwd();
+  const scan = scanDependencies(projectRoot);
+  const includeVulns = input.includeVulnerabilities !== false;
+
+  const auditDeps: AuditDependency[] = [];
+
+  const depsWithVersion = scan.dependencies.filter((d) => d.version !== null);
+  const depsWithoutVersion = scan.dependencies.filter((d) => d.version === null);
+
+  // Fetch latest versions in parallel
+  const versionResults = await Promise.all(
+    depsWithVersion.map(async (dep) => {
+      try {
+        const metadata = await resolveAll(repos, dep.groupId, dep.artifactId);
+        const latest = findLatestVersionForCurrent(metadata.versions, dep.version!);
+        const upgradeType = latest ? getUpgradeType(dep.version!, latest) : "none";
+        return { dep, latest, upgradeType };
+      } catch {
+        return { dep, latest: undefined, upgradeType: "none" as const };
+      }
+    }),
+  );
+
+  for (const { dep, latest, upgradeType } of versionResults) {
+    auditDeps.push({
+      groupId: dep.groupId,
+      artifactId: dep.artifactId,
+      currentVersion: dep.version!,
+      latestVersion: latest,
+      upgradeType,
+    });
+  }
+
+  for (const dep of depsWithoutVersion) {
+    auditDeps.push({ groupId: dep.groupId, artifactId: dep.artifactId });
+  }
+
+  // Vulnerability check
+  if (includeVulns && depsWithVersion.length > 0) {
+    const vulnResults = await queryOsvBatch(
+      depsWithVersion.map((d) => ({
+        groupId: d.groupId, artifactId: d.artifactId, version: d.version!,
+      })),
+    );
+    for (let i = 0; i < vulnResults.length; i++) {
+      auditDeps[i].vulnerabilities = vulnResults[i].vulnerabilities.map((v) => ({
+        id: v.id, severity: v.severity, fixedVersion: v.fixedVersion,
+      }));
+    }
+  }
+
+  const summary = {
+    total: auditDeps.length,
+    upgradeable: auditDeps.filter((d) => d.upgradeType && d.upgradeType !== "none").length,
+    vulnerable: auditDeps.filter((d) => d.vulnerabilities && d.vulnerabilities.length > 0).length,
+    major: auditDeps.filter((d) => d.upgradeType === "major").length,
+    minor: auditDeps.filter((d) => d.upgradeType === "minor").length,
+    patch: auditDeps.filter((d) => d.upgradeType === "patch").length,
+  };
+
+  return { buildSystem: scan.buildSystem, dependencies: auditDeps, summary };
+}

--- a/src/tools/audit-project-dependencies.ts
+++ b/src/tools/audit-project-dependencies.ts
@@ -75,22 +75,35 @@ export async function auditProjectDependenciesHandler(
     auditDeps.push({ groupId: dep.groupId, artifactId: dep.artifactId });
   }
 
-  // Vulnerability check — correlate by groupId:artifactId key, not positional index
+  // Vulnerability check — correlate by groupId:artifactId:version key
   if (includeVulns && depsWithVersion.length > 0) {
     const vulnResults = await queryOsvBatch(
       depsWithVersion.map((d) => ({
         groupId: d.groupId, artifactId: d.artifactId, version: d.version!,
       })),
     );
+    const auditDepMap = new Map<string, AuditDependency[]>();
+    for (const a of auditDeps) {
+      if (!a.currentVersion) continue;
+      const key = `${a.groupId}:${a.artifactId}:${a.currentVersion}`;
+      const existing = auditDepMap.get(key);
+      if (existing) {
+        existing.push(a);
+      } else {
+        auditDepMap.set(key, [a]);
+      }
+    }
     for (let i = 0; i < depsWithVersion.length; i++) {
       const dep = depsWithVersion[i];
-      const target = auditDeps.find(
-        (a) => a.groupId === dep.groupId && a.artifactId === dep.artifactId,
-      );
-      if (target) {
-        target.vulnerabilities = vulnResults[i].vulnerabilities.map((v) => ({
+      const key = `${dep.groupId}:${dep.artifactId}:${dep.version!}`;
+      const targets = auditDepMap.get(key);
+      if (targets) {
+        const mappedVulns = vulnResults[i].vulnerabilities.map((v) => ({
           id: v.id, severity: v.severity, fixedVersion: v.fixedVersion,
         }));
+        for (const target of targets) {
+          target.vulnerabilities = mappedVulns;
+        }
       }
     }
   }

--- a/src/tools/audit-project-dependencies.ts
+++ b/src/tools/audit-project-dependencies.ts
@@ -22,7 +22,7 @@ export interface AuditDependency {
 }
 
 export interface AuditResult {
-  buildSystem: string;
+  buildSystem: ReturnType<typeof scanDependencies>["buildSystem"];
   dependencies: AuditDependency[];
   summary: {
     total: number;
@@ -81,13 +81,8 @@ export async function auditProjectDependenciesHandler(
     auditDeps.push({ groupId: dep.groupId, artifactId: dep.artifactId });
   }
 
-  // Vulnerability check — correlate by groupId:artifactId:version key
+  // Vulnerability check — deduplicate OSV queries by GAV, then map results back
   if (includeVulns && depsWithVersion.length > 0) {
-    const vulnResults = await queryOsvBatch(
-      depsWithVersion.map((d) => ({
-        groupId: d.groupId, artifactId: d.artifactId, version: d.version!,
-      })),
-    );
     const auditDepMap = new Map<string, AuditDependency[]>();
     for (const a of auditDeps) {
       if (!a.currentVersion) continue;
@@ -99,10 +94,20 @@ export async function auditProjectDependenciesHandler(
         auditDepMap.set(key, [a]);
       }
     }
-    for (let i = 0; i < depsWithVersion.length; i++) {
-      const dep = depsWithVersion[i];
-      const key = `${dep.groupId}:${dep.artifactId}:${dep.version!}`;
-      const targets = auditDepMap.get(key);
+
+    const uniqueGavs = [...auditDepMap.entries()].map(([key, deps]) => {
+      const d = deps[0];
+      return { key, groupId: d.groupId, artifactId: d.artifactId, version: d.currentVersion! };
+    });
+
+    const vulnResults = await queryOsvBatch(
+      uniqueGavs.map((d) => ({
+        groupId: d.groupId, artifactId: d.artifactId, version: d.version,
+      })),
+    );
+
+    for (let i = 0; i < uniqueGavs.length; i++) {
+      const targets = auditDepMap.get(uniqueGavs[i].key);
       if (targets) {
         const mappedVulns = vulnResults[i].vulnerabilities.map((v) => ({
           id: v.id, severity: v.severity, fixedVersion: v.fixedVersion,

--- a/src/tools/audit-project-dependencies.ts
+++ b/src/tools/audit-project-dependencies.ts
@@ -47,11 +47,17 @@ export async function auditProjectDependenciesHandler(
   const depsWithVersion = scan.dependencies.filter((d) => d.version !== null);
   const depsWithoutVersion = scan.dependencies.filter((d) => d.version === null);
 
-  // Fetch latest versions in parallel
+  // Memoize resolveAll per GA to avoid redundant metadata fetches for duplicate deps
+  const metadataCache = new Map<string, ReturnType<typeof resolveAll>>();
+
   const versionResults = await Promise.all(
     depsWithVersion.map(async (dep) => {
       try {
-        const metadata = await resolveAll(repos, dep.groupId, dep.artifactId);
+        const gaKey = `${dep.groupId}:${dep.artifactId}`;
+        if (!metadataCache.has(gaKey)) {
+          metadataCache.set(gaKey, resolveAll(repos, dep.groupId, dep.artifactId));
+        }
+        const metadata = await metadataCache.get(gaKey)!;
         const latest = findLatestVersionForCurrent(metadata.versions, dep.version!);
         const upgradeType = latest ? getUpgradeType(dep.version!, latest) : "none" as const;
         return { dep, latest, upgradeType };


### PR DESCRIPTION
## Summary
- Adds `audit_project_dependencies` orchestrator tool that combines scan + version comparison + vulnerability checking in one call
- Scans project build files, compares each dependency against latest available version, and optionally checks for CVEs via OSV
- Returns a structured audit report with per-dependency details and summary counts (total, upgradeable, vulnerable, major/minor/patch)

## Test plan
- [x] Unit tests: scans, compares versions, and checks vulnerabilities in one call
- [x] Unit tests: handles dependencies without version gracefully
- [x] Build passes (`tsc`)
- [x] All 184 tests pass
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)