### PR TITLE
refactor: simplify code, fix doc/code sync, remove dead types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ src/
   maven/
     repository.ts       # MavenRepository interface + HttpMavenRepository (works with any Maven repo)
     resolver.ts         # resolveFirst (sequential) / resolveAll (parallel + merge) strategies
-    types.ts            # MavenMetadata, MavenSearchResponse
+    types.ts            # MavenMetadata
   discovery/
     discover.ts         # Orchestrator: scans project build files, returns RepositoryConfig[]
     gradle-parser.ts    # Regex-based parser for build.gradle[.kts] / settings.gradle[.kts]
@@ -54,7 +54,7 @@ src/
   cache/
     file-cache.ts        # Persistent JSON file cache (~/.cache/maven-central-mcp/)
   version/
-    classify.ts         # classifyVersion() + findLatestVersion() — stability detection
+    classify.ts         # classifyVersion() + findLatestVersion() + findLatestVersionForCurrent() — stability detection
     compare.ts          # getUpgradeType() — major/minor/patch comparison
     range.ts            # filterVersionRange() — extract versions between two bounds
     types.ts            # StabilityType, StabilityFilter, UpgradeType
@@ -86,7 +86,7 @@ src/
 - Tests colocated in `__tests__/` directories next to source
 - No XML parser dependency — all XML parsing is regex-based
 - Tool handlers that resolve versions accept `MavenRepository[]` as first argument; tools that don't need repo resolution (`scan_project_dependencies`, `search_artifacts`, `get_dependency_vulnerabilities`) accept only input
-- `findLatestVersion()` in `version/classify.ts` is the single source of truth for stable version selection logic
+- `findLatestVersion()` and `findLatestVersionForCurrent()` in `version/classify.ts` are the version selection functions; `findLatestVersion` is used by `get_latest_version` and `check_multiple_dependencies`, while `findLatestVersionForCurrent` is used by `compare_dependency_versions` and `audit_project_dependencies`
 - `get_dependency_changes` fetches POM from Maven repos to discover GitHub SCM URL; falls back to guessing from `groupId` pattern (`io.github.*`/`com.github.*`)
 - `audit_project_dependencies` is an orchestrator: scan → version compare → vulnerability check; memoizes `resolveAll` per GA and deduplicates OSV queries per GAV
 - GitHub API: unauthenticated = 60 req/h; set `GITHUB_TOKEN` env for 5000 req/h

--- a/src/cache/__tests__/file-cache.test.ts
+++ b/src/cache/__tests__/file-cache.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
 import { FileCache } from "../file-cache.js";
 
-vi.mock("node:fs");
+vi.mock("node:fs/promises");
 
-const mockedFs = vi.mocked(fs);
+const mockedFsp = vi.mocked(fsp);
 
 describe("FileCache", () => {
   const baseDir = "/tmp/test-cache";
@@ -17,25 +17,25 @@ describe("FileCache", () => {
 
   describe("get", () => {
     it("returns undefined when file does not exist", async () => {
-      mockedFs.existsSync.mockReturnValue(false);
+      mockedFsp.readFile.mockRejectedValue(new Error("ENOENT"));
 
       const result = await cache.get("some-key");
 
       expect(result).toBeUndefined();
-      expect(mockedFs.existsSync).toHaveBeenCalledWith(
-        "/tmp/test-cache/some-key.json"
+      expect(mockedFsp.readFile).toHaveBeenCalledWith(
+        "/tmp/test-cache/some-key.json",
+        "utf-8"
       );
     });
 
     it("returns cached data when file exists and no TTL", async () => {
       const entry = { data: { version: "1.0.0" }, timestamp: Date.now() };
-      mockedFs.existsSync.mockReturnValue(true);
-      mockedFs.readFileSync.mockReturnValue(JSON.stringify(entry));
+      mockedFsp.readFile.mockResolvedValue(JSON.stringify(entry));
 
       const result = await cache.get<{ version: string }>("my-key");
 
       expect(result).toEqual({ version: "1.0.0" });
-      expect(mockedFs.readFileSync).toHaveBeenCalledWith(
+      expect(mockedFsp.readFile).toHaveBeenCalledWith(
         "/tmp/test-cache/my-key.json",
         "utf-8"
       );
@@ -43,8 +43,7 @@ describe("FileCache", () => {
 
     it("returns cached data when TTL has not expired", async () => {
       const entry = { data: "hello", timestamp: Date.now() - 1000 };
-      mockedFs.existsSync.mockReturnValue(true);
-      mockedFs.readFileSync.mockReturnValue(JSON.stringify(entry));
+      mockedFsp.readFile.mockResolvedValue(JSON.stringify(entry));
 
       const result = await cache.get<string>("key", 5000);
 
@@ -53,8 +52,7 @@ describe("FileCache", () => {
 
     it("returns undefined when TTL has expired", async () => {
       const entry = { data: "hello", timestamp: Date.now() - 10000 };
-      mockedFs.existsSync.mockReturnValue(true);
-      mockedFs.readFileSync.mockReturnValue(JSON.stringify(entry));
+      mockedFsp.readFile.mockResolvedValue(JSON.stringify(entry));
 
       const result = await cache.get<string>("key", 5000);
 
@@ -62,10 +60,7 @@ describe("FileCache", () => {
     });
 
     it("returns undefined when file read throws", async () => {
-      mockedFs.existsSync.mockReturnValue(true);
-      mockedFs.readFileSync.mockImplementation(() => {
-        throw new Error("read error");
-      });
+      mockedFsp.readFile.mockRejectedValue(new Error("read error"));
 
       const result = await cache.get("key");
 
@@ -76,29 +71,69 @@ describe("FileCache", () => {
   describe("set", () => {
     it("creates directories and writes cache entry", async () => {
       vi.spyOn(Date, "now").mockReturnValue(1700000000000);
+      mockedFsp.mkdir.mockResolvedValue(undefined);
+      mockedFsp.writeFile.mockResolvedValue();
 
       await cache.set("my-key", { name: "test" });
 
-      expect(mockedFs.mkdirSync).toHaveBeenCalledWith("/tmp/test-cache", {
+      expect(mockedFsp.mkdir).toHaveBeenCalledWith("/tmp/test-cache", {
         recursive: true,
       });
-      expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
+      expect(mockedFsp.writeFile).toHaveBeenCalledWith(
         "/tmp/test-cache/my-key.json",
         JSON.stringify({ data: { name: "test" }, timestamp: 1700000000000 })
       );
     });
     it("creates nested directories for keys with path separators", async () => {
       vi.spyOn(Date, "now").mockReturnValue(1700000000000);
+      mockedFsp.mkdir.mockResolvedValue(undefined);
+      mockedFsp.writeFile.mockResolvedValue();
 
       await cache.set("scm/io.ktor/ktor-core", { owner: "ktorio", repo: "ktor" });
 
-      expect(mockedFs.mkdirSync).toHaveBeenCalledWith("/tmp/test-cache/scm/io.ktor", {
+      expect(mockedFsp.mkdir).toHaveBeenCalledWith("/tmp/test-cache/scm/io.ktor", {
         recursive: true,
       });
-      expect(mockedFs.writeFileSync).toHaveBeenCalledWith(
+      expect(mockedFsp.writeFile).toHaveBeenCalledWith(
         "/tmp/test-cache/scm/io.ktor/ktor-core.json",
         expect.any(String),
       );
+    });
+  });
+
+  describe("getOrFetch", () => {
+    it("returns cached value without calling fetchFn", async () => {
+      const entry = { data: { name: "cached" }, timestamp: Date.now() };
+      mockedFsp.readFile.mockResolvedValue(JSON.stringify(entry));
+      const fetchFn = vi.fn();
+
+      const result = await cache.getOrFetch("key", undefined, fetchFn);
+
+      expect(result).toEqual({ name: "cached" });
+      expect(fetchFn).not.toHaveBeenCalled();
+    });
+
+    it("calls fetchFn and caches result on cache miss", async () => {
+      mockedFsp.readFile.mockRejectedValue(new Error("ENOENT"));
+      mockedFsp.mkdir.mockResolvedValue(undefined);
+      mockedFsp.writeFile.mockResolvedValue();
+      const fetchFn = vi.fn().mockResolvedValue({ name: "fetched" });
+
+      const result = await cache.getOrFetch("key", undefined, fetchFn);
+
+      expect(result).toEqual({ name: "fetched" });
+      expect(fetchFn).toHaveBeenCalledOnce();
+      expect(mockedFsp.writeFile).toHaveBeenCalled();
+    });
+
+    it("does not cache null results from fetchFn", async () => {
+      mockedFsp.readFile.mockRejectedValue(new Error("ENOENT"));
+      const fetchFn = vi.fn().mockResolvedValue(null);
+
+      const result = await cache.getOrFetch("key", undefined, fetchFn);
+
+      expect(result).toBeNull();
+      expect(mockedFsp.writeFile).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/cache/file-cache.ts
+++ b/src/cache/file-cache.ts
@@ -35,6 +35,10 @@ export class FileCache {
     await writeFile(filePath, JSON.stringify(entry));
   }
 
+  /**
+   * Returns cached value if present, otherwise calls fetchFn and caches the result.
+   * Results that are null or undefined are NOT cached, so subsequent calls will retry.
+   */
   async getOrFetch<T>(
     key: string,
     ttlMs: number | undefined,

--- a/src/cache/file-cache.ts
+++ b/src/cache/file-cache.ts
@@ -1,4 +1,4 @@
-import * as fs from "node:fs";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 
@@ -13,14 +13,8 @@ export class FileCache {
   constructor(private readonly baseDir: string = DEFAULT_CACHE_DIR) {}
 
   async get<T>(key: string, ttlMs?: number): Promise<T | undefined> {
-    const filePath = this.filePath(key);
-
-    if (!fs.existsSync(filePath)) {
-      return undefined;
-    }
-
     try {
-      const raw = fs.readFileSync(filePath, "utf-8");
+      const raw = await readFile(this.filePath(key), "utf-8");
       const entry: CacheEntry<T> = JSON.parse(raw);
 
       if (ttlMs !== undefined && Date.now() - entry.timestamp > ttlMs) {
@@ -35,10 +29,25 @@ export class FileCache {
 
   async set<T>(key: string, data: T): Promise<void> {
     const filePath = this.filePath(key);
-    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    await mkdir(path.dirname(filePath), { recursive: true });
 
     const entry: CacheEntry<T> = { data, timestamp: Date.now() };
-    fs.writeFileSync(filePath, JSON.stringify(entry));
+    await writeFile(filePath, JSON.stringify(entry));
+  }
+
+  async getOrFetch<T>(
+    key: string,
+    ttlMs: number | undefined,
+    fetchFn: () => Promise<T>,
+  ): Promise<T> {
+    const cached = await this.get<T>(key, ttlMs);
+    if (cached !== undefined) return cached;
+
+    const data = await fetchFn();
+    if (data !== null && data !== undefined) {
+      await this.set(key, data);
+    }
+    return data;
   }
 
   private filePath(key: string): string {

--- a/src/github/github-client.ts
+++ b/src/github/github-client.ts
@@ -11,21 +11,16 @@ const ACCEPT_HEADER = "application/vnd.github.v3+json";
 const CHANGELOG_NAMES = ["CHANGELOG.md", "changelog.md", "CHANGES.md"];
 
 export class GitHubClient {
-  private readonly token?: string;
+  private readonly headers: Record<string, string>;
 
   constructor(token?: string) {
-    this.token = token;
-  }
-
-  private buildHeaders(): Record<string, string> {
-    const headers: Record<string, string> = {
+    this.headers = {
       Accept: ACCEPT_HEADER,
       "User-Agent": USER_AGENT,
     };
-    if (this.token) {
-      headers["Authorization"] = `Bearer ${this.token}`;
+    if (token) {
+      this.headers["Authorization"] = `Bearer ${token}`;
     }
-    return headers;
   }
 
   async fetchReleases(owner: string, repo: string): Promise<GitHubRelease[]> {
@@ -33,7 +28,7 @@ export class GitHubClient {
       const response = await fetch(
         `${GITHUB_API}/repos/${owner}/${repo}/releases?per_page=100`,
         {
-          headers: this.buildHeaders(),
+          headers: this.headers,
           signal: AbortSignal.timeout(15_000),
         }
       );
@@ -50,7 +45,7 @@ export class GitHubClient {
         const response = await fetch(
           `${GITHUB_API}/repos/${owner}/${repo}/contents/${name}`,
           {
-            headers: this.buildHeaders(),
+            headers: this.headers,
             signal: AbortSignal.timeout(10_000),
           }
         );
@@ -69,7 +64,7 @@ export class GitHubClient {
       const response = await fetch(
         `${GITHUB_API}/repos/${owner}/${repo}`,
         {
-          headers: this.buildHeaders(),
+          headers: this.headers,
           signal: AbortSignal.timeout(10_000),
         }
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ server.tool(
     stabilityFilter: z
       .enum(["STABLE_ONLY", "PREFER_STABLE", "ALL"])
       .optional()
-      .describe("Version stability filter (default: STABLE_ONLY)"),
+      .describe("Version stability filter (default: PREFER_STABLE)"),
   },
   async (params) => {
     const result = await getLatestVersionHandler(getRepositories(), params);

--- a/src/maven/types.ts
+++ b/src/maven/types.ts
@@ -1,20 +1,3 @@
-export interface MavenSearchResponse {
-  response: {
-    numFound: number;
-    docs: MavenArtifact[];
-  };
-}
-
-export interface MavenArtifact {
-  id: string;
-  g: string;
-  a: string;
-  v: string;
-  latestVersion: string;
-  timestamp: number;
-  versionCount: number;
-}
-
 export interface MavenMetadata {
   groupId: string;
   artifactId: string;

--- a/src/tools/__tests__/get-dependency-changes.test.ts
+++ b/src/tools/__tests__/get-dependency-changes.test.ts
@@ -2,12 +2,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { getDependencyChangesHandler } from "../get-dependency-changes.js";
 import type { MavenRepository } from "../../maven/repository.js";
 
-// Mock node:fs to prevent FileCache from writing to disk
-vi.mock("node:fs", () => ({
-  existsSync: vi.fn().mockReturnValue(false),
-  readFileSync: vi.fn().mockReturnValue(""),
-  writeFileSync: vi.fn(),
-  mkdirSync: vi.fn(),
+// Mock node:fs/promises to prevent FileCache from writing to disk
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  mkdir: vi.fn().mockResolvedValue(undefined),
 }));
 
 function mockRepo(versions: string[]): MavenRepository {

--- a/src/tools/check-multiple-dependencies.ts
+++ b/src/tools/check-multiple-dependencies.ts
@@ -31,7 +31,7 @@ export async function checkMultipleDependenciesHandler(
     input.dependencies.map(async (dep) => {
       try {
         const metadata = await resolveAll(repos, dep.groupId, dep.artifactId);
-        const latest = findLatestVersion(metadata.versions)!;
+        const latest = findLatestVersion(metadata.versions, "PREFER_STABLE")!;
         return {
           groupId: dep.groupId,
           artifactId: dep.artifactId,

--- a/src/tools/get-dependency-changes.ts
+++ b/src/tools/get-dependency-changes.ts
@@ -73,14 +73,9 @@ export async function getDependencyChangesHandler(
 
   // Step 3: Discover GitHub repo
   const scmCacheKey = `scm/${groupId}/${artifactId}`;
-  let ghRepo: GitHubRepo | null | undefined = await cache.get<GitHubRepo>(scmCacheKey);
-
-  if (ghRepo === undefined) {
-    ghRepo = await discoverGitHubRepo(repos, groupId, artifactId, toVersion, githubClient);
-    if (ghRepo) {
-      await cache.set(scmCacheKey, ghRepo);
-    }
-  }
+  const ghRepo = await cache.getOrFetch<GitHubRepo | null>(scmCacheKey, undefined, () =>
+    discoverGitHubRepo(repos, groupId, artifactId, toVersion, githubClient),
+  );
 
   if (!ghRepo) {
     return { ...baseResult, repositoryNotFound: true };
@@ -90,12 +85,11 @@ export async function getDependencyChangesHandler(
   const repositoryUrl = `https://github.com/${owner}/${repo}`;
 
   // Step 4: Fetch GitHub releases (with cache)
-  const releasesCacheKey = `releases/${owner}/${repo}`;
-  let releases: GitHubRelease[] | undefined = await cache.get<GitHubRelease[]>(releasesCacheKey, TTL_24H);
-  if (releases === undefined) {
-    releases = await githubClient.fetchReleases(owner, repo);
-    await cache.set(releasesCacheKey, releases);
-  }
+  const releases = await cache.getOrFetch<GitHubRelease[]>(
+    `releases/${owner}/${repo}`,
+    TTL_24H,
+    () => githubClient.fetchReleases(owner, repo),
+  );
 
   // Step 5: Match releases to versions
   const changes: VersionChange[] = [];
@@ -117,14 +111,11 @@ export async function getDependencyChangesHandler(
   // Step 6: For unmatched versions, try CHANGELOG.md
   let changelogUrl: string | undefined;
   if (unmatchedVersions.length > 0) {
-    const changelogCacheKey = `changelog/${owner}/${repo}`;
-    let changelogContent: string | null | undefined = await cache.get<string | null>(changelogCacheKey, TTL_24H);
-    if (changelogContent === undefined) {
-      changelogContent = await githubClient.fetchChangelog(owner, repo);
-      if (changelogContent !== null) {
-        await cache.set(changelogCacheKey, changelogContent);
-      }
-    }
+    const changelogContent = await cache.getOrFetch<string | null>(
+      `changelog/${owner}/${repo}`,
+      TTL_24H,
+      () => githubClient.fetchChangelog(owner, repo),
+    );
 
     if (changelogContent) {
       changelogUrl = `https://github.com/${owner}/${repo}/blob/main/CHANGELOG.md`;

--- a/src/version/classify.ts
+++ b/src/version/classify.ts
@@ -27,15 +27,21 @@ function stabilityRank(stability: StabilityType): number {
   return STABILITY_RANK.indexOf(stability);
 }
 
+function lastWhere(versions: string[], predicate: (v: string) => boolean): string | undefined {
+  for (let i = versions.length - 1; i >= 0; i--) {
+    if (predicate(versions[i])) return versions[i];
+  }
+  return undefined;
+}
+
 export function findLatestVersion(
   versions: string[],
-  filter: StabilityFilter = "STABLE_ONLY",
+  filter: StabilityFilter = "PREFER_STABLE",
 ): string | undefined {
-  const reversed = [...versions].reverse();
-  if (filter === "ALL") return reversed[0];
-  const stable = reversed.find((v) => classifyVersion(v) === "stable");
+  if (filter === "ALL") return versions[versions.length - 1];
+  const stable = lastWhere(versions, (v) => classifyVersion(v) === "stable");
   if (filter === "STABLE_ONLY") return stable;
-  return stable ?? reversed[0];
+  return stable ?? versions[versions.length - 1];
 }
 
 /**
@@ -49,6 +55,5 @@ export function findLatestVersionForCurrent(
 ): string | undefined {
   const currentStability = classifyVersion(currentVersion);
   const maxRank = stabilityRank(currentStability);
-  const reversed = [...versions].reverse();
-  return reversed.find((v) => stabilityRank(classifyVersion(v)) <= maxRank);
+  return lastWhere(versions, (v) => stabilityRank(classifyVersion(v)) <= maxRank);
 }


### PR DESCRIPTION
## Summary

- **Fix doc/code sync:** stabilityFilter tool description said `STABLE_ONLY` but handler defaults to `PREFER_STABLE`; aligned description. Updated CLAUDE.md to document `findLatestVersionForCurrent()` alongside `findLatestVersion()`.
- **Remove dead code:** deleted unused `MavenSearchResponse` and `MavenArtifact` types from `maven/types.ts`.
- **Simplify FileCache:** added `getOrFetch()` helper (skips caching null results), switched from sync `node:fs` to async `node:fs/promises`. Refactored `get-dependency-changes.ts` to use `getOrFetch()` — eliminates repeated cache-check-fetch-store boilerplate.
- **Quality improvements:** changed `findLatestVersion()` default to `PREFER_STABLE` for consistency across tools, replaced `[...versions].reverse()` with zero-allocation `lastWhere()` helper, cached `GitHubClient` headers in constructor.

## Test plan

- [x] `npm run build` — compiles cleanly
- [x] `npm run test` — 31 files, 193 tests passing (3 new tests for `getOrFetch`)
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)