### PR TITLE
chore: rename package to @krozov/maven-central-mcp

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       },
       "version": "0.2.0",
       "category": "development",
-      "homepage": "https://github.com/kirich1409/maven-central-mcp",
+      "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugin"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -1,16 +1,22 @@
-# maven-central-mcp
+# krozov-ai-tools
+
+Collection of AI tools by Kirill Rozov.
+
+## Packages
+
+### @krozov/maven-central-mcp
 
 MCP server for Maven dependency intelligence. Provides AI assistants with structured, live dependency data from Maven repositories (Maven Central, Google Maven, custom repos).
 
 Works with any JVM build tool that uses Maven coordinates (Maven, Gradle, SBT, etc). Auto-discovers custom repositories from Gradle and Maven project build files.
 
-## Quick Start
+#### Quick Start
 
 ```bash
-npx maven-central-mcp
+npx @krozov/maven-central-mcp
 ```
 
-### Claude Desktop
+##### Claude Desktop
 
 Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_desktop_config.json`):
 
@@ -19,13 +25,13 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
   "mcpServers": {
     "maven-central": {
       "command": "npx",
-      "args": ["maven-central-mcp"]
+      "args": ["@krozov/maven-central-mcp"]
     }
   }
 }
 ```
 
-### VS Code
+##### VS Code
 
 Create `.vscode/mcp.json` in your workspace:
 
@@ -35,13 +41,13 @@ Create `.vscode/mcp.json` in your workspace:
     "maven-central": {
       "type": "stdio",
       "command": "npx",
-      "args": ["maven-central-mcp"]
+      "args": ["@krozov/maven-central-mcp"]
     }
   }
 }
 ```
 
-## Tools
+#### Tools
 
 | Tool | Description |
 |------|-------------|
@@ -55,7 +61,7 @@ Create `.vscode/mcp.json` in your workspace:
 | `get_dependency_vulnerabilities` | Check dependencies for known vulnerabilities (CVEs) via OSV database |
 | `audit_project_dependencies` | Full project dependency audit: scan build files, compare versions, check vulnerabilities |
 
-## Features
+#### Features
 
 - **Version intelligence** — stability-aware version selection, upgrade type classification (major/minor/patch)
 - **Project scanning** — parse Gradle (`build.gradle.kts`, `build.gradle`), Maven (`pom.xml`), and version catalogs (`libs.versions.toml`)
@@ -64,7 +70,7 @@ Create `.vscode/mcp.json` in your workspace:
 - **Change tracking** — fetches GitHub release notes and changelogs between versions
 - **Artifact search** — keyword search across Maven Central
 
-## Environment Variables
+#### Environment Variables
 
 | Variable | Required | Description |
 |----------|----------|-------------|

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "maven-central-mcp",
-  "version": "0.1.0",
+  "name": "@krozov/maven-central-mcp",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "maven-central-mcp",
-      "version": "0.1.0",
+      "name": "@krozov/maven-central-mcp",
+      "version": "0.2.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "maven-central-mcp",
+  "name": "@krozov/maven-central-mcp",
   "version": "0.2.6",
   "description": "MCP server for Maven Central dependency intelligence",
   "main": "./dist/index.js",
@@ -24,7 +24,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kirich1409/maven-central-mcp.git"
+    "url": "git+https://github.com/kirich1409/krozov-ai-tools.git"
   },
   "files": [
     "dist",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "mcpServers": {
     "maven-mcp": {
       "command": "npx",
-      "args": ["-y", "maven-central-mcp"]
+      "args": ["-y", "@krozov/maven-central-mcp"]
     }
   },
   "skills": "./skills"


### PR DESCRIPTION
## Summary
- Rename npm package from `maven-central-mcp` to `@krozov/maven-central-mcp`
- Update repository URL to `krozov-ai-tools`
- Restructure README as a multi-package collection

## Test plan
- [ ] `npm run build` passes
- [ ] `npm run test` passes
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)