### PR TITLE
feat: add AndroidX changelog provider for get_dependency_changes

### DIFF
--- a/src/androidx/__tests__/release-notes-parser.test.ts
+++ b/src/androidx/__tests__/release-notes-parser.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { parseAndroidXReleaseNotes } from "../release-notes-parser.js";
+
+describe("parseAndroidXReleaseNotes", () => {
+  it("parses version sections from HTML", () => {
+    const html = `
+      <h3 id="1.2.0">Version 1.2.0</h3>
+      <p>January 15, 2025</p>
+      <p>Bug fixes and improvements.</p>
+      <ul><li>Fixed crash on startup</li></ul>
+      <h3 id="1.1.0">Version 1.1.0</h3>
+      <p>December 01, 2024</p>
+      <p>New features added.</p>
+    `;
+    const result = parseAndroidXReleaseNotes(html);
+    expect(result.size).toBe(2);
+    expect(result.has("1.2.0")).toBe(true);
+    expect(result.has("1.1.0")).toBe(true);
+    expect(result.get("1.2.0")).toContain("Bug fixes and improvements");
+    expect(result.get("1.2.0")).toContain("Fixed crash on startup");
+    expect(result.get("1.1.0")).toContain("New features added");
+  });
+
+  it("handles pre-release versions (alpha, beta, rc)", () => {
+    const html = `
+      <h3 id="1.0.0-alpha01">Version 1.0.0-alpha01</h3>
+      <p>March 01, 2025</p>
+      <p>First alpha release.</p>
+    `;
+    const result = parseAndroidXReleaseNotes(html);
+    expect(result.size).toBe(1);
+    expect(result.has("1.0.0-alpha01")).toBe(true);
+    expect(result.get("1.0.0-alpha01")).toContain("First alpha release");
+  });
+
+  it("strips HTML tags from body, preserving text content", () => {
+    const html = `
+      <h3 id="2.0.0">Version 2.0.0</h3>
+      <p><code>androidx.core:core:2.0.0</code> is released.</p>
+      <p><b>New features</b></p>
+      <ul>
+        <li>Added <code>newApi()</code> method</li>
+        <li>Improved performance</li>
+      </ul>
+    `;
+    const result = parseAndroidXReleaseNotes(html);
+    expect(result.has("2.0.0")).toBe(true);
+    const body = result.get("2.0.0")!;
+    expect(body).not.toContain("<p>");
+    expect(body).not.toContain("<code>");
+    expect(body).not.toContain("<ul>");
+    expect(body).toContain("newApi()");
+    expect(body).toContain("Improved performance");
+  });
+
+  it("returns empty map for HTML with no version headings", () => {
+    const html = `<h1>Some Page</h1><p>No versions here.</p>`;
+    const result = parseAndroidXReleaseNotes(html);
+    expect(result.size).toBe(0);
+  });
+
+  it("returns empty map for empty string", () => {
+    const result = parseAndroidXReleaseNotes("");
+    expect(result.size).toBe(0);
+  });
+
+  it("handles h2 version headings too", () => {
+    const html = `
+      <h2 id="1.5.0">Version 1.5.0</h2>
+      <p>Release notes content.</p>
+    `;
+    const result = parseAndroidXReleaseNotes(html);
+    expect(result.size).toBe(1);
+    expect(result.has("1.5.0")).toBe(true);
+  });
+
+  it("preserves h4 subheadings as content within a version section", () => {
+    const html = `
+      <h3 id="1.0.0">Version 1.0.0</h3>
+      <h4>Bug Fixes</h4>
+      <p>Fixed a crash.</p>
+      <h4>New Features</h4>
+      <p>Added new API.</p>
+    `;
+    const result = parseAndroidXReleaseNotes(html);
+    expect(result.size).toBe(1);
+    const body = result.get("1.0.0")!;
+    expect(body).toContain("Bug Fixes");
+    expect(body).toContain("Fixed a crash");
+    expect(body).toContain("New Features");
+    expect(body).toContain("Added new API");
+  });
+
+  it("stops section at next version heading", () => {
+    const html = `
+      <h3 id="2.0.0">Version 2.0.0</h3>
+      <p>Second version notes.</p>
+      <h3 id="1.0.0">Version 1.0.0</h3>
+      <p>First version notes.</p>
+    `;
+    const result = parseAndroidXReleaseNotes(html);
+    expect(result.get("2.0.0")).not.toContain("First version notes");
+    expect(result.get("1.0.0")).not.toContain("Second version notes");
+  });
+});

--- a/src/androidx/__tests__/url.test.ts
+++ b/src/androidx/__tests__/url.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { isAndroidXArtifact, getAndroidXReleasesUrl, getAndroidXVersionUrl } from "../url.js";
+
+describe("isAndroidXArtifact", () => {
+  it("returns true for androidx.core", () => {
+    expect(isAndroidXArtifact("androidx.core")).toBe(true);
+  });
+
+  it("returns true for androidx.compose.material3", () => {
+    expect(isAndroidXArtifact("androidx.compose.material3")).toBe(true);
+  });
+
+  it("returns false for io.ktor", () => {
+    expect(isAndroidXArtifact("io.ktor")).toBe(false);
+  });
+
+  it("returns false for com.google.android.material", () => {
+    expect(isAndroidXArtifact("com.google.android.material")).toBe(false);
+  });
+});
+
+describe("getAndroidXReleasesUrl", () => {
+  it("maps androidx.core to /releases/core", () => {
+    expect(getAndroidXReleasesUrl("androidx.core")).toBe(
+      "https://developer.android.com/jetpack/androidx/releases/core",
+    );
+  });
+
+  it("maps androidx.compose.material3 to /releases/compose-material3", () => {
+    expect(getAndroidXReleasesUrl("androidx.compose.material3")).toBe(
+      "https://developer.android.com/jetpack/androidx/releases/compose-material3",
+    );
+  });
+
+  it("maps androidx.compose.ui to /releases/compose-ui", () => {
+    expect(getAndroidXReleasesUrl("androidx.compose.ui")).toBe(
+      "https://developer.android.com/jetpack/androidx/releases/compose-ui",
+    );
+  });
+
+  it("maps androidx.lifecycle to /releases/lifecycle", () => {
+    expect(getAndroidXReleasesUrl("androidx.lifecycle")).toBe(
+      "https://developer.android.com/jetpack/androidx/releases/lifecycle",
+    );
+  });
+});
+
+describe("getAndroidXVersionUrl", () => {
+  it("appends version anchor", () => {
+    expect(getAndroidXVersionUrl("androidx.core", "1.17.0")).toBe(
+      "https://developer.android.com/jetpack/androidx/releases/core#1.17.0",
+    );
+  });
+});

--- a/src/androidx/release-notes-parser.ts
+++ b/src/androidx/release-notes-parser.ts
@@ -1,0 +1,49 @@
+const VERSION_HEADING_RE = /<h[23][^>]*>\s*Version\s+([\d][^\s<]*)\s*<\/h[23]>/gi;
+
+function htmlToText(html: string): string {
+  return html
+    .replace(/<li[^>]*>/gi, "- ")
+    .replace(/<\/li>/gi, "\n")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/p>/gi, "\n\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+export function parseAndroidXReleaseNotes(html: string): Map<string, string> {
+  const sections = new Map<string, string>();
+  const headings: { version: string; startIndex: number; endIndex: number }[] = [];
+  let match: RegExpExecArray | null;
+
+  VERSION_HEADING_RE.lastIndex = 0;
+
+  while ((match = VERSION_HEADING_RE.exec(html)) !== null) {
+    headings.push({
+      version: match[1],
+      startIndex: match.index,
+      endIndex: match.index + match[0].length,
+    });
+  }
+
+  for (let i = 0; i < headings.length; i++) {
+    const start = headings[i].endIndex;
+    const end = i + 1 < headings.length
+      ? headings[i + 1].startIndex
+      : html.length;
+
+    const rawContent = html.slice(start, end);
+    const body = htmlToText(rawContent);
+
+    if (body) {
+      sections.set(headings[i].version, body);
+    }
+  }
+
+  return sections;
+}

--- a/src/androidx/release-notes-parser.ts
+++ b/src/androidx/release-notes-parser.ts
@@ -1,17 +1,31 @@
 const VERSION_HEADING_RE = /<h[23][^>]*>\s*Version\s+([\d][^\s<]*)\s*<\/h[23]>/gi;
 
+function unescapeEntities(text: string): string {
+  return text
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+function stripTags(text: string): string {
+  let result = text;
+  let prev: string;
+  do {
+    prev = result;
+    result = result.replace(/<[^>]*>/g, "");
+  } while (result !== prev);
+  return result;
+}
+
 function htmlToText(html: string): string {
-  return html
+  const formatted = html
     .replace(/<li[^>]*>/gi, "- ")
     .replace(/<\/li>/gi, "\n")
     .replace(/<br\s*\/?>/gi, "\n")
-    .replace(/<\/p>/gi, "\n\n")
-    .replace(/<[^>]+>/g, "")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&amp;/g, "&")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
+    .replace(/<\/p>/gi, "\n\n");
+  return unescapeEntities(stripTags(unescapeEntities(formatted)))
     .replace(/\n{3,}/g, "\n\n")
     .trim();
 }

--- a/src/androidx/release-notes-parser.ts
+++ b/src/androidx/release-notes-parser.ts
@@ -25,7 +25,7 @@ function htmlToText(html: string): string {
     .replace(/<\/li>/gi, "\n")
     .replace(/<br\s*\/?>/gi, "\n")
     .replace(/<\/p>/gi, "\n\n");
-  return unescapeEntities(stripTags(unescapeEntities(formatted)))
+  return unescapeEntities(stripTags(formatted))
     .replace(/\n{3,}/g, "\n\n")
     .trim();
 }

--- a/src/androidx/url.ts
+++ b/src/androidx/url.ts
@@ -1,0 +1,18 @@
+const ANDROIDX_PREFIX = "androidx.";
+const BASE_URL = "https://developer.android.com/jetpack/androidx/releases";
+
+export function isAndroidXArtifact(groupId: string): boolean {
+  return groupId.startsWith(ANDROIDX_PREFIX);
+}
+
+export function getAndroidXSlug(groupId: string): string {
+  return groupId.slice(ANDROIDX_PREFIX.length).replaceAll(".", "-");
+}
+
+export function getAndroidXReleasesUrl(groupId: string): string {
+  return `${BASE_URL}/${getAndroidXSlug(groupId)}`;
+}
+
+export function getAndroidXVersionUrl(groupId: string, version: string): string {
+  return `${getAndroidXReleasesUrl(groupId)}#${version}`;
+}

--- a/src/changelog/__tests__/androidx-provider.test.ts
+++ b/src/changelog/__tests__/androidx-provider.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { AndroidXChangelogProvider } from "../androidx-provider.js";
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe("AndroidXChangelogProvider", () => {
+  let provider: AndroidXChangelogProvider;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    provider = new AndroidXChangelogProvider();
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  describe("canHandle", () => {
+    it("returns true for androidx.core", () => {
+      expect(provider.canHandle("androidx.core", "core")).toBe(true);
+    });
+
+    it("returns true for androidx.compose.material3", () => {
+      expect(provider.canHandle("androidx.compose.material3", "material3")).toBe(true);
+    });
+
+    it("returns false for io.ktor", () => {
+      expect(provider.canHandle("io.ktor", "ktor-core")).toBe(false);
+    });
+  });
+
+  describe("fetchChangelog", () => {
+    it("fetches and parses AndroidX release notes", async () => {
+      const html = `
+        <h3 id="1.2.0">Version 1.2.0</h3>
+        <p>New features.</p>
+        <h3 id="1.1.0">Version 1.1.0</h3>
+        <p>Bug fixes.</p>
+      `;
+      globalThis.fetch = vi.fn().mockResolvedValueOnce(
+        new Response(html, { status: 200 }),
+      ) as typeof fetch;
+
+      const result = await provider.fetchChangelog("androidx.core", "core", "1.2.0", []);
+
+      expect(result).not.toBeNull();
+      expect(result!.repositoryUrl).toBe(
+        "https://developer.android.com/jetpack/androidx/releases/core",
+      );
+      expect(result!.entries.size).toBe(2);
+      expect(result!.entries.has("1.2.0")).toBe(true);
+      expect(result!.entries.get("1.2.0")!.body).toContain("New features");
+      expect(result!.entries.has("1.1.0")).toBe(true);
+    });
+
+    it("returns null when fetch fails", async () => {
+      globalThis.fetch = vi.fn().mockRejectedValueOnce(
+        new Error("Network error"),
+      ) as typeof fetch;
+
+      const result = await provider.fetchChangelog("androidx.core", "core", "1.0.0", []);
+      expect(result).toBeNull();
+    });
+
+    it("returns null when page returns 404", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValueOnce(
+        new Response("Not Found", { status: 404 }),
+      ) as typeof fetch;
+
+      const result = await provider.fetchChangelog("androidx.core", "core", "1.0.0", []);
+      expect(result).toBeNull();
+    });
+
+    it("returns null when page has no version headings", async () => {
+      globalThis.fetch = vi.fn().mockResolvedValueOnce(
+        new Response("<h1>Empty Page</h1>", { status: 200 }),
+      ) as typeof fetch;
+
+      const result = await provider.fetchChangelog("androidx.core", "core", "1.0.0", []);
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/changelog/__tests__/github-provider.test.ts
+++ b/src/changelog/__tests__/github-provider.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { GitHubChangelogProvider } from "../github-provider.js";
+import type { MavenRepository } from "../../maven/repository.js";
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+}));
+
+const POM_WITH_SCM = `<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <scm><url>https://github.com/ktorio/ktor</url></scm>
+</project>`;
+
+const POM_WITHOUT_SCM = `<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>com.example</groupId>
+</project>`;
+
+function mockRepo(): MavenRepository {
+  return {
+    name: "central",
+    url: "https://repo1.maven.org/maven2",
+    fetchMetadata: vi.fn(),
+  };
+}
+
+describe("GitHubChangelogProvider", () => {
+  let provider: GitHubChangelogProvider;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    provider = new GitHubChangelogProvider();
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  describe("canHandle", () => {
+    it("returns true for any artifact (universal fallback)", () => {
+      expect(provider.canHandle("io.ktor", "ktor-core")).toBe(true);
+      expect(provider.canHandle("com.example", "lib")).toBe(true);
+    });
+  });
+
+  describe("fetchChangelog", () => {
+    it("returns entries from GitHub releases", async () => {
+      const releases = [
+        { tag_name: "2.0.0", body: "New features", html_url: "https://github.com/ktorio/ktor/releases/tag/2.0.0" },
+      ];
+
+      globalThis.fetch = vi.fn()
+        .mockResolvedValueOnce(new Response(POM_WITH_SCM, { status: 200 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify(releases), { status: 200 }))
+        .mockResolvedValueOnce(new Response("", { status: 404 })) as typeof fetch;
+
+      const result = await provider.fetchChangelog("io.ktor", "ktor-core", "2.0.0", [mockRepo()]);
+
+      expect(result).not.toBeNull();
+      expect(result!.repositoryUrl).toBe("https://github.com/ktorio/ktor");
+      expect(result!.entries.has("2.0.0")).toBe(true);
+      expect(result!.entries.get("2.0.0")!.body).toContain("New features");
+      expect(result!.entries.get("2.0.0")!.releaseUrl).toBe("https://github.com/ktorio/ktor/releases/tag/2.0.0");
+    });
+
+    it("returns null when no GitHub repo discovered", async () => {
+      globalThis.fetch = vi.fn()
+        .mockResolvedValueOnce(new Response(POM_WITHOUT_SCM, { status: 200 }))
+        .mockResolvedValueOnce(new Response("", { status: 404 })) as typeof fetch;
+
+      const result = await provider.fetchChangelog("com.example", "lib", "1.0.0", [mockRepo()]);
+      expect(result).toBeNull();
+    });
+
+    it("falls back to CHANGELOG.md when no releases match", async () => {
+      const changelogContent = Buffer.from(
+        "## [1.0.0] - 2024-01-01\n\nInitial release\n",
+      ).toString("base64");
+
+      globalThis.fetch = vi.fn()
+        .mockResolvedValueOnce(new Response(POM_WITH_SCM, { status: 200 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ content: changelogContent }), { status: 200 })) as typeof fetch;
+
+      const result = await provider.fetchChangelog("io.ktor", "ktor-core", "1.0.0", [mockRepo()]);
+
+      expect(result).not.toBeNull();
+      expect(result!.entries.has("1.0.0")).toBe(true);
+      expect(result!.entries.get("1.0.0")!.body).toContain("Initial release");
+      expect(result!.changelogUrl).toContain("CHANGELOG.md");
+    });
+  });
+});

--- a/src/changelog/__tests__/resolver.test.ts
+++ b/src/changelog/__tests__/resolver.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+import { resolveChangelog } from "../resolver.js";
+import type { ChangelogProvider, ChangelogResult } from "../types.js";
+
+function mockProvider(
+  handles: boolean,
+  result: ChangelogResult | null,
+): ChangelogProvider {
+  return {
+    canHandle: vi.fn().mockReturnValue(handles),
+    fetchChangelog: vi.fn().mockResolvedValue(result),
+  };
+}
+
+describe("resolveChangelog", () => {
+  it("returns result from first matching provider", async () => {
+    const expected: ChangelogResult = {
+      repositoryUrl: "https://example.com",
+      entries: new Map([["1.0.0", { body: "Notes" }]]),
+    };
+    const p1 = mockProvider(true, expected);
+    const p2 = mockProvider(true, { repositoryUrl: "other", entries: new Map() });
+
+    const result = await resolveChangelog([p1, p2], [], "g", "a", "1.0.0");
+    expect(result).toBe(expected);
+    expect(p2.fetchChangelog).not.toHaveBeenCalled();
+  });
+
+  it("skips providers that cannot handle the artifact", async () => {
+    const p1 = mockProvider(false, null);
+    const expected: ChangelogResult = {
+      repositoryUrl: "https://example.com",
+      entries: new Map([["1.0.0", { body: "Notes" }]]),
+    };
+    const p2 = mockProvider(true, expected);
+
+    const result = await resolveChangelog([p1, p2], [], "g", "a", "1.0.0");
+    expect(result).toBe(expected);
+    expect(p1.fetchChangelog).not.toHaveBeenCalled();
+  });
+
+  it("falls through to next provider when first returns null", async () => {
+    const p1 = mockProvider(true, null);
+    const expected: ChangelogResult = {
+      repositoryUrl: "https://example.com",
+      entries: new Map([["1.0.0", { body: "Notes" }]]),
+    };
+    const p2 = mockProvider(true, expected);
+
+    const result = await resolveChangelog([p1, p2], [], "g", "a", "1.0.0");
+    expect(result).toBe(expected);
+  });
+
+  it("returns null when no providers match", async () => {
+    const p1 = mockProvider(false, null);
+
+    const result = await resolveChangelog([p1], [], "g", "a", "1.0.0");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when all providers return null", async () => {
+    const p1 = mockProvider(true, null);
+    const p2 = mockProvider(true, null);
+
+    const result = await resolveChangelog([p1, p2], [], "g", "a", "1.0.0");
+    expect(result).toBeNull();
+  });
+
+  it("returns null for empty providers list", async () => {
+    const result = await resolveChangelog([], [], "g", "a", "1.0.0");
+    expect(result).toBeNull();
+  });
+});

--- a/src/changelog/androidx-provider.ts
+++ b/src/changelog/androidx-provider.ts
@@ -1,5 +1,4 @@
 import type { ChangelogProvider, ChangelogResult, ChangelogEntry } from "./types.js";
-import type { MavenRepository } from "../maven/repository.js";
 import { isAndroidXArtifact, getAndroidXReleasesUrl, getAndroidXSlug, getAndroidXVersionUrl } from "../androidx/url.js";
 import { parseAndroidXReleaseNotes } from "../androidx/release-notes-parser.js";
 import { FileCache } from "../cache/file-cache.js";
@@ -9,15 +8,12 @@ const TTL_7_DAYS = 7 * 24 * 60 * 60 * 1000;
 export class AndroidXChangelogProvider implements ChangelogProvider {
   private readonly cache = new FileCache();
 
-  canHandle(groupId: string, _artifactId: string): boolean {
+  canHandle(groupId: string): boolean {
     return isAndroidXArtifact(groupId);
   }
 
   async fetchChangelog(
     groupId: string,
-    _artifactId: string,
-    _version: string,
-    _repos: MavenRepository[],
   ): Promise<ChangelogResult | null> {
     const slug = getAndroidXSlug(groupId);
     const cacheKey = `androidx/${slug}`;

--- a/src/changelog/androidx-provider.ts
+++ b/src/changelog/androidx-provider.ts
@@ -46,11 +46,13 @@ export class AndroidXChangelogProvider implements ChangelogProvider {
       const response = await fetch(url, {
         signal: AbortSignal.timeout(15_000),
       });
-      if (!response.ok) return null;
+      if (!response.ok) {
+        return response.status === 404 ? [] : null;
+      }
 
       const html = await response.text();
       const entries = parseAndroidXReleaseNotes(html);
-      if (entries.size === 0) return null;
+      if (entries.size === 0) return [];
 
       return [...entries.entries()];
     } catch {

--- a/src/changelog/androidx-provider.ts
+++ b/src/changelog/androidx-provider.ts
@@ -1,0 +1,64 @@
+import type { ChangelogProvider, ChangelogResult, ChangelogEntry } from "./types.js";
+import type { MavenRepository } from "../maven/repository.js";
+import { isAndroidXArtifact, getAndroidXReleasesUrl, getAndroidXSlug, getAndroidXVersionUrl } from "../androidx/url.js";
+import { parseAndroidXReleaseNotes } from "../androidx/release-notes-parser.js";
+import { FileCache } from "../cache/file-cache.js";
+
+const TTL_7_DAYS = 7 * 24 * 60 * 60 * 1000;
+
+export class AndroidXChangelogProvider implements ChangelogProvider {
+  private readonly cache = new FileCache();
+
+  canHandle(groupId: string, _artifactId: string): boolean {
+    return isAndroidXArtifact(groupId);
+  }
+
+  async fetchChangelog(
+    groupId: string,
+    _artifactId: string,
+    _version: string,
+    _repos: MavenRepository[],
+  ): Promise<ChangelogResult | null> {
+    const slug = getAndroidXSlug(groupId);
+    const cacheKey = `androidx/${slug}`;
+
+    const rawEntries = await this.cache.getOrFetch<[string, string][] | null>(
+      cacheKey,
+      TTL_7_DAYS,
+      () => this.fetchAndParse(groupId),
+    );
+
+    if (!rawEntries || rawEntries.length === 0) return null;
+
+    const entries = new Map<string, ChangelogEntry>();
+    for (const [version, body] of rawEntries) {
+      entries.set(version, {
+        body,
+        releaseUrl: getAndroidXVersionUrl(groupId, version),
+      });
+    }
+
+    return {
+      repositoryUrl: getAndroidXReleasesUrl(groupId),
+      entries,
+    };
+  }
+
+  private async fetchAndParse(groupId: string): Promise<[string, string][] | null> {
+    try {
+      const url = getAndroidXReleasesUrl(groupId);
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!response.ok) return null;
+
+      const html = await response.text();
+      const entries = parseAndroidXReleaseNotes(html);
+      if (entries.size === 0) return null;
+
+      return [...entries.entries()];
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/changelog/github-provider.ts
+++ b/src/changelog/github-provider.ts
@@ -13,7 +13,7 @@ export class GitHubChangelogProvider implements ChangelogProvider {
   private readonly cache = new FileCache();
   private readonly githubClient = new GitHubClient(process.env.GITHUB_TOKEN);
 
-  canHandle(_groupId: string, _artifactId: string): boolean {
+  canHandle(): boolean {
     return true;
   }
 

--- a/src/changelog/github-provider.ts
+++ b/src/changelog/github-provider.ts
@@ -9,23 +9,27 @@ import { FileCache } from "../cache/file-cache.js";
 
 const TTL_24H = 24 * 60 * 60 * 1000;
 
+const VERSION_RE = /^\d+(?:\.\d+)*(?:[.-].*)?$/;
+
 /**
  * Extract version from a Git tag using the same strategies as matchReleaseToVersion:
- * 1. Exact (no prefix) — return as-is
- * 2. v-prefix — strip leading "v"
- * 3. Suffix after `-` or `/` — extract the trailing version part
+ * 1. v-prefix — strip leading "v" only when followed by a digit (e.g. "v1.2.3")
+ * 2. Suffix after `-` or `/` — extract trailing part only if it looks like a version
+ * 3. Exact — return tag as-is
  */
 function normalizeTag(tag: string): string {
-  if (tag.startsWith("v")) {
+  if (tag.length > 1 && tag[0] === "v" && tag[1] >= "0" && tag[1] <= "9") {
     return tag.slice(1);
   }
   const dashIdx = tag.lastIndexOf("-");
   if (dashIdx !== -1) {
-    return tag.slice(dashIdx + 1);
+    const suffix = tag.slice(dashIdx + 1);
+    if (VERSION_RE.test(suffix)) return suffix;
   }
   const slashIdx = tag.lastIndexOf("/");
   if (slashIdx !== -1) {
-    return tag.slice(slashIdx + 1);
+    const suffix = tag.slice(slashIdx + 1);
+    if (VERSION_RE.test(suffix)) return suffix;
   }
   return tag;
 }

--- a/src/changelog/github-provider.ts
+++ b/src/changelog/github-provider.ts
@@ -1,0 +1,76 @@
+import type { ChangelogProvider, ChangelogResult, ChangelogEntry } from "./types.js";
+import type { MavenRepository } from "../maven/repository.js";
+import type { GitHubRepo } from "../github/pom-scm.js";
+import type { GitHubRelease } from "../github/github-client.js";
+import { discoverGitHubRepo } from "../github/discover-repo.js";
+import { GitHubClient } from "../github/github-client.js";
+import { parseChangelogSections } from "../github/changelog-parser.js";
+import { FileCache } from "../cache/file-cache.js";
+
+const TTL_24H = 24 * 60 * 60 * 1000;
+
+export class GitHubChangelogProvider implements ChangelogProvider {
+  private readonly cache = new FileCache();
+  private readonly githubClient = new GitHubClient(process.env.GITHUB_TOKEN);
+
+  canHandle(_groupId: string, _artifactId: string): boolean {
+    return true;
+  }
+
+  async fetchChangelog(
+    groupId: string,
+    artifactId: string,
+    version: string,
+    repos: MavenRepository[],
+  ): Promise<ChangelogResult | null> {
+    const scmCacheKey = `scm/${groupId}/${artifactId}`;
+    const ghRepo = await this.cache.getOrFetch<GitHubRepo | null>(
+      scmCacheKey,
+      undefined,
+      () => discoverGitHubRepo(repos, groupId, artifactId, version, this.githubClient),
+    );
+
+    if (!ghRepo) return null;
+
+    const { owner, repo } = ghRepo;
+    const repositoryUrl = `https://github.com/${owner}/${repo}`;
+    const entries = new Map<string, ChangelogEntry>();
+    let changelogUrl: string | undefined;
+
+    const releases = await this.cache.getOrFetch<GitHubRelease[]>(
+      `releases/${owner}/${repo}`,
+      TTL_24H,
+      () => this.githubClient.fetchReleases(owner, repo),
+    );
+
+    for (const release of releases) {
+      if (!release.body) continue;
+      const tag = release.tag_name;
+      const ver = tag.startsWith("v") ? tag.slice(1) : tag;
+      entries.set(ver, {
+        body: release.body,
+        releaseUrl: release.html_url,
+      });
+    }
+
+    const changelogContent = await this.cache.getOrFetch<string | null>(
+      `changelog/${owner}/${repo}`,
+      TTL_24H,
+      () => this.githubClient.fetchChangelog(owner, repo),
+    );
+
+    if (changelogContent) {
+      changelogUrl = `https://github.com/${owner}/${repo}/blob/main/CHANGELOG.md`;
+      const sections = parseChangelogSections(changelogContent);
+      for (const [ver, body] of sections) {
+        if (!entries.has(ver)) {
+          entries.set(ver, { body });
+        }
+      }
+    }
+
+    if (entries.size === 0) return null;
+
+    return { repositoryUrl, changelogUrl, entries };
+  }
+}

--- a/src/changelog/github-provider.ts
+++ b/src/changelog/github-provider.ts
@@ -9,6 +9,27 @@ import { FileCache } from "../cache/file-cache.js";
 
 const TTL_24H = 24 * 60 * 60 * 1000;
 
+/**
+ * Extract version from a Git tag using the same strategies as matchReleaseToVersion:
+ * 1. Exact (no prefix) — return as-is
+ * 2. v-prefix — strip leading "v"
+ * 3. Suffix after `-` or `/` — extract the trailing version part
+ */
+function normalizeTag(tag: string): string {
+  if (tag.startsWith("v")) {
+    return tag.slice(1);
+  }
+  const dashIdx = tag.lastIndexOf("-");
+  if (dashIdx !== -1) {
+    return tag.slice(dashIdx + 1);
+  }
+  const slashIdx = tag.lastIndexOf("/");
+  if (slashIdx !== -1) {
+    return tag.slice(slashIdx + 1);
+  }
+  return tag;
+}
+
 export class GitHubChangelogProvider implements ChangelogProvider {
   private readonly cache = new FileCache();
   private readonly githubClient = new GitHubClient(process.env.GITHUB_TOKEN);
@@ -45,8 +66,7 @@ export class GitHubChangelogProvider implements ChangelogProvider {
 
     for (const release of releases) {
       if (!release.body) continue;
-      const tag = release.tag_name;
-      const ver = tag.startsWith("v") ? tag.slice(1) : tag;
+      const ver = normalizeTag(release.tag_name);
       entries.set(ver, {
         body: release.body,
         releaseUrl: release.html_url,

--- a/src/changelog/resolver.ts
+++ b/src/changelog/resolver.ts
@@ -11,8 +11,12 @@ export async function resolveChangelog(
   for (const provider of providers) {
     if (!provider.canHandle(groupId, artifactId)) continue;
 
-    const result = await provider.fetchChangelog(groupId, artifactId, version, repos);
-    if (result) return result;
+    try {
+      const result = await provider.fetchChangelog(groupId, artifactId, version, repos);
+      if (result) return result;
+    } catch {
+      continue;
+    }
   }
   return null;
 }

--- a/src/changelog/resolver.ts
+++ b/src/changelog/resolver.ts
@@ -1,0 +1,18 @@
+import type { ChangelogProvider, ChangelogResult } from "./types.js";
+import type { MavenRepository } from "../maven/repository.js";
+
+export async function resolveChangelog(
+  providers: ChangelogProvider[],
+  repos: MavenRepository[],
+  groupId: string,
+  artifactId: string,
+  version: string,
+): Promise<ChangelogResult | null> {
+  for (const provider of providers) {
+    if (!provider.canHandle(groupId, artifactId)) continue;
+
+    const result = await provider.fetchChangelog(groupId, artifactId, version, repos);
+    if (result) return result;
+  }
+  return null;
+}

--- a/src/changelog/types.ts
+++ b/src/changelog/types.ts
@@ -1,0 +1,22 @@
+import type { MavenRepository } from "../maven/repository.js";
+
+export interface ChangelogEntry {
+  body: string;
+  releaseUrl?: string;
+}
+
+export interface ChangelogResult {
+  repositoryUrl?: string;
+  changelogUrl?: string;
+  entries: Map<string, ChangelogEntry>;
+}
+
+export interface ChangelogProvider {
+  canHandle(groupId: string, artifactId: string): boolean;
+  fetchChangelog(
+    groupId: string,
+    artifactId: string,
+    version: string,
+    repos: MavenRepository[],
+  ): Promise<ChangelogResult | null>;
+}

--- a/src/tools/__tests__/get-dependency-changes.test.ts
+++ b/src/tools/__tests__/get-dependency-changes.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { getDependencyChangesHandler } from "../get-dependency-changes.js";
 import type { MavenRepository } from "../../maven/repository.js";
 
-// Mock node:fs/promises to prevent FileCache from writing to disk
 vi.mock("node:fs/promises", () => ({
   readFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
   writeFile: vi.fn().mockResolvedValue(undefined),
@@ -61,10 +60,14 @@ describe("getDependencyChangesHandler", () => {
     ];
 
     globalThis.fetch = vi.fn()
-      // First call: POM fetch (from discoverGitHubRepo)
+      // POM fetch (from discoverGitHubRepo)
       .mockResolvedValueOnce(new Response(POM_WITH_SCM, { status: 200 }))
-      // Second call: GitHub releases
-      .mockResolvedValueOnce(new Response(JSON.stringify(releases), { status: 200 })) as typeof fetch;
+      // GitHub releases
+      .mockResolvedValueOnce(new Response(JSON.stringify(releases), { status: 200 }))
+      // CHANGELOG.md fetch (404 - not found) — tries 3 filenames
+      .mockResolvedValueOnce(new Response("Not Found", { status: 404 }))
+      .mockResolvedValueOnce(new Response("Not Found", { status: 404 }))
+      .mockResolvedValueOnce(new Response("Not Found", { status: 404 })) as typeof fetch;
 
     const result = await getDependencyChangesHandler([repo], {
       groupId: "io.ktor",
@@ -98,7 +101,7 @@ describe("getDependencyChangesHandler", () => {
     globalThis.fetch = vi.fn()
       // POM fetch returns no SCM info
       .mockResolvedValueOnce(new Response(POM_WITHOUT_SCM, { status: 200 }))
-      // repoExists check for guessed repo fails
+      // repoExists check for guessed repo fails (may or may not be called)
       .mockResolvedValueOnce(new Response("", { status: 404 })) as typeof fetch;
 
     const result = await getDependencyChangesHandler([repo], {
@@ -157,5 +160,37 @@ describe("getDependencyChangesHandler", () => {
 
     expect(result.error).toContain("No versions found between");
     expect(result.changes).toEqual([]);
+  });
+
+  it("returns changes from AndroidX release notes", async () => {
+    const repo = mockRepo(["1.15.0", "1.16.0", "1.17.0"]);
+
+    const html = `
+      <h3 id="1.17.0">Version 1.17.0</h3>
+      <p>New features in core 1.17.0.</p>
+      <h3 id="1.16.0">Version 1.16.0</h3>
+      <p>Bug fixes in core 1.16.0.</p>
+    `;
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      new Response(html, { status: 200 }),
+    ) as typeof fetch;
+
+    const result = await getDependencyChangesHandler([repo], {
+      groupId: "androidx.core",
+      artifactId: "core",
+      fromVersion: "1.15.0",
+      toVersion: "1.17.0",
+    });
+
+    expect(result.repositoryNotFound).toBeUndefined();
+    expect(result.repositoryUrl).toBe(
+      "https://developer.android.com/jetpack/androidx/releases/core",
+    );
+    expect(result.changes).toHaveLength(2);
+    expect(result.changes[0].version).toBe("1.16.0");
+    expect(result.changes[0].body).toContain("Bug fixes in core 1.16.0");
+    expect(result.changes[0].releaseUrl).toContain("#1.16.0");
+    expect(result.changes[1].version).toBe("1.17.0");
+    expect(result.changes[1].body).toContain("New features in core 1.17.0");
   });
 });

--- a/src/tools/get-dependency-changes.ts
+++ b/src/tools/get-dependency-changes.ts
@@ -1,13 +1,10 @@
 import type { MavenRepository } from "../maven/repository.js";
 import { resolveAll } from "../maven/resolver.js";
 import { filterVersionRange } from "../version/range.js";
-import { discoverGitHubRepo } from "../github/discover-repo.js";
-import { GitHubClient } from "../github/github-client.js";
-import type { GitHubRelease } from "../github/github-client.js";
-import { matchReleaseToVersion } from "../github/tag-matcher.js";
-import { parseChangelogSections } from "../github/changelog-parser.js";
-import { FileCache } from "../cache/file-cache.js";
-import type { GitHubRepo } from "../github/pom-scm.js";
+import { resolveChangelog } from "../changelog/resolver.js";
+import type { ChangelogProvider } from "../changelog/types.js";
+import { AndroidXChangelogProvider } from "../changelog/androidx-provider.js";
+import { GitHubChangelogProvider } from "../changelog/github-provider.js";
 
 export interface DependencyChangesInput {
   groupId: string;
@@ -34,14 +31,15 @@ export interface DependencyChangesResult {
   error?: string;
 }
 
-const TTL_24H = 24 * 60 * 60 * 1000;
-
-const cache = new FileCache();
-const githubClient = new GitHubClient(process.env.GITHUB_TOKEN);
+const defaultProviders: ChangelogProvider[] = [
+  new AndroidXChangelogProvider(),
+  new GitHubChangelogProvider(),
+];
 
 export async function getDependencyChangesHandler(
   repos: MavenRepository[],
   input: DependencyChangesInput,
+  providers: ChangelogProvider[] = defaultProviders,
 ): Promise<DependencyChangesResult> {
   const { groupId, artifactId, fromVersion, toVersion } = input;
 
@@ -71,79 +69,28 @@ export async function getDependencyChangesHandler(
     };
   }
 
-  // Step 3: Discover GitHub repo
-  const scmCacheKey = `scm/${groupId}/${artifactId}`;
-  const ghRepo = await cache.getOrFetch<GitHubRepo | null>(scmCacheKey, undefined, () =>
-    discoverGitHubRepo(repos, groupId, artifactId, toVersion, githubClient),
-  );
+  // Step 3: Resolve changelog from providers
+  const changelog = await resolveChangelog(providers, repos, groupId, artifactId, toVersion);
 
-  if (!ghRepo) {
+  if (!changelog) {
     return { ...baseResult, repositoryNotFound: true };
   }
 
-  const { owner, repo } = ghRepo;
-  const repositoryUrl = `https://github.com/${owner}/${repo}`;
-
-  // Step 4: Fetch GitHub releases (with cache)
-  const releases = await cache.getOrFetch<GitHubRelease[]>(
-    `releases/${owner}/${repo}`,
-    TTL_24H,
-    () => githubClient.fetchReleases(owner, repo),
-  );
-
-  // Step 5: Match releases to versions
-  const changes: VersionChange[] = [];
-  const unmatchedVersions: string[] = [];
-
-  for (const version of intermediateVersions) {
-    const release = matchReleaseToVersion(releases, version);
-    if (release) {
-      changes.push({
-        version,
-        releaseUrl: release.html_url,
-        body: release.body,
-      });
-    } else {
-      unmatchedVersions.push(version);
-    }
-  }
-
-  // Step 6: For unmatched versions, try CHANGELOG.md
-  let changelogUrl: string | undefined;
-  if (unmatchedVersions.length > 0) {
-    const changelogContent = await cache.getOrFetch<string | null>(
-      `changelog/${owner}/${repo}`,
-      TTL_24H,
-      () => githubClient.fetchChangelog(owner, repo),
-    );
-
-    if (changelogContent) {
-      changelogUrl = `https://github.com/${owner}/${repo}/blob/main/CHANGELOG.md`;
-      const sections = parseChangelogSections(changelogContent);
-
-      for (const version of unmatchedVersions) {
-        const body = sections.get(version);
-        if (body) {
-          changes.push({ version, body });
-        } else {
-          changes.push({ version });
-        }
-      }
-    } else {
-      for (const version of unmatchedVersions) {
-        changes.push({ version });
-      }
-    }
-  }
-
-  // Step 7: Sort changes by version order (same order as intermediateVersions)
-  const versionOrder = new Map(intermediateVersions.map((v, i) => [v, i]));
-  changes.sort((a, b) => (versionOrder.get(a.version) ?? 0) - (versionOrder.get(b.version) ?? 0));
+  // Step 4: Build changes from changelog entries
+  const changes: VersionChange[] = intermediateVersions.map((version) => {
+    const entry = changelog.entries.get(version);
+    if (!entry) return { version };
+    return {
+      version,
+      ...(entry.releaseUrl && { releaseUrl: entry.releaseUrl }),
+      ...(entry.body && { body: entry.body }),
+    };
+  });
 
   return {
     ...baseResult,
-    repositoryUrl,
+    repositoryUrl: changelog.repositoryUrl,
     changes,
-    changelogUrl,
+    changelogUrl: changelog.changelogUrl,
   };
 }


### PR DESCRIPTION
## Summary

- Add pluggable `ChangelogProvider` abstraction so `get_dependency_changes` can resolve release notes from multiple sources (not just GitHub)
- Add `AndroidXChangelogProvider` that fetches release notes from `developer.android.com/jetpack/androidx/releases/{slug}` for `androidx.*` artifacts, with 7-day cache TTL
- Wrap existing GitHub discovery/releases/changelog logic into `GitHubChangelogProvider` as universal fallback
- Refactor `get_dependency_changes` handler to use `resolveChangelog()` instead of direct GitHub calls

## Test Plan

- [x] 228 tests passing (35 new tests added across 5 new test files)
- [x] Lint passes
- [x] Build compiles cleanly
- [ ] CI checks pass
- [ ] Manual smoke test with real AndroidX artifact (e.g. `androidx.core:core` 1.15.0 → 1.16.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)