### PR TITLE
feat: add AGP changelog provider for get_dependency_changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,11 @@ src/
     changelog-parser.ts  # Parse CHANGELOG.md sections by version
     tag-matcher.ts       # Match GitHub release tags to Maven versions
     discover-repo.ts     # Orchestrator: POM → guess → validate
+  agp/
+    url.ts               # AGP version → developer.android.com URL mapping
+    release-notes-parser.ts  # Parse AGP release notes HTML (data-text headings)
+  html/
+    to-text.ts           # Shared htmlToText utility (strip tags, unescape entities)
   cache/
     file-cache.ts        # Persistent JSON file cache (~/.cache/maven-central-mcp/)
   version/

--- a/src/agp/__tests__/release-notes-parser.test.ts
+++ b/src/agp/__tests__/release-notes-parser.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { parseAgpReleaseNotes } from "../release-notes-parser.js";
+
+describe("parseAgpReleaseNotes", () => {
+  it("parses version sections from data-text attributes", () => {
+    const html = `
+      <h3 id="fixed-issues-agp-8.5.2" data-text="Android Gradle plugin 8.5.2" tabindex="-1">Android Gradle plugin 8.5.2</h3>
+      <p>Bug fixes for 8.5.2.</p>
+      <h3 id="fixed-issues-agp-8.5.1" data-text="Android Gradle plugin 8.5.1" tabindex="-1">Android Gradle plugin 8.5.1</h3>
+      <p>Bug fixes for 8.5.1.</p>
+    `;
+    const result = parseAgpReleaseNotes(html);
+    expect(result.size).toBe(2);
+    expect(result.has("8.5.2")).toBe(true);
+    expect(result.has("8.5.1")).toBe(true);
+    expect(result.get("8.5.2")).toContain("Bug fixes for 8.5.2");
+    expect(result.get("8.5.1")).toContain("Bug fixes for 8.5.1");
+  });
+
+  it("handles pre-release versions (alpha, beta, rc)", () => {
+    const html = `
+      <h3 id="fixed-issues-agp-9.1.0-rc01" data-text="Android Gradle plugin 9.1.0-rc01" tabindex="-1">Android Gradle plugin 9.1.0-rc01</h3>
+      <p>Release candidate fixes.</p>
+    `;
+    const result = parseAgpReleaseNotes(html);
+    expect(result.size).toBe(1);
+    expect(result.has("9.1.0-rc01")).toBe(true);
+  });
+
+  it("strips HTML tags from body", () => {
+    const html = `
+      <h3 id="fixed-issues-agp-8.5.0" data-text="Android Gradle plugin 8.5.0" tabindex="-1">Android Gradle plugin 8.5.0</h3>
+      <p><b>Important:</b> New <code>dslOption</code> added.</p>
+      <ul><li>Fixed build issue</li></ul>
+    `;
+    const result = parseAgpReleaseNotes(html);
+    const body = result.get("8.5.0")!;
+    expect(body).not.toContain("<p>");
+    expect(body).not.toContain("<b>");
+    expect(body).toContain("dslOption");
+    expect(body).toContain("Fixed build issue");
+  });
+
+  it("ignores h3 headings without AGP data-text", () => {
+    const html = `
+      <h3 class="devsite-footer-linkbox-heading no-link">More Android</h3>
+      <p>Footer content</p>
+      <h3 id="fixed-issues-agp-8.5.0" data-text="Android Gradle plugin 8.5.0" tabindex="-1">Android Gradle plugin 8.5.0</h3>
+      <p>Real release notes.</p>
+    `;
+    const result = parseAgpReleaseNotes(html);
+    expect(result.size).toBe(1);
+    expect(result.has("8.5.0")).toBe(true);
+  });
+
+  it("returns empty map for HTML with no AGP headings", () => {
+    const html = `<h1>Some Page</h1><p>No versions here.</p>`;
+    const result = parseAgpReleaseNotes(html);
+    expect(result.size).toBe(0);
+  });
+
+  it("returns empty map for empty string", () => {
+    expect(parseAgpReleaseNotes("").size).toBe(0);
+  });
+
+  it("stops section at next AGP heading", () => {
+    const html = `
+      <h3 id="fixed-issues-agp-8.5.2" data-text="Android Gradle plugin 8.5.2" tabindex="-1">Android Gradle plugin 8.5.2</h3>
+      <p>Notes for 8.5.2</p>
+      <h3 id="fixed-issues-agp-8.5.1" data-text="Android Gradle plugin 8.5.1" tabindex="-1">Android Gradle plugin 8.5.1</h3>
+      <p>Notes for 8.5.1</p>
+    `;
+    const result = parseAgpReleaseNotes(html);
+    expect(result.get("8.5.2")).not.toContain("Notes for 8.5.1");
+    expect(result.get("8.5.1")).not.toContain("Notes for 8.5.2");
+  });
+});

--- a/src/agp/__tests__/url.test.ts
+++ b/src/agp/__tests__/url.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { isAgpArtifact, getAgpReleasesUrl, getAgpVersionUrl } from "../url.js";
+
+describe("isAgpArtifact", () => {
+  it("returns true for com.android.tools.build", () => {
+    expect(isAgpArtifact("com.android.tools.build")).toBe(true);
+  });
+
+  it("returns false for androidx.core", () => {
+    expect(isAgpArtifact("androidx.core")).toBe(false);
+  });
+
+  it("returns false for com.android.tools", () => {
+    expect(isAgpArtifact("com.android.tools")).toBe(false);
+  });
+});
+
+describe("getAgpReleasesUrl", () => {
+  it("builds URL for version 8.5.1", () => {
+    expect(getAgpReleasesUrl("8.5.1")).toBe(
+      "https://developer.android.com/build/releases/agp-8-5-0-release-notes",
+    );
+  });
+
+  it("builds URL for version 9.1.0-alpha03", () => {
+    expect(getAgpReleasesUrl("9.1.0-alpha03")).toBe(
+      "https://developer.android.com/build/releases/agp-9-1-0-release-notes",
+    );
+  });
+
+  it("builds URL for version 8.5.0", () => {
+    expect(getAgpReleasesUrl("8.5.0")).toBe(
+      "https://developer.android.com/build/releases/agp-8-5-0-release-notes",
+    );
+  });
+});
+
+describe("getAgpVersionUrl", () => {
+  it("appends version anchor for 8.5.2", () => {
+    expect(getAgpVersionUrl("8.5.2")).toBe(
+      "https://developer.android.com/build/releases/agp-8-5-0-release-notes#fixed-issues-agp-8.5.2",
+    );
+  });
+
+  it("appends version anchor for 9.1.0-rc01", () => {
+    expect(getAgpVersionUrl("9.1.0-rc01")).toBe(
+      "https://developer.android.com/build/releases/agp-9-1-0-release-notes#fixed-issues-agp-9.1.0-rc01",
+    );
+  });
+});

--- a/src/agp/release-notes-parser.ts
+++ b/src/agp/release-notes-parser.ts
@@ -1,0 +1,35 @@
+import { htmlToText } from "../html/to-text.js";
+
+const AGP_HEADING_RE = /<h3[^>]*\s+data-text="Android Gradle plugin ([\d][^\s"]*)"[^>]*>/gi;
+
+export function parseAgpReleaseNotes(html: string): Map<string, string> {
+  const sections = new Map<string, string>();
+  const headings: { version: string; startIndex: number; endIndex: number }[] = [];
+  let match: RegExpExecArray | null;
+
+  AGP_HEADING_RE.lastIndex = 0;
+
+  while ((match = AGP_HEADING_RE.exec(html)) !== null) {
+    headings.push({
+      version: match[1],
+      startIndex: match.index,
+      endIndex: match.index + match[0].length,
+    });
+  }
+
+  for (let i = 0; i < headings.length; i++) {
+    const start = headings[i].endIndex;
+    const end = i + 1 < headings.length
+      ? headings[i + 1].startIndex
+      : html.length;
+
+    const rawContent = html.slice(start, end);
+    const body = htmlToText(rawContent);
+
+    if (body) {
+      sections.set(headings[i].version, body);
+    }
+  }
+
+  return sections;
+}

--- a/src/agp/url.ts
+++ b/src/agp/url.ts
@@ -1,0 +1,20 @@
+const AGP_GROUP_ID = "com.android.tools.build";
+const BASE_URL = "https://developer.android.com/build/releases";
+
+export function isAgpArtifact(groupId: string): boolean {
+  return groupId === AGP_GROUP_ID;
+}
+
+function extractMajorMinor(version: string): { major: string; minor: string } {
+  const parts = version.split(".");
+  return { major: parts[0], minor: parts[1] };
+}
+
+export function getAgpReleasesUrl(version: string): string {
+  const { major, minor } = extractMajorMinor(version);
+  return `${BASE_URL}/agp-${major}-${minor}-0-release-notes`;
+}
+
+export function getAgpVersionUrl(version: string): string {
+  return `${getAgpReleasesUrl(version)}#fixed-issues-agp-${version}`;
+}

--- a/src/androidx/release-notes-parser.ts
+++ b/src/androidx/release-notes-parser.ts
@@ -1,34 +1,6 @@
+import { htmlToText } from "../html/to-text.js";
+
 const VERSION_HEADING_RE = /<h[23][^>]*>\s*Version\s+([\d][^\s<]*)\s*<\/h[23]>/gi;
-
-function unescapeEntities(text: string): string {
-  return text
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&amp;/g, "&");
-}
-
-function stripTags(text: string): string {
-  let result = text;
-  let prev: string;
-  do {
-    prev = result;
-    result = result.replace(/<[^>]*>/g, "");
-  } while (result !== prev);
-  return result;
-}
-
-function htmlToText(html: string): string {
-  const formatted = html
-    .replace(/<li[^>]*>/gi, "- ")
-    .replace(/<\/li>/gi, "\n")
-    .replace(/<br\s*\/?>/gi, "\n")
-    .replace(/<\/p>/gi, "\n\n");
-  return unescapeEntities(stripTags(formatted))
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-}
 
 export function parseAndroidXReleaseNotes(html: string): Map<string, string> {
   const sections = new Map<string, string>();

--- a/src/changelog/__tests__/agp-provider.test.ts
+++ b/src/changelog/__tests__/agp-provider.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { AgpChangelogProvider } from "../agp-provider.js";
+
+vi.mock("node:fs/promises");
+
+const AGP_HTML = `
+  <h3 id="fixed-issues-agp-8.5.2" data-text="Android Gradle plugin 8.5.2" tabindex="-1">Android Gradle plugin 8.5.2</h3>
+  <p>Fixed critical build issue.</p>
+  <h3 id="fixed-issues-agp-8.5.1" data-text="Android Gradle plugin 8.5.1" tabindex="-1">Android Gradle plugin 8.5.1</h3>
+  <p>Minor improvements.</p>
+  <h3 id="fixed-issues-agp-8.5.0" data-text="Android Gradle plugin 8.5.0" tabindex="-1">Android Gradle plugin 8.5.0</h3>
+  <p>Initial release.</p>
+`;
+
+describe("AgpChangelogProvider", () => {
+  let provider: AgpChangelogProvider;
+
+  beforeEach(() => {
+    provider = new AgpChangelogProvider();
+    vi.restoreAllMocks();
+  });
+
+  it("canHandle returns true for com.android.tools.build", () => {
+    expect(provider.canHandle("com.android.tools.build")).toBe(true);
+  });
+
+  it("canHandle returns false for other groupIds", () => {
+    expect(provider.canHandle("androidx.core")).toBe(false);
+    expect(provider.canHandle("com.android.tools")).toBe(false);
+  });
+
+  it("fetches and parses AGP release notes", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(AGP_HTML, { status: 200 }),
+    );
+
+    const result = await provider.fetchChangelog(
+      "com.android.tools.build", "gradle", "8.5.1", [],
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.entries.size).toBe(3);
+    expect(result!.entries.has("8.5.2")).toBe(true);
+    expect(result!.entries.has("8.5.1")).toBe(true);
+    expect(result!.entries.has("8.5.0")).toBe(true);
+    expect(result!.entries.get("8.5.2")!.body).toContain("Fixed critical build issue");
+    expect(result!.entries.get("8.5.2")!.releaseUrl).toContain("#fixed-issues-agp-8.5.2");
+    expect(result!.repositoryUrl).toContain("agp-8-5-0-release-notes");
+  });
+
+  it("returns null on fetch failure", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("", { status: 500 }),
+    );
+    const result = await provider.fetchChangelog(
+      "com.android.tools.build", "gradle", "8.5.0", [],
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null on 404 (cached as empty)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("Not found", { status: 404 }),
+    );
+    const result = await provider.fetchChangelog(
+      "com.android.tools.build", "gradle", "99.0.0", [],
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null on network error", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("Network error"));
+    const result = await provider.fetchChangelog(
+      "com.android.tools.build", "gradle", "8.5.0", [],
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/src/changelog/agp-provider.ts
+++ b/src/changelog/agp-provider.ts
@@ -1,0 +1,69 @@
+import type { ChangelogProvider, ChangelogResult, ChangelogEntry } from "./types.js";
+import { isAgpArtifact, getAgpReleasesUrl, getAgpVersionUrl } from "../agp/url.js";
+import { parseAgpReleaseNotes } from "../agp/release-notes-parser.js";
+import { FileCache } from "../cache/file-cache.js";
+
+const TTL_7_DAYS = 7 * 24 * 60 * 60 * 1000;
+
+export class AgpChangelogProvider implements ChangelogProvider {
+  private readonly cache = new FileCache();
+
+  canHandle(groupId: string): boolean {
+    return isAgpArtifact(groupId);
+  }
+
+  async fetchChangelog(
+    groupId: string,
+    artifactId: string,
+    version: string,
+  ): Promise<ChangelogResult | null> {
+    const { major, minor } = extractMajorMinor(version);
+    const cacheKey = `agp/${major}.${minor}`;
+
+    const rawEntries = await this.cache.getOrFetch<[string, string][] | null>(
+      cacheKey,
+      TTL_7_DAYS,
+      () => this.fetchAndParse(version),
+    );
+
+    if (!rawEntries || rawEntries.length === 0) return null;
+
+    const entries = new Map<string, ChangelogEntry>();
+    for (const [ver, body] of rawEntries) {
+      entries.set(ver, {
+        body,
+        releaseUrl: getAgpVersionUrl(ver),
+      });
+    }
+
+    return {
+      repositoryUrl: getAgpReleasesUrl(version),
+      entries,
+    };
+  }
+
+  private async fetchAndParse(version: string): Promise<[string, string][] | null> {
+    try {
+      const url = getAgpReleasesUrl(version);
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!response.ok) {
+        return response.status === 404 ? [] : null;
+      }
+
+      const html = await response.text();
+      const entries = parseAgpReleaseNotes(html);
+      if (entries.size === 0) return [];
+
+      return [...entries.entries()];
+    } catch {
+      return null;
+    }
+  }
+}
+
+function extractMajorMinor(version: string): { major: string; minor: string } {
+  const parts = version.split(".");
+  return { major: parts[0], minor: parts[1] };
+}

--- a/src/html/__tests__/to-text.test.ts
+++ b/src/html/__tests__/to-text.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { htmlToText } from "../to-text.js";
+
+describe("htmlToText", () => {
+  it("strips HTML tags", () => {
+    expect(htmlToText("<p>Hello <b>world</b></p>")).toBe("Hello world");
+  });
+
+  it("converts <li> to bullet points", () => {
+    expect(htmlToText("<ul><li>First</li><li>Second</li></ul>")).toBe("- First\n- Second");
+  });
+
+  it("converts <br> to newline", () => {
+    expect(htmlToText("Line 1<br/>Line 2")).toBe("Line 1\nLine 2");
+  });
+
+  it("unescapes HTML entities", () => {
+    expect(htmlToText("&lt;T&gt; &amp; &quot;foo&quot;")).toBe('<T> & "foo"');
+  });
+
+  it("collapses multiple newlines", () => {
+    expect(htmlToText("<p>A</p><p>B</p><p>C</p>")).toBe("A\n\nB\n\nC");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(htmlToText("")).toBe("");
+  });
+
+  it("preserves escaped angle brackets (does not strip them as tags)", () => {
+    expect(htmlToText("Use &lt;Fragment&gt; here")).toContain("<Fragment>");
+  });
+});

--- a/src/html/to-text.ts
+++ b/src/html/to-text.ts
@@ -1,0 +1,29 @@
+function unescapeEntities(text: string): string {
+  return text
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+function stripTags(text: string): string {
+  let result = text;
+  let prev: string;
+  do {
+    prev = result;
+    result = result.replace(/<[^>]*>/g, "");
+  } while (result !== prev);
+  return result;
+}
+
+export function htmlToText(html: string): string {
+  const formatted = html
+    .replace(/<li[^>]*>/gi, "- ")
+    .replace(/<\/li>/gi, "\n")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/p>/gi, "\n\n");
+  return unescapeEntities(stripTags(formatted))
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}

--- a/src/tools/__tests__/get-dependency-changes.test.ts
+++ b/src/tools/__tests__/get-dependency-changes.test.ts
@@ -162,6 +162,38 @@ describe("getDependencyChangesHandler", () => {
     expect(result.changes).toEqual([]);
   });
 
+  it("returns changes from AGP release notes", async () => {
+    const repo = mockRepo(["8.5.0", "8.5.1", "8.5.2"]);
+
+    const html = `
+      <h3 id="fixed-issues-agp-8.5.2" data-text="Android Gradle plugin 8.5.2" tabindex="-1">Android Gradle plugin 8.5.2</h3>
+      <p>Fixed critical build issue.</p>
+      <h3 id="fixed-issues-agp-8.5.1" data-text="Android Gradle plugin 8.5.1" tabindex="-1">Android Gradle plugin 8.5.1</h3>
+      <p>Minor improvements.</p>
+      <h3 id="fixed-issues-agp-8.5.0" data-text="Android Gradle plugin 8.5.0" tabindex="-1">Android Gradle plugin 8.5.0</h3>
+      <p>Initial release.</p>
+    `;
+    globalThis.fetch = vi.fn().mockResolvedValueOnce(
+      new Response(html, { status: 200 }),
+    ) as typeof fetch;
+
+    const result = await getDependencyChangesHandler([repo], {
+      groupId: "com.android.tools.build",
+      artifactId: "gradle",
+      fromVersion: "8.5.0",
+      toVersion: "8.5.2",
+    });
+
+    expect(result.repositoryNotFound).toBeUndefined();
+    expect(result.repositoryUrl).toContain("agp-8-5-0-release-notes");
+    expect(result.changes).toHaveLength(2);
+    expect(result.changes[0].version).toBe("8.5.1");
+    expect(result.changes[0].body).toContain("Minor improvements");
+    expect(result.changes[0].releaseUrl).toContain("#fixed-issues-agp-8.5.1");
+    expect(result.changes[1].version).toBe("8.5.2");
+    expect(result.changes[1].body).toContain("Fixed critical build issue");
+  });
+
   it("returns changes from AndroidX release notes", async () => {
     const repo = mockRepo(["1.15.0", "1.16.0", "1.17.0"]);
 

--- a/src/tools/get-dependency-changes.ts
+++ b/src/tools/get-dependency-changes.ts
@@ -4,6 +4,7 @@ import { filterVersionRange } from "../version/range.js";
 import { resolveChangelog } from "../changelog/resolver.js";
 import type { ChangelogProvider } from "../changelog/types.js";
 import { AndroidXChangelogProvider } from "../changelog/androidx-provider.js";
+import { AgpChangelogProvider } from "../changelog/agp-provider.js";
 import { GitHubChangelogProvider } from "../changelog/github-provider.js";
 
 export interface DependencyChangesInput {
@@ -33,6 +34,7 @@ export interface DependencyChangesResult {
 
 const defaultProviders: ChangelogProvider[] = [
   new AndroidXChangelogProvider(),
+  new AgpChangelogProvider(),
   new GitHubChangelogProvider(),
 ];
 


### PR DESCRIPTION
## Summary
- Extract shared `htmlToText()` utility from AndroidX parser to `src/html/to-text.ts`
- Add `AgpChangelogProvider` that fetches release notes from `developer.android.com/build/releases/agp-*`
- Register AGP provider in `get_dependency_changes` tool between AndroidX and GitHub providers

## Details
- Detection: `groupId === "com.android.tools.build"`
- URL pattern: `agp-{major}-{minor}-0-release-notes` derived from requested version
- HTML parsing: `<h3 data-text="Android Gradle plugin X.Y.Z">` headings
- Cache: 7-day TTL per major.minor series
- 29 new tests (257 total)

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes  
- [x] `npm run test` — 257 tests passing
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)