### PR TITLE
feat: add Firebase changelog provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,9 @@ src/
   agp/
     url.ts               # AGP version → developer.android.com URL mapping
     release-notes-parser.ts  # Parse AGP release notes HTML (data-text headings)
+  firebase/
+    url.ts               # Firebase artifactId → slug mapping, release notes URL
+    release-notes-parser.ts  # Parse Firebase release notes HTML (slug-filtered headings)
   html/
     to-text.ts           # Shared htmlToText utility (strip tags, unescape entities)
   cache/

--- a/src/changelog/__tests__/firebase-provider.test.ts
+++ b/src/changelog/__tests__/firebase-provider.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { FirebaseChangelogProvider } from "../firebase-provider.js";
+
+vi.mock("node:fs/promises");
+
+const FIREBASE_HTML = `
+  <h2 id="2026-02-26">Update - February 26, 2026</h2>
+  <h3 id="firestore_v26-1-1" data-text="Cloud Firestore version 26.1.1">Cloud Firestore version 26.1.1</h3>
+  <p>Bug fixes for Firestore.</p>
+  <h3 id="auth_v23-1-0" data-text="Auth version 23.1.0">Auth version 23.1.0</h3>
+  <p>Auth improvements.</p>
+  <h2 id="2026-01-15">Update - January 15, 2026</h2>
+  <h3 id="firestore_v26-1-0" data-text="Cloud Firestore version 26.1.0">Cloud Firestore version 26.1.0</h3>
+  <p>New Firestore features.</p>
+`;
+
+describe("FirebaseChangelogProvider", () => {
+  let provider: FirebaseChangelogProvider;
+
+  beforeEach(() => {
+    provider = new FirebaseChangelogProvider();
+    vi.restoreAllMocks();
+  });
+
+  it("canHandle returns true for com.google.firebase", () => {
+    expect(provider.canHandle("com.google.firebase")).toBe(true);
+  });
+
+  it("canHandle returns false for other groupIds", () => {
+    expect(provider.canHandle("androidx.core")).toBe(false);
+    expect(provider.canHandle("com.google.android.gms")).toBe(false);
+  });
+
+  it("fetches and parses Firebase release notes for firestore", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(FIREBASE_HTML, { status: 200 }),
+    );
+
+    const result = await provider.fetchChangelog(
+      "com.google.firebase", "firebase-firestore", "26.1.1", [],
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.entries.size).toBe(2);
+    expect(result!.entries.has("26.1.1")).toBe(true);
+    expect(result!.entries.has("26.1.0")).toBe(true);
+    expect(result!.entries.get("26.1.1")!.body).toContain("Bug fixes for Firestore");
+    expect(result!.entries.get("26.1.1")!.releaseUrl).toContain("#firestore_v26-1-1");
+    expect(result!.repositoryUrl).toContain("release-notes/android");
+  });
+
+  it("returns null when slug has no matches", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(FIREBASE_HTML, { status: 200 }),
+    );
+
+    const result = await provider.fetchChangelog(
+      "com.google.firebase", "firebase-nonexistent", "1.0.0", [],
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null on fetch failure", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("", { status: 500 }),
+    );
+    const result = await provider.fetchChangelog(
+      "com.google.firebase", "firebase-firestore", "26.1.1", [],
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns null on network error", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("Network error"));
+    const result = await provider.fetchChangelog(
+      "com.google.firebase", "firebase-firestore", "26.1.1", [],
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/src/changelog/firebase-provider.ts
+++ b/src/changelog/firebase-provider.ts
@@ -1,0 +1,63 @@
+import type { ChangelogProvider, ChangelogResult, ChangelogEntry } from "./types.js";
+import { isFirebaseArtifact, getFirebaseSlug, getFirebaseReleasesUrl, getFirebaseVersionUrl } from "../firebase/url.js";
+import { parseFirebaseReleaseNotes } from "../firebase/release-notes-parser.js";
+import { FileCache } from "../cache/file-cache.js";
+
+const TTL_7_DAYS = 7 * 24 * 60 * 60 * 1000;
+
+export class FirebaseChangelogProvider implements ChangelogProvider {
+  private readonly cache = new FileCache();
+
+  canHandle(groupId: string): boolean {
+    return isFirebaseArtifact(groupId);
+  }
+
+  async fetchChangelog(
+    groupId: string,
+    artifactId: string,
+  ): Promise<ChangelogResult | null> {
+    const slug = getFirebaseSlug(artifactId);
+    const cacheKey = `firebase/${slug}`;
+
+    const rawEntries = await this.cache.getOrFetch<[string, string][] | null>(
+      cacheKey,
+      TTL_7_DAYS,
+      () => this.fetchAndParse(slug),
+    );
+
+    if (!rawEntries || rawEntries.length === 0) return null;
+
+    const entries = new Map<string, ChangelogEntry>();
+    for (const [version, body] of rawEntries) {
+      entries.set(version, {
+        body,
+        releaseUrl: getFirebaseVersionUrl(artifactId, version),
+      });
+    }
+
+    return {
+      repositoryUrl: getFirebaseReleasesUrl(),
+      entries,
+    };
+  }
+
+  private async fetchAndParse(slug: string): Promise<[string, string][] | null> {
+    try {
+      const url = getFirebaseReleasesUrl();
+      const response = await fetch(url, {
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!response.ok) {
+        return response.status === 404 ? [] : null;
+      }
+
+      const html = await response.text();
+      const entries = parseFirebaseReleaseNotes(html, slug);
+      if (entries.size === 0) return [];
+
+      return [...entries.entries()];
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/firebase/__tests__/release-notes-parser.test.ts
+++ b/src/firebase/__tests__/release-notes-parser.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { parseFirebaseReleaseNotes } from "../release-notes-parser.js";
+
+describe("parseFirebaseReleaseNotes", () => {
+  it("parses version sections matching the given slug", () => {
+    const html = `
+      <h3 id="firestore_v26-1-1" data-text="Cloud Firestore version 26.1.1">
+        <span class="notranslate">Cloud Firestore</span> version 26.1.1</h3>
+      <p>Bug fixes for Firestore.</p>
+      <h3 id="firestore_v26-1-0" data-text="Cloud Firestore version 26.1.0">
+        <span class="notranslate">Cloud Firestore</span> version 26.1.0</h3>
+      <p>New features for Firestore.</p>
+    `;
+    const result = parseFirebaseReleaseNotes(html, "firestore");
+    expect(result.size).toBe(2);
+    expect(result.has("26.1.1")).toBe(true);
+    expect(result.has("26.1.0")).toBe(true);
+    expect(result.get("26.1.1")).toContain("Bug fixes for Firestore");
+    expect(result.get("26.1.0")).toContain("New features for Firestore");
+  });
+
+  it("filters out headings for other slugs", () => {
+    const html = `
+      <h3 id="firestore_v26-1-1" data-text="Cloud Firestore version 26.1.1">Cloud Firestore version 26.1.1</h3>
+      <p>Firestore notes.</p>
+      <h3 id="analytics_v22-1-0" data-text="Analytics version 22.1.0">Analytics version 22.1.0</h3>
+      <p>Analytics notes.</p>
+    `;
+    const result = parseFirebaseReleaseNotes(html, "firestore");
+    expect(result.size).toBe(1);
+    expect(result.has("26.1.1")).toBe(true);
+  });
+
+  it("handles pre-release versions (beta, rc)", () => {
+    const html = `
+      <h4 id="ai-ondevice_v16-0-0-beta01" data-text="Firebase AI Logic On-Device version 16.0.0-beta01">
+        Firebase AI Logic On-Device version 16.0.0-beta01</h4>
+      <p>First beta release.</p>
+    `;
+    const result = parseFirebaseReleaseNotes(html, "ai-ondevice");
+    expect(result.size).toBe(1);
+    expect(result.has("16.0.0-beta01")).toBe(true);
+  });
+
+  it("handles h4 headings", () => {
+    const html = `
+      <h4 id="appcheck-debug_v19-0-2" data-text="App Check Debug version 19.0.2">
+        App Check Debug version 19.0.2</h4>
+      <p>Debug provider update.</p>
+    `;
+    const result = parseFirebaseReleaseNotes(html, "appcheck-debug");
+    expect(result.size).toBe(1);
+    expect(result.has("19.0.2")).toBe(true);
+  });
+
+  it("strips HTML tags from body", () => {
+    const html = `
+      <h3 id="auth_v23-1-0" data-text="Auth version 23.1.0">Auth version 23.1.0</h3>
+      <p><b>New:</b> Added <code>signInAnonymously()</code> support.</p>
+      <ul><li>Bug fix for token refresh</li></ul>
+    `;
+    const result = parseFirebaseReleaseNotes(html, "auth");
+    const body = result.get("23.1.0")!;
+    expect(body).not.toContain("<p>");
+    expect(body).not.toContain("<b>");
+    expect(body).toContain("signInAnonymously()");
+    expect(body).toContain("Bug fix for token refresh");
+  });
+
+  it("returns empty map when slug has no matches", () => {
+    const html = `
+      <h3 id="firestore_v26-1-1" data-text="Cloud Firestore version 26.1.1">Cloud Firestore version 26.1.1</h3>
+      <p>Notes.</p>
+    `;
+    const result = parseFirebaseReleaseNotes(html, "nonexistent");
+    expect(result.size).toBe(0);
+  });
+
+  it("returns empty map for empty HTML", () => {
+    expect(parseFirebaseReleaseNotes("", "firestore").size).toBe(0);
+  });
+
+  it("handles content between matching and non-matching headings", () => {
+    const html = `
+      <h3 id="crashlytics_v20-0-4" data-text="Crashlytics version 20.0.4">Crashlytics version 20.0.4</h3>
+      <p>Crashlytics notes.</p>
+      <h3 id="crashlytics-ndk_v20-0-4" data-text="Crashlytics NDK version 20.0.4">Crashlytics NDK version 20.0.4</h3>
+      <p>NDK notes.</p>
+      <h3 id="data-connect_v17-1-3" data-text="Data Connect version 17.1.3">Data Connect version 17.1.3</h3>
+      <p>Data Connect notes.</p>
+    `;
+    const crashlytics = parseFirebaseReleaseNotes(html, "crashlytics");
+    expect(crashlytics.size).toBe(1);
+    expect(crashlytics.get("20.0.4")).toContain("Crashlytics notes");
+    expect(crashlytics.get("20.0.4")).not.toContain("NDK notes");
+
+    const ndk = parseFirebaseReleaseNotes(html, "crashlytics-ndk");
+    expect(ndk.size).toBe(1);
+    expect(ndk.get("20.0.4")).toContain("NDK notes");
+    expect(ndk.get("20.0.4")).not.toContain("Data Connect notes");
+  });
+});

--- a/src/firebase/__tests__/url.test.ts
+++ b/src/firebase/__tests__/url.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { isFirebaseArtifact, getFirebaseSlug, getFirebaseReleasesUrl, getFirebaseVersionUrl } from "../url.js";
+
+describe("isFirebaseArtifact", () => {
+  it("returns true for com.google.firebase", () => {
+    expect(isFirebaseArtifact("com.google.firebase")).toBe(true);
+  });
+
+  it("returns false for com.google.android.gms", () => {
+    expect(isFirebaseArtifact("com.google.android.gms")).toBe(false);
+  });
+
+  it("returns false for androidx.core", () => {
+    expect(isFirebaseArtifact("androidx.core")).toBe(false);
+  });
+});
+
+describe("getFirebaseSlug", () => {
+  it("strips firebase- prefix from firebase-firestore", () => {
+    expect(getFirebaseSlug("firebase-firestore")).toBe("firestore");
+  });
+
+  it("strips firebase- prefix from firebase-analytics", () => {
+    expect(getFirebaseSlug("firebase-analytics")).toBe("analytics");
+  });
+
+  it("strips firebase- prefix from firebase-crashlytics-ndk", () => {
+    expect(getFirebaseSlug("firebase-crashlytics-ndk")).toBe("crashlytics-ndk");
+  });
+
+  it("returns artifactId as-is when no firebase- prefix", () => {
+    expect(getFirebaseSlug("firebase-bom")).toBe("bom");
+  });
+});
+
+describe("getFirebaseReleasesUrl", () => {
+  it("returns the Firebase Android release notes URL", () => {
+    expect(getFirebaseReleasesUrl()).toBe(
+      "https://firebase.google.com/support/release-notes/android",
+    );
+  });
+});
+
+describe("getFirebaseVersionUrl", () => {
+  it("builds anchor URL for firestore 26.1.1", () => {
+    expect(getFirebaseVersionUrl("firebase-firestore", "26.1.1")).toBe(
+      "https://firebase.google.com/support/release-notes/android#firestore_v26-1-1",
+    );
+  });
+
+  it("builds anchor URL for crashlytics-ndk 20.0.4", () => {
+    expect(getFirebaseVersionUrl("firebase-crashlytics-ndk", "20.0.4")).toBe(
+      "https://firebase.google.com/support/release-notes/android#crashlytics-ndk_v20-0-4",
+    );
+  });
+
+  it("builds anchor URL for pre-release version", () => {
+    expect(getFirebaseVersionUrl("firebase-ai", "16.0.0-beta01")).toBe(
+      "https://firebase.google.com/support/release-notes/android#ai_v16-0-0-beta01",
+    );
+  });
+});

--- a/src/firebase/release-notes-parser.ts
+++ b/src/firebase/release-notes-parser.ts
@@ -1,0 +1,60 @@
+import { htmlToText } from "../html/to-text.js";
+
+/**
+ * Match h3/h4 headings with id="{slug}_v{version-dashed}".
+ * Captures: [1] = slug, [2] = dashed version.
+ */
+const HEADING_RE = /<h[34][^>]*\s+id="([a-z][a-z0-9_-]*)_v([\da-z][\da-z.-]*)"[^>]*>/gi;
+
+/**
+ * Convert dashed version back to dotted.
+ * Only replace `-` between consecutive digit groups:
+ * "26-1-1" → "26.1.1", "16-0-0-beta01" → "16.0.0-beta01"
+ */
+function dashedToVersion(dashed: string): string {
+  return dashed.replace(/(\d)-(?=\d)/g, "$1.");
+}
+
+export function parseFirebaseReleaseNotes(
+  html: string,
+  slug: string,
+): Map<string, string> {
+  const sections = new Map<string, string>();
+
+  // Collect ALL headings (for boundary detection) and mark which ones match our slug
+  const allHeadings: { startIndex: number; endIndex: number; version?: string }[] = [];
+  let match: RegExpExecArray | null;
+
+  HEADING_RE.lastIndex = 0;
+
+  while ((match = HEADING_RE.exec(html)) !== null) {
+    const headingSlug = match[1];
+    const entry: { startIndex: number; endIndex: number; version?: string } = {
+      startIndex: match.index,
+      endIndex: match.index + match[0].length,
+    };
+    if (headingSlug === slug) {
+      entry.version = dashedToVersion(match[2]);
+    }
+    allHeadings.push(entry);
+  }
+
+  for (let i = 0; i < allHeadings.length; i++) {
+    const heading = allHeadings[i];
+    if (!heading.version) continue;
+
+    const start = heading.endIndex;
+    const end = i + 1 < allHeadings.length
+      ? allHeadings[i + 1].startIndex
+      : html.length;
+
+    const rawContent = html.slice(start, end);
+    const body = htmlToText(rawContent);
+
+    if (body) {
+      sections.set(heading.version, body);
+    }
+  }
+
+  return sections;
+}

--- a/src/firebase/url.ts
+++ b/src/firebase/url.ts
@@ -1,0 +1,26 @@
+const FIREBASE_GROUP_ID = "com.google.firebase";
+const RELEASES_URL = "https://firebase.google.com/support/release-notes/android";
+const FIREBASE_PREFIX = "firebase-";
+
+export function isFirebaseArtifact(groupId: string): boolean {
+  return groupId === FIREBASE_GROUP_ID;
+}
+
+export function getFirebaseSlug(artifactId: string): string {
+  return artifactId.startsWith(FIREBASE_PREFIX)
+    ? artifactId.slice(FIREBASE_PREFIX.length)
+    : artifactId;
+}
+
+export function getFirebaseReleasesUrl(): string {
+  return RELEASES_URL;
+}
+
+function versionToDashed(version: string): string {
+  return version.replaceAll(".", "-");
+}
+
+export function getFirebaseVersionUrl(artifactId: string, version: string): string {
+  const slug = getFirebaseSlug(artifactId);
+  return `${RELEASES_URL}#${slug}_v${versionToDashed(version)}`;
+}

--- a/src/tools/get-dependency-changes.ts
+++ b/src/tools/get-dependency-changes.ts
@@ -5,6 +5,7 @@ import { resolveChangelog } from "../changelog/resolver.js";
 import type { ChangelogProvider } from "../changelog/types.js";
 import { AndroidXChangelogProvider } from "../changelog/androidx-provider.js";
 import { AgpChangelogProvider } from "../changelog/agp-provider.js";
+import { FirebaseChangelogProvider } from "../changelog/firebase-provider.js";
 import { GitHubChangelogProvider } from "../changelog/github-provider.js";
 
 export interface DependencyChangesInput {
@@ -35,6 +36,7 @@ export interface DependencyChangesResult {
 const defaultProviders: ChangelogProvider[] = [
   new AndroidXChangelogProvider(),
   new AgpChangelogProvider(),
+  new FirebaseChangelogProvider(),
   new GitHubChangelogProvider(),
 ];
 


### PR DESCRIPTION
## Summary
- Add `FirebaseChangelogProvider` for `com.google.firebase` artifacts
- Parse release notes from https://firebase.google.com/support/release-notes/android
- Extract per-library changelog entries by slug (artifactId minus `firebase-` prefix)
- Cache per-slug with 7-day TTL
- Register provider in `get_dependency_changes` (after AGP, before GitHub fallback)

## New files
- `src/firebase/url.ts` — artifact detection, slug mapping, URL helpers
- `src/firebase/release-notes-parser.ts` — regex HTML parser with slug filtering
- `src/changelog/firebase-provider.ts` — `ChangelogProvider` implementation

## Test plan
- [x] 11 URL helper tests (detection, slug extraction, URL building)
- [x] 8 parser tests (slug filtering, pre-release versions, h3/h4 headings, cross-slug boundaries)
- [x] 6 provider tests (fetch, cache, error handling)
- [x] Build passes, lint clean, all 282 tests pass

> **Note:** Based on `feature/agp-changelog-provider` (#14). Retarget to `main` after #14 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)