### PR TITLE
chore: bump maven-mcp to v0.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.2.0",
+      "version": "0.3.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/maven-mcp/plugin"

--- a/plugins/maven-mcp/package-lock.json
+++ b/plugins/maven-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@krozov/maven-central-mcp",
-      "version": "0.2.6",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/plugins/maven-mcp/package.json
+++ b/plugins/maven-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "description": "MCP server for Maven Central dependency intelligence",
   "main": "./dist/index.js",
   "type": "module",

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maven-mcp",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps and /latest-version skills",
   "mcpServers": {
     "maven-mcp": {


### PR DESCRIPTION
## Summary
- Bump `@krozov/maven-central-mcp` package version to `0.3.0`
- Update plugin manifest version to `0.3.0`
- Update marketplace.json maven-mcp version to `0.3.0`

First release under `@krozov` scope and monorepo layout.

## After merge
Create tag `v0.3.0` to trigger npm publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)