### PR TITLE
feat: add developer-workflow plugin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,19 +4,21 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-Monorepo for Claude Code plugins by krozov. Contains two plugins:
+Monorepo for Claude Code plugins by krozov. Contains three plugins:
 
 | Plugin | Directory | Description |
 |--------|-----------|-------------|
 | maven-mcp | `plugins/maven-mcp/` | MCP server for Maven dependency intelligence |
 | sensitive-guard | `plugins/sensitive-guard/` | Scans files for secrets and PII before they reach AI servers |
+| developer-workflow | `plugins/developer-workflow/` | Skills for developer workflow — PR preparation and lifecycle |
 
 ## Structure
 
 ```
 plugins/
-  maven-mcp/        # TypeScript, npm package @krozov/maven-central-mcp
-  sensitive-guard/   # Shell-based Claude Code plugin
+  maven-mcp/           # TypeScript, npm package @krozov/maven-central-mcp
+  sensitive-guard/      # Shell-based Claude Code plugin
+  developer-workflow/   # Skills-only plugin for developer workflow habits
 ```
 
 See each plugin's own `CLAUDE.md` for plugin-specific instructions.

--- a/plugins/developer-workflow/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "developer-workflow",
+  "version": "0.1.0",
+  "description": "Developer workflow skills — prepare branches for PR and manage the full PR lifecycle through CI/CD and code review",
+  "skills": "./skills"
+}

--- a/plugins/developer-workflow/README.md
+++ b/plugins/developer-workflow/README.md
@@ -1,0 +1,32 @@
+# developer-workflow
+
+Claude Code plugin with skills for developer workflow habits — preparing branches for code review and managing the full PR lifecycle.
+
+## Skills
+
+### `prepare-for-pr`
+
+Runs a quality loop over branch changes before creating a PR:
+- Build → Simplify → Self-review → Lint/Tests
+- Loops until only minor issues remain
+- Fixes only what belongs to the current changes
+- Asks the user when a problem is caused by something outside the current scope
+
+Use after implementation is complete, before creating the PR.
+
+### `pr-lifecycle`
+
+Drives an existing PR/MR to merge:
+- Monitors CI/CD checks; fixes failures caused by current changes
+- Triages reviewer comments autonomously (major → fix, minor → respond only)
+- Responds to and resolves every comment thread
+- Requests re-review after fixes, loops until merge requirements are met
+- Asks the user only when a problem is outside the current PR scope
+
+Use after the PR is created.
+
+## Installation
+
+```bash
+claude plugin install plugins/developer-workflow
+```

--- a/plugins/developer-workflow/README.md
+++ b/plugins/developer-workflow/README.md
@@ -14,7 +14,7 @@ Runs a quality loop over branch changes before creating a PR:
 
 Use after implementation is complete, before creating the PR.
 
-### `pr-lifecycle`
+### `pr-drive-to-merge`
 
 Drives an existing PR/MR to merge:
 - Monitors CI/CD checks; fixes failures caused by current changes

--- a/plugins/developer-workflow/README.md
+++ b/plugins/developer-workflow/README.md
@@ -18,7 +18,7 @@ Use after implementation is complete, before creating the PR.
 
 Drives an existing PR/MR to merge:
 - Monitors CI/CD checks; fixes failures caused by current changes
-- Triages reviewer comments autonomously (major → fix, minor → respond only)
+- Triages reviewer comments autonomously (BLOCKING/IMPORTANT → fix, OPTIONAL → acknowledge, OUT OF SCOPE → ask user)
 - Responds to and resolves every comment thread
 - Requests re-review after fixes, loops until merge requirements are met
 - Asks the user only when a problem is outside the current PR scope

--- a/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
+++ b/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
@@ -3,7 +3,7 @@ name: pr-drive-to-merge
 description: Use when a PR/MR already exists and needs to be driven to merge — monitors CI/CD, handles multi-round code review, responds to and resolves reviewer comments, and loops until all merge requirements are met.
 ---
 
-# PR Lifecycle
+# PR Drive to Merge
 
 ## Overview
 
@@ -16,20 +16,20 @@ Takes an existing PR/MR and drives it to merge autonomously. Loops through CI/CD
 Before starting, detect the PR and platform:
 
 ```bash
-# GitHub — detect PR number from current branch
+# GitHub — detect PR number and base branch
 PR_NUMBER=$(gh pr view --json number -q .number)
 BASE=$(gh pr view --json baseRefName -q .baseRefName)
+IS_DRAFT=$(gh pr view --json isDraft -q .isDraft)
 
-# GitLab — detect MR number from current branch
+# GitLab — detect MR number and base branch
 MR_NUMBER=$(glab mr view --output json | jq .iid)
 BASE=$(glab mr view --output json | jq -r .target_branch)
-
-# Check if PR is still in draft — undraft before proceeding if CI/CD passed
-# GitHub: gh pr ready <PR_NUMBER>
-# GitLab: glab mr update <MR_NUMBER> --draft=false
+IS_DRAFT=$(glab mr view --output json | jq .draft)
 ```
 
-Detect platform from remote URL (`github.com` → `gh`, `gitlab` → `glab`).
+**Platform detection:** check `git remote get-url origin`.
+- Contains `github.com` (HTTPS: `https://github.com/...` or SSH: `git@github.com:...`) → use `gh`
+- Contains `gitlab` → use `glab`
 
 ## Phase 1: CI/CD Monitoring
 
@@ -38,35 +38,36 @@ digraph cicd {
     rankdir=TB;
 
     start [label="PR/MR exists", shape=doublecircle];
+    fetch_status [label="Fetch current CI/CD status\n+ check if draft", shape=box];
     has_ci [label="CI/CD configured?", shape=diamond];
-    draft [label="PR in draft?", shape=diamond];
-    undraft [label="Undraft PR", shape=box];
+    ci_state [label="Current state?", shape=diamond];
     wait [label="Poll checks every ~2 min\nuntil complete", shape=box];
     passing [label="All required checks passing?", shape=diamond];
     investigate [label="Investigate failure logs", shape=box];
     our_fault [label="Caused by current changes?", shape=diamond];
-    fix [label="Fix → invoke prepare-for-pr\n→ commit → push", shape=box];
+    fix [label="Fix → invoke prepare-for-pr\n→ push", shape=box];
     ask [label="Ask user", shape=box];
+    undraft [label="Undraft PR/MR\nif still draft", shape=box];
     review [label="Proceed to Code Review", shape=box];
 
-    start -> has_ci;
-    has_ci -> draft [label="yes, all passing"];
-    has_ci -> wait [label="yes, pending"];
-    has_ci -> review [label="no CI"];
-    draft -> undraft [label="yes"];
-    draft -> review [label="no"];
-    undraft -> review;
+    start -> fetch_status;
+    fetch_status -> has_ci;
+    has_ci -> ci_state [label="yes"];
+    has_ci -> undraft [label="no CI"];
+    ci_state -> wait [label="pending/running"];
+    ci_state -> passing [label="complete"];
     wait -> passing;
-    passing -> draft [label="yes"];
+    passing -> undraft [label="yes"];
     passing -> investigate [label="no"];
     investigate -> our_fault;
     our_fault -> fix [label="yes"];
     our_fault -> ask [label="no — stop"];
     fix -> wait;
+    undraft -> review;
 }
 ```
 
-**Invoking prepare-for-pr for fixes:** run the `prepare-for-pr` skill as a sub-skill. It runs its own loop and commits fixes. If it pauses for user input, this skill also pauses. After it exits, push the branch (`git push`).
+**Invoking `prepare-for-pr` for fixes:** invoke it as a sub-skill. It runs its own quality loop, commits fixes, and exits when clean. If it pauses for user input, this skill also pauses. After it exits, push: `git push`.
 
 ## Phase 2: Code Review Cycle
 
@@ -76,17 +77,20 @@ digraph review {
 
     start [label="CI/CD passing", shape=doublecircle];
     reviewers [label="Reviewers assigned?", shape=diamond];
-    approvals_required [label="Approvals required\nby repo rules?", shape=diamond];
-    notify_user [label="Notify user:\nno reviewers but\napprovals required", shape=box];
-    wait [label="Poll for new reviews\nevery ~5 min", shape=box];
-    read_all [label="Read ALL comments\n(incl. on approved reviews)", shape=box];
-    any_comments [label="Unaddressed\ncomments?", shape=diamond];
+    approvals_req [label="Approvals required\nby repo rules?", shape=diamond];
+    ask_assign [label="Notify user: approvals required\nbut no reviewers assigned.\nPause until user assigns.", shape=box];
+    wait [label="Poll for new reviews/comments\nevery ~5 min", shape=box];
+    stale_check [label="No activity for\n>4 hours?", shape=diamond];
+    notify_stale [label="Notify user, ask\nhow to proceed.\nPause.", shape=box];
+    read_all [label="Read ALL comments\n(reviews + inline review comments)", shape=box];
+    any_comments [label="Unaddressed comments?", shape=diamond];
     categorize [label="Categorize + show table\n(BLOCKING/IMPORTANT/OPTIONAL\n/INVALID/OUT OF SCOPE)", shape=box];
     oos [label="OUT OF SCOPE\ncomments?", shape=diamond];
-    ask_oos [label="Ask user for each\nOUT OF SCOPE", shape=box];
-    fix [label="Fix BLOCKING + IMPORTANT\n→ prepare-for-pr → push", shape=box];
-    respond [label="Respond to every comment\nindividually (in PR language)\nReference push commit hash", shape=box];
-    resolve [label="Resolve threads\n(see Resolving Threads)", shape=box];
+    ask_oos [label="Ask user for each\nOUT OF SCOPE comment.\nPause until resolved.", shape=box];
+    any_fix [label="Any BLOCKING or\nIMPORTANT comments?", shape=diamond];
+    fix [label="Fix → prepare-for-pr → push", shape=box];
+    respond [label="Respond to every comment\nindividually (in PR language)\nReference pushed commit hash", shape=box];
+    resolve [label="Resolve threads", shape=box];
     fixes_made [label="Fixes were made?", shape=diamond];
     rereview [label="Request re-review", shape=box];
     ci_loop [label="Back to CI/CD monitoring", shape=box];
@@ -94,19 +98,23 @@ digraph review {
     done [label="MERGE", shape=doublecircle];
 
     start -> reviewers;
-    reviewers -> approvals_required [label="no"];
-    approvals_required -> notify_user [label="yes"];
-    approvals_required -> merge_check [label="no"];
-    notify_user -> merge_check;
+    reviewers -> approvals_req [label="no"];
+    approvals_req -> ask_assign [label="yes — stop"];
+    approvals_req -> merge_check [label="no"];
+    ask_assign -> wait [label="user assigns reviewers"];
     reviewers -> wait [label="yes"];
-    wait -> read_all;
+    wait -> stale_check;
+    stale_check -> notify_stale [label="yes"];
+    stale_check -> read_all [label="no"];
     read_all -> any_comments;
     any_comments -> categorize [label="yes"];
     any_comments -> merge_check [label="no, approved"];
     categorize -> oos;
     oos -> ask_oos [label="yes — pause\nuntil resolved"];
-    oos -> fix [label="no"];
-    ask_oos -> fix [label="user decided"];
+    oos -> any_fix [label="no"];
+    ask_oos -> any_fix [label="user decided"];
+    any_fix -> fix [label="yes"];
+    any_fix -> respond [label="no — skip fix"];
     fix -> respond;
     respond -> resolve;
     resolve -> fixes_made;
@@ -114,17 +122,17 @@ digraph review {
     fixes_made -> merge_check [label="no"];
     rereview -> ci_loop -> wait;
     merge_check -> done [label="yes"];
-    merge_check -> wait [label="no — poll"];
+    merge_check -> wait [label="no — keep polling"];
 }
 ```
 
-**Reading comments:** always read ALL comments including inline on approved reviews — `gh pr view <N> --comments` does not return inline review comments. Use:
+**Reading comments:** `gh pr view <N> --comments` does not return inline review comments. Fetch them separately:
 
 ```bash
-# GitHub — get all review comments (inline)
+# GitHub — inline review comments
 gh api repos/{owner}/{repo}/pulls/{number}/comments
 
-# GitLab — get all discussions
+# GitLab — all discussions (includes inline)
 glab api /projects/:fullpath/merge_requests/:iid/discussions
 ```
 
@@ -164,8 +172,8 @@ Proceeding with BLOCKING + IMPORTANT fixes. Waiting on your input for OUT OF SCO
 
 | Category | Response template |
 |----------|------------------|
-| BLOCKING/IMPORTANT (fixed) | `✅ Fixed in [commit hash]. [What changed and why.]` |
-| OPTIONAL | `Good suggestion. Acknowledging — keeping this PR focused on [goal].` |
+| BLOCKING/IMPORTANT (fixed) | `Fixed in [commit hash]. [What changed and why.]` |
+| OPTIONAL | `Good point. Not addressing in this PR to keep it focused on [goal].` *(If genuinely useful: "Logged as [issue link] for follow-up.")* |
 | INVALID (outdated) | `This was addressed in [commit]. [File/code] now [does X].` |
 | INVALID (praise) | `Thank you!` |
 | OUT OF SCOPE | Per user's instruction |
@@ -176,7 +184,7 @@ After responding, resolve threads where the issue is closed. Do NOT resolve if d
 
 ```bash
 # GitHub — resolve review thread via GraphQL
-# 1. Get thread IDs:
+# 1. Get thread node IDs:
 gh api graphql -f query='
   query($owner:String!,$repo:String!,$number:Int!) {
     repository(owner:$owner,name:$repo) {
@@ -202,7 +210,7 @@ glab api /projects/:fullpath/merge_requests/:iid/discussions/:discussion_id \
 Request re-review only from reviewers whose BLOCKING or IMPORTANT comments were fixed:
 
 ```bash
-# GitHub — re-request review (NOT --add-reviewer, which only adds new reviewers)
+# GitHub — re-request review (use API, not --add-reviewer which only adds new reviewers)
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 gh api --method POST /repos/$REPO/pulls/$PR_NUMBER/requested_reviewers \
   -f "reviewers[]=username1" -f "reviewers[]=username2"
@@ -210,8 +218,6 @@ gh api --method POST /repos/$REPO/pulls/$PR_NUMBER/requested_reviewers \
 # GitLab
 glab mr update <MR_NUMBER> --reviewer @username1,@username2
 ```
-
-Do not request re-review for OPTIONAL or INVALID comments.
 
 ## Merge Requirements Checklist
 
@@ -221,21 +227,26 @@ Before merging, verify all of:
 - [ ] No unresolved blocking threads
 - [ ] Branch up to date with base branch
 
-**Branch behind base:**
+**Branch behind base — update and handle conflicts:**
 ```bash
 # GitHub
 gh pr update-branch <PR_NUMBER>
-# or: git fetch origin <base> && git rebase origin/<base> && git push --force-with-lease
+# or: git fetch origin $BASE && git rebase origin/$BASE
+# If rebase produces conflicts:
+#   resolve manually → git add <resolved files> → git rebase --continue
+#   if conflicts touch files outside this PR scope → ask user before proceeding
+git push --force-with-lease
 
 # GitLab
 glab mr rebase <MR_NUMBER>
+# If conflict: resolve manually, then git push --force-with-lease
 ```
 
 ## Tools Priority
 
 **GitHub/GitLab CLI → REST API → MCP**
 
-| Platform | Detect from remote | CLI |
+| Platform | Remote URL pattern | CLI |
 |----------|-------------------|-----|
-| GitHub | `github.com` in remote URL | `gh` |
-| GitLab | `gitlab` in remote URL | `glab` |
+| GitHub | `github.com` (HTTPS or SSH `git@github.com:...`) | `gh` |
+| GitLab | `gitlab` in URL | `glab` |

--- a/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
+++ b/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: pr-lifecycle
+name: pr-drive-to-merge
 description: Use when a PR/MR already exists and needs to be driven to merge — monitors CI/CD, handles multi-round code review, responds to and resolves reviewer comments, and loops until all merge requirements are met.
 ---
 

--- a/plugins/developer-workflow/skills/pr-lifecycle/SKILL.md
+++ b/plugins/developer-workflow/skills/pr-lifecycle/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: pr-lifecycle
+description: Use when a PR/MR already exists and needs to be driven to merge — monitors CI/CD, handles multi-round code review, responds to and resolves reviewer comments, and loops until all merge requirements are met.
+---
+
+# PR Lifecycle
+
+## Overview
+
+Takes an existing PR/MR and drives it to merge autonomously. Loops through CI/CD monitoring and code review cycles until all requirements are satisfied.
+
+**Core principle:** Fix only what belongs to the current PR. If a failure or comment is caused by something outside the current scope and the fix isn't obvious — ask the user.
+
+## Phase 1: CI/CD Monitoring
+
+```dot
+digraph cicd {
+    rankdir=TB;
+
+    start [label="PR/MR exists", shape=doublecircle];
+    has_ci [label="CI/CD configured?", shape=diamond];
+    wait [label="Wait for checks", shape=box];
+    passing [label="All checks passing?", shape=diamond];
+    investigate [label="Investigate\nfailure logs", shape=box];
+    our_fault [label="Caused by\ncurrent changes?", shape=diamond];
+    fix [label="Fix →\nprepare-for-pr →\npush", shape=box];
+    ask [label="Ask user", shape=box];
+    review [label="Proceed to\nCode Review", shape=box];
+
+    start -> has_ci;
+    has_ci -> wait [label="yes"];
+    has_ci -> review [label="no"];
+    wait -> passing;
+    passing -> review [label="yes"];
+    passing -> investigate [label="no"];
+    investigate -> our_fault;
+    our_fault -> fix [label="yes"];
+    our_fault -> ask [label="no — stop"];
+    fix -> wait;
+}
+```
+
+## Phase 2: Code Review Cycle
+
+```dot
+digraph review {
+    rankdir=TB;
+
+    start [label="CI/CD passing", shape=doublecircle];
+    reviewers [label="Reviewers assigned?", shape=diamond];
+    wait [label="Wait for review", shape=box];
+    comments [label="Comments received?", shape=diamond];
+    triage [label="Triage each comment", shape=box];
+    all_minor [label="All minor?", shape=diamond];
+    fix_major [label="Fix major →\nprepare-for-pr →\npush", shape=box];
+    respond [label="Respond to every comment", shape=box];
+    resolve [label="Mark all threads Resolved", shape=box];
+    fixes_made [label="Fixes were made?", shape=diamond];
+    rereview [label="Request re-review", shape=box];
+    ci_again [label="Back to CI/CD monitoring", shape=box];
+    merge_ok [label="Merge requirements met?", shape=diamond];
+    done [label="MERGE", shape=doublecircle];
+    no_rev [label="No reviewers path", shape=box];
+
+    start -> reviewers;
+    reviewers -> wait [label="yes"];
+    reviewers -> no_rev [label="no"];
+    no_rev -> merge_ok;
+
+    wait -> comments;
+    comments -> triage [label="yes"];
+    comments -> merge_ok [label="approved / no comments"];
+    triage -> all_minor;
+    all_minor -> respond [label="yes — respond only"];
+    all_minor -> fix_major [label="no"];
+    fix_major -> respond;
+    respond -> resolve;
+    resolve -> fixes_made;
+    fixes_made -> rereview [label="yes"];
+    fixes_made -> merge_ok [label="no"];
+    rereview -> ci_again;
+    ci_again -> wait;
+    merge_ok -> done [label="yes"];
+    merge_ok -> wait [label="no — waiting on reviews"];
+}
+```
+
+## Comment Triage Rules
+
+Classify each comment autonomously. Respond individually to every comment — never a single summary response.
+
+| Type | Criteria | Action |
+|------|----------|--------|
+| **Major** | Bug, incorrect behavior, security issue, design flaw | Fix → respond with explanation → Resolve |
+| **Minor** | Style, naming preference, optional refactor, nitpick | Respond acknowledging → Resolve without fixing |
+| **Question** | Needs clarification | Answer fully → Resolve |
+| **Out of scope** | Requires changes outside this PR's scope, fix not obvious | Ask user before acting |
+
+**Always respond in the same language as the PR and review comments.**
+
+See `responding-to-pr-comments` for response templates and resolve mechanics.
+
+## Merge Requirements Checklist
+
+Before merging, confirm all of:
+- [ ] All required CI/CD checks pass
+- [ ] Required approvals received (or no reviewers assigned)
+- [ ] No unresolved blocking threads
+- [ ] Branch is up to date with base branch
+
+## When to Ask the User
+
+Ask only when:
+- CI/CD failure is caused by something outside the current PR
+- A reviewer comment requires changes outside the current PR scope and the right fix isn't obvious
+- Merge is blocked for a reason unrelated to the PR changes
+
+Don't ask for minor/major comment classification, standard fixes, or routine re-review requests.

--- a/plugins/developer-workflow/skills/pr-lifecycle/SKILL.md
+++ b/plugins/developer-workflow/skills/pr-lifecycle/SKILL.md
@@ -51,7 +51,7 @@ digraph review {
     wait [label="Wait for review", shape=box];
     comments [label="Comments received?", shape=diamond];
     categorize [label="Categorize all comments\n+ show table to user", shape=box];
-    out_of_scope [label="OUT_OF_SCOPE\ncomments?", shape=diamond];
+    out_of_scope [label="OUT OF SCOPE\ncomments?", shape=diamond];
     ask_user [label="Ask user\nfor each OOS", shape=box];
     fix_blocking [label="Fix BLOCKING +\nIMPORTANT", shape=box];
     respond_all [label="Respond to every\ncomment individually\n(in PR language)", shape=box];
@@ -87,7 +87,7 @@ digraph review {
 
 ## Comment Categories
 
-Assign ONE category per comment. Show the full table to user before acting — then proceed without waiting for approval, except for OUT_OF_SCOPE.
+Assign ONE category per comment. Show the full table to user before acting — then proceed without waiting for approval, except for OUT OF SCOPE.
 
 | Category | When to use | Action |
 |----------|-------------|--------|
@@ -95,7 +95,7 @@ Assign ONE category per comment. Show the full table to user before acting — t
 | **IMPORTANT** | Bugs, missing error handling, missing tests | Fix → respond with explanation → Resolve |
 | **OPTIONAL** | Style, naming preference, refactor suggestions, nitpicks | Respond acknowledging → Resolve without fixing |
 | **INVALID** | Already fixed, no longer applies, praise | Respond acknowledging → Resolve |
-| **OUT_OF_SCOPE** | Requires changes outside this PR's scope | Ask user before acting |
+| **OUT OF SCOPE** | Requires changes outside this PR's scope | Ask user before acting |
 
 **Show before acting:**
 
@@ -108,9 +108,9 @@ Assign ONE category per comment. Show the full table to user before acting — t
 | 2 | @dev | auth.ts:12 | "Rename doAuth" | OPTIONAL | Will acknowledge |
 | 3 | @qa | auth.ts:45 | "Missing error handling" | IMPORTANT | Will fix |
 | 4 | @dev | auth.ts:67 | "Nice work!" | INVALID | Will acknowledge |
-| 5 | @dev | utils.ts:10 | "This whole file needs refactor" | OUT_OF_SCOPE | Need your input |
+| 5 | @dev | utils.ts:10 | "This whole file needs refactor" | OUT OF SCOPE | Need your input |
 
-Proceeding with BLOCKING + IMPORTANT fixes. OUT_OF_SCOPE items need your decision first.
+Proceeding with BLOCKING + IMPORTANT fixes. OUT OF SCOPE items need your decision first.
 ```
 
 ## Responding to Comments
@@ -125,7 +125,7 @@ Respond to **every** comment individually — never a single summary.
 | OPTIONAL (deferred) | `Good suggestion. Deferring to keep this PR focused — created [issue] to track.` |
 | INVALID (outdated) | `This was addressed in [commit]. [File/code] now [does X].` |
 | INVALID (praise) | `Thank you!` |
-| OUT_OF_SCOPE (after user decision) | Per user's instruction |
+| OUT OF SCOPE (after user decision) | Per user's instruction |
 
 ## Resolving Threads
 

--- a/plugins/developer-workflow/skills/pr-lifecycle/SKILL.md
+++ b/plugins/developer-workflow/skills/pr-lifecycle/SKILL.md
@@ -9,7 +9,27 @@ description: Use when a PR/MR already exists and needs to be driven to merge —
 
 Takes an existing PR/MR and drives it to merge autonomously. Loops through CI/CD monitoring and code review cycles until all requirements are satisfied.
 
-**Core principle:** Fix only what belongs to the current PR. Ask the user when a problem is outside the current scope and the fix isn't obvious.
+**Core principle:** Fix only what belongs to the current PR. Ask the user only when a problem is outside the current PR scope and the fix isn't obvious.
+
+## Setup
+
+Before starting, detect the PR and platform:
+
+```bash
+# GitHub — detect PR number from current branch
+PR_NUMBER=$(gh pr view --json number -q .number)
+BASE=$(gh pr view --json baseRefName -q .baseRefName)
+
+# GitLab — detect MR number from current branch
+MR_NUMBER=$(glab mr view --output json | jq .iid)
+BASE=$(glab mr view --output json | jq -r .target_branch)
+
+# Check if PR is still in draft — undraft before proceeding if CI/CD passed
+# GitHub: gh pr ready <PR_NUMBER>
+# GitLab: glab mr update <MR_NUMBER> --draft=false
+```
+
+Detect platform from remote URL (`github.com` → `gh`, `gitlab` → `glab`).
 
 ## Phase 1: CI/CD Monitoring
 
@@ -19,19 +39,25 @@ digraph cicd {
 
     start [label="PR/MR exists", shape=doublecircle];
     has_ci [label="CI/CD configured?", shape=diamond];
-    wait [label="Wait for checks", shape=box];
-    passing [label="All checks passing?", shape=diamond];
-    investigate [label="Investigate\nfailure logs", shape=box];
-    our_fault [label="Caused by\ncurrent changes?", shape=diamond];
-    fix [label="Fix →\nprepare-for-pr →\npush", shape=box];
+    draft [label="PR in draft?", shape=diamond];
+    undraft [label="Undraft PR", shape=box];
+    wait [label="Poll checks every ~2 min\nuntil complete", shape=box];
+    passing [label="All required checks passing?", shape=diamond];
+    investigate [label="Investigate failure logs", shape=box];
+    our_fault [label="Caused by current changes?", shape=diamond];
+    fix [label="Fix → invoke prepare-for-pr\n→ commit → push", shape=box];
     ask [label="Ask user", shape=box];
-    review [label="Proceed to\nCode Review", shape=box];
+    review [label="Proceed to Code Review", shape=box];
 
     start -> has_ci;
-    has_ci -> wait [label="yes"];
-    has_ci -> review [label="no"];
+    has_ci -> draft [label="yes, all passing"];
+    has_ci -> wait [label="yes, pending"];
+    has_ci -> review [label="no CI"];
+    draft -> undraft [label="yes"];
+    draft -> review [label="no"];
+    undraft -> review;
     wait -> passing;
-    passing -> review [label="yes"];
+    passing -> draft [label="yes"];
     passing -> investigate [label="no"];
     investigate -> our_fault;
     our_fault -> fix [label="yes"];
@@ -39,6 +65,8 @@ digraph cicd {
     fix -> wait;
 }
 ```
+
+**Invoking prepare-for-pr for fixes:** run the `prepare-for-pr` skill as a sub-skill. It runs its own loop and commits fixes. If it pauses for user input, this skill also pauses. After it exits, push the branch (`git push`).
 
 ## Phase 2: Code Review Cycle
 
@@ -48,125 +76,166 @@ digraph review {
 
     start [label="CI/CD passing", shape=doublecircle];
     reviewers [label="Reviewers assigned?", shape=diamond];
-    wait [label="Wait for review", shape=box];
-    comments [label="Comments received?", shape=diamond];
-    categorize [label="Categorize all comments\n+ show table to user", shape=box];
-    out_of_scope [label="OUT OF SCOPE\ncomments?", shape=diamond];
-    ask_user [label="Ask user\nfor each OOS", shape=box];
-    fix_blocking [label="Fix BLOCKING +\nIMPORTANT", shape=box];
-    respond_all [label="Respond to every\ncomment individually\n(in PR language)", shape=box];
-    resolve [label="Resolve all threads", shape=box];
+    approvals_required [label="Approvals required\nby repo rules?", shape=diamond];
+    notify_user [label="Notify user:\nno reviewers but\napprovals required", shape=box];
+    wait [label="Poll for new reviews\nevery ~5 min", shape=box];
+    read_all [label="Read ALL comments\n(incl. on approved reviews)", shape=box];
+    any_comments [label="Unaddressed\ncomments?", shape=diamond];
+    categorize [label="Categorize + show table\n(BLOCKING/IMPORTANT/OPTIONAL\n/INVALID/OUT OF SCOPE)", shape=box];
+    oos [label="OUT OF SCOPE\ncomments?", shape=diamond];
+    ask_oos [label="Ask user for each\nOUT OF SCOPE", shape=box];
+    fix [label="Fix BLOCKING + IMPORTANT\n→ prepare-for-pr → push", shape=box];
+    respond [label="Respond to every comment\nindividually (in PR language)\nReference push commit hash", shape=box];
+    resolve [label="Resolve threads\n(see Resolving Threads)", shape=box];
     fixes_made [label="Fixes were made?", shape=diamond];
     rereview [label="Request re-review", shape=box];
-    ci_again [label="Back to CI/CD", shape=box];
-    merge_ok [label="Merge requirements\nmet?", shape=diamond];
+    ci_loop [label="Back to CI/CD monitoring", shape=box];
+    merge_check [label="Merge requirements met?", shape=diamond];
     done [label="MERGE", shape=doublecircle];
 
     start -> reviewers;
+    reviewers -> approvals_required [label="no"];
+    approvals_required -> notify_user [label="yes"];
+    approvals_required -> merge_check [label="no"];
+    notify_user -> merge_check;
     reviewers -> wait [label="yes"];
-    reviewers -> merge_ok [label="no"];
-
-    wait -> comments;
-    comments -> categorize [label="yes"];
-    comments -> merge_ok [label="approved"];
-    categorize -> out_of_scope;
-    out_of_scope -> ask_user [label="yes — stop\nuntil resolved"];
-    out_of_scope -> fix_blocking [label="no"];
-    ask_user -> fix_blocking [label="user decided"];
-    fix_blocking -> respond_all;
-    respond_all -> resolve;
+    wait -> read_all;
+    read_all -> any_comments;
+    any_comments -> categorize [label="yes"];
+    any_comments -> merge_check [label="no, approved"];
+    categorize -> oos;
+    oos -> ask_oos [label="yes — pause\nuntil resolved"];
+    oos -> fix [label="no"];
+    ask_oos -> fix [label="user decided"];
+    fix -> respond;
+    respond -> resolve;
     resolve -> fixes_made;
     fixes_made -> rereview [label="yes"];
-    fixes_made -> merge_ok [label="no"];
-    rereview -> ci_again;
-    ci_again -> wait;
-    merge_ok -> done [label="yes"];
-    merge_ok -> wait [label="no"];
+    fixes_made -> merge_check [label="no"];
+    rereview -> ci_loop -> wait;
+    merge_check -> done [label="yes"];
+    merge_check -> wait [label="no — poll"];
 }
+```
+
+**Reading comments:** always read ALL comments including inline on approved reviews — `gh pr view <N> --comments` does not return inline review comments. Use:
+
+```bash
+# GitHub — get all review comments (inline)
+gh api repos/{owner}/{repo}/pulls/{number}/comments
+
+# GitLab — get all discussions
+glab api /projects/:fullpath/merge_requests/:iid/discussions
 ```
 
 ## Comment Categories
 
-Assign ONE category per comment. Show the full table to user before acting — then proceed without waiting for approval, except for OUT OF SCOPE.
+Assign ONE category per comment. Show full table before acting. Proceed without waiting for approval except for OUT OF SCOPE.
 
 | Category | When to use | Action |
 |----------|-------------|--------|
-| **BLOCKING** | Security issues, critical bugs, compliance violations | Fix → respond with explanation → Resolve |
-| **IMPORTANT** | Bugs, missing error handling, missing tests | Fix → respond with explanation → Resolve |
-| **OPTIONAL** | Style, naming preference, refactor suggestions, nitpicks | Respond acknowledging → Resolve without fixing |
+| **BLOCKING** | Security issues, critical bugs, compliance violations | Fix → respond → Resolve |
+| **IMPORTANT** | Bugs, missing error handling, missing tests | Fix → respond → Resolve |
+| **OPTIONAL** | Style, naming preference, refactoring suggestion, nitpick | Respond acknowledging → Resolve without fixing |
 | **INVALID** | Already fixed, no longer applies, praise | Respond acknowledging → Resolve |
-| **OUT OF SCOPE** | Requires changes outside this PR's scope | Ask user before acting |
+| **OUT OF SCOPE** | Requires changes outside this PR | Ask user before acting |
 
-**Show before acting:**
+**Show table format:**
 
 ```markdown
 ## PR Review Comments
 
-| # | Author | Location | Comment | Category | Action |
+| # | Author | Location | Summary | Category | Action |
 |---|--------|----------|---------|----------|--------|
-| 1 | @dev | auth.ts:23 | "Password in plaintext" | BLOCKING | Will fix |
-| 2 | @dev | auth.ts:12 | "Rename doAuth" | OPTIONAL | Will acknowledge |
-| 3 | @qa | auth.ts:45 | "Missing error handling" | IMPORTANT | Will fix |
-| 4 | @dev | auth.ts:67 | "Nice work!" | INVALID | Will acknowledge |
-| 5 | @dev | utils.ts:10 | "This whole file needs refactor" | OUT OF SCOPE | Need your input |
+| 1 | @dev | auth.ts:23 | Password in plaintext | BLOCKING | Will fix |
+| 2 | @dev | auth.ts:12 | Rename doAuth | OPTIONAL | Will acknowledge |
+| 3 | @qa | auth.ts:45 | Missing error handling | IMPORTANT | Will fix |
+| 4 | @dev | auth.ts:67 | Nice work! | INVALID | Will acknowledge |
+| 5 | @dev | utils.ts:10 | Whole file needs refactor | OUT OF SCOPE | Need your input |
 
-Proceeding with BLOCKING + IMPORTANT fixes. OUT OF SCOPE items need your decision first.
+Proceeding with BLOCKING + IMPORTANT fixes. Waiting on your input for OUT OF SCOPE (#5).
 ```
 
 ## Responding to Comments
 
 **Always respond in the same language as the PR and review comments.**
-
-Respond to **every** comment individually — never a single summary.
+**Respond after pushing fixes** — reference the actual commit hash.
+**Respond to every comment individually — never a single summary.**
 
 | Category | Response template |
 |----------|------------------|
-| BLOCKING/IMPORTANT (fixed) | `✅ Fixed in [commit]. [What changed and why.]` |
-| OPTIONAL (deferred) | `Good suggestion. Deferring to keep this PR focused — created [issue] to track.` |
+| BLOCKING/IMPORTANT (fixed) | `✅ Fixed in [commit hash]. [What changed and why.]` |
+| OPTIONAL | `Good suggestion. Acknowledging — keeping this PR focused on [goal].` |
 | INVALID (outdated) | `This was addressed in [commit]. [File/code] now [does X].` |
 | INVALID (praise) | `Thank you!` |
-| OUT OF SCOPE (after user decision) | Per user's instruction |
+| OUT OF SCOPE | Per user's instruction |
 
 ## Resolving Threads
 
-After responding, mark as Resolved if:
-- Fix was implemented
-- Question was answered
-- Comment no longer applies
+After responding, resolve threads where the issue is closed. Do NOT resolve if discussion is ongoing or awaiting reviewer confirmation.
 
-Do NOT resolve if discussion is ongoing or waiting for reviewer confirmation.
+```bash
+# GitHub — resolve review thread via GraphQL
+# 1. Get thread IDs:
+gh api graphql -f query='
+  query($owner:String!,$repo:String!,$number:Int!) {
+    repository(owner:$owner,name:$repo) {
+      pullRequest(number:$number) {
+        reviewThreads(first:100) { nodes { id isResolved } }
+      }
+    }
+  }
+' -f owner=OWNER -f repo=REPO -F number=N
 
-Use GitHub web UI for resolving ("Resolve conversation" button) — `gh` CLI doesn't support it directly.
+# 2. Resolve a thread:
+gh api graphql -f query='
+  mutation($id:ID!) { resolveReviewThread(input:{threadId:$id}) { thread { isResolved } } }
+' -f id=THREAD_NODE_ID
+
+# GitLab — resolve a discussion:
+glab api /projects/:fullpath/merge_requests/:iid/discussions/:discussion_id \
+  --method PUT -f resolved=true
+```
 
 ## Re-Review
 
 Request re-review only from reviewers whose BLOCKING or IMPORTANT comments were fixed:
 
 ```bash
-# GitHub
-gh pr edit <PR_NUMBER> --add-reviewer @username1,@username2
+# GitHub — re-request review (NOT --add-reviewer, which only adds new reviewers)
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+gh api --method POST /repos/$REPO/pulls/$PR_NUMBER/requested_reviewers \
+  -f "reviewers[]=username1" -f "reviewers[]=username2"
+
 # GitLab
 glab mr update <MR_NUMBER> --reviewer @username1,@username2
 ```
 
-Do not request re-review for OPTIONAL deferred items or INVALID comments.
+Do not request re-review for OPTIONAL or INVALID comments.
 
 ## Merge Requirements Checklist
 
+Before merging, verify all of:
 - [ ] All required CI/CD checks pass
-- [ ] Required approvals received (or no reviewers)
+- [ ] Required approvals received
 - [ ] No unresolved blocking threads
 - [ ] Branch up to date with base branch
+
+**Branch behind base:**
+```bash
+# GitHub
+gh pr update-branch <PR_NUMBER>
+# or: git fetch origin <base> && git rebase origin/<base> && git push --force-with-lease
+
+# GitLab
+glab mr rebase <MR_NUMBER>
+```
 
 ## Tools Priority
 
 **GitHub/GitLab CLI → REST API → MCP**
 
-Detect platform from remote URL and use the matching CLI:
-
-| Platform | CLI | Read comments | Reply | Re-review |
-|----------|-----|---------------|-------|-----------|
-| GitHub | `gh` | `gh pr view <N> --comments` | `gh pr comment <N> --body "…"` | `gh pr edit <N> --add-reviewer @user` |
-| GitLab | `glab` | `glab mr view <N> --comments` | `glab mr note <N> --message "…"` | `glab mr update <N> --reviewer @user` |
-
-Fall back to REST API if CLI unavailable, then MCP as last resort.
+| Platform | Detect from remote | CLI |
+|----------|-------------------|-----|
+| GitHub | `github.com` in remote URL | `gh` |
+| GitLab | `gitlab` in remote URL | `glab` |

--- a/plugins/developer-workflow/skills/pr-lifecycle/SKILL.md
+++ b/plugins/developer-workflow/skills/pr-lifecycle/SKILL.md
@@ -143,7 +143,10 @@ Use GitHub web UI for resolving ("Resolve conversation" button) — `gh` CLI doe
 Request re-review only from reviewers whose BLOCKING or IMPORTANT comments were fixed:
 
 ```bash
+# GitHub
 gh pr edit <PR_NUMBER> --add-reviewer @username1,@username2
+# GitLab
+glab mr update <MR_NUMBER> --reviewer @username1,@username2
 ```
 
 Do not request re-review for OPTIONAL deferred items or INVALID comments.
@@ -157,10 +160,13 @@ Do not request re-review for OPTIONAL deferred items or INVALID comments.
 
 ## Tools Priority
 
-**gh CLI → REST API → GitHub MCP**
+**GitHub/GitLab CLI → REST API → MCP**
 
-```bash
-gh pr view <PR_NUMBER> --comments   # read comments
-gh pr comment <PR_NUMBER> --body "…" # reply
-gh pr edit <PR_NUMBER> --add-reviewer @user  # re-review
-```
+Detect platform from remote URL and use the matching CLI:
+
+| Platform | CLI | Read comments | Reply | Re-review |
+|----------|-----|---------------|-------|-----------|
+| GitHub | `gh` | `gh pr view <N> --comments` | `gh pr comment <N> --body "…"` | `gh pr edit <N> --add-reviewer @user` |
+| GitLab | `glab` | `glab mr view <N> --comments` | `glab mr note <N> --message "…"` | `glab mr update <N> --reviewer @user` |
+
+Fall back to REST API if CLI unavailable, then MCP as last resort.

--- a/plugins/developer-workflow/skills/pr-lifecycle/SKILL.md
+++ b/plugins/developer-workflow/skills/pr-lifecycle/SKILL.md
@@ -9,7 +9,7 @@ description: Use when a PR/MR already exists and needs to be driven to merge —
 
 Takes an existing PR/MR and drives it to merge autonomously. Loops through CI/CD monitoring and code review cycles until all requirements are satisfied.
 
-**Core principle:** Fix only what belongs to the current PR. If a failure or comment is caused by something outside the current scope and the fix isn't obvious — ask the user.
+**Core principle:** Fix only what belongs to the current PR. Ask the user when a problem is outside the current scope and the fix isn't obvious.
 
 ## Phase 1: CI/CD Monitoring
 
@@ -50,69 +50,117 @@ digraph review {
     reviewers [label="Reviewers assigned?", shape=diamond];
     wait [label="Wait for review", shape=box];
     comments [label="Comments received?", shape=diamond];
-    triage [label="Triage each comment", shape=box];
-    all_minor [label="All minor?", shape=diamond];
-    fix_major [label="Fix major →\nprepare-for-pr →\npush", shape=box];
-    respond [label="Respond to every comment", shape=box];
-    resolve [label="Mark all threads Resolved", shape=box];
+    categorize [label="Categorize all comments\n+ show table to user", shape=box];
+    out_of_scope [label="OUT_OF_SCOPE\ncomments?", shape=diamond];
+    ask_user [label="Ask user\nfor each OOS", shape=box];
+    fix_blocking [label="Fix BLOCKING +\nIMPORTANT", shape=box];
+    respond_all [label="Respond to every\ncomment individually\n(in PR language)", shape=box];
+    resolve [label="Resolve all threads", shape=box];
     fixes_made [label="Fixes were made?", shape=diamond];
     rereview [label="Request re-review", shape=box];
-    ci_again [label="Back to CI/CD monitoring", shape=box];
-    merge_ok [label="Merge requirements met?", shape=diamond];
+    ci_again [label="Back to CI/CD", shape=box];
+    merge_ok [label="Merge requirements\nmet?", shape=diamond];
     done [label="MERGE", shape=doublecircle];
-    no_rev [label="No reviewers path", shape=box];
 
     start -> reviewers;
     reviewers -> wait [label="yes"];
-    reviewers -> no_rev [label="no"];
-    no_rev -> merge_ok;
+    reviewers -> merge_ok [label="no"];
 
     wait -> comments;
-    comments -> triage [label="yes"];
-    comments -> merge_ok [label="approved / no comments"];
-    triage -> all_minor;
-    all_minor -> respond [label="yes — respond only"];
-    all_minor -> fix_major [label="no"];
-    fix_major -> respond;
-    respond -> resolve;
+    comments -> categorize [label="yes"];
+    comments -> merge_ok [label="approved"];
+    categorize -> out_of_scope;
+    out_of_scope -> ask_user [label="yes — stop\nuntil resolved"];
+    out_of_scope -> fix_blocking [label="no"];
+    ask_user -> fix_blocking [label="user decided"];
+    fix_blocking -> respond_all;
+    respond_all -> resolve;
     resolve -> fixes_made;
     fixes_made -> rereview [label="yes"];
     fixes_made -> merge_ok [label="no"];
     rereview -> ci_again;
     ci_again -> wait;
     merge_ok -> done [label="yes"];
-    merge_ok -> wait [label="no — waiting on reviews"];
+    merge_ok -> wait [label="no"];
 }
 ```
 
-## Comment Triage Rules
+## Comment Categories
 
-Classify each comment autonomously. Respond individually to every comment — never a single summary response.
+Assign ONE category per comment. Show the full table to user before acting — then proceed without waiting for approval, except for OUT_OF_SCOPE.
 
-| Type | Criteria | Action |
-|------|----------|--------|
-| **Major** | Bug, incorrect behavior, security issue, design flaw | Fix → respond with explanation → Resolve |
-| **Minor** | Style, naming preference, optional refactor, nitpick | Respond acknowledging → Resolve without fixing |
-| **Question** | Needs clarification | Answer fully → Resolve |
-| **Out of scope** | Requires changes outside this PR's scope, fix not obvious | Ask user before acting |
+| Category | When to use | Action |
+|----------|-------------|--------|
+| **BLOCKING** | Security issues, critical bugs, compliance violations | Fix → respond with explanation → Resolve |
+| **IMPORTANT** | Bugs, missing error handling, missing tests | Fix → respond with explanation → Resolve |
+| **OPTIONAL** | Style, naming preference, refactor suggestions, nitpicks | Respond acknowledging → Resolve without fixing |
+| **INVALID** | Already fixed, no longer applies, praise | Respond acknowledging → Resolve |
+| **OUT_OF_SCOPE** | Requires changes outside this PR's scope | Ask user before acting |
+
+**Show before acting:**
+
+```markdown
+## PR Review Comments
+
+| # | Author | Location | Comment | Category | Action |
+|---|--------|----------|---------|----------|--------|
+| 1 | @dev | auth.ts:23 | "Password in plaintext" | BLOCKING | Will fix |
+| 2 | @dev | auth.ts:12 | "Rename doAuth" | OPTIONAL | Will acknowledge |
+| 3 | @qa | auth.ts:45 | "Missing error handling" | IMPORTANT | Will fix |
+| 4 | @dev | auth.ts:67 | "Nice work!" | INVALID | Will acknowledge |
+| 5 | @dev | utils.ts:10 | "This whole file needs refactor" | OUT_OF_SCOPE | Need your input |
+
+Proceeding with BLOCKING + IMPORTANT fixes. OUT_OF_SCOPE items need your decision first.
+```
+
+## Responding to Comments
 
 **Always respond in the same language as the PR and review comments.**
 
-See `responding-to-pr-comments` for response templates and resolve mechanics.
+Respond to **every** comment individually — never a single summary.
+
+| Category | Response template |
+|----------|------------------|
+| BLOCKING/IMPORTANT (fixed) | `✅ Fixed in [commit]. [What changed and why.]` |
+| OPTIONAL (deferred) | `Good suggestion. Deferring to keep this PR focused — created [issue] to track.` |
+| INVALID (outdated) | `This was addressed in [commit]. [File/code] now [does X].` |
+| INVALID (praise) | `Thank you!` |
+| OUT_OF_SCOPE (after user decision) | Per user's instruction |
+
+## Resolving Threads
+
+After responding, mark as Resolved if:
+- Fix was implemented
+- Question was answered
+- Comment no longer applies
+
+Do NOT resolve if discussion is ongoing or waiting for reviewer confirmation.
+
+Use GitHub web UI for resolving ("Resolve conversation" button) — `gh` CLI doesn't support it directly.
+
+## Re-Review
+
+Request re-review only from reviewers whose BLOCKING or IMPORTANT comments were fixed:
+
+```bash
+gh pr edit <PR_NUMBER> --add-reviewer @username1,@username2
+```
+
+Do not request re-review for OPTIONAL deferred items or INVALID comments.
 
 ## Merge Requirements Checklist
 
-Before merging, confirm all of:
 - [ ] All required CI/CD checks pass
-- [ ] Required approvals received (or no reviewers assigned)
+- [ ] Required approvals received (or no reviewers)
 - [ ] No unresolved blocking threads
-- [ ] Branch is up to date with base branch
+- [ ] Branch up to date with base branch
 
-## When to Ask the User
+## Tools Priority
 
-Ask only when:
-- CI/CD failure is caused by something outside the current PR
-- A reviewer comment requires changes outside the current PR scope and the right fix isn't obvious
-- Merge is blocked for a reason unrelated to the PR changes
+**gh CLI → REST API → GitHub MCP**
 
-Don't ask for minor/major comment classification, standard fixes, or routine re-review requests.
+```bash
+gh pr view <PR_NUMBER> --comments   # read comments
+gh pr comment <PR_NUMBER> --body "…" # reply
+gh pr edit <PR_NUMBER> --add-reviewer @user  # re-review
+```

--- a/plugins/developer-workflow/skills/prepare-for-pr/SKILL.md
+++ b/plugins/developer-workflow/skills/prepare-for-pr/SKILL.md
@@ -9,84 +9,135 @@ description: Use when implementation is complete and the branch needs to be qual
 
 Runs a quality loop over the current branch changes until the code is clean enough to expose in a PR.
 
-**Core principle:** Fix only what belongs to the current changes. If a problem is caused by something outside the current scope and the fix isn't obvious — ask the user.
+**Core principle:** Fix only what belongs to current changes. Out-of-scope issues with an obvious fix can be handled autonomously; otherwise ask the user.
+
+## Setup
+
+Before the loop, establish the diff base and build tooling:
+
+```bash
+# Determine base branch
+git remote show origin | grep "HEAD branch" | awk '{print $NF}'
+# Fallback: try main → master → develop
+
+# Current changes boundary (use throughout for scope decisions)
+git diff <base>...HEAD
+```
+
+**Build system detection:**
+
+| File present | Build | Lint | Test |
+|---|---|---|---|
+| `package.json` | `npm run build` | `npm run lint` | `npm test` |
+| `Cargo.toml` | `cargo build` | `cargo clippy` | `cargo test` |
+| `build.gradle(.kts)` | `./gradlew build` | `./gradlew lint` | `./gradlew test` |
+| `pom.xml` | `mvn package -q` | `mvn checkstyle:check` | `mvn test` |
+| `go.mod` | `go build ./...` | `golangci-lint run` | `go test ./...` |
+| `Makefile` | `make build` | `make lint` | `make test` |
 
 ## Quality Loop
 
-Repeat until only minor issues remain or none at all. Record issues found at each step before fixing.
+**Track all issues found across iterations.** On re-entry to any step, only report and fix issues not seen in a previous iteration. Mark issues as resolved when fixed — never re-report them.
+
+**Simplify runs only on the first iteration** (or after a significant rewrite). Self-review and lint/tests run every iteration.
 
 ```dot
 digraph prepare_for_pr {
     rankdir=TB;
 
     start [label="Implementation complete", shape=doublecircle];
+    setup [label="Detect base branch + build system", shape=box];
     build [label="Build", shape=box];
-    build_ok [label="Build passes?", shape=diamond];
-    build_scope [label="Caused by\ncurrent changes?", shape=diamond];
-    ask_build [label="Ask user", shape=box];
-    fix_build [label="Fix", shape=box];
-    simplify [label="Simplify\n(skill: simplify)", shape=box];
-    selfrev [label="Self-review all diffs", shape=box];
-    issues_found [label="Non-minor issues?", shape=diamond];
-    in_scope [label="In current scope?", shape=diamond];
-    ask_scope [label="Ask user", shape=box];
-    fix [label="Fix", shape=box];
+    build_pass [label="Passes?", shape=diamond];
+    scope_build [label="Scope decision\n(see below)", shape=box];
+    simplify [label="Simplify\n(skill: simplify)\n[1st iteration only]", shape=box];
+    selfrev [label="Self-review\ngit diff <base>...HEAD", shape=box];
     lint [label="Lint + Tests", shape=box];
-    lint_fail [label="Failures?", shape=diamond];
-    lint_scope [label="In current scope?", shape=diamond];
-    ask_lint [label="Ask user", shape=box];
-    fix_lint [label="Fix", shape=box];
-    done [label="Ready for PR", shape=doublecircle];
+    new_issues [label="New non-minor issues?", shape=diamond];
+    scope_issues [label="Scope decision\n(see below)", shape=box];
+    assess [label="Only minor\nor no issues?", shape=diamond];
+    fix [label="Fix", shape=box];
+    commit [label="Commit fixes\n(logical groups)", shape=box];
+    done [label="Code ready for PR", shape=doublecircle];
 
-    start -> build;
-    build -> build_ok;
-    build_ok -> simplify [label="yes"];
-    build_ok -> build_scope [label="no"];
-    build_scope -> fix_build [label="yes"];
-    build_scope -> ask_build [label="no — stop"];
-    fix_build -> build;
-
-    simplify -> selfrev;
-    selfrev -> issues_found;
-    issues_found -> lint [label="no"];
-    issues_found -> in_scope [label="yes"];
-    in_scope -> fix [label="yes"];
-    in_scope -> ask_scope [label="no — stop"];
+    start -> setup -> build;
+    build -> build_pass;
+    build_pass -> simplify [label="yes"];
+    build_pass -> scope_build [label="no"];
+    scope_build -> fix [label="fix decided"];
+    scope_build -> done [label="user exits"];
     fix -> build;
-
-    lint -> lint_fail;
-    lint_fail -> done [label="no failures"];
-    lint_fail -> lint_scope [label="yes"];
-    lint_scope -> fix_lint [label="yes"];
-    lint_scope -> ask_lint [label="no — stop"];
-    fix_lint -> build;
+    simplify -> selfrev -> lint;
+    lint -> new_issues;
+    new_issues -> scope_issues [label="yes"];
+    new_issues -> assess [label="no"];
+    scope_issues -> fix [label="fix decided"];
+    scope_issues -> assess [label="user defers"];
+    assess -> fix [label="non-minor remain"];
+    assess -> commit [label="only minor or none"];
+    commit -> done;
 }
 ```
 
 ## Scope Decision
 
-**In scope — fix autonomously:**
-- Bugs introduced by current changes
-- Tests broken by current changes
-- Lint errors in changed files
-- Logic errors in current implementation
+```dot
+digraph scope {
+    rankdir=LR;
 
-**Out of scope — ask user only if fix isn't obvious:**
-- Pre-existing failures unrelated to this PR
-- Test failures in files not touched
-- Build errors from dependency issues or unrelated commits
+    check [label="In current changes\n(git diff <base>...HEAD)?", shape=diamond];
+    obvious [label="Fix is obvious?", shape=diamond];
+    auto [label="Fix autonomously", shape=box];
+    ask [label="Ask user", shape=box];
 
-When asking, include: what the issue is, why it seems unrelated, and options (fix here / ignore / open separate issue).
+    check -> auto [label="yes"];
+    check -> obvious [label="no"];
+    obvious -> auto [label="yes"];
+    obvious -> ask [label="no"];
+}
+```
+
+**In scope — fix autonomously:** bugs introduced by current changes, tests broken by current changes, lint errors in files touched by this branch, logic/security errors in current implementation.
+
+**Out of scope, obvious fix:** missing import clearly needed by new code, typo in a newly added string, test fixture update required by a changed function signature.
+
+**Out of scope, ask user:** pre-existing failures in untouched files, build errors from unrelated dependency changes, architectural issues not caused by this branch.
+
+When asking, include: what the issue is, why it appears unrelated, and options (fix here / skip / open separate issue). Pause until user responds.
+
+## Self-Review Criteria
+
+Run `git diff <base>...HEAD` and check for:
+- Logic errors or off-by-one mistakes
+- Missing error handling for new code paths
+- Security issues (exposed secrets, injection risks, missing validation)
+- Missing or insufficient tests for new behavior
+- Dead code or unreachable branches introduced
 
 ## What "Minor" Means
 
-**Minor (exit loop — code is ready):** style preferences, optional naming, cosmetic suggestions with no correctness impact.
+**Minor (exit loop):** style preferences, optional naming improvements, cosmetic suggestions with no correctness impact.
 
-**Non-minor (keep looping):** bugs, broken tests, lint errors, security issues, incorrect logic.
+**Non-minor (keep looping):** bugs, broken tests, lint errors, security issues, incorrect logic, missing required tests.
+
+## Committing Fixes
+
+After the loop exits, commit all fixes made during the loop:
+- Group related fixes into logical commits
+- Message format: `fix: <what was fixed>`
+- Do not mix unrelated fixes into a single commit
 
 ## Output
 
-When the loop exits, report:
-- Issues found per step and what was fixed
-- Any items escalated to user
-- Confirmation: **"Code is ready for PR"**
+```markdown
+## Prepare for PR — Result
+
+| Step | Issues found | Fixed | Deferred to user |
+|------|-------------|-------|-----------------|
+| Build | ... | ... | ... |
+| Simplify | ... | ... | — |
+| Self-review | ... | ... | ... |
+| Lint + Tests | ... | ... | ... |
+
+**Code is ready for PR.**
+```

--- a/plugins/developer-workflow/skills/prepare-for-pr/SKILL.md
+++ b/plugins/developer-workflow/skills/prepare-for-pr/SKILL.md
@@ -17,29 +17,32 @@ Before the loop, establish the diff base and build tooling:
 
 ```bash
 # Determine base branch
-git remote show origin | grep "HEAD branch" | awk '{print $NF}'
+BASE=$(git remote show origin 2>/dev/null | grep "HEAD branch" | awk '{print $NF}')
 # Fallback: try main → master → develop
 
 # Current changes boundary (use throughout for scope decisions)
-git diff <base>...HEAD
+git diff $BASE...HEAD
 ```
 
-**Build system detection:**
+**Build system detection — use highest-priority match when multiple files present:**
 
-| File present | Build | Lint | Test |
-|---|---|---|---|
-| `package.json` | `npm run build` | `npm run lint` | `npm test` |
-| `Cargo.toml` | `cargo build` | `cargo clippy` | `cargo test` |
-| `build.gradle(.kts)` | `./gradlew build` | `./gradlew lint` | `./gradlew test` |
-| `pom.xml` | `mvn package -q` | `mvn checkstyle:check` | `mvn test` |
-| `go.mod` | `go build ./...` | `golangci-lint run` | `go test ./...` |
-| `Makefile` | `make build` | `make lint` | `make test` |
+| Priority | File present | Build | Lint | Test |
+|----------|---|---|---|---|
+| 1 | `Makefile` (with build/lint/test targets) | `make build` | `make lint` | `make test` |
+| 2 | `package.json` | `npm run build` | `npm run lint` | `npm test` |
+| 3 | `Cargo.toml` | `cargo build` | `cargo clippy` | `cargo test` |
+| 4 | `build.gradle(.kts)` | `./gradlew build` | `./gradlew lint` | `./gradlew test` |
+| 5 | `pom.xml` | `mvn package -q` | `mvn checkstyle:check` | `mvn test` |
+| 6 | `go.mod` | `go build ./...` | `golangci-lint run` | `go test ./...` |
+| 7 | `pyproject.toml` / `setup.py` | `pip install -e .` | `ruff check .` | `pytest` |
 
 ## Quality Loop
 
-**Track all issues found across iterations.** On re-entry to any step, only report and fix issues not seen in a previous iteration. Mark issues as resolved when fixed — never re-report them.
+**Track all issues found and their status (open / fixed / deferred) across iterations.** On re-entry, only report NEW issues. Deferred issues are removed from the fix queue — never re-prompted.
 
-**Simplify runs only on the first iteration** (or after a significant rewrite). Self-review and lint/tests run every iteration.
+**Stage and commit fixes as you make them** during the loop, grouping related changes together (use specific file paths, not `git add .`). This allows logical commit grouping without having to reconstruct it at the end.
+
+**Simplify runs only on the first iteration.** Self-review and lint/tests run every iteration.
 
 ```dot
 digraph prepare_for_pr {
@@ -50,15 +53,15 @@ digraph prepare_for_pr {
     build [label="Build", shape=box];
     build_pass [label="Passes?", shape=diamond];
     scope_build [label="Scope decision\n(see below)", shape=box];
-    simplify [label="Simplify\n(skill: simplify)\n[1st iteration only]", shape=box];
-    selfrev [label="Self-review\ngit diff <base>...HEAD", shape=box];
+    simplify [label="Simplify (skill: simplify)\n[1st iteration only — skip if unavailable]", shape=box];
+    selfrev [label="Self-review: git diff $BASE...HEAD\nCheck logic, security, edge cases", shape=box];
     lint [label="Lint + Tests", shape=box];
     new_issues [label="New non-minor issues?", shape=diamond];
     scope_issues [label="Scope decision\n(see below)", shape=box];
-    assess [label="Only minor\nor no issues?", shape=diamond];
-    fix [label="Fix", shape=box];
-    commit [label="Commit fixes\n(logical groups)", shape=box];
-    done [label="Code ready for PR", shape=doublecircle];
+    assess [label="Any non-deferred\nnon-minor issues?", shape=diamond];
+    fix [label="Fix + stage changes", shape=box];
+    commit [label="Commit staged fixes\n(logical groups)", shape=box];
+    done [label="Quality loop complete", shape=doublecircle];
 
     start -> setup -> build;
     build -> build_pass;
@@ -72,9 +75,9 @@ digraph prepare_for_pr {
     new_issues -> scope_issues [label="yes"];
     new_issues -> assess [label="no"];
     scope_issues -> fix [label="fix decided"];
-    scope_issues -> assess [label="user defers"];
-    assess -> fix [label="non-minor remain"];
-    assess -> commit [label="only minor or none"];
+    scope_issues -> assess [label="user defers\n(mark deferred, continue)"];
+    assess -> fix [label="yes — non-deferred\nnon-minor remain"];
+    assess -> commit [label="no"];
     commit -> done;
 }
 ```
@@ -85,29 +88,31 @@ digraph prepare_for_pr {
 digraph scope {
     rankdir=LR;
 
-    check [label="In current changes\n(git diff <base>...HEAD)?", shape=diamond];
+    check [label="In current changes\n(git diff $BASE...HEAD)?", shape=diamond];
     obvious [label="Fix is obvious?", shape=diamond];
     auto [label="Fix autonomously", shape=box];
-    ask [label="Ask user", shape=box];
+    ask [label="Ask user\n(issue + reason + options)", shape=box];
+    user_fix [label="User: fix here", shape=box];
+    user_defer [label="User: defer/skip\n(mark deferred)", shape=box];
 
     check -> auto [label="yes"];
     check -> obvious [label="no"];
     obvious -> auto [label="yes"];
     obvious -> ask [label="no"];
+    ask -> user_fix -> auto;
+    ask -> user_defer;
 }
 ```
 
-**In scope — fix autonomously:** bugs introduced by current changes, tests broken by current changes, lint errors in files touched by this branch, logic/security errors in current implementation.
+**In scope — fix autonomously:** bugs introduced by current changes, tests broken by current changes, lint errors in changed files, logic/security errors in current implementation.
 
 **Out of scope, obvious fix:** missing import clearly needed by new code, typo in a newly added string, test fixture update required by a changed function signature.
 
-**Out of scope, ask user:** pre-existing failures in untouched files, build errors from unrelated dependency changes, architectural issues not caused by this branch.
-
-When asking, include: what the issue is, why it appears unrelated, and options (fix here / skip / open separate issue). Pause until user responds.
+**Out of scope, ask user:** pre-existing failures in untouched files, build errors from unrelated dependency changes, failures in files not touched by this branch. When asking, include: what the issue is, why it appears unrelated, and options (fix here / skip / open separate issue). Pause until user responds.
 
 ## Self-Review Criteria
 
-Run `git diff <base>...HEAD` and check for:
+Run `git diff $BASE...HEAD` and check for:
 - Logic errors or off-by-one mistakes
 - Missing error handling for new code paths
 - Security issues (exposed secrets, injection risks, missing validation)
@@ -120,24 +125,17 @@ Run `git diff <base>...HEAD` and check for:
 
 **Non-minor (keep looping):** bugs, broken tests, lint errors, security issues, incorrect logic, missing required tests.
 
-## Committing Fixes
-
-After the loop exits, commit all fixes made during the loop:
-- Group related fixes into logical commits
-- Message format: `fix: <what was fixed>`
-- Do not mix unrelated fixes into a single commit
-
 ## Output
 
 ```markdown
-## Prepare for PR — Result
+## Quality Loop Result
 
-| Step | Issues found | Fixed | Deferred to user |
-|------|-------------|-------|-----------------|
+| Step | Issues found | Fixed | Deferred |
+|------|-------------|-------|---------|
 | Build | ... | ... | ... |
 | Simplify | ... | ... | — |
 | Self-review | ... | ... | ... |
 | Lint + Tests | ... | ... | ... |
 
-**Code is ready for PR.**
+**Quality loop complete.** [If deferred items exist: X items deferred — see above.]
 ```

--- a/plugins/developer-workflow/skills/prepare-for-pr/SKILL.md
+++ b/plugins/developer-workflow/skills/prepare-for-pr/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: prepare-for-pr
+description: Use when implementation is complete and the branch needs to be quality-checked before creating a PR — runs build, simplify, self-review, and lint/tests in a loop until only minor or no issues remain.
+---
+
+# Prepare for PR
+
+## Overview
+
+Runs a quality loop over the current branch changes until the code is clean enough to expose in a PR.
+
+**Core principle:** Fix only what belongs to the current changes. If a problem is caused by something outside the current scope and the fix isn't obvious — ask the user.
+
+## Quality Loop
+
+Repeat until only minor issues remain or none at all. Record issues found at each step before fixing.
+
+```dot
+digraph prepare_for_pr {
+    rankdir=TB;
+
+    start [label="Implementation complete", shape=doublecircle];
+    build [label="Build", shape=box];
+    build_ok [label="Build passes?", shape=diamond];
+    build_scope [label="Caused by\ncurrent changes?", shape=diamond];
+    ask_build [label="Ask user", shape=box];
+    fix_build [label="Fix", shape=box];
+    simplify [label="Simplify\n(skill: simplify)", shape=box];
+    selfrev [label="Self-review all diffs", shape=box];
+    issues_found [label="Non-minor issues?", shape=diamond];
+    in_scope [label="In current scope?", shape=diamond];
+    ask_scope [label="Ask user", shape=box];
+    fix [label="Fix", shape=box];
+    lint [label="Lint + Tests", shape=box];
+    lint_fail [label="Failures?", shape=diamond];
+    lint_scope [label="In current scope?", shape=diamond];
+    ask_lint [label="Ask user", shape=box];
+    fix_lint [label="Fix", shape=box];
+    done [label="Ready for PR", shape=doublecircle];
+
+    start -> build;
+    build -> build_ok;
+    build_ok -> simplify [label="yes"];
+    build_ok -> build_scope [label="no"];
+    build_scope -> fix_build [label="yes"];
+    build_scope -> ask_build [label="no — stop"];
+    fix_build -> build;
+
+    simplify -> selfrev;
+    selfrev -> issues_found;
+    issues_found -> lint [label="no"];
+    issues_found -> in_scope [label="yes"];
+    in_scope -> fix [label="yes"];
+    in_scope -> ask_scope [label="no — stop"];
+    fix -> build;
+
+    lint -> lint_fail;
+    lint_fail -> done [label="no failures"];
+    lint_fail -> lint_scope [label="yes"];
+    lint_scope -> fix_lint [label="yes"];
+    lint_scope -> ask_lint [label="no — stop"];
+    fix_lint -> build;
+}
+```
+
+## Scope Decision
+
+**In scope — fix autonomously:**
+- Bugs introduced by current changes
+- Tests broken by current changes
+- Lint errors in changed files
+- Logic errors in current implementation
+
+**Out of scope — ask user only if fix isn't obvious:**
+- Pre-existing failures unrelated to this PR
+- Test failures in files not touched
+- Build errors from dependency issues or unrelated commits
+
+When asking, include: what the issue is, why it seems unrelated, and options (fix here / ignore / open separate issue).
+
+## What "Minor" Means
+
+**Minor (exit loop — code is ready):** style preferences, optional naming, cosmetic suggestions with no correctness impact.
+
+**Non-minor (keep looping):** bugs, broken tests, lint errors, security issues, incorrect logic.
+
+## Output
+
+When the loop exits, report:
+- Issues found per step and what was fixed
+- Any items escalated to user
+- Confirmation: **"Code is ready for PR"**


### PR DESCRIPTION
## Summary

- Adds `plugins/developer-workflow/` — a new skills-only plugin for developer workflow habits
- `prepare-for-pr` skill: quality loop (build → simplify → self-review → lint/tests) before creating a PR; fixes only issues in current scope, asks user otherwise
- `pr-lifecycle` skill: drives an existing PR/MR to merge through CI/CD monitoring and multi-round code review; autonomous major/minor comment triage, responds and resolves every thread

## Test plan

- [ ] Install plugin locally and verify skills appear in `/skills` list
- [ ] Verify `prepare-for-pr` is triggered correctly by the skill tool
- [ ] Verify `pr-lifecycle` is triggered when working with an existing PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)