### PR TITLE
fix: don't cache empty AndroidX changelog parse results (v0.3.1)

### DIFF
--- a/plugins/maven-mcp/package-lock.json
+++ b/plugins/maven-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@krozov/maven-central-mcp",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/plugins/maven-mcp/package.json
+++ b/plugins/maven-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "MCP server for Maven Central dependency intelligence",
   "main": "./dist/index.js",
   "type": "module",

--- a/plugins/maven-mcp/src/changelog/androidx-provider.ts
+++ b/plugins/maven-mcp/src/changelog/androidx-provider.ts
@@ -52,7 +52,7 @@ export class AndroidXChangelogProvider implements ChangelogProvider {
 
       const html = await response.text();
       const entries = parseAndroidXReleaseNotes(html);
-      if (entries.size === 0) return [];
+      if (entries.size === 0) return null;
 
       return [...entries.entries()];
     } catch {


### PR DESCRIPTION
## Summary

- **Bug:** `AndroidXChangelogProvider` was caching empty parse results (`[]`) for 7 days. If the releases page returned unparseable HTML on first fetch, all subsequent calls within the TTL silently returned `repositoryNotFound: true` — even after the page recovered.
- **Fix:** Return `null` (not `[]`) when parsing finds no version headings. `FileCache.getOrFetch` already skips caching `null`, so failed/empty parses will retry on the next call. The 404 case keeps `[]` since a missing page is confirmed-absent state worth caching.
- **Also ships `get_dependency_changes`** — the tool was implemented but missing from the published package.

## How it was found

Running eval tests for the `/dependency-changes` skill against `androidx.room:room-runtime` — the tool returned `repositoryNotFound: true` despite the live page having 119 parseable version headings. Root cause: a stale `~/.cache/maven-central-mcp/androidx/room.json` with `{"data":[],"timestamp":...}`.

## Test plan

- [x] All 257 tests pass
- [x] `androidx-provider.test.ts` — existing "returns null when page has no version headings" test now validates correct behavior
- [ ] After merge: verify `get_dependency_changes` appears in MCP tool list and Room/Lifecycle changelogs are fetchable

🤖 Generated with [Claude Code](https://claude.com/claude-code)