### PR TITLE
chore: bump plugin manifests to v0.3.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,11 +8,11 @@
   "plugins": [
     {
       "name": "maven-mcp",
-      "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps and /latest-version skills",
+      "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps, /latest-version, and /dependency-changes skills",
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.3.0",
+      "version": "0.3.1",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/maven-mcp/plugin"

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "maven-mcp",
-  "version": "0.3.0",
-  "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps and /latest-version skills",
+  "version": "0.3.1",
+  "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps, /latest-version, and /dependency-changes skills",
   "mcpServers": {
     "maven-mcp": {
       "command": "npx",


### PR DESCRIPTION
Updates `plugin.json` and `marketplace.json` to v0.3.1 and adds `/dependency-changes` to the description, so Claude Code detects the version change and re-fetches the plugin with the `get_dependency_changes` tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)