### PR TITLE
chore: bump maven-mcp to v0.4.0

### DIFF
--- a/plugins/maven-mcp/package.json
+++ b/plugins/maven-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "MCP server for Maven Central dependency intelligence",
   "main": "./dist/index.js",
   "type": "module",

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maven-mcp",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps, /latest-version, and /dependency-changes skills",
   "mcpServers": {
     "maven-mcp": {


### PR DESCRIPTION
## Summary

- Bumps `@krozov/maven-central-mcp` npm package to **0.4.0**
- Bumps `maven-mcp` plugin manifest to **0.4.0**

### What's new in 0.4.0

- `/dependency-changes` skill — show what changed between two versions of a Maven artifact (release notes, changelog entries, GitHub releases)
- `developer-workflow` plugin — `/prepare-for-pr` and `/pr-drive-to-merge` skills

## Test plan

- [x] 257 tests passing
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)