### PR TITLE
fix: add developer-workflow plugin to marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.3.1",
+      "version": "0.4.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/maven-mcp/plugin"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,6 +27,17 @@
       "category": "security",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/sensitive-guard"
+    },
+    {
+      "name": "developer-workflow",
+      "description": "Developer workflow skills — prepare branches for PR and manage the full PR lifecycle through CI/CD and code review",
+      "author": {
+        "name": "kirich1409"
+      },
+      "version": "0.1.0",
+      "category": "development",
+      "homepage": "https://github.com/kirich1409/krozov-ai-tools",
+      "source": "./plugins/developer-workflow"
     }
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,18 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check all plugins are registered in marketplace.json
         run: |
+          set -euo pipefail
+          MARKETPLACE=".claude-plugin/marketplace.json"
+          REGISTERED=$(jq -r '.plugins[].name' "$MARKETPLACE")
           MISSING=0
           for dir in plugins/*/; do
-            plugin="${dir%/}"
-            name=$(basename "$plugin")
-            if ! jq -e --arg name "$name" '.plugins[] | select(.name == $name)' .claude-plugin/marketplace.json > /dev/null 2>&1; then
-              echo "ERROR: '$name' is in plugins/ but missing from .claude-plugin/marketplace.json"
+            name=$(basename "$dir")
+            if ! echo "$REGISTERED" | grep -Fxq "$name"; then
+              echo "ERROR: '$name' is in plugins/ but missing from $MARKETPLACE"
               MISSING=1
             fi
           done
-          exit $MISSING
+          exit "$MISSING"
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,23 @@ on:
     branches: [main]
 
 jobs:
+  validate-marketplace:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check all plugins are registered in marketplace.json
+        run: |
+          MISSING=0
+          for dir in plugins/*/; do
+            plugin="${dir%/}"
+            name=$(basename "$plugin")
+            if ! jq -e --arg name "$name" '.plugins[] | select(.name == $name)' .claude-plugin/marketplace.json > /dev/null 2>&1; then
+              echo "ERROR: '$name' is in plugins/ but missing from .claude-plugin/marketplace.json"
+              MISSING=1
+            fi
+          done
+          exit $MISSING
+
   build:
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
## Summary

- `developer-workflow` plugin had its own `.claude-plugin/plugin.json` but was never added to the root `.claude-plugin/marketplace.json`
- This caused it to be invisible in the Claude Code plugin store — only `maven-mcp` and `sensitive-guard` appeared
- Added the missing entry with matching metadata (name, description, version, category, source path)

## Root cause

The plugin was added in #21 but the `marketplace.json` registration was missed at that time.

## Test plan

- [ ] Open `/plugin` → Discover — `developer-workflow` now appears alongside the other two plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)