### PR TITLE
feat(developer-workflow): improve pr-drive-to-merge with review rigor

### DIFF
--- a/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
+++ b/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
@@ -88,6 +88,7 @@ digraph review {
     push [label="Fix → prepare-for-pr → push", shape=box];
     respond_fixed [label="Respond to BLOCKING/IMPORTANT\nwith commit hash", shape=box];
     resolve [label="Resolve all threads", shape=box];
+    fixes_made [label="Push was made\n(BLOCKING/IMPORTANT fixed)?", shape=diamond];
     rereview [label="Request re-review from reviewers\nwhose comments led to changes", shape=box];
     wait [label="Wait for re-review\n(poll every ~5 min)", shape=box];
     stale_check [label="No activity for\n>4 hours?", shape=diamond];
@@ -99,7 +100,7 @@ digraph review {
     start -> read_all;
     read_all -> any_comments;
     any_comments -> categorize [label="yes"];
-    any_comments -> wait [label="no — wait for\nfirst review"];
+    any_comments -> confirm_merge [label="no"];
     categorize -> ask_oos [label="OUT OF SCOPE present\n— pause until resolved"];
     ask_oos -> respond_optional [label="user decided"];
     categorize -> respond_optional [label="no OUT OF SCOPE"];
@@ -108,7 +109,9 @@ digraph review {
     any_fix -> resolve [label="no"];
     push -> respond_fixed;
     respond_fixed -> resolve;
-    resolve -> rereview;
+    resolve -> fixes_made;
+    fixes_made -> rereview [label="yes — push\nwas made"];
+    fixes_made -> confirm_merge [label="no — only optional/\ninvalid addressed"];
     rereview -> wait;
     wait -> stale_check;
     stale_check -> notify_stale [label="yes"];
@@ -174,7 +177,8 @@ Assign ONE category per comment. Show full table before acting. Proceed without 
 | **BLOCKING** | Security issues, critical bugs, compliance violations | Verify → Fix → respond → Resolve |
 | **IMPORTANT** | Bugs, missing error handling, missing tests | Verify → Fix → respond → Resolve |
 | **OPTIONAL** | Style, naming preference, refactoring suggestion, nitpick | Respond acknowledging → Resolve without fixing |
-| **INVALID** | Already fixed, no longer applies, praise | Respond acknowledging → Resolve |
+| **INVALID** | Already fixed, no longer applies | Respond acknowledging → Resolve |
+| **INVALID (praise)** | Compliments, thanks | Resolve without responding |
 | **OUT OF SCOPE** | Requires changes outside this PR | Ask user before acting |
 
 **Show table format:**
@@ -195,12 +199,15 @@ Proceeding with BLOCKING + IMPORTANT fixes. Waiting on your input for OUT OF SCO
 
 ## Responding to Comments
 
-**Reply in the comment thread, not as a top-level PR comment.** For fixed comments: respond after pushing, referencing the commit hash. For all others: respond inline immediately.
+**Reply in the comment thread when possible.** For fixed comments: respond after pushing, referencing the commit hash. For all others: respond immediately.
 
 ```bash
-# GitHub — reply in an inline review comment thread
-gh api repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies \
+# GitHub — reply to an inline review comment (omit pull number — it's not part of this endpoint)
+gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/replies \
   --method POST -f body="Your reply here"
+
+# GitHub — reply to a review summary or top-level PR comment (not an inline thread)
+gh pr comment $PR_NUMBER --body "Your reply here"
 ```
 
 **No performative agreement.** Never write "You're absolutely right!", "Great point!", "Excellent feedback!", or thank the reviewer. Actions speak — just fix it and show what changed.
@@ -254,9 +261,13 @@ gh api --method POST /repos/$REPO/pulls/$PR_NUMBER/requested_reviewers \
 
 # GitLab — re-request review via API (glab mr update has no --reviewer flag)
 FULLPATH=$(glab repo view --output json | jq -r '.nameWithNamespace | gsub(" "; "") | gsub("/"; "%2F")')
-REVIEWER_IDS=$(glab api /users?username=username1 --jq '.[0].id')
-glab api /projects/$FULLPATH/merge_requests/$MR_NUMBER --method PUT \
-  -f "reviewer_ids[]=$REVIEWER_IDS"
+# Build reviewer_ids[] args for each username
+REVIEWER_ARGS=()
+for username in username1 username2; do
+  id=$(glab api "/users?username=${username}" --jq '.[0].id')
+  REVIEWER_ARGS+=(-f "reviewer_ids[]=${id}")
+done
+glab api /projects/$FULLPATH/merge_requests/$MR_NUMBER --method PUT "${REVIEWER_ARGS[@]}"
 ```
 
 ## Merge Requirements Checklist

--- a/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
+++ b/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
@@ -82,8 +82,9 @@ digraph review {
     read_all [label="Read ALL comments\n(reviews + inline review comments)", shape=box];
     any_comments [label="Any unaddressed\ncomments?", shape=diamond];
     categorize [label="Categorize + show table\n(BLOCKING/IMPORTANT/OPTIONAL\n/INVALID/OUT OF SCOPE)", shape=box];
+    oos_present [label="OUT OF SCOPE\ncomments?", shape=diamond];
     ask_oos [label="Ask user for each OUT OF SCOPE\ncomment. Pause until resolved.", shape=box];
-    respond_optional [label="Respond to OPTIONAL/INVALID\ncomments immediately", shape=box];
+    respond_optional [label="Respond to OPTIONAL and\nnon-praise INVALID immediately", shape=box];
     any_fix [label="Any BLOCKING or\nIMPORTANT comments?", shape=diamond];
     push [label="Fix → prepare-for-pr → push", shape=box];
     respond_fixed [label="Respond to BLOCKING/IMPORTANT\nwith commit hash", shape=box];
@@ -101,9 +102,10 @@ digraph review {
     read_all -> any_comments;
     any_comments -> categorize [label="yes"];
     any_comments -> confirm_merge [label="no"];
-    categorize -> ask_oos [label="OUT OF SCOPE present\n— pause until resolved"];
+    categorize -> oos_present;
+    oos_present -> ask_oos [label="yes"];
+    oos_present -> respond_optional [label="no"];
     ask_oos -> respond_optional [label="user decided"];
-    categorize -> respond_optional [label="no OUT OF SCOPE"];
     respond_optional -> any_fix;
     any_fix -> push [label="yes"];
     any_fix -> resolve [label="no"];

--- a/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
+++ b/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
@@ -89,7 +89,7 @@ digraph review {
     oos [label="OUT OF SCOPE\ncomments?", shape=diamond];
     ask_oos [label="Ask user for each\nOUT OF SCOPE comment.\nPause until resolved.", shape=box];
     any_fix [label="Any BLOCKING or\nIMPORTANT comments?", shape=diamond];
-    verify [label="Verify each suggestion\nagainst codebase reality\n(see Verification section)", shape=box];
+    verify [label="Verify ALL BLOCKING/IMPORTANT\nsuggestions before fixing any\n(see Verification section)", shape=box];
     fix [label="Fix → prepare-for-pr → push", shape=box];
     respond [label="Respond to every comment\nindividually in thread\n(in PR language)\nReference pushed commit hash", shape=box];
     resolve [label="Resolve threads", shape=box];
@@ -107,6 +107,7 @@ digraph review {
     reviewers -> wait [label="yes"];
     wait -> stale_check;
     stale_check -> notify_stale [label="yes"];
+    notify_stale -> wait [label="user responds"];
     stale_check -> read_all [label="no"];
     read_all -> any_comments;
     any_comments -> clarify [label="yes"];
@@ -144,13 +145,7 @@ glab api /projects/:fullpath/merge_requests/:iid/discussions
 
 ## Handling Unclear Feedback
 
-```
-IF any comment is unclear:
-  STOP — do not implement anything yet
-  Ask for clarification on ALL unclear items at once
-
-WHY: Items may be related. Partial understanding = wrong implementation.
-```
+If any comment is unclear, stop — do not implement anything yet. Ask for clarification on ALL unclear items at once.
 
 **Example:**
 ```
@@ -237,7 +232,7 @@ gh api repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies \
 | Category | Response template |
 |----------|------------------|
 | BLOCKING/IMPORTANT (fixed) | `Fixed in [commit hash]. [What changed and why.]` |
-| BLOCKING/IMPORTANT (pushed back, then verified correct) | `You were right — checked [X] and it does [Y]. Fixed in [commit hash].` |
+| BLOCKING/IMPORTANT (pushed back, then verified correct) | `Checked [X] — confirmed it does [Y]. Fixed in [commit hash].` |
 | BLOCKING/IMPORTANT (pushing back) | `[Technical reasoning]. [Evidence from codebase.] Leaving as-is.` |
 | OPTIONAL | `Not addressing in this PR to keep it focused on [goal].` *(If genuinely useful: "Logged as [issue link] for follow-up.")* |
 | INVALID (outdated) | `This was addressed in [commit]. [File/code] now [does X].` |
@@ -246,12 +241,7 @@ gh api repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies \
 
 ## When to Push Back
 
-Push back when:
-- Suggestion breaks existing functionality
-- Reviewer lacks full context (e.g., missed why the code is the way it is)
-- Violates YAGNI (unused feature)
-- Technically incorrect for this stack or platform
-- Conflicts with architectural decisions made for this PR
+Trigger conditions are the same as the verification checklist above — push back when any check fails. See "Verifying Suggestions Before Implementing".
 
 **How to push back:**
 - Use technical reasoning, not defensiveness
@@ -261,7 +251,7 @@ Push back when:
 
 **If you pushed back and were wrong:**
 ```
-"You were right — checked [X] and it does [Y]. Fixed in [commit hash]."
+"Checked [X] — confirmed it does [Y]. Fixed in [commit hash]."
 ```
 State the correction factually. No apology, no over-explaining.
 

--- a/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
+++ b/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
@@ -252,9 +252,11 @@ REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 gh api --method POST /repos/$REPO/pulls/$PR_NUMBER/requested_reviewers \
   -f "reviewers[]=username1" -f "reviewers[]=username2"
 
-# GitLab — re-request review (replace reviewers, which triggers re-review notification)
-glab mr update <MR_NUMBER> --reviewer username1,username2
-# To add without removing existing: --reviewer +username1,+username2
+# GitLab — re-request review via API (glab mr update has no --reviewer flag)
+FULLPATH=$(glab repo view --output json | jq -r '.nameWithNamespace | gsub(" "; "") | gsub("/"; "%2F")')
+REVIEWER_IDS=$(glab api /users?username=username1 --jq '.[0].id')
+glab api /projects/$FULLPATH/merge_requests/$MR_NUMBER --method PUT \
+  -f "reviewer_ids[]=$REVIEWER_IDS"
 ```
 
 ## Merge Requirements Checklist

--- a/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
+++ b/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
@@ -98,6 +98,7 @@ digraph review {
     fixes_made [label="Fixes were made?", shape=diamond];
     rereview [label="Request re-review", shape=box];
     ci_loop [label="Back to CI/CD monitoring", shape=box];
+    pending_rereview [label="Pending re-review\nrequests?", shape=diamond];
     merge_check [label="Merge requirements met?", shape=diamond];
     confirm_merge [label="Ask user:\n'All requirements met — ready to merge.\nShould I go ahead?'", shape=box];
     done [label="MERGE", shape=doublecircle];
@@ -114,7 +115,7 @@ digraph review {
     stale_check -> read_all [label="no"];
     read_all -> any_comments;
     any_comments -> clarify [label="yes"];
-    any_comments -> merge_check [label="no, approved"];
+    any_comments -> pending_rereview [label="no"];
     clarify -> categorize [label="no"];
     clarify -> ask_clarify [label="yes"];
     ask_clarify -> categorize;
@@ -132,11 +133,25 @@ digraph review {
     fixes_made -> rereview [label="yes"];
     fixes_made -> merge_check [label="no"];
     rereview -> ci_loop -> wait;
+    pending_rereview -> wait [label="yes — keep waiting"];
+    pending_rereview -> merge_check [label="no"];
     merge_check -> confirm_merge [label="yes"];
     merge_check -> wait [label="no — keep polling"];
     confirm_merge -> done [label="user confirms"];
 }
 ```
+
+**Checking for pending re-review requests:** before proceeding to merge check, verify no reviewer is still waiting to re-review:
+
+```bash
+# GitHub — non-zero means reviewers were re-requested and haven't responded yet
+gh pr view <N> --json reviewRequests --jq '.reviewRequests | length'
+
+# GitLab — check for reviewers who haven't submitted a review since last push
+glab mr view <N> --output json | jq '.reviewers | map(select(.state == "requested")) | length'
+```
+
+If the count is > 0, stay in the wait loop — do not proceed to merge check.
 
 **Reading comments:** `gh pr view <N> --comments` does not return inline review comments. Fetch them separately:
 

--- a/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
+++ b/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
@@ -77,81 +77,46 @@ digraph review {
     rankdir=TB;
 
     start [label="CI/CD passing", shape=doublecircle];
-    reviewers [label="Reviewers assigned?", shape=diamond];
-    approvals_req [label="Approvals required\nby repo rules?", shape=diamond];
-    ask_assign [label="Notify user: approvals required\nbut no reviewers assigned.\nPause until user assigns.", shape=box];
-    wait [label="Poll for new reviews/comments\nevery ~5 min", shape=box];
-    stale_check [label="No activity for\n>4 hours?", shape=diamond];
-    notify_stale [label="Notify user, ask\nhow to proceed.\nPause.", shape=box];
     read_all [label="Read ALL comments\n(reviews + inline review comments)", shape=box];
-    any_comments [label="Unaddressed comments?", shape=diamond];
-    clarify [label="Any comment unclear?", shape=diamond];
-    ask_clarify [label="Ask user, await\nclarification", shape=box];
+    any_comments [label="Any unaddressed\ncomments?", shape=diamond];
     categorize [label="Categorize + show table\n(BLOCKING/IMPORTANT/OPTIONAL\n/INVALID/OUT OF SCOPE)", shape=box];
-    oos [label="OUT OF SCOPE\ncomments?", shape=diamond];
-    ask_oos [label="Ask user for each\nOUT OF SCOPE comment.\nPause until resolved.", shape=box];
+    ask_oos [label="Ask user for each OUT OF SCOPE\ncomment. Pause until resolved.", shape=box];
+    respond_optional [label="Respond to OPTIONAL/INVALID\ncomments immediately", shape=box];
     any_fix [label="Any BLOCKING or\nIMPORTANT comments?", shape=diamond];
-    verify [label="Verify ALL BLOCKING/IMPORTANT\nsuggestions before fixing any\n(see Verification section)", shape=box];
-    fix [label="Fix → prepare-for-pr → push", shape=box];
-    respond [label="Respond to every comment\nindividually in thread\n(in PR language)\nReference pushed commit hash", shape=box];
-    resolve [label="Resolve threads", shape=box];
-    fixes_made [label="Fixes were made?", shape=diamond];
-    rereview [label="Request re-review", shape=box];
-    ci_loop [label="Back to CI/CD monitoring", shape=box];
-    pending_rereview [label="Pending re-review\nrequests?", shape=diamond];
-    merge_check [label="Merge requirements met?", shape=diamond];
+    push [label="Fix → prepare-for-pr → push", shape=box];
+    respond_fixed [label="Respond to BLOCKING/IMPORTANT\nwith commit hash", shape=box];
+    resolve [label="Resolve all threads", shape=box];
+    rereview [label="Request re-review from reviewers\nwhose comments led to changes", shape=box];
+    wait [label="Wait for re-review\n(poll every ~5 min)", shape=box];
+    stale_check [label="No activity for\n>4 hours?", shape=diamond];
+    notify_stale [label="Notify user, ask\nhow to proceed. Pause.", shape=box];
+    new_comments [label="New unaddressed\ncomments?", shape=diamond];
     confirm_merge [label="Ask user:\n'All requirements met — ready to merge.\nShould I go ahead?'", shape=box];
     done [label="MERGE", shape=doublecircle];
 
-    start -> reviewers;
-    reviewers -> approvals_req [label="no"];
-    approvals_req -> ask_assign [label="yes — stop"];
-    approvals_req -> merge_check [label="no"];
-    ask_assign -> wait [label="user assigns reviewers"];
-    reviewers -> wait [label="yes"];
+    start -> read_all;
+    read_all -> any_comments;
+    any_comments -> categorize [label="yes"];
+    any_comments -> wait [label="no — wait for\nfirst review"];
+    categorize -> ask_oos [label="OUT OF SCOPE present\n— pause until resolved"];
+    ask_oos -> respond_optional [label="user decided"];
+    categorize -> respond_optional [label="no OUT OF SCOPE"];
+    respond_optional -> any_fix;
+    any_fix -> push [label="yes"];
+    any_fix -> resolve [label="no"];
+    push -> respond_fixed;
+    respond_fixed -> resolve;
+    resolve -> rereview;
+    rereview -> wait;
     wait -> stale_check;
     stale_check -> notify_stale [label="yes"];
     notify_stale -> wait [label="user responds"];
-    stale_check -> read_all [label="no"];
-    read_all -> any_comments;
-    any_comments -> clarify [label="yes"];
-    any_comments -> pending_rereview [label="no"];
-    clarify -> categorize [label="no"];
-    clarify -> ask_clarify [label="yes"];
-    ask_clarify -> categorize;
-    categorize -> oos;
-    oos -> ask_oos [label="yes — pause\nuntil resolved"];
-    oos -> any_fix [label="no"];
-    ask_oos -> any_fix [label="user decided"];
-    any_fix -> verify [label="yes"];
-    any_fix -> respond [label="no — skip fix"];
-    verify -> fix [label="technically correct"];
-    verify -> respond [label="push back — no fix"];
-    fix -> respond;
-    respond -> resolve;
-    resolve -> fixes_made;
-    fixes_made -> rereview [label="yes"];
-    fixes_made -> merge_check [label="no"];
-    rereview -> ci_loop -> wait;
-    pending_rereview -> wait [label="yes — keep waiting"];
-    pending_rereview -> merge_check [label="no"];
-    merge_check -> confirm_merge [label="yes"];
-    merge_check -> wait [label="no — keep polling"];
+    stale_check -> new_comments [label="no"];
+    new_comments -> read_all [label="yes — repeat"];
+    new_comments -> confirm_merge [label="no"];
     confirm_merge -> done [label="user confirms"];
 }
 ```
-
-**Checking for pending re-review requests:** before proceeding to merge check, verify no reviewer is still waiting to re-review:
-
-```bash
-# GitHub — non-zero means reviewers were re-requested and haven't responded yet
-gh pr view <N> --json reviewRequests --jq '.reviewRequests | length'
-
-# GitLab — check for reviewers who haven't submitted a review since last push
-glab mr view <N> --output json | jq '.reviewers | map(select(.state == "requested")) | length'
-```
-
-If the count is > 0, stay in the wait loop — do not proceed to merge check.
 
 **Reading comments:** `gh pr view <N> --comments` does not return inline review comments. Fetch them separately:
 
@@ -295,7 +260,7 @@ glab api /projects/:fullpath/merge_requests/:iid/discussions/:discussion_id \
 
 ## Re-Review
 
-Request re-review only from reviewers whose BLOCKING or IMPORTANT comments were fixed:
+Request re-review only from reviewers whose BLOCKING or IMPORTANT comments led to actual changes. Do not re-request from reviewers who only left OPTIONAL or INVALID comments.
 
 ```bash
 # GitHub — re-request review (use API, not --add-reviewer which only adds new reviewers)

--- a/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
+++ b/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
@@ -18,15 +18,15 @@ Before starting, detect the PR and platform:
 ```bash
 # GitHub — fetch all needed fields in one call
 PR_INFO=$(gh pr view --json number,baseRefName,isDraft)
-PR_NUMBER=$(echo $PR_INFO | jq -r .number)
-BASE=$(echo $PR_INFO | jq -r .baseRefName)
-IS_DRAFT=$(echo $PR_INFO | jq -r .isDraft)
+PR_NUMBER=$(echo "$PR_INFO" | jq -r .number)
+BASE=$(echo "$PR_INFO" | jq -r .baseRefName)
+IS_DRAFT=$(echo "$PR_INFO" | jq -r .isDraft)
 
 # GitLab — detect MR number and base branch
 MR_INFO=$(glab mr view --output json)
-MR_NUMBER=$(echo $MR_INFO | jq .iid)
-BASE=$(echo $MR_INFO | jq -r .target_branch)
-IS_DRAFT=$(echo $MR_INFO | jq .draft)
+MR_NUMBER=$(echo "$MR_INFO" | jq .iid)
+BASE=$(echo "$MR_INFO" | jq -r .target_branch)
+IS_DRAFT=$(echo "$MR_INFO" | jq .draft)
 ```
 
 **Platform detection:** check `git remote get-url origin`.
@@ -71,12 +71,6 @@ digraph cicd {
 ```
 
 **Invoking `prepare-for-pr` for fixes:** invoke it as a sub-skill. It runs its own quality loop, commits fixes, and exits when clean. If it pauses for user input, this skill also pauses. After it exits, push: `git push`.
-
-**After every push — check branch is up to date with base:**
-```bash
-git fetch origin $BASE && git status  # look for "behind"
-```
-If behind: rebase immediately (`git rebase origin/$BASE && git push --force-with-lease`) rather than deferring to merge time. Resolve any conflicts that touch files within this PR's scope; for conflicts outside scope, ask the user.
 
 ## Phase 2: Code Review Cycle
 
@@ -135,8 +129,6 @@ gh api repos/{owner}/{repo}/pulls/{number}/comments
 # GitLab — all discussions (includes inline)
 glab api /projects/:fullpath/merge_requests/:iid/discussions
 ```
-
-**Stale detection:** while waiting for re-review, if no new review activity appears after 4 hours, notify the user with the PR link and ask how to proceed (ping the reviewer, wait longer, or merge without the re-review). Pause until the user responds.
 
 ## Handling Unclear Feedback
 
@@ -280,7 +272,7 @@ When all boxes are checked, **stop and ask the user for confirmation**:
 
 Only merge after explicit confirmation. Exception: if the user already pre-approved the merge earlier in the conversation (e.g. "merge it when it's ready"), proceed without asking again.
 
-**Branch behind base — update and handle conflicts:**
+**Branch behind base** — check after every push and before merging. If behind:
 ```bash
 # GitHub
 gh pr update-branch <PR_NUMBER>

--- a/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
+++ b/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
@@ -62,6 +62,7 @@ digraph cicd {
     investigate -> our_fault;
     our_fault -> fix [label="yes"];
     our_fault -> ask [label="no — pause\nuntil user decides"];
+    ask -> fetch_status [label="user decides"];
     fix -> wait;
     undraft -> review;
 }
@@ -84,7 +85,8 @@ digraph review {
     notify_stale [label="Notify user, ask\nhow to proceed.\nPause.", shape=box];
     read_all [label="Read ALL comments\n(reviews + inline review comments)", shape=box];
     any_comments [label="Unaddressed comments?", shape=diamond];
-    clarify [label="Any comment unclear?\nStop — clarify ALL unclear\nitems before proceeding.", shape=diamond];
+    clarify [label="Any comment unclear?", shape=diamond];
+    ask_clarify [label="Ask user, await\nclarification", shape=box];
     categorize [label="Categorize + show table\n(BLOCKING/IMPORTANT/OPTIONAL\n/INVALID/OUT OF SCOPE)", shape=box];
     oos [label="OUT OF SCOPE\ncomments?", shape=diamond];
     ask_oos [label="Ask user for each\nOUT OF SCOPE comment.\nPause until resolved.", shape=box];
@@ -113,7 +115,8 @@ digraph review {
     any_comments -> clarify [label="yes"];
     any_comments -> merge_check [label="no, approved"];
     clarify -> categorize [label="all clear"];
-    clarify -> wait [label="unclear — pause\nuntil resolved"];
+    clarify -> ask_clarify [label="yes"];
+    ask_clarify -> categorize;
     categorize -> oos;
     oos -> ask_oos [label="yes — pause\nuntil resolved"];
     oos -> any_fix [label="no"];
@@ -145,9 +148,7 @@ glab api /projects/:fullpath/merge_requests/:iid/discussions
 
 ## Handling Unclear Feedback
 
-If any comment is unclear, stop — do not implement anything yet. Ask for clarification on ALL unclear items at once.
-
-**Example:**
+Ask for clarification on ALL unclear items at once — not one at a time. **Example:**
 ```
 Reviewer: "Fix 1-6"
 You understand 1,2,3,6. Unclear on 4,5.
@@ -216,10 +217,7 @@ Proceeding with BLOCKING + IMPORTANT fixes. Waiting on your input for OUT OF SCO
 
 ## Responding to Comments
 
-**Always respond in the same language as the PR and review comments.**
-**Respond after pushing fixes** — reference the actual commit hash.
-**Respond to every comment individually — never a single summary.**
-**Reply in the comment thread, not as a top-level PR comment.**
+**Reply in the comment thread, not as a top-level PR comment.** For fixed comments: respond after pushing, referencing the commit hash. For all others: respond inline immediately.
 
 ```bash
 # GitHub — reply in an inline review comment thread
@@ -249,11 +247,7 @@ Trigger conditions are the same as the verification checklist above — push bac
 - Reference working tests or existing code as evidence
 - Involve the user if the disagreement is architectural
 
-**If you pushed back and were wrong:**
-```
-"Checked [X] — confirmed it does [Y]. Fixed in [commit hash]."
-```
-State the correction factually. No apology, no over-explaining.
+Use the response table template for the correction — state it factually, no apology, no over-explaining.
 
 ## Resolving Threads
 

--- a/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
+++ b/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
@@ -95,7 +95,7 @@ digraph review {
     stale_check [label="No activity for\n>4 hours?", shape=diamond];
     notify_stale [label="Notify user, ask\nhow to proceed. Pause.", shape=box];
     new_comments [label="New unaddressed\ncomments?", shape=diamond];
-    confirm_merge [label="Ask user:\n'All requirements met — ready to merge.\nShould I go ahead?'", shape=box];
+    confirm_merge [label="Verify merge requirements checklist.\nIf all met, ask user:\n'Ready to merge — should I go ahead?'", shape=box];
     done [label="MERGE", shape=doublecircle];
 
     start -> read_all;
@@ -193,7 +193,7 @@ Assign ONE category per comment. Show full table before acting. Proceed without 
 | 1 | @dev | auth.ts:23 | Password in plaintext | BLOCKING | Will fix |
 | 2 | @dev | auth.ts:12 | Rename doAuth | OPTIONAL | Will acknowledge |
 | 3 | @qa | auth.ts:45 | Missing error handling | IMPORTANT | Will fix |
-| 4 | @dev | auth.ts:67 | Nice work! | INVALID | Will acknowledge |
+| 4 | @dev | auth.ts:67 | Nice work! | INVALID (praise) | Will resolve |
 | 5 | @dev | utils.ts:10 | Whole file needs refactor | OUT OF SCOPE | Need your input |
 
 Proceeding with BLOCKING + IMPORTANT fixes. Waiting on your input for OUT OF SCOPE (#5).
@@ -262,14 +262,14 @@ gh api --method POST /repos/$REPO/pulls/$PR_NUMBER/requested_reviewers \
   -f "reviewers[]=username1" -f "reviewers[]=username2"
 
 # GitLab — re-request review via API (glab mr update has no --reviewer flag)
-FULLPATH=$(glab repo view --output json | jq -r '.nameWithNamespace | gsub(" "; "") | gsub("/"; "%2F")')
+PROJECT_ID=$(glab repo view --output json | jq -r '.id')
 # Build reviewer_ids[] args for each username
 REVIEWER_ARGS=()
 for username in username1 username2; do
   id=$(glab api "/users?username=${username}" --jq '.[0].id')
   REVIEWER_ARGS+=(-f "reviewer_ids[]=${id}")
 done
-glab api /projects/$FULLPATH/merge_requests/$MR_NUMBER --method PUT "${REVIEWER_ARGS[@]}"
+glab api /projects/$PROJECT_ID/merge_requests/$MR_NUMBER --method PUT "${REVIEWER_ARGS[@]}"
 ```
 
 ## Merge Requirements Checklist

--- a/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
+++ b/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
@@ -9,22 +9,24 @@ description: Use when a PR/MR already exists and needs to be driven to merge —
 
 Takes an existing PR/MR and drives it to merge autonomously. Loops through CI/CD monitoring and code review cycles until all requirements are satisfied.
 
-**Core principle:** Fix only what belongs to the current PR. Verify suggestions before implementing. Ask the user only when a problem is outside the current PR scope and the fix isn't obvious.
+**Core principle:** Fix only what belongs to the current PR. Ask the user only when a problem is outside the current PR scope and the fix isn't obvious.
 
 ## Setup
 
 Before starting, detect the PR and platform:
 
 ```bash
-# GitHub — detect PR number and base branch
-PR_NUMBER=$(gh pr view --json number -q .number)
-BASE=$(gh pr view --json baseRefName -q .baseRefName)
-IS_DRAFT=$(gh pr view --json isDraft -q .isDraft)
+# GitHub — fetch all needed fields in one call
+PR_INFO=$(gh pr view --json number,baseRefName,isDraft)
+PR_NUMBER=$(echo $PR_INFO | jq -r .number)
+BASE=$(echo $PR_INFO | jq -r .baseRefName)
+IS_DRAFT=$(echo $PR_INFO | jq -r .isDraft)
 
 # GitLab — detect MR number and base branch
-MR_NUMBER=$(glab mr view --output json | jq .iid)
-BASE=$(glab mr view --output json | jq -r .target_branch)
-IS_DRAFT=$(glab mr view --output json | jq .draft)
+MR_INFO=$(glab mr view --output json)
+MR_NUMBER=$(echo $MR_INFO | jq .iid)
+BASE=$(echo $MR_INFO | jq -r .target_branch)
+IS_DRAFT=$(echo $MR_INFO | jq .draft)
 ```
 
 **Platform detection:** check `git remote get-url origin`.
@@ -69,6 +71,12 @@ digraph cicd {
 ```
 
 **Invoking `prepare-for-pr` for fixes:** invoke it as a sub-skill. It runs its own quality loop, commits fixes, and exits when clean. If it pauses for user input, this skill also pauses. After it exits, push: `git push`.
+
+**After every push — check branch is up to date with base:**
+```bash
+git fetch origin $BASE && git status  # look for "behind"
+```
+If behind: rebase immediately (`git rebase origin/$BASE && git push --force-with-lease`) rather than deferring to merge time. Resolve any conflicts that touch files within this PR's scope; for conflicts outside scope, ask the user.
 
 ## Phase 2: Code Review Cycle
 
@@ -128,6 +136,8 @@ gh api repos/{owner}/{repo}/pulls/{number}/comments
 glab api /projects/:fullpath/merge_requests/:iid/discussions
 ```
 
+**Stale detection:** while waiting for re-review, if no new review activity appears after 4 hours, notify the user with the PR link and ask how to proceed (ping the reviewer, wait longer, or merge without the re-review). Pause until the user responds.
+
 ## Handling Unclear Feedback
 
 Ask for clarification on ALL unclear items at once — not one at a time. **Example:**
@@ -139,9 +149,9 @@ Wrong: Implement 1,2,3,6 now, ask about 4,5 later
 Right: "I understand items 1,2,3,6. Need clarification on 4 and 5 before proceeding."
 ```
 
-## Verifying Suggestions Before Implementing
+## Verifying Suggestions and Pushing Back
 
-Before implementing any BLOCKING or IMPORTANT suggestion from an external reviewer:
+Before implementing any BLOCKING or IMPORTANT suggestion, verify it first:
 
 ```
 1. Check: Technically correct for THIS codebase?
@@ -149,25 +159,19 @@ Before implementing any BLOCKING or IMPORTANT suggestion from an external review
 3. Check: Is there a reason the current code is written this way?
 4. Check: Works on all platforms/versions targeted by this PR?
 5. Check: Does the reviewer have full context?
-
-IF suggestion seems wrong:
-  Push back with technical reasoning (see Push Back section below)
-
-IF can't easily verify:
-  Say so: "I can't verify this without [X]. Should I [investigate/ask/proceed]?"
-
-IF conflicts with prior decisions made for this PR:
-  Discuss with user first
 ```
 
-**YAGNI check** — if a reviewer suggests "implementing it properly" or adding infrastructure:
+**If any check fails — push back:**
+- Use technical reasoning, not defensiveness
+- Ask specific questions; reference working tests or existing code as evidence
+- Involve the user if the disagreement is architectural
+- State it factually in the response thread — no apology, no over-explaining
 
-```
-Search codebase for actual usage.
+**If you can't easily verify:** say so — "I can't verify this without [X]. Should I [investigate/ask/proceed]?"
 
-IF unused: push back — "This isn't called anywhere. Remove it?"
-IF used:   implement properly
-```
+**If it conflicts with prior decisions for this PR:** discuss with user first.
+
+**YAGNI check** — if a reviewer suggests "implementing it properly" or adding infrastructure: search codebase for actual usage. If unused: push back. If used: implement properly.
 
 ## Comment Categories
 
@@ -218,18 +222,6 @@ gh api repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies \
 | INVALID (outdated) | `This was addressed in [commit]. [File/code] now [does X].` |
 | INVALID (praise) | *(no response needed — just resolve)* |
 | OUT OF SCOPE | Per user's instruction |
-
-## When to Push Back
-
-Trigger conditions are the same as the verification checklist above — push back when any check fails. See "Verifying Suggestions Before Implementing".
-
-**How to push back:**
-- Use technical reasoning, not defensiveness
-- Ask specific questions
-- Reference working tests or existing code as evidence
-- Involve the user if the disagreement is architectural
-
-Use the response table template for the correction — state it factually, no apology, no over-explaining.
 
 ## Resolving Threads
 
@@ -305,9 +297,4 @@ glab mr rebase <MR_NUMBER>
 
 ## Tools Priority
 
-**GitHub/GitLab CLI → REST API → MCP**
-
-| Platform | Remote URL pattern | CLI |
-|----------|-------------------|-----|
-| GitHub | `github.com` (HTTPS or SSH `git@github.com:...`) | `gh` |
-| GitLab | `gitlab` in URL | `glab` |
+Prefer **CLI → REST API → MCP** in that order. Platform detection is covered in Setup.

--- a/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
+++ b/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
@@ -9,7 +9,7 @@ description: Use when a PR/MR already exists and needs to be driven to merge —
 
 Takes an existing PR/MR and drives it to merge autonomously. Loops through CI/CD monitoring and code review cycles until all requirements are satisfied.
 
-**Core principle:** Fix only what belongs to the current PR. Ask the user only when a problem is outside the current PR scope and the fix isn't obvious.
+**Core principle:** Fix only what belongs to the current PR. Verify suggestions before implementing. Ask the user only when a problem is outside the current PR scope and the fix isn't obvious.
 
 ## Setup
 
@@ -84,12 +84,14 @@ digraph review {
     notify_stale [label="Notify user, ask\nhow to proceed.\nPause.", shape=box];
     read_all [label="Read ALL comments\n(reviews + inline review comments)", shape=box];
     any_comments [label="Unaddressed comments?", shape=diamond];
+    clarify [label="Any comment unclear?\nStop — clarify ALL unclear\nitems before proceeding.", shape=diamond];
     categorize [label="Categorize + show table\n(BLOCKING/IMPORTANT/OPTIONAL\n/INVALID/OUT OF SCOPE)", shape=box];
     oos [label="OUT OF SCOPE\ncomments?", shape=diamond];
     ask_oos [label="Ask user for each\nOUT OF SCOPE comment.\nPause until resolved.", shape=box];
     any_fix [label="Any BLOCKING or\nIMPORTANT comments?", shape=diamond];
+    verify [label="Verify each suggestion\nagainst codebase reality\n(see Verification section)", shape=box];
     fix [label="Fix → prepare-for-pr → push", shape=box];
-    respond [label="Respond to every comment\nindividually (in PR language)\nReference pushed commit hash", shape=box];
+    respond [label="Respond to every comment\nindividually in thread\n(in PR language)\nReference pushed commit hash", shape=box];
     resolve [label="Resolve threads", shape=box];
     fixes_made [label="Fixes were made?", shape=diamond];
     rereview [label="Request re-review", shape=box];
@@ -107,14 +109,18 @@ digraph review {
     stale_check -> notify_stale [label="yes"];
     stale_check -> read_all [label="no"];
     read_all -> any_comments;
-    any_comments -> categorize [label="yes"];
+    any_comments -> clarify [label="yes"];
     any_comments -> merge_check [label="no, approved"];
+    clarify -> categorize [label="all clear"];
+    clarify -> wait [label="unclear — pause\nuntil resolved"];
     categorize -> oos;
     oos -> ask_oos [label="yes — pause\nuntil resolved"];
     oos -> any_fix [label="no"];
     ask_oos -> any_fix [label="user decided"];
-    any_fix -> fix [label="yes"];
+    any_fix -> verify [label="yes"];
     any_fix -> respond [label="no — skip fix"];
+    verify -> fix [label="technically correct"];
+    verify -> respond [label="push back — no fix"];
     fix -> respond;
     respond -> resolve;
     resolve -> fixes_made;
@@ -136,14 +142,63 @@ gh api repos/{owner}/{repo}/pulls/{number}/comments
 glab api /projects/:fullpath/merge_requests/:iid/discussions
 ```
 
+## Handling Unclear Feedback
+
+```
+IF any comment is unclear:
+  STOP — do not implement anything yet
+  Ask for clarification on ALL unclear items at once
+
+WHY: Items may be related. Partial understanding = wrong implementation.
+```
+
+**Example:**
+```
+Reviewer: "Fix 1-6"
+You understand 1,2,3,6. Unclear on 4,5.
+
+Wrong: Implement 1,2,3,6 now, ask about 4,5 later
+Right: "I understand items 1,2,3,6. Need clarification on 4 and 5 before proceeding."
+```
+
+## Verifying Suggestions Before Implementing
+
+Before implementing any BLOCKING or IMPORTANT suggestion from an external reviewer:
+
+```
+1. Check: Technically correct for THIS codebase?
+2. Check: Would it break existing functionality?
+3. Check: Is there a reason the current code is written this way?
+4. Check: Works on all platforms/versions targeted by this PR?
+5. Check: Does the reviewer have full context?
+
+IF suggestion seems wrong:
+  Push back with technical reasoning (see Push Back section below)
+
+IF can't easily verify:
+  Say so: "I can't verify this without [X]. Should I [investigate/ask/proceed]?"
+
+IF conflicts with prior decisions made for this PR:
+  Discuss with user first
+```
+
+**YAGNI check** — if a reviewer suggests "implementing it properly" or adding infrastructure:
+
+```
+Search codebase for actual usage.
+
+IF unused: push back — "This isn't called anywhere. Remove it?"
+IF used:   implement properly
+```
+
 ## Comment Categories
 
 Assign ONE category per comment. Show full table before acting. Proceed without waiting for approval except for OUT OF SCOPE.
 
 | Category | When to use | Action |
 |----------|-------------|--------|
-| **BLOCKING** | Security issues, critical bugs, compliance violations | Fix → respond → Resolve |
-| **IMPORTANT** | Bugs, missing error handling, missing tests | Fix → respond → Resolve |
+| **BLOCKING** | Security issues, critical bugs, compliance violations | Verify → Fix → respond → Resolve |
+| **IMPORTANT** | Bugs, missing error handling, missing tests | Verify → Fix → respond → Resolve |
 | **OPTIONAL** | Style, naming preference, refactoring suggestion, nitpick | Respond acknowledging → Resolve without fixing |
 | **INVALID** | Already fixed, no longer applies, praise | Respond acknowledging → Resolve |
 | **OUT OF SCOPE** | Requires changes outside this PR | Ask user before acting |
@@ -169,14 +224,46 @@ Proceeding with BLOCKING + IMPORTANT fixes. Waiting on your input for OUT OF SCO
 **Always respond in the same language as the PR and review comments.**
 **Respond after pushing fixes** — reference the actual commit hash.
 **Respond to every comment individually — never a single summary.**
+**Reply in the comment thread, not as a top-level PR comment.**
+
+```bash
+# GitHub — reply in an inline review comment thread
+gh api repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies \
+  --method POST -f body="Your reply here"
+```
+
+**No performative agreement.** Never write "You're absolutely right!", "Great point!", "Excellent feedback!", or thank the reviewer. Actions speak — just fix it and show what changed.
 
 | Category | Response template |
 |----------|------------------|
 | BLOCKING/IMPORTANT (fixed) | `Fixed in [commit hash]. [What changed and why.]` |
-| OPTIONAL | `Good point. Not addressing in this PR to keep it focused on [goal].` *(If genuinely useful: "Logged as [issue link] for follow-up.")* |
+| BLOCKING/IMPORTANT (pushed back, then verified correct) | `You were right — checked [X] and it does [Y]. Fixed in [commit hash].` |
+| BLOCKING/IMPORTANT (pushing back) | `[Technical reasoning]. [Evidence from codebase.] Leaving as-is.` |
+| OPTIONAL | `Not addressing in this PR to keep it focused on [goal].` *(If genuinely useful: "Logged as [issue link] for follow-up.")* |
 | INVALID (outdated) | `This was addressed in [commit]. [File/code] now [does X].` |
-| INVALID (praise) | `Thank you!` |
+| INVALID (praise) | *(no response needed — just resolve)* |
 | OUT OF SCOPE | Per user's instruction |
+
+## When to Push Back
+
+Push back when:
+- Suggestion breaks existing functionality
+- Reviewer lacks full context (e.g., missed why the code is the way it is)
+- Violates YAGNI (unused feature)
+- Technically incorrect for this stack or platform
+- Conflicts with architectural decisions made for this PR
+
+**How to push back:**
+- Use technical reasoning, not defensiveness
+- Ask specific questions
+- Reference working tests or existing code as evidence
+- Involve the user if the disagreement is architectural
+
+**If you pushed back and were wrong:**
+```
+"You were right — checked [X] and it does [Y]. Fixed in [commit hash]."
+```
+State the correction factually. No apology, no over-explaining.
 
 ## Resolving Threads
 

--- a/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
+++ b/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
@@ -99,6 +99,7 @@ digraph review {
     rereview [label="Request re-review", shape=box];
     ci_loop [label="Back to CI/CD monitoring", shape=box];
     merge_check [label="Merge requirements met?", shape=diamond];
+    confirm_merge [label="Ask user:\n'All requirements met — ready to merge.\nShould I go ahead?'", shape=box];
     done [label="MERGE", shape=doublecircle];
 
     start -> reviewers;
@@ -131,8 +132,9 @@ digraph review {
     fixes_made -> rereview [label="yes"];
     fixes_made -> merge_check [label="no"];
     rereview -> ci_loop -> wait;
-    merge_check -> done [label="yes"];
+    merge_check -> confirm_merge [label="yes"];
     merge_check -> wait [label="no — keep polling"];
+    confirm_merge -> done [label="user confirms"];
 }
 ```
 
@@ -298,6 +300,13 @@ Before merging, verify all of:
 - [ ] Required approvals received
 - [ ] No unresolved blocking threads
 - [ ] Branch up to date with base branch
+
+When all boxes are checked, **stop and ask the user for confirmation**:
+
+> All merge requirements are met — CI passing, approvals received, all threads resolved, branch up to date.
+> Should I go ahead and merge?
+
+Only merge after explicit confirmation. Exception: if the user already pre-approved the merge earlier in the conversation (e.g. "merge it when it's ready"), proceed without asking again.
 
 **Branch behind base — update and handle conflicts:**
 ```bash

--- a/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
+++ b/plugins/developer-workflow/skills/pr-drive-to-merge/SKILL.md
@@ -114,7 +114,7 @@ digraph review {
     read_all -> any_comments;
     any_comments -> clarify [label="yes"];
     any_comments -> merge_check [label="no, approved"];
-    clarify -> categorize [label="all clear"];
+    clarify -> categorize [label="no"];
     clarify -> ask_clarify [label="yes"];
     ask_clarify -> categorize;
     categorize -> oos;


### PR DESCRIPTION
## Summary

- Add **verification step** before implementing any BLOCKING/IMPORTANT suggestion (check technical correctness, codebase compatibility, context)
- Add **push back mechanism** for technically wrong reviewer suggestions, with guidance on how and when
- Add **YAGNI check** for "implement it properly" requests — grep for actual usage first
- Add **unclear feedback handling** — stop and clarify ALL unclear items before implementing anything (avoids partial/wrong implementation)
- Require **inline thread replies** using `gh api .../comments/{id}/replies`, not top-level PR comments
- Prohibit **performative agreement** ("You're absolutely right!", "Great point!") — actions speak instead
- Add **correction template** for when pushback turns out to be wrong

Based on patterns from [obra/superpowers receiving-code-review skill](https://github.com/obra/superpowers/blob/main/skills/receiving-code-review/SKILL.md).

## Test plan
- [ ] Review the updated SKILL.md for clarity and completeness
- [ ] Verify the flowchart additions (clarify + verify nodes) are logically consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)