### PR TITLE
chore: improve release flow and GitHub repo presentation

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -34,7 +34,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.1.0",
+      "version": "0.2.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: Bug Report
+description: Something isn't working as expected
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: plugin
+    attributes:
+      label: Plugin
+      options:
+        - maven-mcp
+        - sensitive-guard
+        - developer-workflow
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      placeholder: |
+        - Claude Code version:
+        - Plugin version:
+        - OS:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,36 @@
+name: Feature Request
+description: Suggest an idea or improvement
+labels: ["enhancement"]
+body:
+  - type: dropdown
+    id: plugin
+    attributes:
+      label: Plugin
+      options:
+        - maven-mcp
+        - sensitive-guard
+        - developer-workflow
+        - new plugin
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this solve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: What would you like to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- What does this PR do? Why? -->
+
+## Changes
+
+<!-- Key files/components changed -->
+
+## Testing
+
+<!-- How was this tested? -->
+
+## Checklist
+
+- [ ] Build passes (`npm run build`)
+- [ ] Tests pass (`npm test`)
+- [ ] Lint passes (`npm run lint`)
+- [ ] Version bumped if releasing (both `package.json` and `plugin.json`)
+- [ ] `marketplace.json` updated if plugin version changed

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,29 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+  categories:
+    - title: "New Features"
+      labels:
+        - feat
+        - feature
+        - enhancement
+    - title: "Bug Fixes"
+      labels:
+        - fix
+        - bug
+        - bugfix
+    - title: "Documentation"
+      labels:
+        - docs
+        - documentation
+    - title: "Maintenance"
+      labels:
+        - chore
+        - refactor
+        - ci
+        - build
+    - title: "Dependencies"
+      labels:
+        - dependencies
+        - deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,28 @@ jobs:
           done
           exit "$MISSING"
 
+      - name: Check marketplace.json versions match plugin.json versions
+        run: |
+          set -euo pipefail
+          MARKETPLACE=".claude-plugin/marketplace.json"
+          MISMATCH=0
+          while IFS=$'\t' read -r name version source; do
+            plugin_json="${source}/.claude-plugin/plugin.json"
+            if [ ! -f "$plugin_json" ]; then
+              echo "ERROR: '$name' plugin.json not found at $plugin_json"
+              MISMATCH=1
+              continue
+            fi
+            plugin_version=$(jq -r '.version' "$plugin_json")
+            if [ "$version" != "$plugin_version" ]; then
+              echo "ERROR: '$name' version mismatch: marketplace.json=$version, plugin.json=$plugin_version"
+              MISMATCH=1
+            else
+              echo "OK: '$name' version $version"
+            fi
+          done < <(jq -r '.plugins[] | [.name, .version, .source] | @tsv' "$MARKETPLACE")
+          exit "$MISMATCH"
+
   build:
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Check all plugins are registered in marketplace.json
+
+      - name: Check no duplicate plugin names in marketplace.json
+        run: |
+          set -euo pipefail
+          MARKETPLACE=".claude-plugin/marketplace.json"
+          DUPES=$(jq -r '[.plugins[].name] | group_by(.) | map(select(length > 1) | .[0]) | .[]' "$MARKETPLACE")
+          if [ -n "$DUPES" ]; then
+            echo "ERROR: Duplicate plugin names in marketplace.json: $DUPES"
+            exit 1
+          fi
+          echo "OK: no duplicate names"
+
+      - name: Check all plugins/ directories are registered in marketplace.json
         run: |
           set -euo pipefail
           MARKETPLACE=".claude-plugin/marketplace.json"
@@ -25,6 +37,54 @@ jobs:
             fi
           done
           exit "$MISSING"
+
+      - name: Check all marketplace.json entries have a plugins/ directory
+        run: |
+          set -euo pipefail
+          MARKETPLACE=".claude-plugin/marketplace.json"
+          MISSING=0
+          while IFS= read -r name; do
+            if [ ! -d "plugins/$name" ]; then
+              echo "ERROR: marketplace.json has '$name' but plugins/$name/ does not exist"
+              MISSING=1
+            else
+              echo "OK: plugins/$name/"
+            fi
+          done < <(jq -r '.plugins[].name' "$MARKETPLACE")
+          exit "$MISSING"
+
+      - name: Check source paths exist
+        run: |
+          set -euo pipefail
+          MARKETPLACE=".claude-plugin/marketplace.json"
+          MISSING=0
+          while IFS=$'\t' read -r name source; do
+            if [ ! -d "$source" ]; then
+              echo "ERROR: '$name' source path does not exist: $source"
+              MISSING=1
+            else
+              echo "OK: '$name' source $source"
+            fi
+          done < <(jq -r '.plugins[] | [.name, .source] | @tsv' "$MARKETPLACE")
+          exit "$MISSING"
+
+      - name: Check plugin.json name matches marketplace.json name
+        run: |
+          set -euo pipefail
+          MARKETPLACE=".claude-plugin/marketplace.json"
+          MISMATCH=0
+          while IFS=$'\t' read -r name source; do
+            plugin_json="${source}/.claude-plugin/plugin.json"
+            [ -f "$plugin_json" ] || continue
+            plugin_name=$(jq -r '.name' "$plugin_json")
+            if [ "$name" != "$plugin_name" ]; then
+              echo "ERROR: '$name' name mismatch: marketplace.json=$name, plugin.json=$plugin_name"
+              MISMATCH=1
+            else
+              echo "OK: '$name' name consistent"
+            fi
+          done < <(jq -r '.plugins[] | [.name, .source] | @tsv' "$MARKETPLACE")
+          exit "$MISMATCH"
 
       - name: Check marketplace.json versions match plugin.json versions
         run: |
@@ -48,6 +108,67 @@ jobs:
           done < <(jq -r '.plugins[] | [.name, .version, .source] | @tsv' "$MARKETPLACE")
           exit "$MISMATCH"
 
+      - name: Check all versions are valid semver (x.y.z)
+        run: |
+          set -euo pipefail
+          MARKETPLACE=".claude-plugin/marketplace.json"
+          SEMVER='^[0-9]+\.[0-9]+\.[0-9]+$'
+          INVALID=0
+          while IFS=$'\t' read -r name version source; do
+            if ! echo "$version" | grep -qE "$SEMVER"; then
+              echo "ERROR: '$name' marketplace.json version is not semver: $version"
+              INVALID=1
+            fi
+            plugin_json="${source}/.claude-plugin/plugin.json"
+            if [ -f "$plugin_json" ]; then
+              plugin_version=$(jq -r '.version' "$plugin_json")
+              if ! echo "$plugin_version" | grep -qE "$SEMVER"; then
+                echo "ERROR: '$name' plugin.json version is not semver: $plugin_version"
+                INVALID=1
+              fi
+            fi
+          done < <(jq -r '.plugins[] | [.name, .version, .source] | @tsv' "$MARKETPLACE")
+          exit "$INVALID"
+
+      - name: Check skills directories exist
+        run: |
+          set -euo pipefail
+          MARKETPLACE=".claude-plugin/marketplace.json"
+          MISSING=0
+          while IFS=$'\t' read -r name source; do
+            plugin_json="${source}/.claude-plugin/plugin.json"
+            [ -f "$plugin_json" ] || continue
+            skills_rel=$(jq -r '.skills // empty' "$plugin_json")
+            [ -n "$skills_rel" ] || continue
+            skills_path="${source}/${skills_rel#./}"
+            if [ ! -d "$skills_path" ]; then
+              echo "ERROR: '$name' skills path does not exist: $skills_path"
+              MISSING=1
+            else
+              echo "OK: '$name' skills at $skills_path"
+            fi
+          done < <(jq -r '.plugins[] | [.name, .source] | @tsv' "$MARKETPLACE")
+          exit "$MISSING"
+
+      - name: Check hook scripts are executable
+        run: |
+          set -euo pipefail
+          MARKETPLACE=".claude-plugin/marketplace.json"
+          ERRORS=0
+          while IFS=$'\t' read -r name source; do
+            hooks_dir="${source}/hooks"
+            [ -d "$hooks_dir" ] || continue
+            while IFS= read -r script; do
+              if [ ! -x "$script" ]; then
+                echo "ERROR: '$name' hook script is not executable: $script"
+                ERRORS=1
+              else
+                echo "OK: '$name' $(basename "$script") is executable"
+              fi
+            done < <(find "$hooks_dir" -name "*.sh")
+          done < <(jq -r '.plugins[] | [.name, .source] | @tsv' "$MARKETPLACE")
+          exit "$ERRORS"
+
   build:
     runs-on: ubuntu-latest
     defaults:
@@ -66,6 +187,17 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: plugins/maven-mcp/package-lock.json
+
+      - name: Verify package.json version matches plugin.json version
+        run: |
+          set -euo pipefail
+          PKG_VERSION=$(node -p 'require("./package.json").version')
+          PLUGIN_VERSION=$(jq -r '.version' plugin/.claude-plugin/plugin.json)
+          if [ "$PKG_VERSION" != "$PLUGIN_VERSION" ]; then
+            echo "::error::package.json version ($PKG_VERSION) does not match plugin.json version ($PLUGIN_VERSION)"
+            exit 1
+          fi
+          echo "OK: version $PKG_VERSION"
 
       - run: npm ci
       - run: npm run lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
         working-directory: plugins/maven-mcp
 
     permissions:
-      contents: read
+      contents: write
 
     steps:
       - uses: actions/checkout@v4
@@ -42,3 +42,9 @@ jobs:
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          make_latest: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # krozov-ai-tools
 
+[![CI](https://github.com/kirich1409/krozov-ai-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/kirich1409/krozov-ai-tools/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/@krozov/maven-central-mcp)](https://www.npmjs.com/package/@krozov/maven-central-mcp)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE.md)
+
 Claude Code plugin marketplace by Kirill Rozov.
 
 ## Installation
@@ -51,13 +55,15 @@ See [`plugins/sensitive-guard/`](plugins/sensitive-guard/) for full documentatio
 
 ### developer-workflow
 
-Developer workflow skills — preparing branches for code review and managing the full PR lifecycle.
+Developer workflow skills — preparing branches for code review, managing the full PR lifecycle, and safely migrating technology in Android/Kotlin/KMP projects.
 
 **Features:**
 - `prepare-for-pr` — quality loop (build → simplify → self-review → lint/tests) before creating a PR
 - `pr-drive-to-merge` — drives an existing PR/MR to merge: monitors CI/CD, triages reviewer comments, responds and resolves threads, loops until merge requirements are met
+- `code-migration` — safe in-place or parallel migration of any technology in Gradle/Android/Kotlin projects
+- `kmp-migration` — full Kotlin Multiplatform migration for Android modules
 
-**Skills:** `/prepare-for-pr`, `/pr-drive-to-merge`
+**Skills:** `/prepare-for-pr`, `/pr-drive-to-merge`, `/code-migration`, `/kmp-migration`
 
 See [`plugins/developer-workflow/`](plugins/developer-workflow/) for full documentation.
 


### PR DESCRIPTION
## Summary

- Creates GitHub Releases automatically when publishing to npm (was: only published to npm, no GH Release)
- Adds CI check enforcing `marketplace.json` versions always match each plugin's `plugin.json`
- Adds standard GitHub repo scaffolding: release notes config, PR template, issue templates
- Fixes stale state: developer-workflow version in marketplace (0.1.0 → 0.2.0), README skills list

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | `contents: write` permission + GitHub Release creation step |
| `.github/release.yml` | Auto-categorized release notes by label (Features, Bug Fixes, Maintenance, Dependencies) |
| `.github/workflows/ci.yml` | New step: verify `marketplace.json` versions match `plugin.json` versions |
| `.claude-plugin/marketplace.json` | Fix developer-workflow version 0.1.0 → 0.2.0 |
| `README.md` | CI/npm/license badges; add `/code-migration`, `/kmp-migration` to developer-workflow |
| `.github/pull_request_template.md` | Standard PR checklist |
| `.github/ISSUE_TEMPLATE/` | Bug report + feature request templates |

## Test plan

- [ ] CI passes (version check should show OK for all 3 plugins)
- [ ] Verify release.yml creates a GitHub Release on next tag push
- [ ] Review release notes config categories match your label conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)