### PR TITLE
chore: unify plugin versioning

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,18 +23,18 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.1.0",
+      "version": "0.4.0",
       "category": "security",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/sensitive-guard"
     },
     {
       "name": "developer-workflow",
-      "description": "Developer workflow skills — prepare branches for PR and manage the full PR lifecycle through CI/CD and code review",
+      "description": "Developer workflow skills — safe code migration, PR preparation, and full PR lifecycle through CI/CD and code review",
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.2.0",
+      "version": "0.4.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,13 +26,40 @@ jobs:
           cache-dependency-path: plugins/maven-mcp/package-lock.json
           registry-url: https://registry.npmjs.org
 
-      - name: Verify version matches tag
+      - name: Verify all versions match tag
+        working-directory: .
         run: |
-          PKG_VERSION="v$(node -p 'require("./package.json").version')"
-          if [ "$PKG_VERSION" != "${{ github.ref_name }}" ]; then
-            echo "::error::Tag ${{ github.ref_name }} does not match package.json version $PKG_VERSION"
-            exit 1
-          fi
+          TAG="${{ github.ref_name }}"
+          VERSION="${TAG#v}"
+          ERRORS=0
+
+          check() {
+            FILE="$1"
+            ACTUAL=$(node -p "require('./$FILE').version")
+            if [ "$ACTUAL" != "$VERSION" ]; then
+              echo "::error::$FILE version \"$ACTUAL\" does not match tag $TAG"
+              ERRORS=$((ERRORS + 1))
+            fi
+          }
+
+          check plugins/maven-mcp/package.json
+          check plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+          check plugins/sensitive-guard/.claude-plugin/plugin.json
+          check plugins/developer-workflow/.claude-plugin/plugin.json
+
+          # Check all plugin versions in marketplace.json
+          node -e "
+            const m = require('./.claude-plugin/marketplace.json');
+            let errors = 0;
+            for (const p of m.plugins) {
+              if (p.version !== '$VERSION') {
+                console.error('::error::marketplace.json plugin \"' + p.name + '\" version \"' + p.version + '\" does not match tag $TAG');
+                errors++;
+              }
+            }
+            process.exit(errors > 0 ? 1 : 0);
+          "
+          [ $ERRORS -eq 0 ] || exit 1
 
       - run: npm ci
       - run: npm run lint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,13 +31,18 @@ Always work on changes in a separate branch using a worktree (`.worktrees/`). Cr
 
 **Never run `npm publish` locally.** Publishing happens exclusively via GitHub Actions.
 
-To release a new version of `@krozov/maven-central-mcp`:
-1. Bump `version` in `plugins/maven-mcp/package.json` and `plugins/maven-mcp/plugin/.claude-plugin/plugin.json`
-2. Merge to `main`
-3. Push a git tag matching the version: `git tag v0.4.0 && git push origin v0.4.0`
-4. GitHub Actions (`.github/workflows/release.yml`) triggers on `v*` tags, runs lint/tests/build, then publishes to npm
+All plugins use **unified versioning** — every release bumps all plugins to the same version.
 
-The workflow verifies that the tag matches `package.json` version before publishing.
+To release a new version:
+1. Bump `version` in all of these files to the new version:
+   - `plugins/maven-mcp/package.json`
+   - `plugins/maven-mcp/plugin/.claude-plugin/plugin.json`
+   - `plugins/sensitive-guard/.claude-plugin/plugin.json`
+   - `plugins/developer-workflow/.claude-plugin/plugin.json`
+   - `.claude-plugin/marketplace.json` (all three plugin entries)
+2. Merge to `main`
+3. Push a git tag matching the version: `git tag v0.5.0 && git push origin v0.5.0`
+4. GitHub Actions (`.github/workflows/release.yml`) triggers on `v*` tags, verifies all versions match the tag, runs lint/tests/build, then publishes to npm
 
 ## Worktrees
 

--- a/plugins/developer-workflow/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "description": "Developer workflow skills — safe code migration, PR preparation, and full PR lifecycle through CI/CD and code review",
   "skills": "./skills"
 }

--- a/plugins/sensitive-guard/.claude-plugin/plugin.json
+++ b/plugins/sensitive-guard/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "sensitive-guard",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "description": "Prevents sensitive data (secrets, PII) from reaching AI servers by scanning files before they are read into conversation"
 }


### PR DESCRIPTION
## Summary

- All three plugins now use unified versioning — same version number as the release tag
- Bumped `sensitive-guard` and `developer-workflow` `plugin.json` to `0.4.0` to align with current tag
- Updated `marketplace.json` accordingly (all plugins at `0.4.0`)
- Extended `release.yml` to verify **all** `plugin.json` files and all `marketplace.json` plugin entries match the tag before publishing — CI will catch any drift at release time
- Updated `CLAUDE.md` release checklist to document the new unified versioning rule

## Test plan

- [ ] Verify `release.yml` verify step passes when all versions match the tag
- [ ] Verify `release.yml` verify step fails when any version is out of sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)