### PR TITLE
chore: release v0.4.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.4.0",
+      "version": "0.4.1",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/maven-mcp/plugin"
@@ -23,7 +23,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.4.0",
+      "version": "0.4.1",
       "category": "security",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/sensitive-guard"
@@ -34,7 +34,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.4.0",
+      "version": "0.4.1",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow"

--- a/plugins/developer-workflow/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Developer workflow skills — safe code migration, PR preparation, and full PR lifecycle through CI/CD and code review",
   "skills": "./skills"
 }

--- a/plugins/maven-mcp/package.json
+++ b/plugins/maven-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "MCP server for Maven Central dependency intelligence",
   "main": "./dist/index.js",
   "type": "module",

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maven-mcp",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps, /latest-version, and /dependency-changes skills",
   "mcpServers": {
     "maven-mcp": {

--- a/plugins/sensitive-guard/.claude-plugin/plugin.json
+++ b/plugins/sensitive-guard/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "sensitive-guard",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Prevents sensitive data (secrets, PII) from reaching AI servers by scanning files before they are read into conversation"
 }


### PR DESCRIPTION
## Summary
- Bumps all plugins (maven-mcp, sensitive-guard, developer-workflow) from v0.4.0 → v0.4.1
- Unified versioning: all 5 version fields updated in sync

## Test plan
- [ ] CI passes (build, lint, tests)
- [ ] After merge: `git tag v0.4.1 && git push origin v0.4.1` to trigger npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)