### PR TITLE
feat(developer-workflow): add implement-task and create-pr skills

### DIFF
--- a/plugins/developer-workflow/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow",
   "version": "0.4.1",
-  "description": "Developer workflow skills — safe code migration, PR preparation, and full PR lifecycle through CI/CD and code review",
+  "description": "Developer workflow skills — full task implementation cycle, safe code migration, PR preparation, PR creation (draft or ready), and full PR lifecycle through CI/CD and code review",
   "skills": "./skills"
 }

--- a/plugins/developer-workflow/README.md
+++ b/plugins/developer-workflow/README.md
@@ -20,7 +20,7 @@ Creates a pull request or merge request for the current branch:
 - Auto-generates title from branch name and commit history
 - Produces a structured description from the diff
 - Selects labels from the repo's existing label set
-- Suggests reviewers from git blame history
+- Suggests reviewers from recent git history on changed files
 - Supports GitHub and GitLab, draft or ready-for-review
 
 ### `code-migration`

--- a/plugins/developer-workflow/README.md
+++ b/plugins/developer-workflow/README.md
@@ -4,6 +4,25 @@ Claude Code plugin with skills for developer workflow habits — safe code migra
 
 ## Skills
 
+### `implement-task`
+
+Orchestrates the full development cycle for any implementation task:
+- Creates an isolated worktree, timeboxes exploration, selects the best-matching sub-skill
+- Brainstorms design for multi-file changes; follows TDD throughout
+- Creates a draft PR early, runs quality loop (`prepare-for-pr` + `code-review`), then marks the PR ready
+- Delegates CI/CD monitoring and review to `pr-drive-to-merge`
+
+Explicit-only — invoke directly with `/developer-workflow:implement-task`.
+
+### `create-pr`
+
+Creates a pull request or merge request for the current branch:
+- Auto-generates title from branch name and commit history
+- Produces a structured description from the diff
+- Selects labels from the repo's existing label set
+- Suggests reviewers from git blame history
+- Supports GitHub and GitLab, draft or ready-for-review
+
 ### `code-migration`
 
 Guides safe, verified technology migrations in Gradle/Android/Kotlin/KMP projects:

--- a/plugins/developer-workflow/skills/.gitignore
+++ b/plugins/developer-workflow/skills/.gitignore
@@ -1,0 +1,1 @@
+*-workspace/

--- a/plugins/developer-workflow/skills/create-pr/SKILL.md
+++ b/plugins/developer-workflow/skills/create-pr/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: create-pr
+description: >
+  Use when creating a new pull request (GitHub) or merge request (GitLab) for the current branch.
+  Handles branch push, draft/ready decision, title and description generation, label selection,
+  reviewer suggestions from git history, and PR creation.
+  Invoke whenever the user says "create a PR", "open a PR", "make a PR", "create a draft PR",
+  "submit for review", "push a PR", "open an MR", or any variation — draft or not.
+  Also invoke proactively after prepare-for-pr completes if no PR exists yet.
+---
+
+# Create PR
+
+Creates a pull request (GitHub) or merge request (GitLab) for the current branch,
+with a rich description, appropriate labels, and reviewers derived from git history.
+
+---
+
+## Step 1: Setup
+
+```bash
+# Platform: check remote URL
+git remote get-url origin
+# Contains github.com → use gh; contains gitlab → use glab
+
+# Base branch
+BASE=$(git remote show origin 2>/dev/null | grep "HEAD branch" | awk '{print $NF}')
+# Fallback order: main → master → develop
+
+# Current branch and author
+BRANCH=$(git branch --show-current)
+CURRENT_EMAIL=$(git config user.email)
+CURRENT_NAME=$(git config user.name)
+```
+
+**Check if a PR already exists** for this branch — if so, show its URL and stop:
+
+```bash
+gh pr view --json url,isDraft 2>/dev/null   # GitHub
+glab mr view 2>/dev/null                    # GitLab
+```
+
+---
+
+## Step 2: Push branch if needed
+
+```bash
+git rev-parse --abbrev-ref @{u} 2>/dev/null || git push -u origin "$BRANCH"
+```
+
+---
+
+## Step 3: Draft decision
+
+Look for a clear signal in the current conversation:
+
+| Signal | Decision |
+|--------|----------|
+| User said "draft", "WIP", "work in progress" | **Draft** |
+| User said "ready for review", "not draft", "final", "ready" | **Not draft** |
+| Invoked right after `prepare-for-pr` completed cleanly | Lean **not draft** — confirm |
+| No clear signal | **Ask the user** |
+
+If unclear, ask exactly this — one question, nothing else:
+
+> Draft PR or ready for review?
+
+Wait for the answer before continuing.
+
+---
+
+## Step 4: Analyse the branch
+
+Run these in parallel to gather all the material needed for labels, reviewers, and description:
+
+```bash
+# 1. Commits on this branch
+git log $BASE..HEAD --oneline
+
+# 2. Changed files
+git diff --name-only $BASE...HEAD
+
+# 3. Full diff stat
+git diff $BASE...HEAD --stat
+
+# 4. Full diff (for understanding what changed)
+git diff $BASE...HEAD
+```
+
+---
+
+## Step 5: Labels
+
+Fetch all labels that exist in the remote repo:
+
+```bash
+# GitHub
+gh label list --json name,description --limit 100
+
+# GitLab
+glab api /projects/:fullpath/labels --jq '[.[] | {name, description}]'
+```
+
+Read the available labels and select the ones that fit the changes. Base the decision on:
+- Changed file paths (e.g. `src/ui/` → ui label, `src/test/` → testing label)
+- Commit message types (`feat` → enhancement/feature, `fix` → bug, `docs` → documentation)
+- Scope of impact (e.g. `breaking-change` if public API is modified)
+
+Do not invent labels — only pick from what exists. If nothing clearly fits, apply no labels.
+
+---
+
+## Step 6: Reviewers
+
+Find the people most familiar with the changed code by looking at who has touched those files recently:
+
+```bash
+# For each changed file, collect recent commit authors (last 20 commits per file)
+git diff --name-only $BASE...HEAD | while read file; do
+  git log --follow -n 20 --format="%ae %an" -- "$file" 2>/dev/null
+done | sort | uniq -c | sort -rn
+```
+
+Filter out the current author (`$CURRENT_EMAIL`). Take the top 3 candidates by commit count.
+
+**Map emails to platform usernames:**
+
+```bash
+# GitHub — search by email
+gh api "/search/users?q=EMAIL+in:email" --jq '.items[0].login' 2>/dev/null
+
+# GitHub — fallback: look up recent commits on the repo by name
+gh api /repos/{owner}/{repo}/commits --jq '.[].author.login' 2>/dev/null | sort | uniq
+
+# GitLab — search by email or name
+glab api "/users?search=EMAIL" --jq '.[0].username' 2>/dev/null
+```
+
+Present the suggested reviewers to the user before adding them — don't add silently.
+The user may accept, change, or skip.
+
+---
+
+## Step 7: Generate title and description
+
+**Title:**
+- Derive from branch name + most meaningful commit message
+- Strip prefixes: `feat/`, `fix/`, `chore/`, `refactor/`, `docs/`
+- Convert `kebab-case` to sentence case
+- Keep under 70 characters
+- Do not add "WIP:" or "Draft:" — the draft state on the PR conveys this
+
+**Detect visual changes** — look at changed file paths for any of:
+- Android/Compose: `*Screen.kt`, `*Composable.kt`, `res/layout/`, `res/drawable/`
+- Compose Multiplatform: same Kotlin patterns, plus `commonMain` UI directories
+- Web: `*.tsx`, `*.jsx`, `*.css`, `*.scss`, `*.html`
+- iOS: `*.swift` (SwiftUI), `*.xib`, `*.storyboard`
+
+If visual changes are detected, the description must include a Screenshots / Demo section (see template below). Prompt the user to provide screenshots or a screen recording if they haven't already — a PR with visual changes but no visuals is hard to review.
+
+**Description template — ready-for-review PR:**
+
+```markdown
+## What changed
+<!-- Concise technical description of the changes: what was added, removed, or modified -->
+
+## Why / motivation
+<!-- Context: the requirement, issue, or problem this solves. Link to ticket if applicable -->
+
+## How to test
+<!-- Step-by-step instructions for a reviewer to verify the change works as intended -->
+- [ ] Step 1
+- [ ] Step 2
+
+## Checklist
+- [ ] Tests added or updated
+- [ ] No breaking changes (or breaking changes are documented in this PR)
+- [ ] Relevant documentation updated
+
+## Screenshots / demo
+<!-- For visual changes: before/after screenshots or a short screen recording.
+     Delete this section if there are no visual changes. -->
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+Fill every section from the diff and commit log — no placeholder comments left in the final text. The description must be self-contained: a reviewer who has no context about the task should be able to understand what changed, why, and how to verify it.
+
+**Description template — draft PR (early, work in progress):**
+
+```markdown
+## What this PR is about
+<!-- Brief statement of intent — even one line is fine -->
+
+## Status
+<!-- What's done, what's still in progress -->
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+A draft description can be minimal. It will be updated when the PR is marked ready.
+
+---
+
+## Step 8: Create
+
+```bash
+# GitHub — draft
+gh pr create --draft \
+  --title "<title>" \
+  --body "<body>" \
+  --base "$BASE" \
+  --label "<label1>" --label "<label2>" \
+  --reviewer "<username1>" --reviewer "<username2>"
+
+# GitHub — ready for review
+gh pr create \
+  --title "<title>" \
+  --body "<body>" \
+  --base "$BASE" \
+  --label "<label1>" --label "<label2>" \
+  --reviewer "<username1>" --reviewer "<username2>"
+
+# GitLab — draft
+glab mr create --draft \
+  --title "<title>" \
+  --description "<body>" \
+  --target-branch "$BASE" \
+  --label "<label1>,<label2>" \
+  --reviewer "<username1>"
+
+# GitLab — ready for review
+glab mr create \
+  --title "<title>" \
+  --description "<body>" \
+  --target-branch "$BASE" \
+  --label "<label1>,<label2>" \
+  --reviewer "<username1>"
+```
+
+Omit `--label` and `--reviewer` flags entirely if there are no applicable labels or reviewers — don't pass empty values.
+
+---
+
+## Output
+
+Print the PR/MR URL immediately after creation.
+
+**Draft PR:**
+> Draft PR created: \<url\>
+> When implementation is complete, run `prepare-for-pr` to quality-check the branch, then mark it ready for review.
+
+**Ready-for-review PR:**
+> PR created: \<url\>
+> Run `pr-drive-to-merge` to monitor CI/CD and handle review.

--- a/plugins/developer-workflow/skills/create-pr/SKILL.md
+++ b/plugins/developer-workflow/skills/create-pr/SKILL.md
@@ -116,7 +116,7 @@ Find the people most familiar with the changed code by looking at who has touche
 
 ```bash
 # For each changed file, collect recent commit authors (last 20 commits per file)
-git diff --name-only $BASE...HEAD | while read file; do
+git diff --name-only -z "$BASE"...HEAD | while IFS= read -r -d '' file; do
   git log --follow -n 20 --format="%ae %an" -- "$file" 2>/dev/null
 done | sort | uniq -c | sort -rn
 ```

--- a/plugins/developer-workflow/skills/create-pr/SKILL.md
+++ b/plugins/developer-workflow/skills/create-pr/SKILL.md
@@ -130,7 +130,8 @@ Filter out the current author (`$CURRENT_EMAIL`). Take the top 3 candidates by c
 gh api "/search/users?q=EMAIL+in:email" --jq '.items[0].login' 2>/dev/null
 
 # GitHub — fallback: look up recent commits on the repo by name
-gh api /repos/{owner}/{repo}/commits --jq '.[].author.login' 2>/dev/null | sort | uniq
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+gh api /repos/$REPO/commits --jq '.[].author.login' 2>/dev/null | sort | uniq
 
 # GitLab — search by email or name
 glab api "/users?search=EMAIL" --jq '.[0].username' 2>/dev/null

--- a/plugins/developer-workflow/skills/create-pr/SKILL.md
+++ b/plugins/developer-workflow/skills/create-pr/SKILL.md
@@ -6,7 +6,6 @@ description: >
   reviewer suggestions from git history, and PR creation.
   Invoke whenever the user says "create a PR", "open a PR", "make a PR", "create a draft PR",
   "submit for review", "push a PR", "open an MR", or any variation — draft or not.
-  Also invoke proactively after prepare-for-pr completes if no PR exists yet.
 ---
 
 # Create PR

--- a/plugins/developer-workflow/skills/implement-task/SKILL.md
+++ b/plugins/developer-workflow/skills/implement-task/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: implement-task
 description: >
-  Explicit-only skill — only invoke when the user directly requests it (e.g. "/implement-task").
+  Explicit-only skill — only invoke when the user directly requests it (e.g. "/developer-workflow:implement-task").
   Do NOT trigger automatically on implementation requests — the user controls when this workflow runs.
   Orchestrates the full development cycle: isolated worktree → TDD → implementation → quality loop
   (simplify + code review) → draft PR → CI/CD monitoring → merge-ready PR.
@@ -11,7 +11,7 @@ description: >
 
 ## Overview
 
-**Explicit-only.** Run this skill only when directly requested — not on every implementation task.
+**Explicit-only.** Run this skill only when directly requested via `/developer-workflow:implement-task` — not on every implementation task.
 
 Full autonomous implementation cycle — from understanding the task to a merge-ready PR.
 Ask the user only when a decision is **architecturally significant** or **irreversible**. Everything else: decide and proceed.
@@ -29,7 +29,7 @@ Invoke `superpowers:using-git-worktrees`. All subsequent work happens in that wo
 ### 0.2 Understand the task
 
 Establish three things before writing any code:
-- **What** needs to change (behaviour, not just files)
+- **What** needs to change (behavior, not just files)
 - **Why** (context for edge-case decisions)
 - **Done criteria** — what does success look like?
 
@@ -50,7 +50,7 @@ Select the most specific applicable skill and invoke it:
 | Android/Kotlin technology migration | `developer-workflow:code-migration` |
 | KMP migration | `developer-workflow:kmp-migration` |
 | Multi-step feature or architecture change | `superpowers:writing-plans` → `superpowers:executing-plans` |
-| Bug or unexpected behaviour | `superpowers:systematic-debugging` |
+| Bug or unexpected behavior | `superpowers:systematic-debugging` |
 | Any other implementation work | `superpowers:test-driven-development` (default) |
 
 Follow the chosen skill throughout implementation. Switch to a more specific skill if a better match emerges.
@@ -69,7 +69,7 @@ Update the PR description after each major change so it stays current.
 
 ## Phase 2: Quality Loop
 
-Once implementation is complete, invoke `developer-workflow:prepare-for-pr`. It runs build, simplify, self-review, and lint/tests in a loop — exit criteria and hook behaviour are defined inside that skill.
+Once implementation is complete, invoke `developer-workflow:prepare-for-pr`. It runs build, simplify, self-review, and lint/tests in a loop — exit criteria and hook behavior are defined inside that skill.
 
 After `prepare-for-pr` exits clean, run `code-review:code-review`. Fix any non-minor issues, commit, push, and repeat until only minor issues remain.
 

--- a/plugins/developer-workflow/skills/implement-task/SKILL.md
+++ b/plugins/developer-workflow/skills/implement-task/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: implement-task
+description: >
+  Explicit-only skill — only invoke when the user directly requests it (e.g. "/implement-task").
+  Do NOT trigger automatically on implementation requests — the user controls when this workflow runs.
+  Orchestrates the full development cycle: isolated worktree → TDD → implementation → quality loop
+  (simplify + code review) → draft PR → CI/CD monitoring → merge-ready PR.
+---
+
+# Implement Task
+
+## Overview
+
+**Explicit-only.** Run this skill only when directly requested — not on every implementation task.
+
+Full autonomous implementation cycle — from understanding the task to a merge-ready PR.
+Ask the user only when a decision is **architecturally significant** or **irreversible**. Everything else: decide and proceed.
+
+If any phase fails: identify the root cause — if it's in current changes, fix and re-enter the phase; if pre-existing, ask the user; if unclear, invoke `superpowers:systematic-debugging`.
+
+---
+
+## Phase 0: Setup
+
+### 0.1 Worktree
+
+Invoke `superpowers:using-git-worktrees`. All subsequent work happens in that worktree.
+
+### 0.2 Understand the task
+
+Establish three things before writing any code:
+- **What** needs to change (behaviour, not just files)
+- **Why** (context for edge-case decisions)
+- **Done criteria** — what does success look like?
+
+Ask **one clarifying question** if any of these is ambiguous. Otherwise proceed.
+
+**Timebox exploration.** Read only the entry point and immediate change surface. The goal is knowing enough to write the first failing test — you'll learn more as you implement.
+
+### 0.3 Design (non-trivial tasks only)
+
+For tasks that touch more than one file or introduce a new abstraction, invoke `superpowers:brainstorming` before writing code. Skip for single-file changes and focused bugfixes.
+
+### 0.4 Skill selection
+
+Select the most specific applicable skill and invoke it:
+
+| Task type | Skill |
+|-----------|-------|
+| Android/Kotlin technology migration | `developer-workflow:code-migration` |
+| KMP migration | `developer-workflow:kmp-migration` |
+| Multi-step feature or architecture change | `superpowers:writing-plans` → `superpowers:executing-plans` |
+| Bug or unexpected behaviour | `superpowers:systematic-debugging` |
+| Any other implementation work | `superpowers:test-driven-development` (default) |
+
+Follow the chosen skill throughout implementation. Switch to a more specific skill if a better match emerges.
+
+The core TDD contract: **write a failing test before writing the implementation code it covers.** If the codebase has no test infrastructure, proceed implementation-first and flag the gap in the PR description.
+
+---
+
+## Phase 1: Draft PR (create early)
+
+Invoke `developer-workflow:create-pr` with draft intent as soon as the first meaningful commit exists — even before implementation is complete. This gives CI a head start and keeps progress visible.
+
+Update the PR description after each major change so it stays current.
+
+---
+
+## Phase 2: Quality Loop
+
+Once implementation is complete, invoke `developer-workflow:prepare-for-pr`. It runs build, simplify, self-review, and lint/tests in a loop — exit criteria and hook behaviour are defined inside that skill.
+
+After `prepare-for-pr` exits clean, run `code-review:code-review`. Fix any non-minor issues, commit, push, and repeat until only minor issues remain.
+
+---
+
+## Phase 3: Move PR to Ready for Review
+
+Undraft the PR and update its title and description using the ready-for-review template from `developer-workflow:create-pr` (the "Description template — ready-for-review PR" section). The description must be self-contained — a reviewer with no prior context should understand what changed, why, and how to verify it.
+
+```bash
+# GitHub
+gh pr ready
+gh pr edit --title "<final title>" --body "<final description>"
+
+# GitLab
+glab mr update --remove-draft --title "<final title>" --description "<final description>"
+```
+
+---
+
+## Phase 4: CI/CD and Review
+
+Invoke `developer-workflow:pr-drive-to-merge` and let it run. This skill pauses only when human input is needed (out-of-scope issues, merge confirmation, stale review).
+
+---
+
+## Phase 5: Wrap-up
+
+After the PR is merged, invoke `superpowers:finishing-a-development-branch` for worktree cleanup and branch deletion.
+
+---
+
+## Decision Guide
+
+| Ask the user | Decide autonomously |
+|---|---|
+| Architecture choices with long-term implications | Which file to edit |
+| Breaking changes visible outside the PR | Variable or method naming |
+| Unclear done criteria before starting | Whether to add a test |
+| Reviewer raises an architectural concern | Order of code review fixes |
+| Merge confirmation (handled by pr-drive-to-merge) | Obvious lint fixes |
+
+---
+
+## Commit Hygiene
+
+- One logical change per commit — don't batch everything at the end
+- Stage specific files: `git add path/to/file`, never `git add .`
+- Message format: `<type>(<scope>): <what and why>` (`feat`, `fix`, `refactor`, `test`, `chore`, `docs`)
+- Never `--no-verify`


### PR DESCRIPTION
## What changed

Added two new skills to the `developer-workflow` plugin:

**`implement-task`** — explicit-only skill that orchestrates the full development cycle:
- Worktree isolation via `superpowers:using-git-worktrees`
- Task understanding with timeboxed exploration
- Brainstorming for non-trivial multi-file changes
- Skill selection (migration, debugging, TDD, plans)
- TDD-first implementation
- Draft PR via `create-pr` (created early, kept current)
- Quality loop: `prepare-for-pr` → `code-review:code-review` until clean
- PR ready-for-review + `pr-drive-to-merge`
- Wrap-up via `superpowers:finishing-a-development-branch`

**`create-pr`** — handles PR/MR creation with auto-generated title, description template, label selection from repo labels, and reviewer suggestions from git blame history.

## Why / motivation

The plugin had skills for preparing a branch (`prepare-for-pr`) and driving a PR to merge (`pr-drive-to-merge`) but no skill covering the full cycle from task start to merge-ready PR.

## How to test

- Install the plugin and invoke `/developer-workflow:implement-task` with a task description
- Verify phases run in order and the skill delegates to sub-skills rather than reimplementing their logic
- Invoke `/developer-workflow:create-pr` on a branch with commits and verify it generates a PR with correct title, description, and reviewer suggestions

## Checklist
- [x] implement-task delegates to existing sub-skills rather than duplicating logic
- [x] create-pr handles both GitHub and GitLab
- [x] Both skills are explicit-only (not auto-triggered)
- [x] plugin.json description updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)