### PR TITLE
feat(developer-workflow): add QA testing skills

### DIFF
--- a/plugins/developer-workflow/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "developer-workflow",
   "version": "0.4.1",
-  "description": "Developer workflow skills — full task implementation cycle, View→Compose UI migration, safe code migration, PR preparation, PR creation (draft or ready), and full PR lifecycle through CI/CD and code review",
+  "description": "Developer workflow skills — full task implementation cycle, View→Compose UI migration, safe code migration, test plan generation, exploratory QA testing, feature verification, PR preparation, PR creation (draft or ready), and full PR lifecycle through CI/CD and code review",
   "skills": "./skills",
   "agents": "./agents"
 }

--- a/plugins/developer-workflow/README.md
+++ b/plugins/developer-workflow/README.md
@@ -1,6 +1,6 @@
 # developer-workflow
 
-Claude Code plugin with skills for developer workflow habits — safe code migration, preparing branches for code review, and managing the full PR lifecycle.
+Claude Code plugin with skills for developer workflow habits — safe code migration, test plan generation, exploratory QA testing, feature verification, preparing branches for code review, and managing the full PR lifecycle.
 
 ## Skills
 
@@ -68,6 +68,39 @@ Guides a full migration of an Android module to Kotlin Multiplatform (KMP):
 - Verifies all targets compile and tests pass; cleans up Android-only artifacts
 
 Use when migrating a module to share code with iOS, JVM, or other platforms.
+
+### `generate-test-plan`
+
+Creates a structured, reusable test plan from a specification source without executing any tests:
+- Accepts Figma mockups, PRDs, acceptance criteria, issues, or existing code as input
+- Identifies risk areas, edge cases, and state combinations
+- Writes prioritized test cases (P0–P3) across Smoke / Feature / Regression tiers
+- Cross-references multiple spec sources and flags discrepancies
+- Produces a `docs/testplans/<feature>-test-plan.md` ready for `manual-tester` or `test-feature`
+
+Use when planning testing separately from execution — for review, reuse, or handoff.
+
+### `test-feature`
+
+Verifies a running application against a specification:
+- Accepts a spec (Figma, PRD, acceptance criteria) and/or a test plan
+- Ensures the app is running on device/simulator/browser
+- Launches the `manual-tester` agent for full QA execution
+- Produces a verification result: VERIFIED, FAILED, or PARTIAL
+- Supports re-verification loops after bug fixes
+
+Use after implementing a feature to confirm it matches the spec before PR.
+
+### `exploratory-test`
+
+Undirected bug hunting on a running app — no spec or test plan required:
+- Explores screens guided by usability heuristics, error handling checks, and input edge cases
+- Reports bugs (standard format with severity) and observations (non-bug UX findings)
+- Produces a coverage map showing which screens were visited and what was checked
+- Scope-bounded by screen count: Quick (~5), Standard (~15), or Deep (30+)
+- Recommends next steps based on severity of findings
+
+Use for pre-release QA sweeps, sanity checks, or finding issues specs don't anticipate.
 
 ## Agents
 

--- a/plugins/developer-workflow/skills/exploratory-test/SKILL.md
+++ b/plugins/developer-workflow/skills/exploratory-test/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: exploratory-test
+description: >-
+  IMPORTANT: You MUST use this skill whenever the user asks you to test, check, explore, or QA a
+  running app WITHOUT providing a specification or formal test plan. This skill launches the
+  manual-tester agent which has access to device/browser MCP tools — you cannot replicate this
+  workflow yourself. Use this skill even if the request seems simple — "check if anything is broken",
+  "poke around the app", "find bugs" all require this skill because they need real device/browser
+  interaction via the manual-tester agent.
+
+  Trigger on ANY of these patterns: the user mentions a running app (emulator, simulator, device,
+  localhost URL, staging URL) and wants you to find bugs, check quality, explore screens, do a
+  sanity check, stress test, find edge cases, find UX issues, check for crashes, do pre-release QA,
+  or generally assess app quality — and they have NOT provided a spec/PRD/Figma/acceptance criteria
+  to verify against. Also trigger when: the user says the feature is built but has no spec yet and
+  wants feedback, the user wants to check if a refactor broke anything, the user reports vague bugs
+  and wants you to explore and reproduce, or the user wants a quick accessibility sweep.
+
+  Do NOT trigger when: the user provides a spec/mockup/PRD and wants verification against it (use
+  test-feature), the user only wants test cases written without execution (use generate-test-plan),
+  or the user asks about automated unit/integration tests (out of scope).
+---
+
+# Exploratory Test
+
+Explore a running application to discover bugs, UX issues, and edge cases — guided by testing
+heuristics rather than a specification. This is fundamentally different from `test-feature`:
+there is no spec to verify against, no pass/fail verdict, and no predefined test plan. The goal
+is to find problems the team hasn't anticipated.
+
+The skill launches the `manual-tester` agent in exploratory mode: instead of following a test
+plan and comparing results against a spec, the agent navigates the app freely, applies heuristics
+at each screen, probes edge cases, and reports everything it finds.
+
+---
+
+## Step 1: Establish Target
+
+Determine what is being tested and how to connect.
+
+### 1.1 Target type
+
+Ask or infer from context:
+- **Mobile / desktop app** — need a device/simulator/emulator and an app identifier
+- **Web app** — need a URL
+
+If the user says "the app is already running" or provides a device/URL, use it directly.
+Otherwise, follow the same launch logic as `test-feature` Step 2 (build, install, start
+dev server, etc.).
+
+### 1.2 Focus area (optional)
+
+The user may name a specific area to concentrate on: "payments flow", "settings screen",
+"onboarding", "the new search feature". If provided, exploration starts there and goes deep
+before branching out. If not provided, start from the app's entry point and explore
+systematically screen by screen.
+
+Do not ask for a focus area if the user didn't mention one — just start broad.
+
+### 1.3 Scope
+
+Exploration is bounded by screen count to keep sessions productive:
+
+| Scope | Screens | When to use |
+|-------|---------|-------------|
+| **Quick** | ~5 | Fast sanity check, single flow |
+| **Standard** | ~15 | Default — good coverage of core flows |
+| **Deep** | 30+ | Pre-release sweep, complex app |
+
+Use **Standard** by default. Only ask for scope preference if the user's intent is ambiguous.
+If they say "quick check" or "just the settings screen", use Quick. If they say "full QA" or
+"before we release", use Deep.
+
+---
+
+## Step 2: Launch Manual Tester in Exploratory Mode
+
+Spawn the `manual-tester` agent with an exploratory prompt. The prompt structure differs from
+`test-feature` — instead of a spec and test plan, it provides heuristics and exploration rules.
+
+```
+You are performing exploratory testing — there is no specification to verify against.
+Your goal is to discover bugs, UX problems, crashes, and edge cases by navigating the app
+and applying testing heuristics at every screen you visit.
+
+## Target
+[Device/URL/connection details from Step 1]
+
+## Focus Area
+[User-provided focus area, or: "None — start from the entry point and explore systematically"]
+
+## Scope
+Explore up to [N] unique screens or flows. Maintain a running list of visited screens.
+Stop when you reach the boundary or have covered all reachable screens.
+
+## Exploration Heuristics
+
+At each screen, apply these checks:
+
+**Visibility of system status** — Does the app show loading indicators, progress bars,
+success confirmations, error messages? Try triggering a slow operation and watch.
+
+**Error handling** — Enter invalid input in every field you find. Try submitting empty forms.
+What happens with no network? Does the app show helpful error messages or fail silently?
+
+**Navigation consistency** — Does the back button work as expected? Are there dead ends?
+Can you reach the same screen from multiple paths and get consistent results?
+
+**State preservation** — Rotate the device (mobile) or resize the browser window (web).
+Background and foreground the app. Is state preserved across these transitions?
+
+**Input edge cases** — For each input field you encounter, try ONE of these:
+- A string longer than 200 characters
+- Special characters: emoji (😀), RTL text (مرحبا), HTML tags (<b>test</b>)
+- Empty submission (leave required fields blank)
+Do not try all three on every field — pick the one most likely to cause trouble.
+
+**Empty states** — Navigate to screens that display lists or data. What happens when
+there is no data? Is there a meaningful empty state, or does the screen look broken?
+
+**Performance** — Note any visible lag, janky animations, slow transitions, or unresponsive
+UI. You don't need to measure precisely — just flag what feels wrong.
+
+**Visual consistency** — Compare the current screen to others you've seen. Are fonts, spacing,
+colors, and alignment consistent? Flag anything that looks out of place.
+
+**Accessibility basics** — Are there buttons without labels? Touch targets that look too small
+(below ~44×44 dp on mobile)? Text that's hard to read against its background?
+
+## Reporting
+
+Report issues in two categories:
+
+**Bugs** — Use the standard BUG format (BUG-[SESSION_ID]-[n]) for anything that is clearly
+wrong: crashes, broken functionality, visual defects, data loss, incorrect behavior.
+
+**Observations** — Use a new OBSERVATION format for things that aren't clearly bugs but are
+noteworthy: confusing UX, inconsistent patterns, surprisingly slow transitions, missing
+feedback, questionable design choices. These are "a reasonable user might struggle here"
+findings.
+
+OBSERVATION-[SESSION_ID]-[n]: [Title]
+Screen: [where you saw it]
+Details: [what you noticed and why it matters to users]
+Heuristic: [which heuristic flagged this — e.g., "error handling", "visual consistency"]
+
+**Coverage log** — After each screen, add it to your running coverage list with a one-line
+note of what heuristics you applied and what (if anything) you found.
+
+Do NOT produce a pass/fail verdict or a ship/no-ship recommendation.
+There is no spec to verify against — you are discovering, not judging.
+```
+
+Let the agent run its full cycle. Do not interfere unless it asks a question or hits a P0
+blocker (P0 escalation rule still applies — a crash or data loss warrants immediate attention
+even in exploratory mode).
+
+---
+
+## Step 3: Collect and Present Exploration Report
+
+When the manual-tester agent completes, process its output into a structured report.
+
+### Report Format
+
+```
+## Exploratory Testing Report
+
+**Date:** [date]
+**App:** [name, version, or URL]
+**Device / Browser:** [device name + OS version, or browser + viewport]
+**Focus Area:** [area, or "General — full app exploration"]
+**Scope:** [Quick / Standard / Deep] — [N] screens visited
+
+---
+
+### Coverage Map
+
+| # | Screen / Flow | Heuristics Applied | Issues |
+|---|---------------|-------------------|--------|
+| 1 | [screen name] | [which checks were done] | BUG-..., OBS-... or "—" |
+| 2 | ... | ... | ... |
+
+---
+
+### Bugs ([n] total)
+
+P0 Blockers: [n] | P1 Major: [n] | P2 Minor: [n] | P3 Cosmetic: [n]
+
+[Full BUG entries in standard manual-tester format, ordered P0-first]
+
+---
+
+### Observations ([n] total)
+
+[Full OBSERVATION entries, grouped by heuristic category]
+
+---
+
+### Summary
+
+[2-3 sentence overall quality assessment based on what was found]
+```
+
+---
+
+## Step 4: Recommend Next Steps
+
+Based on findings, guide the user toward the right next action:
+
+**P0 blockers found** — Critical issues need fixing before further testing. After fixes,
+re-run exploratory-test on the affected area, or use `test-feature` with a spec for targeted
+verification.
+
+**P1/P2 bugs found, no blockers** — The app is functional but has issues. Consider creating
+a test plan for the affected areas using `generate-test-plan`, then verifying fixes with
+`test-feature`.
+
+**Only P3 bugs or observations** — No critical issues. The app is in reasonable shape for the
+areas explored. If pre-release confidence is needed, consider a spec-based verification pass
+with `test-feature`.
+
+**Nothing found** — The explored scope looks clean. Consider increasing scope to Deep, focusing
+on a specific area the team is concerned about, or moving on to spec-based verification.
+
+---
+
+## Re-exploration After Fixes
+
+When the user fixes reported bugs and wants to check again:
+
+1. Re-launch with the same focus area (or the area where bugs were found)
+2. The agent verifies previously reported bugs are fixed
+3. The agent continues exploring adjacent areas for regressions
+4. Updated report replaces or appends to the previous one

--- a/plugins/developer-workflow/skills/exploratory-test/evals/evals.json
+++ b/plugins/developer-workflow/skills/exploratory-test/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "exploratory-test",
+  "evals": [
+    {
+      "id": 0,
+      "prompt": "Just poke around our Android app and tell me if anything looks broken. The app is already running on the emulator, package name is com.example.todoapp.",
+      "expected_output": "Launches manual-tester agent in exploratory mode with Standard scope, no focus area. Agent explores from entry point, applies heuristics, produces exploration report with coverage map, bugs, and observations.",
+      "files": []
+    },
+    {
+      "id": 1,
+      "prompt": "We're about to release v2.0. Can you do a deep exploratory QA pass on the checkout flow? The web app is at http://localhost:3000.",
+      "expected_output": "Launches manual-tester in exploratory mode with Deep scope, focused on checkout flow. Agent explores checkout and adjacent screens, applies all heuristics including input edge cases and error handling, produces comprehensive exploration report.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Quick sanity check on the settings screen — we just refactored it. iOS simulator is running, bundle ID is com.example.myapp.",
+      "expected_output": "Launches manual-tester in exploratory mode with Quick scope (~5 screens), focused on settings. Agent checks settings screen and immediate sub-screens, applies heuristics, produces concise exploration report.",
+      "files": []
+    }
+  ]
+}

--- a/plugins/developer-workflow/skills/exploratory-test/evals/trigger-eval.json
+++ b/plugins/developer-workflow/skills/exploratory-test/evals/trigger-eval.json
@@ -1,0 +1,22 @@
+[
+  {"query": "just poke around our Android app and see if anything looks off. it's running on the Pixel 8 emulator, package is com.mycompany.shopapp. no spec or anything, we just want a general vibe check before the demo tomorrow", "should_trigger": true},
+  {"query": "we're cutting the 3.1 release this friday. can you do a thorough QA sweep of the whole app before we ship? iOS simulator is up, bundle id is com.example.fitnessapp. I want you to really try to break things", "should_trigger": true},
+  {"query": "we just rewrote the entire checkout flow last sprint. can you stress test it and find edge cases? the web app is at localhost:3000, focus on /checkout and the payment forms", "should_trigger": true},
+  {"query": "our users keep reporting random crashes but we can't reproduce them. can you explore the app and try weird things to trigger crashes? Android emulator is running, package com.startup.chatapp", "should_trigger": true},
+  {"query": "quick sanity check on the settings screen please, we refactored the preferences storage layer and I want to make sure nothing looks broken visually. app is on the sim already", "should_trigger": true},
+  {"query": "find any UX issues in the onboarding flow — we've had complaints that new users get confused. the app is at https://staging.myapp.com, just go through signup and the first-time experience and tell me what feels off", "should_trigger": true},
+  {"query": "I don't have a spec yet but the feature is mostly built. can you just go through the new dashboard screens on the emulator and tell me if you spot anything broken or weird? package is com.analytics.dashboard", "should_trigger": true},
+  {"query": "the app has a bunch of forms — registration, profile edit, contact support, feedback. can you try throwing weird inputs at them and see what breaks? long strings, emoji, special chars, that kind of thing. web app at localhost:8080", "should_trigger": true},
+  {"query": "can you do a quick accessibility check on our app? just go through the main screens and flag anything that looks like it would be hard to use — tiny buttons, missing labels, bad contrast. iOS sim is running", "should_trigger": true},
+  {"query": "we need to check if the app works properly after the SDK upgrade. no spec changes, everything should look and behave the same. just explore the main flows and flag anything that seems different or broken. Android emulator, com.example.notes", "should_trigger": true},
+  {"query": "I have the Figma mockups for the new profile screen here: https://figma.com/file/abc123. can you verify the implementation matches the design? the app is running on the simulator", "should_trigger": false},
+  {"query": "here's the PRD for the notification feature (attached). can you check that all the acceptance criteria pass on the running app? emulator is up, package com.example.app", "should_trigger": false},
+  {"query": "generate a test plan for our new search feature. here's the spec: users can search by name, filter by category and date range, results are paginated. I don't need you to run the tests yet, just write the plan", "should_trigger": false},
+  {"query": "write test cases for the authentication flow based on this requirements doc. we'll run them manually later, I just need the plan in docs/testplans/", "should_trigger": false},
+  {"query": "can you run the unit tests for the checkout module? I think there might be a regression. the test file is at src/checkout/__tests__/cart.test.ts", "should_trigger": false},
+  {"query": "run ./gradlew :app:testDebugUnitTest and tell me if anything fails. I made some changes to the repository layer", "should_trigger": false},
+  {"query": "review the code in src/features/auth/ — I want feedback on the architecture and error handling patterns before I open a PR", "should_trigger": false},
+  {"query": "can you do a security audit of our API endpoints? check for SQL injection, XSS, and auth bypass vulnerabilities in the Express routes", "should_trigger": false},
+  {"query": "I need load testing on our API — simulate 1000 concurrent users hitting the /api/search endpoint and measure response times and error rates", "should_trigger": false},
+  {"query": "run the test plan in docs/testplans/checkout-test-plan.md against the running app. emulator is ready, package com.shop.app", "should_trigger": false}
+]

--- a/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: generate-test-plan
+description: >-
+  IMPORTANT: You MUST use this skill whenever the user wants test cases, a test plan, QA scenarios,
+  or a testing checklist created from a spec, PRD, Figma mockup, requirements, or existing code.
+  This skill produces a structured, prioritized test plan document saved to docs/testplans/ — you
+  cannot produce the same quality of output (risk analysis, coverage matrix, automation candidates,
+  proper TC format) without it. Use this skill even for simple-sounding requests like "what should
+  I test?" or "what are the edge cases?" — the structured output is what makes it valuable.
+
+  Trigger on ANY of these patterns: the user asks to create a test plan, write test cases, generate
+  QA scenarios, prepare a testing checklist, identify what to test, find edge cases for a feature,
+  plan testing coverage, document test scenarios, or create a QA handoff document. Also trigger
+  when: the user describes requirements or acceptance criteria and asks how to verify them, the user
+  points at code and asks "how would you test this?", or the user wants to plan testing before
+  actually running tests.
+
+  Do NOT trigger when: the user wants to execute tests on a running app (use test-feature or
+  exploratory-test), the user wants automated unit/integration tests written in code (out of scope),
+  or the user wants to run an existing test plan (use test-feature). This skill never launches an
+  app, device, or browser — it only produces a document.
+---
+
+# Generate Test Plan
+
+Analyze a feature from its specification, design, or implementation and produce a structured,
+prioritized test plan as a markdown document. No tests are executed — the output is a plan ready
+for a human QA engineer or the `manual-tester` agent to pick up later.
+
+## Output
+
+Save every test plan to the repository:
+
+```
+docs/testplans/<feature-name>-test-plan.md
+```
+
+Create the `docs/testplans/` directory if it doesn't exist. Use kebab-case for the feature name.
+Examples: `user-authentication-test-plan.md`, `cart-checkout-test-plan.md`.
+
+## Input Discovery
+
+Determine what the user has provided and gather context accordingly.
+
+### 1. Text specification (PRD, acceptance criteria, user story)
+
+Read the document. Extract:
+- Functional requirements (what the feature does)
+- Non-functional requirements (performance, accessibility, security constraints)
+- Acceptance criteria (explicit pass/fail conditions)
+- User roles and permissions mentioned
+
+### 2. Figma mockup
+
+Use Figma MCP tools (`get_design_context`, `get_screenshot`) to retrieve the design.
+Extract:
+- Screen states (default, loading, empty, error, populated)
+- Interactive elements and their expected behavior
+- Navigation flows between screens
+- Responsive or platform-specific variants
+
+### 3. Existing code
+
+When code is the primary (or only) source of truth, read the implementation thoroughly:
+- Public API surface — endpoints, functions, UI entry points
+- State transitions and conditional branches
+- Error handling paths and fallback behavior
+- Input validation rules and boundary values
+- Integration points (APIs, databases, third-party services)
+
+When deriving test cases from code alone, be explicit about assumptions. Mark any inferred
+behavior that has no spec backing with `[inferred from code]` so reviewers know what to verify
+against product intent.
+
+### Combining sources
+
+Often the user provides more than one source. Cross-reference them:
+- Spec says X, but code implements Y → flag the discrepancy as a finding, write test cases for both
+- Design shows a state the spec doesn't mention → note it, write a test case
+- Code handles an edge case not in the spec → include it with `[inferred from code]`
+
+## Analysis
+
+Before writing test cases, identify:
+
+1. **Risk areas** — parts of the feature most likely to break or cause user-visible issues.
+   Consider: complexity, number of integration points, data sensitivity, new vs. changed behavior.
+
+2. **Edge cases** — boundary values, empty/null inputs, concurrent actions, permission boundaries,
+   network failures, locale/timezone effects, large datasets.
+
+3. **State combinations** — which states interact and which transitions are possible. A simple
+   matrix helps: list states on one axis, user actions on the other, mark which intersections need
+   coverage.
+
+## Test Plan Format
+
+Every generated test plan must follow this exact structure:
+
+```markdown
+# Test Plan: [Feature Name]
+
+| Field | Value |
+|-------|-------|
+| **Source** | [spec link / Figma link / code path — whatever was provided] |
+| **Generated** | [YYYY-MM-DD] |
+| **Scope** | [one-line summary of what is covered] |
+| **Status** | Draft / Ready for Review / Approved |
+
+---
+
+## Findings
+
+Discrepancies, ambiguities, or assumptions discovered during analysis.
+Each finding has a short title and explanation.
+
+- **[Finding title]** — [explanation]
+
+> Omit this section entirely if there are no findings.
+
+---
+
+## Risk Areas
+
+| Area | Risk Level | Reason |
+|------|-----------|--------|
+| [area name] | High / Medium / Low | [why this area is risky] |
+
+---
+
+## Test Cases
+
+### [Group Name]
+
+Group related test cases by feature area, screen, or workflow
+(e.g., Authentication, Cart Checkout, Error Handling).
+
+#### TC-[N]: [Short descriptive title]
+
+| Field | Value |
+|-------|-------|
+| **Priority** | P0 Critical / P1 High / P2 Medium / P3 Low |
+| **Tier** | Smoke / Feature / Regression |
+| **Preconditions** | What must be true before starting |
+| **Steps** | 1. First step  2. Second step  3. Third step |
+| **Expected Result** | Observable outcome that means the test passed |
+| **Source** | Spec §section / Figma frame name / `path/to/file.kt:42` / [inferred from code] |
+
+---
+
+## Edge Cases & Negative Scenarios
+
+Same TC format as above. Grouped separately for visibility.
+Includes: boundary values, invalid inputs, error states, permission denials,
+network failures, empty/null data, concurrent operations.
+
+---
+
+## Coverage Matrix
+
+| Requirement / Screen / Flow | Test Cases | Risk |
+|-----------------------------|-----------|------|
+| [requirement or screen name] | TC-1, TC-3 | High |
+| [another requirement] | TC-2 | Low |
+
+---
+
+## Suggested Automation Candidates
+
+Test cases that are good candidates for automated testing.
+
+| Test Case | Rationale |
+|-----------|-----------|
+| TC-[N] | [why this is a good automation candidate] |
+
+> Omit this section if no test cases are suitable for automation.
+```
+
+## Field Definitions
+
+### Priority
+
+| Priority | Meaning | Guideline |
+|----------|---------|-----------|
+| **P0 Critical** | Core happy path | If this fails, the feature is unusable |
+| **P1 High** | Important flows | Security, data integrity, key user journeys |
+| **P2 Medium** | Secondary flows | Edge cases with moderate impact |
+| **P3 Low** | Minor scenarios | Cosmetic, rare edge cases, minor UX |
+
+### Tier
+
+| Tier | Meaning | Guideline |
+|------|---------|-----------|
+| **Smoke** | Is it alive? | Minimum set to confirm the feature works at all (3-5 tests max) |
+| **Feature** | Does it work correctly? | Thorough coverage of the feature's behavior |
+| **Regression** | Did we break anything? | Guards against breaking existing functionality |
+
+### Source
+
+| Source type | Format | Example |
+|-------------|--------|---------|
+| Spec section | `Spec §[section]` | `Spec §3.2 — Login flow` |
+| Figma frame | `Figma: [frame name]` | `Figma: Login / Error State` |
+| Code path | backtick-wrapped path with line | `src/auth/LoginViewModel.kt:87` |
+| Inferred | `[inferred from code]` | Behavior derived from code with no spec backing |
+
+## Guidelines
+
+- Number test cases sequentially: TC-1, TC-2, TC-3, ...
+  (the manual-tester agent will assign session-scoped IDs when executing)
+- Each test case tests exactly one thing — split multi-outcome verifications
+- Steps must be concrete and actionable — a QA engineer unfamiliar with the feature
+  should follow them without asking questions
+- Expected results describe observable behavior, not implementation details:
+  "user sees error toast with message 'Invalid email'" not "catch block executes"
+- Mark inferred behavior with `[inferred from code]` so reviewers can verify against
+  product intent
+- Target 15-30 test cases for a medium feature; fewer for simple changes, more for
+  complex flows — every test case should earn its place

--- a/plugins/developer-workflow/skills/generate-test-plan/evals/evals.json
+++ b/plugins/developer-workflow/skills/generate-test-plan/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "generate-test-plan",
+  "evals": [
+    {
+      "id": 0,
+      "prompt": "Generate a test plan for the changelog resolver module. The code is in plugins/maven-mcp/src/changelog/ — look at resolver.ts and the provider files. I don't have a spec, just the code.",
+      "expected_output": "A structured test plan covering the changelog resolution logic, provider selection, caching, and error handling, saved to docs/testplans/",
+      "files": []
+    },
+    {
+      "id": 1,
+      "prompt": "I need a test plan for a new user authentication feature. Requirements: users log in with email+password, get a JWT token, tokens expire after 24h, refresh tokens last 30 days. Failed login after 5 attempts locks the account for 15 minutes. Password reset via email link that expires in 1 hour. Two user roles: admin and regular user. Admins can manage other users.",
+      "expected_output": "A comprehensive test plan covering login flows, token lifecycle, account lockout, password reset, and role-based access, saved to docs/testplans/",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Create a test plan for the vulnerability scanning feature in maven-mcp. The code is at plugins/maven-mcp/src/vulnerabilities/osv-client.ts and the tool is at plugins/maven-mcp/src/tools/get-dependency-vulnerabilities.ts. The feature should check Maven dependencies against the OSV database and report known CVEs with severity levels.",
+      "expected_output": "A test plan combining code analysis with the provided spec, covering API integration, severity classification, error handling, and edge cases, saved to docs/testplans/",
+      "files": []
+    }
+  ]
+}

--- a/plugins/developer-workflow/skills/generate-test-plan/evals/trigger-eval.json
+++ b/plugins/developer-workflow/skills/generate-test-plan/evals/trigger-eval.json
@@ -1,0 +1,22 @@
+[
+  {"query": "generate a test plan for our new search feature. here's the spec: users can search by name, filter by category and date range, results are paginated with 20 results per page. I don't need you to run any tests, just write the plan", "should_trigger": true},
+  {"query": "write test cases for the authentication flow. requirements: email+password login, JWT tokens, 24h expiry, account lockout after 5 failed attempts. save it somewhere I can review it later", "should_trigger": true},
+  {"query": "what should we test for the new payments integration? we're using Stripe, supporting credit cards and Apple Pay. need a comprehensive list of scenarios before we start QA", "should_trigger": true},
+  {"query": "I have this Figma mockup for the settings screen (link). can you create test cases from it? I want to hand them off to our QA team", "should_trigger": true},
+  {"query": "look at the code in src/features/cart/ and tell me what test cases I should write. there's no spec, the code is the spec. I need a plan document not actual execution", "should_trigger": true},
+  {"query": "how would you test the notification system? it handles push, email, and in-app notifications. user can configure per-channel preferences. I need the test scenarios documented", "should_trigger": true},
+  {"query": "create a QA checklist for the onboarding flow. acceptance criteria: new user signs up, verifies email, completes profile, sees tutorial. also cover error cases and edge cases please", "should_trigger": true},
+  {"query": "we're adding multi-language support (en, es, fr, de). what are the edge cases and scenarios I should test? give me a structured plan I can share with the team", "should_trigger": true},
+  {"query": "prepare testing checklist for the file upload feature. supports jpg/png/pdf up to 10MB, drag and drop, progress indicator, error handling for unsupported formats", "should_trigger": true},
+  {"query": "what are the edge cases for our date picker component? it supports date ranges, min/max dates, disabled dates, and timezone-aware selection. write it up as test cases", "should_trigger": true},
+  {"query": "just poke around the app on the emulator and find bugs. package is com.example.app, no spec, just see what's broken", "should_trigger": false},
+  {"query": "the app is running on the simulator. can you go through the checkout flow and tell me if anything is broken?", "should_trigger": false},
+  {"query": "verify that the profile screen matches these Figma mockups. the app is on the emulator, go through each state and compare", "should_trigger": false},
+  {"query": "run the test plan in docs/testplans/auth-test-plan.md against the running app. emulator is ready", "should_trigger": false},
+  {"query": "run ./gradlew :app:testDebugUnitTest and fix any failures", "should_trigger": false},
+  {"query": "can you run npm test and tell me what's failing? I think the cart tests are broken after my refactor", "should_trigger": false},
+  {"query": "review the PR at #42 — check the code quality and leave comments on anything that needs fixing", "should_trigger": false},
+  {"query": "migrate the date handling from java.util.Date to kotlinx-datetime across the data layer", "should_trigger": false},
+  {"query": "do a pre-release exploratory QA sweep of the whole app, try to break things. iOS sim is up", "should_trigger": false},
+  {"query": "write unit tests for the CartViewModel class. cover addItem, removeItem, calculateTotal, and applyDiscount", "should_trigger": false}
+]

--- a/plugins/developer-workflow/skills/test-feature/SKILL.md
+++ b/plugins/developer-workflow/skills/test-feature/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: test-feature
+description: >
+  Verify a feature against its specification by running manual QA on a live app. Use this skill
+  whenever the user wants to test, verify, or validate an implemented feature — whether they provide
+  a test plan, a spec (PRD, Figma mockup, acceptance criteria, PR description), or both.
+  Trigger on: "test this feature", "verify against spec", "QA the implementation", "check if it matches
+  the design", "run the test plan", "validate the acceptance criteria", "does it match the mockup",
+  "verify the PR", or any request to compare a running app against a specification source.
+  Also trigger when the user finishes implementing a feature and wants confirmation it works before
+  creating or finalizing a PR.
+---
+
+# Test Feature
+
+Verify that a running application matches its specification. This skill bridges implementation and
+review — it takes a spec source and/or a test plan, ensures the app is running, launches QA
+against it, and produces a verification result.
+
+---
+
+## Step 1: Gather Inputs
+
+At least one of the two inputs below is required. Both together give the best results, but
+either one alone is enough to proceed.
+
+### 1.1 Spec Source (optional if test plan is provided)
+
+The specification defines what "correct" looks like. Accept any combination of:
+- **Figma mockups** — URLs or exported frames
+- **PRD / requirements document** — file path, URL, or inline text
+- **Acceptance criteria** — bullet list, user stories, or a checklist
+- **PR description** — when verifying a PR, the description itself is a spec
+- **Issue / ticket** — GitHub issue, Linear ticket, or similar
+
+Read all provided spec sources. If neither a spec nor a test plan is provided, ask the user
+for at least one before proceeding.
+
+### 1.2 Test Plan (optional if spec is provided)
+
+The test plan defines what to check. Three modes:
+
+**Test plan only (no spec)** — the test plan is the single source of truth. Execute it as-is.
+The verification result will be based entirely on whether the test cases pass or fail.
+
+**Test plan + spec** — accept the plan as-is, but cross-reference it against the spec. If the
+plan has obvious gaps (spec mentions flows the plan doesn't cover), flag them: "The spec
+mentions X but the test plan doesn't cover it — should I add test cases for that?" Let the
+user decide.
+
+**Spec only (no test plan)** — generate a test plan from the spec:
+1. Read the spec source thoroughly
+2. Identify all testable flows: happy paths, edge cases, error states, empty states
+3. Write test cases in the manual-tester format (TC-prefixed, with tiers, steps, expected results)
+4. Present the generated plan to the user for approval before executing
+5. Adjust based on their feedback
+
+---
+
+## Step 2: Ensure the App is Running
+
+Before launching QA, verify the app is accessible. The approach depends on what's being tested:
+
+### Mobile / Desktop App
+
+1. Check if a device/simulator/emulator is already connected — call `list_devices` via the mobile MCP
+2. If a device is available and the app is installed, try launching it
+3. If no device is available or the app isn't installed:
+   - Look for a run configuration in the project (Gradle `installDebug`, Xcode build, etc.)
+   - Build and install: pick the appropriate command for the project
+   - If the build system isn't obvious, ask the user how to build and deploy
+
+### Web App
+
+1. Check if a dev server is already running (look for running processes on common ports, or check if the URL responds)
+2. If not running, look for a start command in the project (`npm start`, `npm run dev`, `./gradlew bootRun`, etc.)
+3. Start the dev server and wait for it to be ready
+4. If the start command isn't obvious, ask the user
+
+### Already Running
+
+If the user says the app is already running or provides a URL / device target, skip the launch
+step and proceed directly.
+
+---
+
+## Step 3: Launch Manual Tester
+
+Spawn the `manual-tester` agent with all gathered context. The agent prompt must include:
+
+1. **Spec context** — the full spec content or clear pointers to where the spec lives (URLs, file paths)
+2. **Test plan** — the complete set of test cases to execute (user-provided or generated in step 1)
+3. **Target** — how to reach the app (device name, URL, etc.)
+4. **Scope** — which test tiers to run (default: Smoke + Feature)
+
+Example agent prompt structure:
+
+```
+You are testing a feature against its specification.
+
+## Spec
+[Paste or reference the spec source here]
+
+## Test Plan
+[Paste the test cases here]
+
+## Target
+[Device/URL/connection details]
+
+## Scope
+Run Smoke + Feature tiers. Report all bugs with severity and evidence.
+Deliver a Test Execution Summary with a ship/no-ship recommendation when done.
+```
+
+Let the manual-tester agent handle the full QA cycle: environment setup, test execution,
+bug reporting, and summary generation. Do not interfere with its process unless it asks
+a question or reports a P0 blocker.
+
+---
+
+## Step 4: Collect and Present Verification Result
+
+When the manual-tester agent completes, process its output into a verification result.
+
+### Verification State
+
+The result is one of three states:
+
+| State | Meaning | Condition |
+|-------|---------|-----------|
+| **VERIFIED** | Feature matches spec | All test cases passed, no P0/P1 bugs |
+| **FAILED** | Feature does not match spec | Any P0 or P1 bug, or critical test cases failed |
+| **PARTIAL** | Feature partially matches spec | Only P2/P3 bugs found, or non-critical test cases failed |
+
+### Verification Report
+
+Present a structured report:
+
+```
+## Feature Verification
+
+**Status: [VERIFIED / FAILED / PARTIAL]**
+**Spec source:** [what was used]
+**Test plan:** [user-provided / generated from spec]
+
+### Summary
+[1-3 sentences on the overall state]
+
+### Test Results
+- Total: [n] | Passed: [n] | Failed: [n] | Blocked: [n]
+
+### Bugs Found
+[List bugs by severity — P0 first, then P1, P2, P3]
+[Each with a one-line summary and link to full bug report]
+
+### Recommendation
+[Ship / Do not ship / Ship with known issues — and why]
+```
+
+### What Happens Next
+
+Based on the verification state, guide the user on next steps:
+
+- **VERIFIED** — the feature is ready. If this was part of a PR workflow, proceed to PR creation
+  or mark the PR as ready for review.
+- **FAILED** — fix the bugs first. List the failures clearly so the user (or an implementation
+  agent) can address them. After fixes, offer to re-run verification.
+- **PARTIAL** — present the minor issues and let the user decide: fix now, or ship with known
+  issues documented in the PR.
+
+---
+
+## Re-verification Loop
+
+When the user fixes bugs and wants to re-test:
+
+1. Re-use the same test plan (unless the user modified it)
+2. Tell the manual-tester to focus on previously failed test cases + a smoke pass
+3. Update the verification state based on new results
+4. Repeat until VERIFIED or the user decides to ship as-is


### PR DESCRIPTION
## Summary
- **generate-test-plan** — creates structured, reusable test plans from specs/PRDs/Figma/code without executing tests. Outputs `docs/testplans/<feature>-test-plan.md` in TC-N format consumable by manual-tester agent.
- **exploratory-test** — launches manual-tester agent in heuristic mode for undirected bug hunting on a running app. No spec required. Reports bugs + observations + coverage map.
- **test-feature** — verifies a running app against a spec by launching manual-tester in verification mode. Outputs VERIFIED/FAILED/PARTIAL.

Together with the existing `manual-tester` agent, these three skills form a complete QA toolkit:
- `generate-test-plan` produces the plan
- `test-feature` executes it against a spec
- `exploratory-test` finds what the spec missed

## Eval results (generate-test-plan)

| Eval | With Skill | Baseline | 
|------|-----------|----------|
| Changelog resolver (code-only) | 12/12 | 0/12 |
| User auth (spec-only) | 11/12 | 5/12 |
| Vuln scanning (code+spec) | 12/12 | 2/12 |

Skill adds: TC-N numbering, Priority/Tier fields, Risk Areas, Coverage Matrix, Findings, Automation Candidates sections.

## Test plan
- [x] Skills appear in `/` skill list when plugin installed
- [ ] generate-test-plan: provide a spec and verify output format matches TC template
- [ ] exploratory-test: point at a running app, verify agent launches in exploratory mode
- [ ] test-feature: provide spec + running app, verify VERIFIED/FAILED/PARTIAL result

🤖 Generated with [Claude Code](https://claude.com/claude-code)