### PR TITLE
chore: release 0.5.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.5.0",
+      "version": "0.5.1",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/maven-mcp/plugin"
@@ -23,7 +23,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.5.0",
+      "version": "0.5.1",
       "category": "security",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/sensitive-guard"
@@ -34,7 +34,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.5.0",
+      "version": "0.5.1",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow"

--- a/plugins/developer-workflow/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Developer workflow skills — full task implementation cycle, View→Compose UI migration, safe code migration, test plan generation, exploratory QA testing, feature verification, PR preparation, PR creation (draft or ready), and full PR lifecycle through CI/CD and code review",
   "skills": "./skills",
   "agents": "./agents"

--- a/plugins/maven-mcp/package.json
+++ b/plugins/maven-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "MCP server for Maven Central dependency intelligence",
   "main": "./dist/index.js",
   "type": "module",

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maven-mcp",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps, /latest-version, and /dependency-changes skills",
   "mcpServers": {
     "maven-mcp": {

--- a/plugins/sensitive-guard/.claude-plugin/plugin.json
+++ b/plugins/sensitive-guard/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "sensitive-guard",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Prevents sensitive data (secrets, PII) from reaching AI servers by scanning files before they are read into conversation"
 }


### PR DESCRIPTION
## What changed

- **kotlin-engineer agent** — new agent for writing Kotlin/KMP business logic, data layer, domain layer, ViewModels, UseCases, Repositories, and unit tests
- **Best practices alignment** — skills and agents updated to follow consistent structure and guidance
- **Version bump** — all plugins bumped from 0.5.0 to 0.5.1

## Why / motivation

Bundles the kotlin-engineer agent (partner to compose-ui-architect) and structural improvements to existing skills into a patch release.

## How to test

- [ ] Install the `developer-workflow` plugin and verify the `kotlin-engineer` agent appears
- [ ] Run a skill (e.g. `/code-migration`) and verify it loads correctly
- [ ] Check plugin version reports `0.5.1`

## Checklist

- [x] No breaking changes
- [x] All plugin versions aligned to `0.5.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)