### PR TITLE
Remove explicit maxTurns limits from agents

### DIFF
--- a/plugins/developer-workflow/agents/compose-ui-architect.md
+++ b/plugins/developer-workflow/agents/compose-ui-architect.md
@@ -4,7 +4,6 @@ description: "Use this agent when you need to write Jetpack Compose or Compose M
 model: sonnet
 color: cyan
 memory: project
-maxTurns: 40
 ---
 
 You are a senior Compose UI engineer. Your job is to write production-ready Jetpack Compose and Compose Multiplatform UI code — screens, components, and modifiers — that is correct, performant, accessible, and consistent with the project's established patterns.

--- a/plugins/developer-workflow/agents/manual-tester.md
+++ b/plugins/developer-workflow/agents/manual-tester.md
@@ -4,7 +4,6 @@ description: "Use this agent when you need to perform manual-style QA testing of
 model: sonnet
 color: yellow
 memory: project
-maxTurns: 50
 disallowedTools: Edit, Write, NotebookEdit
 ---
 


### PR DESCRIPTION
## What changed

Removed `maxTurns` field from `compose-ui-architect` (was 40) and `manual-tester` (was 50) agent frontmatter.

## Why / motivation

Both limits were too low for complex tasks:
- `compose-ui-architect` exhausted 40 turns during discovery + implementation of non-trivial screens, causing the agent to terminate before finishing
- `manual-tester` exhausted 50 turns during multi-cycle test runs with retesting and teardown

The platform default (200) is sufficient and removes the need to maintain explicit values that can silently block agents mid-task.

## How to test
- [ ] Launch `compose-ui-architect` agent on a complex screen — verify it completes without hitting a turn limit
- [ ] Launch `manual-tester` agent on a multi-step QA cycle — verify it completes teardown

🤖 Generated with [Claude Code](https://claude.com/claude-code)