### PR TITLE
Update README and bump all plugins to 0.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.5.1",
+      "version": "0.6.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/maven-mcp/plugin"
@@ -23,7 +23,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.5.1",
+      "version": "0.6.0",
       "category": "security",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/sensitive-guard"
@@ -34,7 +34,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.5.1",
+      "version": "0.6.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow"
@@ -45,7 +45,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.5.1",
+      "version": "0.6.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/extend"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Install a plugin:
 /plugin install maven-mcp@krozov-ai-tools
 /plugin install sensitive-guard@krozov-ai-tools
 /plugin install developer-workflow@krozov-ai-tools
+/plugin install extend@krozov-ai-tools
 ```
 
 ## Plugins
@@ -55,17 +56,33 @@ See [`plugins/sensitive-guard/`](plugins/sensitive-guard/) for full documentatio
 
 ### developer-workflow
 
-Developer workflow skills — preparing branches for code review, managing the full PR lifecycle, and safely migrating technology in Android/Kotlin/KMP projects.
+Developer workflow skills and expert agents for the full development cycle — from task implementation to QA testing to PR merge.
 
-**Features:**
-- `prepare-for-pr` — quality loop (build → simplify → self-review → lint/tests) before creating a PR
-- `pr-drive-to-merge` — drives an existing PR/MR to merge: monitors CI/CD, triages reviewer comments, responds and resolves threads, loops until merge requirements are met
-- `code-migration` — safe in-place or parallel migration of any technology in Gradle/Android/Kotlin projects
-- `kmp-migration` — full Kotlin Multiplatform migration for Android modules
+**Skills:**
+- `/prepare-for-pr` — quality loop (build → simplify → self-review → lint/tests) before creating a PR
+- `/create-pr` — create a draft or ready PR with auto-generated title, description, labels, and reviewer suggestions
+- `/pr-drive-to-merge` — drive an existing PR/MR to merge: monitor CI/CD, triage reviewer comments, loop until merged
+- `/code-migration` — safe in-place or parallel migration of any technology in Gradle/Android/Kotlin projects
+- `/kmp-migration` — full Kotlin Multiplatform migration for Android modules
+- `/migrate-to-compose` — migrate View-based Android UI (Activity, Fragment, custom View) to Jetpack Compose
+- `/generate-test-plan` — generate structured, prioritized test plan from spec or code
+- `/test-feature` — verify a feature against its specification on a live app
+- `/exploratory-test` — undirected bug hunting and QA exploration on a running app
+- `/plan-review` — multi-agent review of implementation plans using PoLL consensus protocol
+- `/implement-task` — full development cycle: worktree → TDD → implementation → quality loop → draft PR (explicit invocation only)
 
-**Skills:** `/prepare-for-pr`, `/pr-drive-to-merge`, `/code-migration`, `/kmp-migration`
+**Agents (10):** architecture-expert, build-engineer, business-analyst, compose-developer, devops-expert, kotlin-engineer, manual-tester, performance-expert, security-expert, ux-expert
 
 See [`plugins/developer-workflow/`](plugins/developer-workflow/) for full documentation.
+
+### extend
+
+Extend Claude Code built-in features with review and optimization tools.
+
+**Skills:**
+- `/agent-reviewer` — audit and improve Claude Code agent files: frontmatter, system prompt quality, tool selection, trigger accuracy
+
+See [`plugins/extend/`](plugins/extend/) for full documentation.
 
 ## License
 

--- a/plugins/developer-workflow/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Developer workflow skills — full task implementation cycle, View→Compose UI migration, safe code migration, test plan generation, exploratory QA testing, feature verification, PR preparation, PR creation (draft or ready), and full PR lifecycle through CI/CD and code review",
   "skills": "./skills"
 }

--- a/plugins/extend/.claude-plugin/plugin.json
+++ b/plugins/extend/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "extend",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Extend Claude Code built-in features: agent review, skill optimization, configuration audit",
   "skills": "./skills"
 }

--- a/plugins/maven-mcp/package-lock.json
+++ b/plugins/maven-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.4.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@krozov/maven-central-mcp",
-      "version": "0.4.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/plugins/maven-mcp/package.json
+++ b/plugins/maven-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "MCP server for Maven Central dependency intelligence",
   "main": "./dist/index.js",
   "type": "module",

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maven-mcp",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps, /latest-version, and /dependency-changes skills",
   "mcpServers": {
     "maven-mcp": {

--- a/plugins/sensitive-guard/.claude-plugin/plugin.json
+++ b/plugins/sensitive-guard/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "sensitive-guard",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Prevents sensitive data (secrets, PII) from reaching AI servers by scanning files before they are read into conversation"
 }


### PR DESCRIPTION
## Summary
- README updated to reflect current repository state: added `extend` plugin, listed all 11 developer-workflow skills and 10 expert agents
- All plugin versions bumped from 0.5.1 to 0.6.0 (unified versioning across 6 files)

## Test plan
- [ ] CI validates version consistency across marketplace.json and all plugin.json files
- [ ] CI builds and tests maven-mcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)