### PR TITLE
Enforce full View→Compose migration with API audit

### DIFF
--- a/plugins/developer-workflow/skills/migrate-to-compose/SKILL.md
+++ b/plugins/developer-workflow/skills/migrate-to-compose/SKILL.md
@@ -51,7 +51,9 @@ Read every file that makes up the target: XML layout, host class, ViewModel, nes
 
 ## Phase 3: Gap Analysis
 
-For each UI element with no shared Compose equivalent, resolve using priority: existing UI Kit → already-imported libraries → suggest new library → write custom component. See `references/discovery-and-patterns.md` for the full priority order, custom View special case, and documentation format.
+For each UI element with no shared Compose equivalent, resolve using priority: existing UI Kit → already-imported libraries → suggest new library → write custom component. See `references/discovery-and-patterns.md` for the full priority order and documentation format.
+
+**Custom Views are mandatory migration scope** — they must be fully migrated to Compose composables, not wrapped in `AndroidView`. See `references/custom-view-migration.md` for the decision tree: classify → search for replacements → assess feasibility → choose strategy.
 
 **Present the gap list to the user and confirm before proceeding.**
 

--- a/plugins/developer-workflow/skills/migrate-to-compose/SKILL.md
+++ b/plugins/developer-workflow/skills/migrate-to-compose/SKILL.md
@@ -26,7 +26,7 @@ Never write a single line of Compose until the pattern analysis and gap analysis
 ## Workflow
 
 ```
-DISCOVER → ANALYZE PATTERNS → GAP ANALYSIS → CONFIRM → IMPLEMENT GAPS → MIGRATE → STATIC VERIFY → [device: manual-tester agent (QA)]
+DISCOVER → ANALYZE PATTERNS → GAP ANALYSIS → CONFIRM → IMPLEMENT GAPS → MIGRATE → STATIC VERIFY → VIEW API AUDIT → [device: manual-tester agent (QA)]
 ```
 
 ---
@@ -107,7 +107,24 @@ See `references/migration-and-verify.md` for detailed fidelity review checklist 
 2. **Migration fidelity review** — walk through `behavior-scenarios.md` and XML element by element: layout structure, visual properties, behavioral details, architecture, window insets
 3. **Produce `migration-report.md`** — replacements, new components, ViewModel changes, behavior verification status, visual comparison table, deviations, issues found
 
-After static checks pass: invoke the `manual-tester` agent for device verification.
+After static checks pass: proceed to View API Audit.
+
+---
+
+## Phase 8: View API Audit
+
+**Mandatory.** Scan all migrated and touched files for remaining View-system API usage. Nothing from the old View world should survive in new Compose code unless explicitly allowed.
+
+See `references/migration-and-verify.md` for the full scan procedure, prohibited API list, and allowlist format.
+
+1. **Scan** — grep migrated files for prohibited View API patterns (imports, class references, method calls)
+2. **Classify each hit** — determine if it's: a leftover that must be replaced, an intentional interop usage (`AndroidView`, `ComposeView`), or a false positive
+3. **Check against allowlist** — if the project defines a View API allowlist in the migration plan or `behavior-scenarios.md`, skip approved usages
+4. **Fix** all remaining non-allowed usages — replace with Compose equivalents
+5. **Report** — any usage that cannot be replaced without breaking functionality: present to the user with reasoning and get explicit approval before proceeding
+6. **Block device testing** until every View API usage is either eliminated or user-approved
+
+The audit result is appended to `migration-report.md` as a "View API Audit" section.
 
 ---
 

--- a/plugins/developer-workflow/skills/migrate-to-compose/references/custom-view-migration.md
+++ b/plugins/developer-workflow/skills/migrate-to-compose/references/custom-view-migration.md
@@ -1,0 +1,139 @@
+# Custom View Migration Strategies
+
+## When this applies
+
+Any project-owned custom View or ViewGroup used on the screen being migrated. Third-party Views (MapView, WebView, PlayerView, ExoPlayer) are exempt — wrap them in `AndroidView`.
+
+## Decision tree
+
+For each custom View, walk through these steps **in order**. Stop at the first match.
+
+### Step 1: Classify the View
+
+Before searching for replacements, understand what the View actually does:
+
+| Type | How to recognize | Complexity |
+|---|---|---|
+| **Composite** — assembles standard widgets | Extends `FrameLayout`/`LinearLayout`/`ConstraintLayout`, inflates XML, no `onDraw` | Low |
+| **Behavioral** — adds behavior to children | Extends `ViewGroup`, overrides `onInterceptTouchEvent`/`onTouchEvent`, custom `onMeasure`/`onLayout` | Medium |
+| **Drawing** — custom rendering | Overrides `onDraw`/`dispatchDraw`, uses `Canvas`/`Paint`/`Path` | High |
+| **Hybrid** — combines layout + drawing | Has both custom layout logic and `onDraw` | High |
+
+Document the type and its public API: constructor attrs, public properties/setters, listener interfaces, saved state.
+
+### Step 2: Search for existing replacements
+
+**Priority order — always prefer what's already available:**
+
+**2a. Material3 / Compose Foundation**
+Check if a standard Compose component already does what the custom View does. Common matches:
+
+| Custom View pattern | Compose equivalent |
+|---|---|
+| Custom progress/loading indicator | `CircularProgressIndicator`, `LinearProgressIndicator` |
+| Custom toggle/switch | `Switch`, `Checkbox`, `RadioButton` |
+| Custom chip/tag | `AssistChip`, `FilterChip`, `InputChip`, `SuggestionChip` |
+| Custom badge/count | `Badge`, `BadgedBox` |
+| Custom bottom bar | `NavigationBar`, `NavigationBarItem` |
+| Custom segmented control | `SegmentedButton`, `SingleChoiceSegmentedButtonRow` |
+| Custom slider | `Slider`, `RangeSlider` |
+| Custom tooltip | `PlainTooltip`, `RichTooltip` |
+| Flow/wrap layout | `FlowRow`, `FlowColumn` |
+| Custom card | `Card`, `ElevatedCard`, `OutlinedCard` |
+| Custom divider | `HorizontalDivider`, `VerticalDivider` |
+
+If you find a match: verify it covers the full feature set of the custom View. A 90% match is usually good enough — document the differences.
+
+**2b. Project's UI kit / design system module**
+Search the project's shared UI module (`uikit`, `designsystem`, `ui-components`, or similar) for an existing Compose version of this View. Projects often migrate widgets incrementally — there may already be a Compose version that another screen uses.
+
+**2c. Already-imported Compose libraries**
+Check `build.gradle.kts` / version catalog for libraries already on the classpath that might provide the component. Common ones:
+
+- `accompanist-*` — permissions, system UI controller, web view, placeholder
+- `coil-compose` / `glide-compose` — image loading
+- `lottie-compose` — Lottie animations
+- `compose-richtext` — rich text rendering
+- `compose-shimmer` — shimmer/skeleton loading
+- `compose-charts` / `vico` — charting
+- `telephoto` — zoomable images
+- `compose-calendar` — date pickers / calendars
+
+**2d. Search for a well-known Compose library**
+If nothing on the classpath fits, search for established Compose libraries that provide this component. Criteria for "established":
+- 500+ GitHub stars or part of a known suite
+- Active maintenance (commits in the last 6 months)
+- Compose Multiplatform support is a bonus if the project uses KMP
+
+**Propose to the user with rationale. Do not add without approval.**
+
+### Step 3: Assess if custom implementation is feasible
+
+If no existing replacement found — you need to write a Compose composable. Assess feasibility based on the View type from Step 1:
+
+**Composite View (low complexity)**
+- Straightforward: replace the inflated XML with a composable function
+- Map XML attrs → function parameters
+- Map setters/listeners → lambda parameters
+- Map `addView`/`removeView` patterns → conditional composition or `AnimatedVisibility`
+- Estimated effort: small, do inline with the migration
+
+**Behavioral View (medium complexity)**
+- Map `onMeasure`/`onLayout` → custom `Layout` composable with `MeasurePolicy`
+- Map `onInterceptTouchEvent`/`onTouchEvent` → `Modifier.pointerInput` with gesture detectors
+- Map scroll behavior → `Modifier.nestedScroll` with `NestedScrollConnection`
+- Estimated effort: moderate, may need its own sub-task in Phase 4
+
+**Drawing View (high complexity)**
+- Map `onDraw` → `Canvas { }` composable or `Modifier.drawBehind`/`Modifier.drawWithContent`
+- Map `Paint` → `DrawScope` methods and `Paint` in Compose graphics
+- Map `Path` → `androidx.compose.ui.graphics.Path`
+- Map `clipPath`/`saveLayer` → `clipPath`/`drawWithLayer` in `DrawScope`
+- Map `Bitmap` operations → `ImageBitmap`
+- Map invalidate-driven animation → `Animatable` + `LaunchedEffect`
+- **Flag explicitly to the user**: this is high risk, recommend screenshot testing, may deserve its own PR
+- Estimated effort: significant, always a separate sub-task
+
+**Hybrid View (high complexity)**
+- Decompose into layout part and drawing part
+- Layout → custom `Layout` composable
+- Drawing → `Canvas` or draw modifiers applied to the layout
+- Same risk level as Drawing View — flag and budget accordingly
+
+### Step 4: Plan the migration
+
+Based on the assessment, propose one of these strategies to the user in Phase 4:
+
+| Strategy | When to use | Approach |
+|---|---|---|
+| **Inline replacement** | Composite View with clear Compose equivalent or trivial custom impl | Migrate as part of the screen migration in Phase 6 |
+| **Pre-migration component** | Any View that will be reused across screens, or medium-complexity behavioral View | Build the Compose composable in Phase 5 (Implement Gaps), then use it in Phase 6 |
+| **Dedicated sub-task** | Drawing View, Hybrid View, or any View with complex touch/animation | Separate sub-task with its own `@Preview`, screenshot tests, and verification. Complete before Phase 6 |
+
+### Step 5: Verify completeness
+
+After migration, every custom View must satisfy ALL of these:
+- [ ] No `AndroidView` wrapping of project-owned code
+- [ ] Full public API preserved (all attrs/properties/listeners have Compose parameter equivalents)
+- [ ] Visual appearance matches (verified via `@Preview` at minimum, screenshot test for complex cases)
+- [ ] Behavioral parity (touch handling, animations, state saving)
+- [ ] Placed in shared UI module (not inlined in the screen) if the View was shared or could be reused
+- [ ] Old View class kept intact until device verification passes (same as screen migration rule)
+
+## Example walkthrough
+
+```
+Custom View: RatingBar (extends LinearLayout, inflates 5 star ImageViews, 
+             supports half-stars, has setRating/setOnRatingChanged)
+
+Step 1: Composite View — inflates XML, no onDraw → Low complexity
+Step 2a: No Material3 RatingBar in Compose
+Step 2b: Project UI kit has no Compose version
+Step 2c: No rating library on classpath
+Step 2d: Found compose-ratingbar (800+ stars, maintained) — option A
+         Custom implementation with Row + Icon — option B (simple enough)
+Step 3: Composite, low complexity → feasible to write custom
+Step 4: Recommend option B (no new dependency, simple component)
+        → Pre-migration component in Phase 5
+Step 5: Checklist passes
+```

--- a/plugins/developer-workflow/skills/migrate-to-compose/references/discovery-and-patterns.md
+++ b/plugins/developer-workflow/skills/migrate-to-compose/references/discovery-and-patterns.md
@@ -107,12 +107,21 @@ For each gap, document which option you're proposing and why.
 - Less obvious or requires evaluating alternatives → present options with trade-offs and wait
 - Never add a dependency to `build.gradle.kts` without user approval
 
-**Special case — Custom View migration:** Include an explicit prior-art check:
+**Special case — Custom View migration:**
+
+Custom Views used on the migrated screen **must be migrated to Compose equivalents** as part of this migration. Wrapping a project-owned custom View in `AndroidView` is not acceptable — it defeats the purpose of the migration and will be caught by the View API Audit (Phase 8).
+
+`AndroidView` wrapping is allowed **only** for third-party Views with no Compose equivalent (e.g. `MapView`, `WebView`, `PlayerView`, `ExoPlayer`).
+
+For each custom View, resolve in this order:
 1. Name-check Material3 components — does it already have an equivalent?
-2. Check the project's UI kit module
+2. Check the project's UI kit module for an existing Compose version
 3. Check already-imported libraries on the classpath
+4. **Migrate the custom View to a Compose composable** — implement it as a new shared component in the UI module
 
 State the result of each check explicitly, even when the answer is "no existing equivalent found".
+
+If a custom View is complex enough to be a significant migration on its own (e.g. custom drawing with `onDraw`/`Canvas`, complex touch handling, custom layout with `onMeasure`/`onLayout`), flag it in the migration plan (Phase 4) as a sub-task — but it is still in scope and must be completed before the screen migration is considered done.
 
 ## Phase 4: Confirm
 
@@ -144,6 +153,7 @@ Resolve missing components **before** writing the screen:
 - **UI Kit match found** → confirm import path, move on
 - **Already-imported library** → confirm API, move on
 - **New library approved** → add dependency, sync, verify
-- **Custom component needed** → implement in shared UI module using `compose-developer` agent; each new component gets at least one `@Preview`. **Name the target module explicitly.**
+- **Custom View migration** → migrate each project-owned custom View to a Compose composable using the `compose-developer` agent. This is mandatory — `AndroidView` wrapping of project-owned Views is not acceptable. Place the new composable in the shared UI module.
+- **Custom component needed** (not a View migration) → implement in shared UI module using `compose-developer` agent; each new component gets at least one `@Preview`. **Name the target module explicitly.**
 
-Do not implement the screen migration and new shared components at the same time.
+Do not implement the screen migration and new shared components at the same time. Migrate custom Views first, then proceed to the screen.

--- a/plugins/developer-workflow/skills/migrate-to-compose/references/discovery-and-patterns.md
+++ b/plugins/developer-workflow/skills/migrate-to-compose/references/discovery-and-patterns.md
@@ -109,19 +109,11 @@ For each gap, document which option you're proposing and why.
 
 **Special case — Custom View migration:**
 
-Custom Views used on the migrated screen **must be migrated to Compose equivalents** as part of this migration. Wrapping a project-owned custom View in `AndroidView` is not acceptable — it defeats the purpose of the migration and will be caught by the View API Audit (Phase 8).
+Custom Views used on the migrated screen **must be migrated to Compose equivalents** as part of this migration. Wrapping a project-owned custom View in `AndroidView` is not acceptable — it defeats the purpose of the migration and will be caught by the View API Audit (Phase 8). `AndroidView` wrapping is allowed **only** for third-party Views with no Compose equivalent (e.g. `MapView`, `WebView`, `PlayerView`).
 
-`AndroidView` wrapping is allowed **only** for third-party Views with no Compose equivalent (e.g. `MapView`, `WebView`, `PlayerView`, `ExoPlayer`).
+See `references/custom-view-migration.md` for the full decision tree: classify the View → search for existing replacements (Material3 → project UI kit → imported libraries → new library) → assess custom implementation feasibility → choose a migration strategy (inline / pre-migration component / dedicated sub-task).
 
-For each custom View, resolve in this order:
-1. Name-check Material3 components — does it already have an equivalent?
-2. Check the project's UI kit module for an existing Compose version
-3. Check already-imported libraries on the classpath
-4. **Migrate the custom View to a Compose composable** — implement it as a new shared component in the UI module
-
-State the result of each check explicitly, even when the answer is "no existing equivalent found".
-
-If a custom View is complex enough to be a significant migration on its own (e.g. custom drawing with `onDraw`/`Canvas`, complex touch handling, custom layout with `onMeasure`/`onLayout`), flag it in the migration plan (Phase 4) as a sub-task — but it is still in scope and must be completed before the screen migration is considered done.
+State the result of each search step explicitly, even when the answer is "no existing equivalent found".
 
 ## Phase 4: Confirm
 

--- a/plugins/developer-workflow/skills/migrate-to-compose/references/migration-and-verify.md
+++ b/plugins/developer-workflow/skills/migrate-to-compose/references/migration-and-verify.md
@@ -183,6 +183,101 @@ Brief the `manual-tester` agent with:
 
 The agent captures before/after screenshots, executes all test cases, compares layout/typography/colors/spacing, and populates the screenshot table in the report.
 
+## Phase 8: View API Audit
+
+**This phase is mandatory and blocks device testing.** Its purpose is to guarantee that no deprecated View-system API leaked into the new Compose code.
+
+### Scan procedure
+
+Search all files created or modified during migration (`.kt` files only) for the prohibited patterns below. Use both import scanning and in-body usage scanning — an API can be used via fully qualified name without an import.
+
+### Prohibited API patterns
+
+Scan for any of these in migrated files:
+
+**Imports**
+- `import android.view.*`
+- `import android.widget.*`
+- `import android.app.Activity` (as base class)
+- `import android.app.Fragment` / `import androidx.fragment.app.Fragment`
+- `import android.databinding.*` / `import androidx.databinding.*`
+- `import android.viewbinding.*` / `import androidx.viewbinding.*`
+- `import kotlinx.android.synthetic.*`
+- `import android.animation.*` (unless wrapping in `AndroidView`)
+- `import android.view.animation.*`
+- `import android.graphics.drawable.AnimationDrawable`
+- `import android.transition.*`
+
+**Class references and method calls**
+- `View`, `ViewGroup`, `LayoutInflater`, `LayoutParams` — as types, parameters, or receivers
+- `findViewById`, `requireViewById`
+- `setContentView`, `inflate`
+- `RecyclerView`, `RecyclerView.Adapter`, `RecyclerView.ViewHolder`, `DiffUtil`
+- `DataBindingUtil`, `ViewBinding`, `binding.root`
+- `onCreateView`, `onViewCreated`, `onDestroyView` — in new code (OK in old kept-intact code)
+- `addView`, `removeView`, `removeAllViews`
+- `ViewCompat`, `ViewGroupCompat`
+- `ContextCompat.getDrawable` (use `painterResource` instead)
+- `resources.getDimension`, `resources.getColor` (use Compose theme tokens)
+- `TypedValue`, `TypedArray` — custom attribute resolution
+
+**XML references**
+- `R.layout.*` in new Compose code
+- `R.anim.*`, `R.animator.*` (use Compose animation APIs)
+- `R.style.*`, `R.attr.*` applied to Views
+
+### Allowed exceptions
+
+The following View API usages are legitimate in Compose code and should NOT be flagged:
+
+- `AndroidView { }` / `AndroidViewBinding { }` — intentional interop for components with no Compose equivalent (e.g. `MapView`, `WebView`, `PlayerView`)
+- `ComposeView` / `AbstractComposeView` — embedding Compose in a host that's still View-based
+- `LocalContext.current` — accessing Android `Context` for non-View purposes (intents, resources)
+- `painterResource(R.drawable.*)` — loading drawable resources in Compose is normal
+- `stringResource(R.string.*)`, `dimensionResource(R.dimen.*)` — resource accessors
+- `R.id.*` references in test code (Espresso, UI Automator)
+- Code in files explicitly listed in the project's View API allowlist
+
+### Project allowlist
+
+If the migration plan (Phase 4) or `behavior-scenarios.md` includes a **View API allowlist** section, those usages are pre-approved. Format:
+
+```markdown
+## View API Allowlist
+- `AndroidView` wrapping `MapView` in `MapScreen.kt` — no Compose equivalent
+- `AndroidViewBinding` for `PlayerView` in `VideoPlayer.kt` — ExoPlayer requires View
+```
+
+Any usage matching an allowlist entry is skipped during the audit.
+
+### Handling remaining usages
+
+For each prohibited usage found:
+
+1. **Can be replaced** → replace with Compose equivalent immediately
+2. **Cannot be replaced** (no Compose equivalent exists, interop is the only option) → wrap in `AndroidView`/`AndroidViewBinding`, add to allowlist in migration report, continue
+3. **Unclear** → present to the user with the specific line, explain why it's there, and ask: replace, wrap in interop, or approve as-is
+
+**Do not proceed to device testing until every hit is resolved.**
+
+### Migration report section
+
+Append to `migration-report.md`:
+
+```markdown
+## View API Audit
+
+| # | File | Line | API | Resolution |
+|---|------|------|-----|------------|
+| 1 | OrderScreen.kt | 45 | `ContextCompat.getDrawable` | Replaced with `painterResource` |
+| 2 | MapSection.kt | 12 | `AndroidView { MapView }` | Allowed — no Compose equivalent |
+| 3 | ... | ... | ... | ... |
+
+**Result:** All View API usages eliminated or approved. ✓
+```
+
+---
+
 ## Post-migration Cleanup
 
 Once verification passes, **offer to clean up** (do not do automatically):

--- a/plugins/developer-workflow/skills/migrate-to-compose/references/migration-and-verify.md
+++ b/plugins/developer-workflow/skills/migrate-to-compose/references/migration-and-verify.md
@@ -230,7 +230,7 @@ Scan for any of these in migrated files:
 
 The following View API usages are legitimate in Compose code and should NOT be flagged:
 
-- `AndroidView { }` / `AndroidViewBinding { }` — intentional interop for components with no Compose equivalent (e.g. `MapView`, `WebView`, `PlayerView`)
+- `AndroidView { }` / `AndroidViewBinding { }` — **only for third-party Views** with no Compose equivalent (e.g. `MapView`, `WebView`, `PlayerView`, ExoPlayer). Wrapping a project-owned custom View in `AndroidView` is NOT allowed — it must be migrated to a Compose composable.
 - `ComposeView` / `AbstractComposeView` — embedding Compose in a host that's still View-based
 - `LocalContext.current` — accessing Android `Context` for non-View purposes (intents, resources)
 - `painterResource(R.drawable.*)` — loading drawable resources in Compose is normal

--- a/plugins/developer-workflow/skills/migrate-to-compose/references/migration-and-verify.md
+++ b/plugins/developer-workflow/skills/migrate-to-compose/references/migration-and-verify.md
@@ -174,22 +174,15 @@ _Populated by manual-tester agent._
 - [ ] Old files deleted
 ```
 
-## Device Testing
-
-Brief the `manual-tester` agent with:
-- The `behavior-scenarios.md` from Phase 1
-- The migration report's visual comparison table
-- The list of interactions to verify
-
-The agent captures before/after screenshots, executes all test cases, compares layout/typography/colors/spacing, and populates the screenshot table in the report.
-
 ## Phase 8: View API Audit
 
 **This phase is mandatory and blocks device testing.** Its purpose is to guarantee that no deprecated View-system API leaked into the new Compose code.
 
 ### Scan procedure
 
-Search all files created or modified during migration (`.kt` files only) for the prohibited patterns below. Use both import scanning and in-body usage scanning — an API can be used via fully qualified name without an import.
+Search all newly migrated Compose files and files intended to be Compose-only (`.kt` files only) for the prohibited patterns below. Use both import scanning and in-body usage scanning — an API can be used via fully qualified name without an import.
+
+**Scope clarification:** target only files that were created as part of this migration or fully rewritten to Compose. Legacy host Fragment/Activity files that were only lightly touched during migration (e.g. a single line change to swap in a `ComposeView`) must be explicitly excluded from the audit scope — they will legitimately contain View API usages and including them will produce false positives.
 
 ### Prohibited API patterns
 
@@ -198,10 +191,10 @@ Scan for any of these in migrated files:
 **Imports**
 - `import android.view.*`
 - `import android.widget.*`
-- `import android.app.Activity` (as base class)
-- `import android.app.Fragment` / `import androidx.fragment.app.Fragment`
+- `import android.app.Activity` — heuristic: an import grep cannot distinguish base-class inheritance from legitimate usages (e.g. `ActivityResultLauncher`, casting, test helpers); treat every hit as a candidate requiring manual confirmation that the class is not used as a supertype in the migrated file
+- `import android.app.Fragment` / `import androidx.fragment.app.Fragment` — same heuristic: verify the hit is not a cast, type check, or test helper before flagging it as a violation
 - `import android.databinding.*` / `import androidx.databinding.*`
-- `import android.viewbinding.*` / `import androidx.viewbinding.*`
+- `import androidx.viewbinding.*`
 - `import kotlinx.android.synthetic.*`
 - `import android.animation.*` (unless wrapping in `AndroidView`)
 - `import android.view.animation.*`
@@ -275,6 +268,15 @@ Append to `migration-report.md`:
 
 **Result:** All View API usages eliminated or approved. ✓
 ```
+
+## Device Testing
+
+Brief the `manual-tester` agent with:
+- The `behavior-scenarios.md` from Phase 1
+- The migration report's visual comparison table
+- The list of interactions to verify
+
+The agent captures before/after screenshots, executes all test cases, compares layout/typography/colors/spacing, and populates the screenshot table in the report.
 
 ---
 


### PR DESCRIPTION
## Summary
- **Phase 8: View API Audit** — mandatory step after Static Verification, blocks device testing until all View API usages are eliminated or user-approved
- **Custom View migration is now mandatory scope** — project-owned custom Views must be fully migrated to Compose composables, `AndroidView` wrapping only allowed for third-party Views (MapView, WebView, PlayerView)
- **New reference: `custom-view-migration.md`** — structured decision tree for migrating custom Views:
  - Classify: composite / behavioral / drawing / hybrid
  - Search for replacements: Material3 → project UI kit → imported libraries → new library
  - Assess custom implementation feasibility per View type
  - Choose strategy: inline / pre-migration component / dedicated sub-task
- Comprehensive prohibited View API list (imports, class refs, method calls, XML references)
- Explicit allowed exceptions with third-party-only `AndroidView` constraint
- Project allowlist support for pre-approved interop usages
- Audit results appended to `migration-report.md`

## Changed files
- `SKILL.md` — new Phase 8 in workflow, custom View mandate in Phase 3
- `references/migration-and-verify.md` — View API Audit scan procedure, prohibited list, allowlist format, report template
- `references/discovery-and-patterns.md` — updated gap analysis and Phase 5 for mandatory custom View migration
- `references/custom-view-migration.md` — new file, full decision tree

## Test plan
- [ ] CI passes
- [ ] Review prohibited API patterns for completeness
- [ ] Review custom View decision tree covers edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)