### PR TITLE
Fix consistency: inline superpowers, update README and routing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Monorepo for Claude Code plugins by krozov. Contains four plugins:
 |--------|-----------|-------------|
 | maven-mcp | `plugins/maven-mcp/` | MCP server for Maven dependency intelligence |
 | sensitive-guard | `plugins/sensitive-guard/` | Scans files for secrets and PII before they reach AI servers |
-| developer-workflow | `plugins/developer-workflow/` | Skills for developer workflow — code migration, PR preparation and lifecycle |
+| developer-workflow | `plugins/developer-workflow/` | Full dev workflow pipeline — task decomposition, research, implementation, code review, QA testing, PR lifecycle |
 | extend | `plugins/extend/` | Extend Claude Code built-in features: agent review, skill optimization, configuration audit |
 
 ## Structure
@@ -19,7 +19,7 @@ Monorepo for Claude Code plugins by krozov. Contains four plugins:
 plugins/
   maven-mcp/           # TypeScript, npm package @krozov/maven-central-mcp
   sensitive-guard/      # Shell-based Claude Code plugin
-  developer-workflow/   # Skills-only plugin for developer workflow habits
+  developer-workflow/   # Skills + agents for the full development lifecycle
   extend/               # Meta-tools for improving Claude Code setup
 ```
 

--- a/plugins/developer-workflow/CLAUDE.md
+++ b/plugins/developer-workflow/CLAUDE.md
@@ -12,6 +12,9 @@ docs/WORKFLOW.md          # Full pipeline documentation with diagrams
 ## Conventions
 
 - 100% self-contained — no dependencies on external plugins (superpowers, code-review, etc.)
+- **Dependency policy:** only built-in Claude Code features + own plugins from this repo (maven-mcp, sensitive-guard, extend). No third-party plugin skills/agents.
+- **MCP servers:** `mobile` MCP is explicitly allowed for testing. Other MCP servers (Perplexity, DeepWiki, Context7, etc.) are environment-level — use when available, but skills must NOT hardcode their tool names or break without them. Describe the task ("search the web for approaches"), not the tool (`perplexity_research`).
+- **External tools:** if a capability requires something the user may not have installed, describe what's needed and let the user decide — don't write it as a mandatory instruction.
 - Skills use YAML frontmatter: `name`, `description` (required), optionally `disable-model-invocation`
 - Agents use YAML frontmatter: `name`, `description`, `model`, `color`, `memory`, `tools`, optionally `maxTurns`, `disallowedTools`
 - `code-reviewer` agent is read-only — no Edit, Write, NotebookEdit, or Bash tools

--- a/plugins/developer-workflow/CLAUDE.md
+++ b/plugins/developer-workflow/CLAUDE.md
@@ -1,0 +1,24 @@
+# developer-workflow
+
+## Structure
+
+```
+skills/<name>/SKILL.md    # Each skill is a directory with YAML frontmatter
+agents/<name>.md          # Each agent is a single .md with YAML frontmatter
+agents/references/        # Shared reference material used by agents
+docs/WORKFLOW.md          # Full pipeline documentation with diagrams
+```
+
+## Conventions
+
+- 100% self-contained — no dependencies on external plugins (superpowers, code-review, etc.)
+- Skills use YAML frontmatter: `name`, `description` (required), optionally `disable-model-invocation`
+- Agents use YAML frontmatter: `name`, `description`, `model`, `color`, `memory`, `tools`, optionally `maxTurns`, `disallowedTools`
+- `code-reviewer` agent is read-only — no Edit, Write, NotebookEdit, or Bash tools
+- Workspace directories (`*-workspace/`) are runtime artifacts, not skills
+- Pipeline orchestration rules live at `~/.claude/rules/dev-workflow-orchestration.md` (user-global, not in this repo)
+- Quality Loop gates are defined in orchestration rules, not in any skill
+
+## Expert Agents
+
+Seven expert agents (architecture, build, business-analyst, devops, performance, security, ux) are specialists invoked by skills during quality loop or research. They are not meant for direct user invocation.

--- a/plugins/developer-workflow/CLAUDE.md
+++ b/plugins/developer-workflow/CLAUDE.md
@@ -11,7 +11,7 @@ docs/WORKFLOW.md          # Full pipeline documentation with diagrams
 
 ## Conventions
 
-- 100% self-contained — no dependencies on external plugins (superpowers, code-review, etc.)
+- 100% self-contained — no dependencies on external plugins. Own plugins from this monorepo (maven-mcp, sensitive-guard, extend) are allowed as they ship together.
 - **Dependency policy:** only built-in Claude Code features + own plugins from this repo (maven-mcp, sensitive-guard, extend). No third-party plugin skills/agents.
 - **MCP servers:** `mobile` MCP is explicitly allowed for testing. Other MCP servers (Perplexity, DeepWiki, Context7, etc.) are environment-level — use when available, but skills must NOT hardcode their tool names or break without them. Describe the task ("search the web for approaches"), not the tool (`perplexity_research`).
 - **External tools:** if a capability requires something the user may not have installed, describe what's needed and let the user decide — don't write it as a mandatory instruction.

--- a/plugins/developer-workflow/README.md
+++ b/plugins/developer-workflow/README.md
@@ -95,8 +95,8 @@ Use when migrating Android View-based UI to Jetpack Compose.
 ### `plan-review`
 
 Multi-agent review of an implementation plan using the PoLL (Panel of LLM Evaluators) consensus protocol:
-- Runs 3 independent reviewer agents in parallel, each evaluating the plan blind
-- Aggregates verdicts: APPROVE (all pass), REVISE (majority concerns), REJECT (majority critical issues)
+- Discovers available agents dynamically; presents a multi-select and runs only the agents you choose
+- Aggregates verdicts: PASS (no blockers), CONDITIONAL (improvements needed), FAIL (blockers must be resolved)
 - Produces a structured review report with per-reviewer findings and consensus summary
 
 Use when you want an independent quality check on a plan before implementation.
@@ -106,7 +106,7 @@ Use when you want an independent quality check on a plan before implementation.
 Structured investigation skill for exploring codebases, technologies, and approaches:
 - Launches parallel research agents (codebase, web, docs, deps, architecture)
 - Produces a consolidated research report with findings, recommendations, and open questions
-- Mandatory web lookup — never relies solely on codebase analysis and training data
+- Includes web research for approaches and best practices — never relies solely on codebase analysis and training data
 
 Use for investigation tasks that don't require implementation — evaluations, comparisons, feasibility studies.
 
@@ -159,6 +159,10 @@ Use for pre-release QA sweeps, sanity checks, or finding issues specs don't anti
 
 ## Agents
 
+### User-Invokable Agents
+
+These agents can be invoked directly by the user for specific tasks.
+
 ### `manual-tester`
 
 Performs manual-style QA testing of a running mobile or web application:
@@ -206,6 +210,10 @@ Writes production-ready Kotlin for Android and KMP client applications — busin
 - Writes unit tests alongside implementation (fakes over mocks, Turbine for Flow testing)
 
 Use when you need Kotlin feature code — everything except Compose UI (which goes to `compose-developer`).
+
+### Internal Expert Agents
+
+These agents are invoked by skills and the quality loop orchestration — not meant for direct user invocation. They are selected automatically based on the task (e.g., what code was touched, what the plan covers).
 
 ### `architecture-expert`
 

--- a/plugins/developer-workflow/README.md
+++ b/plugins/developer-workflow/README.md
@@ -106,7 +106,7 @@ Use when you want an independent quality check on a plan before implementation.
 Structured investigation skill for exploring codebases, technologies, and approaches:
 - Launches parallel research agents (codebase, web, docs, deps, architecture)
 - Produces a consolidated research report with findings, recommendations, and open questions
-- Includes web research for approaches and best practices — never relies solely on codebase analysis and training data
+- Can include web research for approaches and best practices when web search is available
 
 Use for investigation tasks that don't require implementation — evaluations, comparisons, feasibility studies.
 

--- a/plugins/developer-workflow/README.md
+++ b/plugins/developer-workflow/README.md
@@ -81,6 +81,35 @@ Guides a full migration of an Android module to Kotlin Multiplatform (KMP):
 
 Use when migrating a module to share code with iOS, JVM, or other platforms.
 
+### `migrate-to-compose`
+
+Guides View-to-Compose migration for Activities, Fragments, and custom Views:
+- Maps View hierarchy to Compose equivalents (layouts, widgets, custom views)
+- Discovers project Compose patterns (theme, state model, shared components) before writing code
+- Delegates implementation to `compose-developer` agent with a structured migration brief
+- Supports incremental migration via `ComposeView` bridge or full rewrite
+- Verifies visual fidelity with before/after comparison
+
+Use when migrating Android View-based UI to Jetpack Compose.
+
+### `plan-review`
+
+Multi-agent review of an implementation plan using the PoLL (Panel of LLM Evaluators) consensus protocol:
+- Runs 3 independent reviewer agents in parallel, each evaluating the plan blind
+- Aggregates verdicts: APPROVE (all pass), REVISE (majority concerns), REJECT (majority critical issues)
+- Produces a structured review report with per-reviewer findings and consensus summary
+
+Use when you want an independent quality check on a plan before implementation.
+
+### `research`
+
+Structured investigation skill for exploring codebases, technologies, and approaches:
+- Launches parallel research agents (codebase, web, docs, deps, architecture)
+- Produces a consolidated research report with findings, recommendations, and open questions
+- Mandatory web lookup — never relies solely on codebase analysis and training data
+
+Use for investigation tasks that don't require implementation — evaluations, comparisons, feasibility studies.
+
 ### `write-tests`
 
 Orchestrates retroactive test generation for existing code that lacks coverage — discovers test infrastructure, plans test cases, delegates code generation to specialist agents:
@@ -177,6 +206,76 @@ Writes production-ready Kotlin for Android and KMP client applications — busin
 - Writes unit tests alongside implementation (fakes over mocks, Turbine for Flow testing)
 
 Use when you need Kotlin feature code — everything except Compose UI (which goes to `compose-developer`).
+
+### `architecture-expert`
+
+Reviews and validates architectural decisions, module structure, and dependency direction:
+- Evaluates module decomposition, layer boundaries, and API design between modules
+- Validates plans and implementations against architectural best practices
+- Analyzes dependency graphs for circular dependencies and incorrect direction
+- Advises on when and how to extract modules or introduce abstractions
+
+Use when a plan or implementation involves architectural decisions that need validation.
+
+### `business-analyst`
+
+Evaluates plans, features, and technical decisions from a product and business value perspective:
+- Analyzes requirements for completeness, consistency, and implicit assumptions
+- Scopes MVPs and prioritizes features by business value
+- Formulates concrete acceptance criteria from vague requirements
+- Performs trade-off analysis covering cost, time-to-market, and risk
+
+Use when you need product-side evaluation of scope, requirements, or technical trade-offs.
+
+### `security-expert`
+
+Reviews code, architecture, and plans for security vulnerabilities:
+- OWASP Top 10 analysis, data storage security, network security
+- Authentication and authorization flow review
+- CI/CD secrets management and mobile platform security
+- Read-only — reports findings with severity and remediation guidance
+
+Use when code touches auth, encryption, token storage, network requests, permissions, or user data.
+
+### `performance-expert`
+
+Analyzes code and plans for performance issues and resource efficiency:
+- Detects N+1 queries, memory leaks, threading problems, UI jank
+- Reviews Compose recomposition scope, LazyList efficiency, network batching
+- Checks coroutine dispatcher usage and potential coroutine leaks
+- Read-only — reports findings with severity and optimization suggestions
+
+Use when code touches RecyclerView/LazyColumn, database queries, image loading, hot loops, or large collections.
+
+### `ux-expert`
+
+Evaluates user experience, UI design decisions, and accessibility:
+- Reviews user flows, navigation structure, and UI state handling
+- Checks platform convention compliance (Material Design, HIG)
+- Validates accessibility: contrast, touch targets, screen reader support
+- Assesses error states, loading states, and empty states completeness
+
+Use when implementing or reviewing screens, navigation, or user-facing features.
+
+### `devops-expert`
+
+Handles CI/CD pipelines, deployment automation, and release workflows:
+- Diagnoses and optimizes CI/CD pipeline performance
+- Configures release automation, artifact publishing, and environment management
+- Sets up dependency scanning and vulnerability monitoring
+- Designs Docker, Kubernetes, and cloud deployment configurations
+
+Use when working with GitHub Actions, GitLab CI, Docker, deployment, or release automation.
+
+### `build-engineer`
+
+Specializes in Gradle configuration, build performance, and multi-module project structure:
+- Diagnoses and optimizes build performance (caching, parallelism, configuration avoidance)
+- Configures AGP, KMP source sets, convention plugins, and version catalogs
+- Manages dependency resolution, conflict handling, and BOM alignment
+- Designs multi-module project structure and module dependency graphs
+
+Use when working with Gradle configuration, build performance, or module structure in JVM/Kotlin/Android projects.
 
 ## Installation
 

--- a/plugins/developer-workflow/skills/code-migration/SKILL.md
+++ b/plugins/developer-workflow/skills/code-migration/SKILL.md
@@ -149,13 +149,13 @@ See `references/snapshot-and-verify.md` for detailed verify procedures (regressi
 ## When Things Go Wrong
 
 **Verify fails (tests don't pass after migration):**
-Use `superpowers:systematic-debugging` if available. Otherwise: read the failing test, compare old vs new code, revert a single file to confirm it was green before, then narrow down what broke it. Fix in the migrated code — never weaken the test.
+Reproduce the issue, isolate the failing component, form a hypothesis, verify, fix. Read error output carefully, check logs. Compare old vs new code, revert a single file to confirm it was green before, then narrow down what broke it. Fix in the migrated code — never weaken the test.
 
 **Before claiming done:**
-Use `superpowers:verification-before-completion` if available. Otherwise: run through the done checklist above line by line. Run the actual commands, don't assume they'll pass.
+Run full build, run all tests, verify acceptance criteria from the migration checklist. Run through the done checklist above line by line. Run the actual commands, don't assume they'll pass.
 
 **Scope unexpectedly larger than expected:**
 Stop. Describe the new scope to the user with a revised file count and risk assessment. Agree on a new strategy before continuing — do not silently expand the migration.
 
 **Large migration needing a structured plan:**
-Use `superpowers:writing-plans` if available. Otherwise: write a `migration-checklist.md` (see Phase 1, step 7 for the format) and share it with the user for approval before starting Phase 2.
+Create a `migration-checklist.md` with: scope, files to migrate, order of operations, verification steps, rollback plan. See Phase 1, step 7 for the format. Share it with the user for approval before starting Phase 2.

--- a/plugins/developer-workflow/skills/research/SKILL.md
+++ b/plugins/developer-workflow/skills/research/SKILL.md
@@ -113,16 +113,15 @@ Be thorough — check build files, configuration, and test code too.
 Respond in the same language as the research topic description. Structure: overview, then findings grouped by category.
 ```
 
-#### Web Expert (Perplexity)
+#### Web Expert
 
-**What:** Research approaches, best practices, common pitfalls, and real-world examples.
+**What:** Search the web for approaches, best practices, common pitfalls, and real-world examples.
 
-**How:** Use Perplexity tools — `perplexity_search` for finding specific information,
-`perplexity_research` for in-depth multi-source investigation.
+**How:** Use web search tools available in the current session (WebSearch, Perplexity, or similar).
 
 **Prompt template:**
 ```
-Use Perplexity to research: {topic}
+Search the web to research: {topic}
 
 Investigate:
 1. Common approaches and best practices (with trade-offs for each)
@@ -131,26 +130,25 @@ Investigate:
 4. Recent developments or changes (last 12 months)
 5. Community consensus — what does the majority recommend and why?
 
-Use perplexity_research for the main investigation. Follow up with perplexity_search
-for specific details if needed.
+Use web search tools available in this session. Perform an in-depth investigation first,
+then follow up with targeted searches for specific details if needed.
 
 Respond in the same language as the research topic description. Include source URLs for key claims.
 ```
 
-#### Docs Expert (DeepWiki / Context7)
+#### Docs Expert
 
-**What:** Retrieve official documentation for libraries and frameworks involved.
+**What:** Find official documentation for involved libraries and frameworks.
 
-**How:** Use DeepWiki tools (`mcp__deepwiki__read_wiki_structure` to get topic structure,
-then `mcp__deepwiki__ask_question` for specific questions) or Context7
-(`resolve-library-id` then `query-docs`).
+**How:** Use documentation tools available in the current session (DeepWiki, Context7,
+or fetch raw documentation via WebFetch).
 
 **Prompt template:**
 ```
 Find official documentation for: {libraries/frameworks related to topic}
 
 For each library/framework:
-1. Read the wiki structure first (DeepWiki) or resolve the library ID (Context7)
+1. Look up library documentation using documentation tools available in this session
 2. Find documentation for: API surface, migration guides, compatibility notes,
    configuration options, known limitations
 3. Check for version-specific documentation if version matters

--- a/plugins/developer-workflow/skills/research/SKILL.md
+++ b/plugins/developer-workflow/skills/research/SKILL.md
@@ -117,7 +117,7 @@ Respond in the same language as the research topic description. Structure: overv
 
 **What:** Search the web for approaches, best practices, common pitfalls, and real-world examples.
 
-**How:** Use web search tools available in the current session (WebSearch, Perplexity, or similar).
+**How:** Search the web for approaches and best practices; find recent articles and community discussions.
 
 **Prompt template:**
 ```
@@ -130,7 +130,7 @@ Investigate:
 4. Recent developments or changes (last 12 months)
 5. Community consensus — what does the majority recommend and why?
 
-Use web search tools available in this session. Perform an in-depth investigation first,
+Search the web for approaches and best practices. Perform an in-depth investigation first,
 then follow up with targeted searches for specific details if needed.
 
 Respond in the same language as the research topic description. Include source URLs for key claims.
@@ -140,15 +140,14 @@ Respond in the same language as the research topic description. Include source U
 
 **What:** Find official documentation for involved libraries and frameworks.
 
-**How:** Use documentation tools available in the current session (DeepWiki, Context7,
-or fetch raw documentation via WebFetch).
+**How:** Look up official documentation for the libraries involved; fetch API reference and usage examples.
 
 **Prompt template:**
 ```
 Find official documentation for: {libraries/frameworks related to topic}
 
 For each library/framework:
-1. Look up library documentation using documentation tools available in this session
+1. Look up official documentation for the library (API reference, guides, changelogs)
 2. Find documentation for: API surface, migration guides, compatibility notes,
    configuration options, known limitations
 3. Check for version-specific documentation if version matters

--- a/plugins/developer-workflow/skills/research/SKILL.md
+++ b/plugins/developer-workflow/skills/research/SKILL.md
@@ -115,23 +115,25 @@ Respond in the same language as the research topic description. Structure: overv
 
 #### Web Expert
 
-**What:** Search the web for approaches, best practices, common pitfalls, and real-world examples.
+**What:** Search the web for approaches, best practices, common pitfalls, and real-world examples — if web search is available.
 
-**How:** Search the web for approaches and best practices; find recent articles and community discussions.
+**How:** If web search is available, look for approaches and best practices; find recent articles and community discussions. If web search is not available, note this as a limitation in the research report.
 
 **Prompt template:**
 ```
-Search the web to research: {topic}
+Research: {topic}
 
-Investigate:
+If web search is available, investigate:
 1. Common approaches and best practices (with trade-offs for each)
 2. Known pitfalls and mistakes to avoid
 3. Real-world examples from open-source projects
 4. Recent developments or changes (last 12 months)
 5. Community consensus — what does the majority recommend and why?
 
-Search the web for approaches and best practices. Perform an in-depth investigation first,
+If web search is available, perform an in-depth investigation first,
 then follow up with targeted searches for specific details if needed.
+If web search is not available, note this as a limitation in the research report
+and rely on training knowledge where possible.
 
 Respond in the same language as the research topic description. Include source URLs for key claims.
 ```


### PR DESCRIPTION
## Summary

- Remove 3 `superpowers:*` references from code-migration (replaced with inline instructions)
- Add 3 missing skills to orchestration rules routing table (research, plan-review, address-review-feedback)
- Add 3 missing skills and 7 missing agents to README
- developer-workflow is now 100% self-contained with zero external plugin dependencies

## Verification

`grep -rn "superpowers:" plugins/developer-workflow/skills/` → 0 results

## Test plan

- [ ] All skills in routing table exist as directories
- [ ] All agents in README exist as files
- [ ] code-migration works without superpowers installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)