### PR TITLE
Simplify plan-review agent selection UX

### DIFF
--- a/plugins/developer-workflow/skills/plan-review/SKILL.md
+++ b/plugins/developer-workflow/skills/plan-review/SKILL.md
@@ -150,7 +150,7 @@ Extract from the plan:
 Find all available agents by scanning for real agent definition files:
 
 1. **Plugin agent directories** — `Glob("**/agents/*.md")` across plugin paths in the project
-2. **Built-in subagent types** — only those listed in the system prompt under "Available agent types" (e.g., `general-purpose`, `kotlin-engineer`, `compose-developer`, `manual-tester`, etc.)
+2. **Built-in subagent types** — only those listed in the system prompt under "Available agent types" (e.g., `general-purpose`, `manual-tester`, etc.)
 
 **Critical rule: only include agents that actually exist.** Read each agent file's frontmatter
 (`name`, `description`) to confirm it's real. Never invent, imagine, or assume agents that aren't
@@ -170,7 +170,7 @@ Mark the top-scoring agents as `recommended`. Prefer 2–3 agents, but quality o
 
 Use `AskUserQuestion` with `multiSelect: true` showing all discovered agents. Recommended agents are listed first with "(Recommended)" in the label and a one-sentence reason specific to this plan (not generic descriptions). Non-recommended agents are available below — the user knows their context best.
 
-**Explicit agent specification:** if the user named specific agents (e.g., "review with kotlin-engineer and security"), skip discovery entirely and use those agents directly. No confirmation needed — the user already chose.
+**Explicit agent specification:** if the user named specific agents (e.g., "review with kotlin-engineer and security-expert"), skip discovery entirely and use those agents directly. No confirmation needed — the user already chose.
 
 ## Step 3 — Parallel Independent Review
 

--- a/plugins/developer-workflow/skills/plan-review/SKILL.md
+++ b/plugins/developer-workflow/skills/plan-review/SKILL.md
@@ -160,46 +160,17 @@ check before listing it. A phantom agent in the selection list erodes trust.
 ### Pre-selection
 
 Score each discovered agent's relevance **to the specific content of this plan** based on:
-- **Technology match** — does the plan mention technologies, frameworks, or layers this agent specializes in? Generic "architecture" or "security" relevance is NOT enough — the plan must specifically touch that domain.
-- **Problem-specific value** — would this agent catch issues that others on the panel wouldn't? An agent that merely overlaps with another's coverage adds noise, not signal.
+- **Technology match** — the plan must specifically mention technologies, frameworks, or layers this agent specializes in. Generic "architecture" or "security" relevance is NOT enough — e.g., `security-expert` only when the plan touches auth, encryption, tokens, or user data; `architecture-expert` only when new modules, dependency direction changes, or public API modifications are involved.
+- **Problem-specific value** — would this agent catch issues that others on the panel wouldn't? An agent that merely overlaps with another's coverage adds noise, not signal. Do not recommend an agent just because its domain is tangentially related.
 - **Gap coverage** — does this agent cover a blind spot that the other recommended agents miss?
 
-**Anti-patterns — do NOT do these:**
-- Do NOT recommend `architecture-expert` on every plan. Only when the plan introduces new modules, changes dependency direction, or modifies public APIs.
-- Do NOT recommend `security-expert` on every plan. Only when the plan touches auth, encryption, token storage, network requests, permissions, or user data.
-- Do NOT recommend an agent just because its domain is tangentially related. The plan must specifically involve that agent's core expertise.
-- Do NOT pad recommendations to reach a number. If only 1 agent is genuinely relevant, recommend just 1.
+Mark the top-scoring agents as `recommended`. Prefer 2–3 agents, but quality over quantity — if only 1 agent is genuinely relevant, recommend just 1. Do not pad recommendations to reach a number. `general-purpose` is a fallback only when no specialist covers a genuine gap.
 
-Mark the top-scoring agents as `recommended`. Prefer 2–3 agents, but quality over quantity.
-`general-purpose` is a fallback only when no specialist covers a genuine gap.
+### Present Agent Selection
 
-### Present Confirmation
+Use `AskUserQuestion` with `multiSelect: true` showing all discovered agents. Recommended agents are listed first with "(Recommended)" in the label and a one-sentence reason specific to this plan (not generic descriptions). Non-recommended agents are available below — the user knows their context best.
 
-**Phase 1 — Confirm recommended agents:**
-
-Use `AskUserQuestion` to present the recommended agents as a pre-made selection. Structure:
-
-- In the **question text**, list the recommended agents with a one-sentence reason each, specific to this plan (not generic descriptions)
-- Offer two options (single-select, NOT multiSelect):
-  - **"Confirm"** — proceed with the listed agents
-  - **"Change selection"** — go to Phase 2
-
-Example question text:
-> For this plan I recommend reviewing with:
-> • **security-expert** — the plan adds JWT token storage and new API endpoints
-> • **kotlin-engineer** — core business logic changes in the domain layer
->
-> Confirm or change the selection?
-
-**Phase 2 — Full agent selection (only if user chose "Change selection"):**
-
-Use `AskUserQuestion` with `multiSelect: true` showing all discovered agents. Each agent gets
-a short description of what perspective they bring to THIS specific plan. Show max 4 options;
-mention overflow agents in question text so the user can type them.
-
-**Explicit agent specification:** if the user named specific agents (e.g., "review with
-kotlin-engineer and security"), skip discovery entirely and use those agents directly. No
-confirmation needed — the user already chose.
+**Explicit agent specification:** if the user named specific agents (e.g., "review with kotlin-engineer and security"), skip discovery entirely and use those agents directly. No confirmation needed — the user already chose.
 
 ## Step 3 — Parallel Independent Review
 


### PR DESCRIPTION
## What changed
- Merged the separate "Anti-patterns" section into the scoring criteria — specific examples (when to recommend `security-expert`, `architecture-expert`) are now inline clarifications, not a separate block
- Replaced two-phase agent confirmation flow (Phase 1: confirm recommended → Phase 2: change selection) with a single `multiSelect` step where recommended agents are listed first
- Removed artificial "max 4 options" constraint on agent selection

## Why / motivation
Code review during `/simplify` identified redundancy (anti-patterns restated scoring criteria negatively) and unnecessary UX overhead (extra confirmation round-trip before showing the full agent list). Single multiSelect preserves all flexibility with one fewer user interaction.

## How to test
- [ ] Read the updated SKILL.md and verify the agent selection instructions are clear and unambiguous
- [ ] Run `/plan-review` on a sample plan and confirm agent selection works in one step

## Checklist
- [x] No breaking changes
- [x] Relevant documentation updated (the skill file IS the documentation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)