### PR TITLE
Bump all plugins to 0.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.6.0",
+      "version": "0.7.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/maven-mcp/plugin"
@@ -23,7 +23,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.6.0",
+      "version": "0.7.0",
       "category": "security",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/sensitive-guard"
@@ -34,7 +34,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.6.0",
+      "version": "0.7.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow"
@@ -45,7 +45,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.6.0",
+      "version": "0.7.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/extend"

--- a/plugins/developer-workflow/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Developer workflow skills — full task implementation cycle, View→Compose and UIKit→SwiftUI migration, safe code migration, test plan generation, exploratory QA testing, feature verification, PR preparation, PR creation (draft or ready), and review feedback analysis with triage and response",
   "skills": "./skills"
 }

--- a/plugins/extend/.claude-plugin/plugin.json
+++ b/plugins/extend/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "extend",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Extend Claude Code built-in features: agent review, skill optimization, configuration audit",
   "skills": "./skills"
 }

--- a/plugins/maven-mcp/package.json
+++ b/plugins/maven-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "MCP server for Maven Central dependency intelligence",
   "main": "./dist/index.js",
   "type": "module",

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maven-mcp",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps, /latest-version, and /dependency-changes skills",
   "mcpServers": {
     "maven-mcp": {

--- a/plugins/sensitive-guard/.claude-plugin/plugin.json
+++ b/plugins/sensitive-guard/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "sensitive-guard",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Prevents sensitive data (secrets, PII) from reaching AI servers by scanning files before they are read into conversation"
 }


### PR DESCRIPTION
## What changed
Bump version from 0.6.0 to 0.7.0 in all plugin manifests and marketplace.json.

## Files
- `plugins/maven-mcp/package.json`
- `plugins/maven-mcp/plugin/.claude-plugin/plugin.json`
- `plugins/sensitive-guard/.claude-plugin/plugin.json`
- `plugins/developer-workflow/.claude-plugin/plugin.json`
- `plugins/extend/.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json`

## Release contents (v0.6.0..main)
- Simplify plan-review agent selection UX (#73)
- Improve plan-review agent selection scoring and confirmation UX (#72)
- Add swift-engineer and swiftui-developer agents (#71)
- Add systematic debugging skill and debugging-expert agent (#70)
- Fix consistency: inline superpowers, update README and routing (#69)
- Add comprehensive workflow documentation (#68)
- Add pr-drive-to-merge skill (#67)
- Add write-tests skill (#66)
- Add decompose-feature skill (#65)
- Add code-reviewer agent (#64)
- Remove prepare-for-pr skill (#63)
- Add pipeline orchestration to implement-task (#62)
- Improve quality loop and research integration (#61)
- Add research skill (#60)
- Add address-review-feedback skill (#59)
- Fix agent routing (#55)
- Enforce full View→Compose migration with API audit (#54)
- Dependency bumps (vite, @hono/node-server, hono)

🤖 Generated with [Claude Code](https://claude.com/claude-code)