### PR TITLE
Fix skills/agents path resolution in plugin.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
             [ -f "$plugin_json" ] || continue
             skills_rel=$(jq -r '.skills // empty' "$plugin_json")
             [ -n "$skills_rel" ] || continue
-            skills_path="${source}/${skills_rel#./}"
+            skills_path=$(realpath -m "${source}/.claude-plugin/${skills_rel}")
             if [ ! -d "$skills_path" ]; then
               echo "ERROR: '$name' skills path does not exist: $skills_path"
               MISSING=1
@@ -160,7 +160,7 @@ jobs:
             [ -f "$plugin_json" ] || continue
             agents_rel=$(jq -r '.agents // empty' "$plugin_json")
             [ -n "$agents_rel" ] || continue
-            agents_path="${source}/${agents_rel#./}"
+            agents_path=$(realpath -m "${source}/.claude-plugin/${agents_rel}")
             if [ ! -d "$agents_path" ]; then
               echo "ERROR: '$name' agents path does not exist: $agents_path"
               MISSING=1

--- a/plugins/developer-workflow/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow/.claude-plugin/plugin.json
@@ -2,5 +2,5 @@
   "name": "developer-workflow",
   "version": "0.8.0",
   "description": "Developer workflow skills — full task implementation cycle, View→Compose and UIKit→SwiftUI migration, safe code migration, test plan generation, exploratory QA testing, feature verification, PR preparation, PR creation (draft or ready), and review feedback analysis with triage and response",
-  "skills": "./skills"
+  "skills": "../skills"
 }

--- a/plugins/extend/.claude-plugin/plugin.json
+++ b/plugins/extend/.claude-plugin/plugin.json
@@ -2,5 +2,5 @@
   "name": "extend",
   "version": "0.8.0",
   "description": "Extend Claude Code built-in features: agent review, skill optimization, configuration audit",
-  "skills": "./skills"
+  "skills": "../skills"
 }

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -8,5 +8,5 @@
       "args": ["-y", "@krozov/maven-central-mcp"]
     }
   },
-  "skills": "./skills"
+  "skills": "../skills"
 }


### PR DESCRIPTION
## Summary
- Skills path `./skills` in plugin.json resolved relative to `.claude-plugin/` — pointing to a non-existent directory. Changed to `../skills` in developer-workflow, extend, and maven-mcp plugins.
- Fixed CI validation (`ci.yml`) to resolve skills/agents paths from `.claude-plugin/` directory, matching Claude Code's actual behavior.

## Test plan
- [ ] After merge, reinstall developer-workflow plugin and verify all 18 skills appear in `/plugins` output
- [ ] CI passes — the updated path check validates the new `../skills` paths correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)