### PR TITLE
Remove worktree setup from feature-flow and bugfix-flow

### DIFF
--- a/plugins/developer-workflow/docs/ORCHESTRATORS.md
+++ b/plugins/developer-workflow/docs/ORCHESTRATORS.md
@@ -3,6 +3,11 @@
 Two thin orchestrators manage the full development cycle. Each routes tasks through
 modular skills — no implementation logic, only state transitions.
 
+**Preconditions (caller's responsibility).** Both orchestrators assume the caller (main
+agent, wrapping agent, or user) has already prepared a working branch/worktree and the
+correct working directory. The orchestrators never inspect, create, switch, or clean up
+branches or worktrees.
+
 For stage contracts and artifact formats, see [WORKFLOW.md](WORKFLOW.md).
 
 ---
@@ -11,7 +16,7 @@ For stage contracts and artifact formats, see [WORKFLOW.md](WORKFLOW.md).
 
 ```mermaid
 flowchart TD
-    start([Task received]) --> setup[Setup: worktree + slug]
+    start([Task received]) --> setup[Setup: slug + intake]
     setup --> confirm{Profile confirmation}
     confirm -->|Bug| redirect_bug[→ /bugfix-flow]
     confirm -->|Trivial| impl
@@ -89,7 +94,7 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-    start([Bug reported]) --> setup[Setup: worktree + slug]
+    start([Bug reported]) --> setup[Setup: slug + intake]
     setup --> confirm{Profile confirmation}
     confirm -->|Feature| redirect_feat[→ /feature-flow]
     confirm -->|Trivial fix| impl

--- a/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
@@ -17,6 +17,13 @@ Contains no implementation logic — each stage is a separate skill invocation v
 **STRICT RULE:** The orchestrator DOES NOT write code, run tests, or perform analysis directly.
 It only manages transitions, passes context between stages, and reports summaries to the user.
 
+**Preconditions (caller's responsibility, NOT this skill's):**
+- A working branch suitable for the fix is already set up (via worktree or otherwise)
+  and the current working directory is where the fix should be made.
+- The caller (main agent, wrapping agent, or user) has resolved this before invoking
+  the skill. The skill itself does not inspect, create, switch, or clean up branches
+  or worktrees.
+
 ---
 
 ## Strict State Machine
@@ -47,14 +54,7 @@ PR         -> Implement        (review feedback requires code changes)
 
 ## Phase 0: Setup
 
-### 0.1 Worktree
-
-Create an isolated worktree:
-1. From the default branch, create a worktree in `.worktrees/<branch-name>`
-2. Branch naming: `fix/short-description` — kebab-case
-3. If already in a fitting worktree — stay
-
-### 0.2 Understand the bug
+### 0.1 Understand the bug
 
 Extract from the user's input:
 - **Symptom** — what's broken
@@ -64,7 +64,7 @@ Extract from the user's input:
 
 Generate a slug: kebab-case, 2-4 words.
 
-### 0.3 Profile confirmation
+### 0.2 Profile confirmation
 
 Auto-detect the profile. Then confirm:
 
@@ -187,7 +187,7 @@ Each backward transition:
 ## Stop Points
 
 The orchestrator **stops and waits for the user** at:
-- Profile confirmation (Phase 0.3)
+- Profile confirmation (Phase 0.2)
 - Bug not reproducible (need more info)
 - Debug escalation (architectural issue, needs decision)
 - PARTIAL acceptance verdict

--- a/plugins/developer-workflow/skills/feature-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/feature-flow/SKILL.md
@@ -17,6 +17,13 @@ logic — each stage is a separate skill invocation via subagents.
 **STRICT RULE:** The orchestrator DOES NOT write code, run tests, or perform analysis directly.
 It only manages transitions, passes context between stages, and reports summaries to the user.
 
+**Preconditions (caller's responsibility, NOT this skill's):**
+- A working branch suitable for the feature is already set up (via worktree or otherwise)
+  and the current working directory is where the work should happen.
+- The caller (main agent, wrapping agent, or user) has resolved this before invoking
+  the skill. The skill itself does not inspect, create, switch, or clean up branches
+  or worktrees.
+
 ---
 
 ## Strict State Machine
@@ -54,14 +61,7 @@ PR         -> Implement        (review feedback requires code changes)
 
 ## Phase 0: Setup
 
-### 0.1 Worktree
-
-Create an isolated worktree for the task:
-1. From the default branch, create a worktree in `.worktrees/<branch-name>`
-2. Branch naming: `feature/short-description` — kebab-case
-3. If already in a fitting worktree — stay
-
-### 0.2 Understand the task
+### 0.1 Understand the task
 
 Extract from the user's input:
 - **What** needs to change
@@ -72,7 +72,7 @@ Generate a slug: kebab-case, 2-4 words.
 
 Ask **one clarifying question** if ambiguous. Otherwise proceed.
 
-### 0.3 Profile confirmation
+### 0.2 Profile confirmation
 
 Auto-detect the profile from keywords and context. Then confirm:
 
@@ -204,7 +204,7 @@ Each backward transition:
 ## Stop Points
 
 The orchestrator **stops and waits for the user** at:
-- Profile confirmation (Phase 0.3)
+- Profile confirmation (Phase 0.2)
 - After `create-pr` — hand-off to user. User runs `triage-feedback` when review
   feedback arrives and decides whether to resume at `implement` with FIXABLE items;
   CI monitoring and merge execution are outside this pipeline.


### PR DESCRIPTION
## What changed

- `plugins/developer-workflow/skills/feature-flow/SKILL.md` and `.../bugfix-flow/SKILL.md`: removed Phase 0 "Worktree" step (creation of `.worktrees/<branch>` and branch naming). Added a `Preconditions` block stating that branch/worktree setup is the caller's responsibility. Renumbered the remaining Phase 0 subsections (0.1 Understand, 0.2 Profile confirmation).
- `plugins/developer-workflow/docs/ORCHESTRATORS.md`: refreshed the Preconditions note so it no longer claims the orchestrators verify the current branch. Updated the mermaid `Setup` node (`Setup: slug + intake`) and removed the `Branch precondition fails` row from the Stop points tables.

## Why / motivation

The orchestrator skills were silently doing git/worktree plumbing that belongs to the outer agent (main session, wrapping agent, or the user). Pulling that out makes the skills single-purpose (state-machine routing only) and matches how the rest of the pipeline already works (`implement` explicitly "Does NOT create worktrees"). Branch discipline on `main`/`master`/`develop` is enforced by the user's global hooks, not by each skill.

## How to test

- [ ] `bash scripts/validate.sh` — green
- [ ] Read both SKILL.md files end-to-end and confirm Phase 0 contains only understand + profile confirmation, no worktree/branch creation step
- [ ] Read `docs/ORCHESTRATORS.md` and confirm no remaining claim that orchestrators create/switch branches or verify the current branch

## Checklist

- [x] No breaking changes (doc-only update to skill behavior documentation)
- [x] Relevant documentation updated (ORCHESTRATORS.md re-synced with the skill files)
- [ ] Tests added or updated — N/A (docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)