### PR TITLE
Integrate test-plan stage into feature-flow pipeline (v0.10.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,11 +8,11 @@
   "plugins": [
     {
       "name": "maven-mcp",
-      "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps, /latest-version, and /dependency-changes skills",
+      "description": "Maven dependency intelligence \u2014 auto-registers MCP server, provides /check-deps, /latest-version, and /dependency-changes skills",
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.9.1",
+      "version": "0.10.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/maven-mcp/plugin"
@@ -23,51 +23,51 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.9.1",
+      "version": "0.10.0",
       "category": "security",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/sensitive-guard"
     },
     {
       "name": "developer-workflow",
-      "description": "Developer workflow pipeline — research, decomposition, specification, plan review, implementation, debugging, QA (test plans, acceptance, bug hunt, retroactive tests), PR creation and review-feedback triage, feature-flow and bugfix-flow orchestrators. Platform-neutral; platform-specific engineers live in developer-workflow-kotlin and developer-workflow-swift.",
+      "description": "Developer workflow pipeline \u2014 research, decomposition, specification, plan review, implementation, debugging, QA (test plans, acceptance, bug hunt, retroactive tests), PR creation and review-feedback triage, feature-flow and bugfix-flow orchestrators. Platform-neutral; platform-specific engineers live in developer-workflow-kotlin and developer-workflow-swift.",
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.9.1",
+      "version": "0.10.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow"
     },
     {
       "name": "developer-workflow-experts",
-      "description": "Reusable expert agents for code review, architecture, security, performance, UX, build, DevOps, business analysis, and debugging. Safe to install standalone — no skills, no hooks, no MCP servers.",
+      "description": "Reusable expert agents for code review, architecture, security, performance, UX, build, DevOps, business analysis, and debugging. Safe to install standalone \u2014 no skills, no hooks, no MCP servers.",
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.9.1",
+      "version": "0.10.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-experts"
     },
     {
       "name": "developer-workflow-kotlin",
-      "description": "Kotlin, Android, and KMP specialist agents and migration skills — kotlin-engineer, compose-developer, code-migration, kmp-migration, migrate-to-compose. Extends developer-workflow for Kotlin/Android projects.",
+      "description": "Kotlin, Android, and KMP specialist agents and migration skills \u2014 kotlin-engineer, compose-developer, code-migration, kmp-migration, migrate-to-compose. Extends developer-workflow for Kotlin/Android projects.",
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.9.1",
+      "version": "0.10.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-kotlin"
     },
     {
       "name": "developer-workflow-swift",
-      "description": "Swift, iOS, and macOS specialist agents — swift-engineer and swiftui-developer, with references covering Swift concurrency, testing, and SwiftUI patterns/state/performance. Extends developer-workflow for Apple platforms.",
+      "description": "Swift, iOS, and macOS specialist agents \u2014 swift-engineer and swiftui-developer, with references covering Swift concurrency, testing, and SwiftUI patterns/state/performance. Extends developer-workflow for Apple platforms.",
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.9.1",
+      "version": "0.10.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-swift"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Monorepo for Claude Code plugins by krozov. Contains six plugins:
 |--------|-----------|-------------|
 | maven-mcp | `plugins/maven-mcp/` | MCP server for Maven dependency intelligence |
 | sensitive-guard | `plugins/sensitive-guard/` | Scans files for secrets and PII before they reach AI servers |
-| developer-workflow | `plugins/developer-workflow/` | Lifecycle pipeline — research, decomposition, spec, plan review, implementation, debugging, QA, PR workflow |
+| developer-workflow | `plugins/developer-workflow/` | Lifecycle pipeline — research, decomposition, spec, plan review, test planning, implementation, debugging, QA, PR workflow |
 | developer-workflow-experts | `plugins/developer-workflow-experts/` | 9 reusable review/consult agents (code-reviewer, architecture-expert, security-expert, …) — safe standalone |
 | developer-workflow-kotlin | `plugins/developer-workflow-kotlin/` | Kotlin/Android/KMP specialists and migration skills |
 | developer-workflow-swift | `plugins/developer-workflow-swift/` | Swift/iOS/macOS specialists and Swift/SwiftUI references |

--- a/plugins/developer-workflow-experts/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-experts/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "developer-workflow-experts",
-  "version": "0.9.1",
-  "description": "Reusable expert agents for code review, architecture, security, performance, UX, build, DevOps, business analysis, and debugging. Safe to install standalone — no skills, no hooks, no MCP servers.",
+  "version": "0.10.0",
+  "description": "Reusable expert agents for code review, architecture, security, performance, UX, build, DevOps, business analysis, and debugging. Safe to install standalone \u2014 no skills, no hooks, no MCP servers.",
   "author": {
     "name": "kirich1409"
   },

--- a/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "developer-workflow-kotlin",
-  "version": "0.9.1",
-  "description": "Kotlin, Android, and KMP specialist agents and migration skills — kotlin-engineer, compose-developer, code-migration, kmp-migration, migrate-to-compose. Extends developer-workflow for Kotlin/Android projects.",
+  "version": "0.10.0",
+  "description": "Kotlin, Android, and KMP specialist agents and migration skills \u2014 kotlin-engineer, compose-developer, code-migration, kmp-migration, migrate-to-compose. Extends developer-workflow for Kotlin/Android projects.",
   "author": {
     "name": "kirich1409"
   },
@@ -18,11 +18,11 @@
   "dependencies": [
     {
       "name": "developer-workflow",
-      "version": "^0.9.1"
+      "version": "^0.10.0"
     },
     {
       "name": "developer-workflow-experts",
-      "version": "^0.9.1"
+      "version": "^0.10.0"
     }
   ]
 }

--- a/plugins/developer-workflow-swift/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-swift/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "developer-workflow-swift",
-  "version": "0.9.1",
-  "description": "Swift, iOS, and macOS specialist agents — swift-engineer and swiftui-developer, with references covering Swift concurrency, testing, and SwiftUI patterns/state/performance. Extends developer-workflow for Apple platforms.",
+  "version": "0.10.0",
+  "description": "Swift, iOS, and macOS specialist agents \u2014 swift-engineer and swiftui-developer, with references covering Swift concurrency, testing, and SwiftUI patterns/state/performance. Extends developer-workflow for Apple platforms.",
   "author": {
     "name": "kirich1409"
   },
@@ -17,11 +17,11 @@
   "dependencies": [
     {
       "name": "developer-workflow",
-      "version": "^0.9.1"
+      "version": "^0.10.0"
     },
     {
       "name": "developer-workflow-experts",
-      "version": "^0.9.1"
+      "version": "^0.10.0"
     }
   ]
 }

--- a/plugins/developer-workflow/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "developer-workflow",
-  "version": "0.9.1",
-  "description": "Developer workflow pipeline — research, decomposition, specification, plan review, implementation, debugging, QA (test plans, acceptance, bug hunt, retroactive tests), PR creation and review-feedback triage, feature-flow and bugfix-flow orchestrators. Platform-neutral; platform-specific engineers live in developer-workflow-kotlin and developer-workflow-swift.",
+  "version": "0.10.0",
+  "description": "Developer workflow pipeline \u2014 research, decomposition, specification, plan review, implementation, debugging, QA (test plans, acceptance, bug hunt, retroactive tests), PR creation and review-feedback triage, feature-flow and bugfix-flow orchestrators. Platform-neutral; platform-specific engineers live in developer-workflow-kotlin and developer-workflow-swift.",
   "author": {
     "name": "kirich1409"
   },
@@ -18,7 +18,7 @@
   "dependencies": [
     {
       "name": "developer-workflow-experts",
-      "version": "^0.9.1"
+      "version": "^0.10.0"
     }
   ]
 }

--- a/plugins/developer-workflow/docs/ORCHESTRATION.md
+++ b/plugins/developer-workflow/docs/ORCHESTRATION.md
@@ -64,7 +64,7 @@ Allowed transitions between stages. Forward is default; backward transitions are
 ```
 Research ──→ Plan
 Plan ──→ TestPlan           (test-plan stage not skipped)
-Plan ──→ Implement          (test-plan stage skipped: 5 skip-detector conditions or --skip-test-plan)
+Plan ──→ Implement          (test-plan stage skipped: skip-detector conditions or --skip-test-plan)
 Plan ──→ Research           (plan review reveals gaps or missing context)
 TestPlan ──→ TestPlanReview
 TestPlanReview ──→ Implement  (PASS or WARN)

--- a/plugins/developer-workflow/docs/ORCHESTRATION.md
+++ b/plugins/developer-workflow/docs/ORCHESTRATION.md
@@ -63,16 +63,21 @@ Allowed transitions between stages. Forward is default; backward transitions are
 
 ```
 Research ──→ Plan
-Plan ──→ Implement
-Plan ──→ Research          (plan review reveals gaps or missing context)
+Plan ──→ TestPlan           (test-plan stage not skipped)
+Plan ──→ Implement          (test-plan stage skipped: 5 skip-detector conditions or --skip-test-plan)
+Plan ──→ Research           (plan review reveals gaps or missing context)
+TestPlan ──→ TestPlanReview
+TestPlanReview ──→ Implement  (PASS or WARN)
+TestPlanReview ──→ TestPlan   (FAIL — revise loop, max 3 cycles, then escalate)
 Implement ──→ Quality
-Implement ──→ Research     (scope is larger than expected — escalate)
+Implement ──→ Research      (scope is larger than expected — escalate)
 Quality ──→ Verify
-Quality ──→ Implement      (quality loop found issues to fix)
+Quality ──→ Implement       (quality loop found issues to fix)
 Verify ──→ PR
-Verify ──→ Implement       (verification fails — fix and re-verify)
+Verify ──→ Implement        (verification fails — fix and re-verify)
+Verify ──→ TestPlan         (new P0/P1 bugs require a `## Regression TC` section appended to the permanent test plan)
 PR ──→ Merge
-PR ──→ Implement           (review feedback requires code changes)
+PR ──→ Implement            (review feedback requires code changes)
 ```
 
 Backward transition requires a reason logged in the stage artifact. No silent rollbacks.
@@ -85,9 +90,11 @@ Each stage produces an artifact in `swarm-report/`. The next stage reads it befo
 |-------|----------|
 | Research | `<slug>-research.md` |
 | Plan | `<slug>-plan.md` |
+| TestPlan | `docs/testplans/<slug>-test-plan.md` (permanent, source of truth) + `<slug>-test-plan.md` (receipt: `status`, `permanent_path`, `source_spec`, `review_verdict`, `phase_coverage`). Created by `generate-test-plan` when invoked from the orchestrator with a slug; read by `plan-review` (test-plan branch) and `acceptance`. |
+| TestPlanReview | `<slug>-test-plan.md` receipt updated in place: `review_verdict` set to PASS / WARN / FAIL, `status` advances Draft → Ready on PASS/WARN. |
 | Implement | `<slug>-implement.md` (summary of changes, files touched) |
 | Quality | `<slug>-quality.md` (build/lint/test results, issues found/fixed) |
-| Verify | `<slug>-verify.md` (verification result: PASS/FAIL, evidence) |
+| Verify | `<slug>-verify.md` / `<slug>-acceptance.md` (verification result: VERIFIED/FAILED/PARTIAL, evidence, `test_plan_source: receipt / mounted / on-the-fly / absent` when the Acceptance stage consumed a test plan) |
 | PR | `<slug>-pr.md` (PR URL, description, reviewers) |
 
 If a stage artifact is missing — the previous stage did not complete. Do not skip ahead.

--- a/plugins/developer-workflow/docs/ORCHESTRATORS.md
+++ b/plugins/developer-workflow/docs/ORCHESTRATORS.md
@@ -30,12 +30,22 @@ flowchart TD
     needs_decompose -->|Yes| decompose[/decompose-feature/]
     decompose --> plan_review
 
-    needs_plan -->|No| impl
+    needs_plan -->|No| testplan_gate
     needs_plan -->|Yes| plan_review[/plan-review/]
 
-    plan_review -->|PASS| impl
-    plan_review -->|CONDITIONAL| impl
+    plan_review -->|PASS| testplan_gate
+    plan_review -->|CONDITIONAL| testplan_gate
     plan_review -->|FAIL| research
+
+    testplan_gate{Skip test plan?<br/>5 skip conditions<br/>or --skip-test-plan}
+    testplan_gate -->|Skip| impl
+    testplan_gate -->|Run| test_plan[/generate-test-plan/]
+
+    test_plan --> test_plan_review[/plan-review<br/>test-plan branch/]
+    test_plan_review -->|PASS| impl
+    test_plan_review -->|WARN| impl
+    test_plan_review -->|FAIL, cycles<3| test_plan
+    test_plan_review -->|FAIL, cycles>=3| escalate_tp([Escalate: user decides])
 
     subgraph loop ["For each task"]
         impl[/implement/] --> acceptance[/acceptance/]
@@ -43,6 +53,7 @@ flowchart TD
         acceptance -->|"FAILED (obvious)"| impl
         acceptance -->|"FAILED (unclear)"| debug_mid[/debug/]
         debug_mid --> impl
+        acceptance -->|"FAILED (new bugs, need Regression TC)"| test_plan
         acceptance -->|PARTIAL| user_decision{User: fix or ship?}
         user_decision -->|Fix| impl
         user_decision -->|Ship| pr_decision
@@ -61,6 +72,8 @@ flowchart TD
     style research fill:#e1f5fe
     style decompose fill:#e1f5fe
     style plan_review fill:#e1f5fe
+    style test_plan fill:#e1f5fe
+    style test_plan_review fill:#e1f5fe
     style impl fill:#e8f5e9
     style acceptance fill:#fff3e0
     style create_pr fill:#f3e5f5
@@ -68,6 +81,7 @@ flowchart TD
     style handoff fill:#ffcdd2
     style done fill:#c8e6c9
     style redirect_bug fill:#ffcdd2
+    style escalate_tp fill:#ffcdd2
 ```
 
 ### Stop points
@@ -76,6 +90,7 @@ flowchart TD
 |------|-------------|
 | Profile confirmation | Ask user to confirm feature profile |
 | PARTIAL acceptance | User decides: fix now or ship as-is |
+| TestPlanReview FAIL after 3 revise cycles | User picks: accept WARN manually, revise spec, or rerun with `--skip-test-plan` |
 | After `create-pr` | Orchestrator stops; user runs `triage-feedback` when review feedback arrives and decides whether to resume at `implement` |
 | Escalation | Scope explosion, 3× same failure, architectural decision needed |
 
@@ -84,7 +99,9 @@ flowchart TD
 | From → To | Max | After limit |
 |-----------|-----|-------------|
 | PlanReview → Research | 2 | Escalate |
+| TestPlanReview → TestPlan | 3 | Escalate |
 | Acceptance → Implement | 3 | Escalate |
+| Acceptance → TestPlan | 3 | Escalate |
 | Acceptance → Debug | 1 | Escalate |
 | PR → Implement | 2 | Escalate |
 

--- a/plugins/developer-workflow/docs/ORCHESTRATORS.md
+++ b/plugins/developer-workflow/docs/ORCHESTRATORS.md
@@ -37,7 +37,7 @@ flowchart TD
     plan_review -->|CONDITIONAL| testplan_gate
     plan_review -->|FAIL| research
 
-    testplan_gate{Skip test plan?<br/>5 skip conditions<br/>or --skip-test-plan}
+    testplan_gate{Skip test plan?<br/>detector conditions<br/>or --skip-test-plan}
     testplan_gate -->|Skip| impl
     testplan_gate -->|Run| test_plan[/generate-test-plan/]
 

--- a/plugins/developer-workflow/docs/WORKFLOW.md
+++ b/plugins/developer-workflow/docs/WORKFLOW.md
@@ -39,6 +39,14 @@ IDEA / FEATURE REQUEST
 [plan-review] ---- PoLL review of the plan (optional)
   |                  Artifact: plan review verdict
   v
+[test-plan] ---- Generate test plan (default-on, skip on 5 conditions or --skip-test-plan)
+  |                Artifacts: docs/testplans/<slug>-test-plan.md (permanent)
+  |                           swarm-report/<slug>-test-plan.md (receipt)
+  v
+[test-plan-review] ---- plan-review with test-plan branch (PASS / WARN / FAIL)
+  |                      FAIL → revise loop back to [test-plan] (max 3 cycles)
+  |                      Artifact: receipt review_verdict updated
+  v
   |   ┌────────────── for each task ──────────────┐
   |   │                                            │
   |   v                                            │
@@ -92,7 +100,7 @@ PR CREATED ---- hand-off to user; triage-feedback triages review comments when t
 
 | Profile | Pipeline | Signals | Skips |
 |---------|----------|---------|-------|
-| **Feature** | Research -> Decompose -> Plan Review -> [Implement -> Acceptance] per task -> Create PR | "add", "implement", "build", "create" | Decompose optional for single-task features |
+| **Feature** | Research -> Decompose -> Plan Review -> Test Plan -> Test Plan Review -> [Implement -> Acceptance] per task -> Create PR | "add", "implement", "build", "create" | Decompose optional for single-task features; Test Plan skipped for 5 explicit conditions or `--skip-test-plan` override |
 | **Bug Fix** | Debug -> Implement -> Acceptance -> Create PR | "fix", "broken", "crash", "regression" | Research, Plan |
 | **Migration** | Research -> Snapshot -> Migrate -> Acceptance -> Create PR | "migrate", "replace", "switch to" | Plan (delegates to `code-migration`) |
 | **Research** | Research -> Report | "investigate", "compare", "evaluate" | Implement, Acceptance, PR |
@@ -232,17 +240,24 @@ least one web-sourced insight. Relying solely on the codebase and training data 
 ## 6. State Machine
 
 ```
-Research --> Decompose --> Plan Review --> Implement --> Acceptance --> PR --> Merge
-   ^            |              |              ^  ^           |          |
-   |            |              |              |  |           |          |
-   '-- gaps ----'              |              |  '-- FAILED -'          |
-   ^                           |              |                        |
-   '-- scope too large --------+--------------'                        |
-                               |              ^                        |
-                               '-- FAIL ------'                        |
-                                              ^                        |
-                                              '-- review feedback -----'
+Research --> Decompose --> Plan Review --> Test Plan --> Test Plan Review --> Implement --> Acceptance --> PR --> Merge
+   ^            |              |               ^              |                   ^  ^           |          |
+   |            |              |               |              |                   |  |           |          |
+   '-- gaps ----'              |               '- revise -----'                   |  '-- FAILED -'          |
+   ^                           |                 (max 3 cycles)                   |                         |
+   '-- scope too large --------+--------------------------------------------------'                         |
+                               |              ^                                                             |
+                               '-- FAIL ------'                                                             |
+                                                                                  ^                         |
+                                                                                  '-- review feedback ------'
+                                                          ^
+                                                          '-- Regression TC (Acceptance → Test Plan)
 ```
+
+Test Plan + Test Plan Review are **default-on**. They are skipped when one of the five
+skip-detector conditions holds (see `feature-flow` SKILL §TestPlan Stage Skip Detection)
+or when the user passes the `--skip-test-plan` override — in both cases the pipeline
+transitions directly from Plan Review to Implement.
 
 For Bug Fix pipeline, replace Research + Decompose with Debug:
 
@@ -259,7 +274,10 @@ Debug --> Implement --> Acceptance --> PR --> Merge
 | Research | Decompose | Research complete |
 | Debug | Implement | Root cause identified |
 | Decompose | Plan Review | Tasks defined |
-| Plan Review | Implement | Plan PASS or CONDITIONAL |
+| Plan Review | Test Plan | Plan PASS or CONDITIONAL; test-plan stage not skipped |
+| Plan Review | Implement | Plan PASS or CONDITIONAL; test-plan stage skipped (skip detector or `--skip-test-plan`) |
+| Test Plan | Test Plan Review | Test plan receipt produced (`status: Draft`, `review_verdict: pending`) |
+| Test Plan Review | Implement | Test plan verdict PASS or WARN |
 | Implement | Acceptance | `implement.md` + `quality.md` produced, all gates passed |
 | Acceptance | PR | VERIFIED |
 | PR | Merge | CI green, review approved |
@@ -269,8 +287,10 @@ Debug --> Implement --> Acceptance --> PR --> Merge
 | From | To | Trigger |
 |------|----|---------|
 | Plan Review | Research | Plan review FAIL — knowledge gaps |
+| Test Plan Review | Test Plan | Test plan verdict FAIL — revise loop (max 3 cycles, then escalate) |
 | Implement | Research | Scope significantly larger than expected |
 | Acceptance | Implement | FAILED — P0/P1 bugs found, fix needed |
+| Acceptance | Test Plan | FAILED — new bugs require `## Regression TC` appended to permanent test plan |
 | PR | Implement | Review feedback requires code changes |
 
 ### User Decision Points
@@ -297,8 +317,10 @@ starting work. No stage starts without the previous stage's receipt.
 | Research | `<slug>-research.md` | Plan / Implement (Feature) |
 | Debug | `<slug>-debug.md` | Implement (Bug Fix) |
 | Plan | `<slug>-plan.md` | Implement (when planning is done) |
+| Test Plan | `docs/testplans/<slug>-test-plan.md` (permanent) + `<slug>-test-plan.md` (receipt) | Test Plan Review (Feature) |
+| Test Plan Review | `<slug>-test-plan.md` receipt updated with `review_verdict` PASS / WARN | Implement (Feature) |
 | Implement | `<slug>-implement.md` + `<slug>-quality.md` | Acceptance |
-| Acceptance | `<slug>-acceptance.md` | PR |
+| Acceptance | `<slug>-acceptance.md` (with `test_plan_source` field when Test Plan ran) | PR |
 | PR | `<slug>-pr.md` | Merge |
 
 **Slug:** kebab-case from the task description, 2–4 words.
@@ -319,8 +341,10 @@ artifact required.
 | Debug | `debug` | Bug description (text, issue URL, error log) | `<slug>-debug.md`: symptom, reproduction steps, root cause, fix direction |
 | Decompose | `decompose-feature` | Feature idea/PRD + research artifact | `<slug>-decomposition.md`: tasks with dependencies, acceptance criteria, waves |
 | Plan review | `plan-review` | Plan or decomposition artifact | Verdict: PASS / CONDITIONAL / FAIL with blockers |
+| Test Plan | `generate-test-plan` | Feature slug + available artifacts (`research.md`, `decomposition.md`, `plan.md`, spec) | `docs/testplans/<slug>-test-plan.md` (permanent) + `<slug>-test-plan.md` (receipt: `status`, `permanent_path`, `review_verdict`, `phase_coverage`) |
+| Test Plan Review | `plan-review` (test-plan branch) | Permanent test plan file | Receipt updated with `review_verdict`: PASS / WARN / FAIL |
 | Implement | `implement` | Task + optional artifacts (`research.md`, `debug.md`, `plan.md`) | `<slug>-implement.md`: changes summary, files, decisions + `<slug>-quality.md`: gate results |
-| Acceptance | `acceptance` | Spec source (requirements / `debug.md` reproduction steps) + running app | `<slug>-acceptance.md`: VERIFIED / FAILED / PARTIAL with bug list |
+| Acceptance | `acceptance` | Spec source (requirements / `debug.md` reproduction steps) + test-plan receipt (when available) + running app | `<slug>-acceptance.md`: VERIFIED / FAILED / PARTIAL with bug list; includes `test_plan_source: receipt / mounted / on-the-fly / absent` |
 | PR | `create-pr` | Branch with commits | PR URL |
 | Triage | `triage-feedback` | PR comments / pasted text | `<slug>-triage.md`: categorized, prioritized, grouped action plan |
 

--- a/plugins/developer-workflow/docs/WORKFLOW.md
+++ b/plugins/developer-workflow/docs/WORKFLOW.md
@@ -100,7 +100,7 @@ PR CREATED ---- hand-off to user; triage-feedback triages review comments when t
 
 | Profile | Pipeline | Signals | Skips |
 |---------|----------|---------|-------|
-| **Feature** | Research -> Decompose -> Plan Review -> Test Plan -> Test Plan Review -> [Implement -> Acceptance] per task -> Create PR | "add", "implement", "build", "create" | Decompose optional for single-task features; Test Plan skipped for 5 explicit conditions or `--skip-test-plan` override |
+| **Feature** | Research -> Decompose -> Plan Review -> Test Plan -> Test Plan Review -> [Implement -> Acceptance] per task -> Create PR | "add", "implement", "build", "create" | Decompose optional for single-task features; Test Plan skipped per [detector conditions](../skills/feature-flow/SKILL.md#testplan-stage-skip-detection) or `--skip-test-plan` override |
 | **Bug Fix** | Debug -> Implement -> Acceptance -> Create PR | "fix", "broken", "crash", "regression" | Research, Plan |
 | **Migration** | Research -> Snapshot -> Migrate -> Acceptance -> Create PR | "migrate", "replace", "switch to" | Plan (delegates to `code-migration`) |
 | **Research** | Research -> Report | "investigate", "compare", "evaluate" | Implement, Acceptance, PR |

--- a/plugins/developer-workflow/docs/WORKFLOW.md
+++ b/plugins/developer-workflow/docs/WORKFLOW.md
@@ -39,7 +39,7 @@ IDEA / FEATURE REQUEST
 [plan-review] ---- PoLL review of the plan (optional)
   |                  Artifact: plan review verdict
   v
-[test-plan] ---- Generate test plan (default-on, skip on 5 conditions or --skip-test-plan)
+[test-plan] ---- Generate test plan (default-on, skip per detector conditions or --skip-test-plan)
   |                Artifacts: docs/testplans/<slug>-test-plan.md (permanent)
   |                           swarm-report/<slug>-test-plan.md (receipt)
   v
@@ -254,8 +254,8 @@ Research --> Decompose --> Plan Review --> Test Plan --> Test Plan Review --> Im
                                                           '-- Regression TC (Acceptance → Test Plan)
 ```
 
-Test Plan + Test Plan Review are **default-on**. They are skipped when one of the five
-skip-detector conditions holds (see `feature-flow` SKILL §TestPlan Stage Skip Detection)
+Test Plan + Test Plan Review are **default-on**. They are skipped when the skip-detector
+conditions hold (see [`feature-flow` SKILL §TestPlan Stage Skip Detection](../skills/feature-flow/SKILL.md#testplan-stage-skip-detection))
 or when the user passes the `--skip-test-plan` override — in both cases the pipeline
 transitions directly from Plan Review to Implement.
 

--- a/plugins/developer-workflow/skills/acceptance/SKILL.md
+++ b/plugins/developer-workflow/skills/acceptance/SKILL.md
@@ -82,7 +82,13 @@ receipt has not been produced yet.
 1. Emit a mount-receipt at `swarm-report/<slug>-test-plan.md` following the canonical
    format in `plugins/developer-workflow/skills/generate-test-plan/SKILL.md` §Receipt
    with the mount overrides: `status: Mounted`, `review_verdict: skipped`,
-   `source_spec: existing (pre-orchestration)`, `phase_coverage: []`.
+   `source_spec: existing (pre-orchestration)`, and `phase_coverage` derived from the
+   permanent file's phase labels when present (scan for `### Phase N ...` headings
+   under `## Test Cases`). Do **not** hardcode `phase_coverage: []`; use the empty
+   list only when the permanent file genuinely has no phase segmentation. When phase
+   coverage cannot be determined reliably from the permanent file (malformed headings,
+   mixed conventions), omit the `phase_coverage` field entirely rather than recording
+   an incorrect value.
 2. Pass the **permanent file** to the `manual-tester` agent as the primary test-plan source.
 3. In the verification report set `test_plan_source: mounted`.
 

--- a/plugins/developer-workflow/skills/acceptance/SKILL.md
+++ b/plugins/developer-workflow/skills/acceptance/SKILL.md
@@ -39,7 +39,71 @@ The specification defines what "correct" looks like. Accept any combination of:
 Read all provided spec sources. If neither a spec nor a test plan is provided, ask the user
 for at least one before proceeding.
 
-### 1.2 Test Plan (optional if spec is provided)
+### 1.2 Test Plan — Source Priority
+
+Select the test-plan source by walking the four branches below in order. The first branch
+whose condition holds is the one used; record which branch fired so the verification report
+can set `test_plan_source` accordingly.
+
+#### Branch 1 — Receipt present (`test_plan_source: receipt`)
+
+**Condition:** `swarm-report/<slug>-test-plan.md` exists (produced by `generate-test-plan`
+when invoked from the orchestrator).
+
+**Actions:**
+1. Read the receipt's YAML frontmatter and load `permanent_path`.
+2. Read `review_verdict`:
+   - `PASS` — proceed.
+   - `WARN` — proceed; carry WARN findings forward into the verification report as context.
+   - `FAIL` — do not execute. Stop and escalate back to `feature-flow`: the plan must be
+     revised via `plan-review` before acceptance runs.
+   - `pending` — treat as not-yet-reviewed; escalate to `feature-flow` to run plan-review
+     first instead of proceeding blindly.
+3. Pass the **permanent file** (resolved via `permanent_path`, not the receipt itself) to
+   the `manual-tester` agent as the primary test-plan source.
+4. In the verification report set `test_plan_source: receipt`.
+
+#### Branch 2 — Permanent file exists without receipt (`test_plan_source: mounted`)
+
+**Condition:** Branch 1 did not fire **and** `docs/testplans/<slug>-test-plan.md` exists on
+disk without a matching receipt in `swarm-report/`.
+
+**Actions:** mount the existing test plan as-is. The file pre-dates the orchestration
+integration, so do not regenerate or re-review it.
+
+1. Create a new receipt at `swarm-report/<slug>-test-plan.md` with `status: Mounted` and
+   `review_verdict: skipped` using the template below.
+2. Pass the **permanent file** to the `manual-tester` agent as the primary test-plan source.
+3. In the verification report set `test_plan_source: mounted`.
+
+Mount-as-existing receipt template:
+
+```markdown
+---
+name: test-plan-receipt
+description: Mounted existing test plan for <slug>
+slug: <slug>
+type: test-plan-receipt
+status: Mounted
+permanent_path: docs/testplans/<slug>-test-plan.md
+source_spec: existing (pre-orchestration)
+review_verdict: skipped
+phase_coverage: []
+created: <date when mounted>
+updated: <same>
+---
+
+# Test Plan Receipt: <slug> (mounted)
+
+Existing permanent test plan mounted without regeneration.
+Review was skipped because the file pre-dates orchestration integration.
+```
+
+#### Branch 3 — On-the-fly generation from available inputs (`test_plan_source: on-the-fly`)
+
+**Condition:** Branches 1 and 2 did not fire **and** the invocation provides a test plan
+inline, a spec source, or both. This branch preserves the pre-orchestration behavior
+verbatim — the three modes below are the original Step 1.2 logic retained unchanged.
 
 The test plan defines what to check. Three modes:
 
@@ -57,6 +121,17 @@ user decide.
 3. Write test cases in the manual-tester format (TC-prefixed, with tiers, steps, expected results)
 4. Present the generated plan to the user for approval before executing
 5. Adjust based on their feedback
+
+In the verification report set `test_plan_source: on-the-fly`.
+
+#### Branch 4 — Nothing available (`test_plan_source: absent`)
+
+**Condition:** no receipt, no permanent file, no inline test plan, and no spec source.
+
+**Actions:** stop and ask the user for at least one of a spec source or a test plan before
+proceeding. In the verification report (only populated if the user provides something and
+the flow restarts) set `test_plan_source: absent` only if acceptance exits without running
+any test cases.
 
 ---
 
@@ -185,6 +260,7 @@ the PR stage. `create-pr` references it for the PR description.
 **Type:** Feature / Bug fix
 **Spec source:** [what was used — requirements, debug.md reproduction steps, etc.]
 **Test plan:** [user-provided / generated from spec]
+**test_plan_source:** receipt | mounted | on-the-fly | absent
 **Context artifacts:** [paths to research.md, debug.md, implement.md used as input]
 
 ## Summary

--- a/plugins/developer-workflow/skills/acceptance/SKILL.md
+++ b/plugins/developer-workflow/skills/acceptance/SKILL.md
@@ -252,7 +252,7 @@ the PR stage. `create-pr` references it for the PR description.
 **Date:** <date>
 **Type:** Feature / Bug fix
 **Spec source:** [what was used — requirements, debug.md reproduction steps, etc.]
-**Test plan:** [user-provided / generated from spec]
+**Test plan:** [resolved permanent path if sourced via receipt or mounted receipt | generated on-the-fly from spec | none]
 **test_plan_source:** receipt | mounted | on-the-fly | absent
 **Context artifacts:** [paths to research.md, debug.md, implement.md used as input]
 

--- a/plugins/developer-workflow/skills/acceptance/SKILL.md
+++ b/plugins/developer-workflow/skills/acceptance/SKILL.md
@@ -68,36 +68,19 @@ when invoked from the orchestrator).
 **Condition:** Branch 1 did not fire **and** `docs/testplans/<slug>-test-plan.md` exists on
 disk without a matching receipt in `swarm-report/`.
 
-**Actions:** mount the existing test plan as-is. The file pre-dates the orchestration
-integration, so do not regenerate or re-review it.
+**Ownership:** the `feature-flow` orchestrator normally emits the mount-receipt in its
+Phase 1.5 Pre-check. This branch runs only when `acceptance` is invoked outside of
+`feature-flow` (standalone QA session, `bugfix-flow`, user-triggered mid-flow), so the
+receipt has not been produced yet.
 
-1. Create a new receipt at `swarm-report/<slug>-test-plan.md` with `status: Mounted` and
-   `review_verdict: skipped` using the template below.
+**Actions:**
+
+1. Emit a mount-receipt at `swarm-report/<slug>-test-plan.md` following the canonical
+   format in `plugins/developer-workflow/skills/generate-test-plan/SKILL.md` §Receipt
+   with the mount overrides: `status: Mounted`, `review_verdict: skipped`,
+   `source_spec: existing (pre-orchestration)`, `phase_coverage: []`.
 2. Pass the **permanent file** to the `manual-tester` agent as the primary test-plan source.
 3. In the verification report set `test_plan_source: mounted`.
-
-Mount-as-existing receipt template:
-
-```markdown
----
-name: test-plan-receipt
-description: Mounted existing test plan for <slug>
-slug: <slug>
-type: test-plan-receipt
-status: Mounted
-permanent_path: docs/testplans/<slug>-test-plan.md
-source_spec: existing (pre-orchestration)
-review_verdict: skipped
-phase_coverage: []
-created: <date when mounted>
-updated: <same>
----
-
-# Test Plan Receipt: <slug> (mounted)
-
-Existing permanent test plan mounted without regeneration.
-Review was skipped because the file pre-dates orchestration integration.
-```
 
 #### Branch 3 — On-the-fly generation from available inputs (`test_plan_source: on-the-fly`)
 

--- a/plugins/developer-workflow/skills/acceptance/SKILL.md
+++ b/plugins/developer-workflow/skills/acceptance/SKILL.md
@@ -55,6 +55,10 @@ when invoked from the orchestrator).
 2. Read `review_verdict`:
    - `PASS` — proceed.
    - `WARN` — proceed; carry WARN findings forward into the verification report as context.
+   - `skipped` — proceed. The receipt was written as a mount (pre-orchestration permanent
+     file adopted without regeneration — see `feature-flow/SKILL.md` §1.5 Pre-check or
+     Branch 2 below). No review was performed; treat the plan as user-authored and
+     authoritative.
    - `FAIL` — do not execute. Stop and escalate back to `feature-flow`: the plan must be
      revised via `plan-review` before acceptance runs.
    - `pending` — treat as not-yet-reviewed; escalate to `feature-flow` to run plan-review

--- a/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
@@ -128,6 +128,12 @@ Wait for `swarm-report/<slug>-implement.md` + `swarm-report/<slug>-quality.md`.
 
 ## Phase 3: Acceptance
 
+Bugfix-flow has no formal TestPlan stage — reproduction steps in `debug.md` act as the
+implicit test case. For bugs in critical flows that need a formal structured plan
+(regression protection, external QA handoff), run `/generate-test-plan` manually **before**
+`/bugfix-flow`: `acceptance` will detect the permanent file via mount-as-existing and use
+it as the primary source (see `acceptance/SKILL.md` §1.2 Branch 2).
+
 Invoke `developer-workflow:acceptance` with:
 - Spec source: `swarm-report/<slug>-debug.md` (reproduction steps = acceptance criteria)
 - The running app

--- a/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
@@ -131,8 +131,11 @@ Wait for `swarm-report/<slug>-implement.md` + `swarm-report/<slug>-quality.md`.
 Bugfix-flow has no formal TestPlan stage — reproduction steps in `debug.md` act as the
 implicit test case. For bugs in critical flows that need a formal structured plan
 (regression protection, external QA handoff), run `/generate-test-plan` manually **before**
-`/bugfix-flow`: `acceptance` will detect the permanent file via mount-as-existing and use
-it as the primary source (see `acceptance/SKILL.md` §1.2 Branch 2).
+`/bugfix-flow`, using the **same slug** as the bugfix so the saved file lands at
+`docs/testplans/<slug>-test-plan.md`. `acceptance` Branch 2 mounts by exact slug match; if
+the plan was generated under a different filename, rename it to
+`docs/testplans/<slug>-test-plan.md` before running `/bugfix-flow` (see
+`acceptance/SKILL.md` §1.2 Branch 2).
 
 Invoke `developer-workflow:acceptance` with:
 - Spec source: `swarm-report/<slug>-debug.md` (reproduction steps = acceptance criteria)

--- a/plugins/developer-workflow/skills/feature-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/feature-flow/SKILL.md
@@ -141,8 +141,10 @@ receipt does NOT exist — this is a user-authored plan. Do NOT regenerate. The
 orchestrator owns this write: emit a mount-receipt following the canonical format from
 `generate-test-plan/SKILL.md` §Receipt (field overrides: `status: Mounted`,
 `review_verdict: skipped`, `source_spec: existing (pre-orchestration)`). Skip both
-TestPlan and TestPlanReview; announce **Stage: PlanReview → Implement (test plan mounted
-from existing)**. To regenerate, the user must re-invoke with `--regenerate-test-plan`.
+TestPlan and TestPlanReview; announce **Stage: \<current\> → Implement (test plan mounted
+from existing)**, where `<current>` is whichever stage actually routed here (PlanReview,
+Decompose, or Research — any of these can feed Phase 1.5 when later stages were skipped).
+To regenerate, the user must re-invoke with `--regenerate-test-plan`.
 
 Otherwise, invoke `developer-workflow:generate-test-plan` with the feature slug and
 paths to the available artifacts (`research.md`, `decomposition.md`, `plan.md`, any spec
@@ -240,7 +242,9 @@ pipeline transitions:
   violated items — preserved for downstream review and acceptance context. No revise-loop.
 - **FAIL** — any of (a), (b), (c) violated. Run the revise-loop: **TestPlan ← TestPlanReview**
   up to 3 cycles. Each cycle patches the permanent test-plan file, re-reviews with the
-  same agents, and appends to the receipt's `Verdict History`. After 3 failed cycles →
+  same agents, and appends to the plan-review state file's `Verdict History` (see
+  `plan-review/SKILL.md` §Persistence — the receipt itself carries only the latest
+  `review_verdict`, not the per-cycle history). After 3 failed cycles →
   **escalate to the user** with three options: (a) accept WARN manually and proceed,
   (b) revise the spec and restart the pipeline, (c) use `--skip-test-plan` to bypass the
   stage for this run.

--- a/plugins/developer-workflow/skills/feature-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/feature-flow/SKILL.md
@@ -60,7 +60,7 @@ PR             -> Implement        (review feedback requires code changes)
 - **Skip Research:** task is well-understood, no external APIs, no unfamiliar libraries
 - **Skip Decompose:** task is a single logical unit, no independent sub-parts
 - **Skip PlanReview:** change is straightforward, touches 1-3 files, no architectural impact
-- **Skip TestPlan (+ TestPlanReview):** see [TestPlan Stage Skip Detection](#testplan-stage-skip-detection) — default-on stage, skipped only when one of the five explicit conditions fires.
+- **Skip TestPlan (+ TestPlanReview):** see [TestPlan Stage Skip Detection](#testplan-stage-skip-detection) — default-on stage, skipped only when a detector condition fires.
 
 **ALL other transitions are FORBIDDEN.** Before every transition, announce:
 
@@ -135,29 +135,21 @@ runs unless the skip detector or the `--skip-test-plan` override fires (see
 [Override: --skip-test-plan](#override---skip-test-plan)).
 
 **Pre-check — mount existing permanent test plan:** before invoking
-`generate-test-plan`, check whether a pre-orchestration test plan already exists:
+`generate-test-plan`, check whether a pre-orchestration test plan already exists. If
+`docs/testplans/<slug>-test-plan.md` exists AND `swarm-report/<slug>-test-plan.md`
+receipt does NOT exist — this is a user-authored plan. Do NOT regenerate. The
+orchestrator owns this write: emit a mount-receipt following the canonical format from
+`generate-test-plan/SKILL.md` §Receipt (field overrides: `status: Mounted`,
+`review_verdict: skipped`, `source_spec: existing (pre-orchestration)`). Skip both
+TestPlan and TestPlanReview; announce **Stage: PlanReview → Implement (test plan mounted
+from existing)**. To regenerate, the user must re-invoke with `--regenerate-test-plan`.
 
-- If `docs/testplans/<slug>-test-plan.md` exists AND `swarm-report/<slug>-test-plan.md`
-  receipt does NOT exist — this is a pre-orchestration artifact (e.g., plan written
-  manually before the TestPlan stage was introduced, or carried over from a previous
-  session).
-- Do NOT regenerate. Write a mount-receipt at `swarm-report/<slug>-test-plan.md` with
-  `status: Mounted`, `review_verdict: skipped`, `permanent_path` pointing to the existing
-  file, `source_spec: existing (pre-orchestration)`.
-- Skip both TestPlan and TestPlanReview stages; proceed directly to Implement. Announce:
-  **Stage: PlanReview → Implement (test plan mounted from existing)**.
-- Rationale: respect user-authored plans; regeneration would overwrite intentional
-  content. If the user wants to regenerate, they invoke `--regenerate-test-plan`
-  explicitly.
-
-**Standard path (no existing permanent):**
-
-- Invoke `developer-workflow:generate-test-plan` with the feature slug and paths to the
-  available artifacts (`research.md`, `decomposition.md`, `plan.md`, any spec document).
-- Wait for the permanent test plan at `docs/testplans/<slug>-test-plan.md` and the receipt
-  at `swarm-report/<slug>-test-plan.md` (receipt `status: Draft`, `review_verdict: pending`).
-- Announce: **Stage: PlanReview → TestPlan** (or from Research / Decompose when earlier
-  stages were skipped).
+Otherwise, invoke `developer-workflow:generate-test-plan` with the feature slug and
+paths to the available artifacts (`research.md`, `decomposition.md`, `plan.md`, any spec
+document). Wait for the permanent test plan at `docs/testplans/<slug>-test-plan.md` and
+the receipt at `swarm-report/<slug>-test-plan.md` (receipt `status: Draft`,
+`review_verdict: pending`). Announce: **Stage: PlanReview → TestPlan** (or from Research
+/ Decompose when earlier stages were skipped).
 
 ### 1.6 TestPlanReview (default-on)
 
@@ -175,7 +167,7 @@ Review the generated test plan via the test-plan branch of `plan-review`.
 ## TestPlan Stage Skip Detection
 
 The TestPlan stage (and its paired TestPlanReview) is **default-on**. It is skipped if
-**any one** of the following five conditions holds (boolean OR):
+**any one** of the following conditions holds (boolean OR):
 
 1. **Single-file change without behavior change** — the planned change touches exactly one
    file (per `git diff` stats or the decomposition artifact) AND the spec/task introduces
@@ -189,10 +181,9 @@ The TestPlan stage (and its paired TestPlanReview) is **default-on**. It is skip
 4. **Single-task decompose with low complexity** — `decompose-feature` produced ≤ 2 tasks
    AND every task is complexity `S` (small). Taken straight from the decomposition
    artifact's complexity column.
-5. **`bugfix-flow` invocation** — the pipeline type is `bug` (determined from the parent
-   orchestrator: `feature-flow` is never invoked from `bugfix-flow`, but if the user
-   manually invokes `feature-flow` with a "bug" framing — e.g. slug contains `bugfix-` or
-   user flags the profile as bug during Phase 0.3 — the stage is skipped).
+
+(Bug profiles route to `bugfix-flow` at Phase 0.2 and never reach this gate, so they do
+not need a dedicated skip condition here.)
 
 When the detector triggers, announce the reason on the stage transition, e.g.:
 
@@ -222,10 +213,8 @@ The permanent artifact `docs/testplans/<slug>-test-plan.md` can be modified afte
 initial TestPlan stage in two scenarios:
 
 **On rollback Acceptance → Implement (bugs discovered):**
-- When bugs of **P0 / P1** severity are found — append a new `## Regression TC` section to
-  the permanent file covering the new bugs. No wholesale regeneration.
-- When bugs of **P2 / P3** severity are found and the user decides to fix them — same
-  behavior: append `## Regression TC`.
+- Whenever a fix is undertaken — regardless of P0/P1/P2/P3 severity — append a new
+  `## Regression TC` section to the permanent file covering the new bugs.
 - The receipt keeps its existing `review_verdict` (no re-review required for appended
   regression TCs); only the `updated` timestamp is refreshed.
 
@@ -360,14 +349,3 @@ The orchestrator **stops and waits for the user** at:
 - TestPlanReview FAIL after 3 revise cycles — user picks: accept WARN manually, revise
   spec, or rerun with `--skip-test-plan`.
 - Escalation (scope explosion, repeated failures, architectural decision needed)
-
----
-
-## Self-reference Skip Note
-
-This PR (v0.10.0), which introduces the TestPlan stage itself, has no user-facing
-behavior — all changes are skill-markdown edits inside the `developer-workflow` plugin.
-It matches skip condition #3 (**internal utility without external contract change**): no
-new public API surface, no exported symbols, no endpoints. The TestPlan stage therefore
-does **not** apply to PR v0.10.0 — this is an intentional self-skip recorded here so
-future maintainers understand the decision.

--- a/plugins/developer-workflow/skills/feature-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/feature-flow/SKILL.md
@@ -31,27 +31,36 @@ It only manages transitions, passes context between stages, and reports summarie
 ### Allowed transitions
 
 ```
-Setup      -> Research         (unknown APIs, libraries, or architectural decisions)
-Setup      -> Implement        (trivial/simple task — skip research/planning)
-Research   -> Decompose        (large feature — split into tasks)
-Research   -> PlanReview       (complex single-task — needs plan review)
-Research   -> Implement        (simple single-task — research was enough)
-Decompose  -> PlanReview       (complex decomposition — needs review)
-Decompose  -> Implement        (straightforward tasks — skip review)
-PlanReview -> Implement
-PlanReview -> Research         (FAIL — knowledge gaps)
-Implement  -> Acceptance
-Acceptance -> PR               (VERIFIED)
-Acceptance -> Implement        (FAILED — bugs to fix)
-Acceptance -> Debug            (FAILED — unclear root cause)
-PR         -> Merge
-PR         -> Implement        (review feedback requires code changes)
+Setup          -> Research         (unknown APIs, libraries, or architectural decisions)
+Setup          -> Implement        (trivial/simple task — skip research/planning)
+Research       -> Decompose        (large feature — split into tasks)
+Research       -> PlanReview       (complex single-task — needs plan review)
+Research       -> TestPlan         (simple single-task, test-plan stage not skipped)
+Research       -> Implement        (simple single-task, test-plan stage skipped)
+Decompose      -> PlanReview       (complex decomposition — needs review)
+Decompose      -> TestPlan         (straightforward tasks, test-plan stage not skipped)
+Decompose      -> Implement        (straightforward tasks, test-plan stage skipped)
+PlanReview     -> TestPlan         (test-plan stage not skipped)
+PlanReview     -> Implement        (test-plan stage skipped)
+PlanReview     -> Research         (FAIL — knowledge gaps)
+TestPlan       -> TestPlanReview
+TestPlanReview -> Implement        (PASS or WARN)
+TestPlanReview -> TestPlan         (FAIL — revise loop, max 3 cycles)
+TestPlanReview -> escalate         (after 3 failed revise cycles)
+Implement      -> Acceptance
+Acceptance     -> PR               (VERIFIED)
+Acceptance     -> Implement        (FAILED — bugs to fix)
+Acceptance     -> TestPlan         (FAILED — add Regression TC for new bugs)
+Acceptance     -> Debug            (FAILED — unclear root cause)
+PR             -> Merge
+PR             -> Implement        (review feedback requires code changes)
 ```
 
 **Decision criteria for skipping stages:**
 - **Skip Research:** task is well-understood, no external APIs, no unfamiliar libraries
 - **Skip Decompose:** task is a single logical unit, no independent sub-parts
 - **Skip PlanReview:** change is straightforward, touches 1-3 files, no architectural impact
+- **Skip TestPlan (+ TestPlanReview):** see [TestPlan Stage Skip Detection](#testplan-stage-skip-detection) — default-on stage, skipped only when one of the five explicit conditions fires.
 
 **ALL other transitions are FORBIDDEN.** Before every transition, announce:
 
@@ -118,6 +127,135 @@ If `swarm-report/<slug>-plan.md` or `swarm-report/<slug>-decomposition.md` was p
 - If CONDITIONAL → proceed with noted concerns
 - If PASS → proceed
 
+### 1.5 TestPlan (default-on)
+
+Generate the test plan for the feature before implementation starts. Default-on stage:
+runs unless the skip detector or the `--skip-test-plan` override fires (see
+[TestPlan Stage Skip Detection](#testplan-stage-skip-detection) and
+[Override: --skip-test-plan](#override---skip-test-plan)).
+
+**Pre-check — mount existing permanent test plan:** before invoking
+`generate-test-plan`, check whether a pre-orchestration test plan already exists:
+
+- If `docs/testplans/<slug>-test-plan.md` exists AND `swarm-report/<slug>-test-plan.md`
+  receipt does NOT exist — this is a pre-orchestration artifact (e.g., plan written
+  manually before the TestPlan stage was introduced, or carried over from a previous
+  session).
+- Do NOT regenerate. Write a mount-receipt at `swarm-report/<slug>-test-plan.md` with
+  `status: Mounted`, `review_verdict: skipped`, `permanent_path` pointing to the existing
+  file, `source_spec: existing (pre-orchestration)`.
+- Skip both TestPlan and TestPlanReview stages; proceed directly to Implement. Announce:
+  **Stage: PlanReview → Implement (test plan mounted from existing)**.
+- Rationale: respect user-authored plans; regeneration would overwrite intentional
+  content. If the user wants to regenerate, they invoke `--regenerate-test-plan`
+  explicitly.
+
+**Standard path (no existing permanent):**
+
+- Invoke `developer-workflow:generate-test-plan` with the feature slug and paths to the
+  available artifacts (`research.md`, `decomposition.md`, `plan.md`, any spec document).
+- Wait for the permanent test plan at `docs/testplans/<slug>-test-plan.md` and the receipt
+  at `swarm-report/<slug>-test-plan.md` (receipt `status: Draft`, `review_verdict: pending`).
+- Announce: **Stage: PlanReview → TestPlan** (or from Research / Decompose when earlier
+  stages were skipped).
+
+### 1.6 TestPlanReview (default-on)
+
+Review the generated test plan via the test-plan branch of `plan-review`.
+
+- Invoke `developer-workflow:plan-review` with the permanent test-plan file
+  (`docs/testplans/<slug>-test-plan.md`) as input — its detector auto-classifies the input
+  as `type: test-plan` and runs the test-plan branch (PASS / WARN / FAIL verdicts).
+- Route by verdict — see [TestPlanReview Verdict Handling](#testplanreview-verdict-handling).
+- On completion (PASS or WARN) the receipt is updated with `review_verdict` and
+  `status: Ready`; the pipeline transitions to Implement.
+
+---
+
+## TestPlan Stage Skip Detection
+
+The TestPlan stage (and its paired TestPlanReview) is **default-on**. It is skipped if
+**any one** of the following five conditions holds (boolean OR):
+
+1. **Single-file change without behavior change** — the planned change touches exactly one
+   file (per `git diff` stats or the decomposition artifact) AND the spec/task introduces
+   **no** new Acceptance Criteria (AC delta = 0 vs. prior state).
+2. **Pure refactor** — the task commit prefix is `refactor:`, OR the spec contains no new
+   AC and only lists technical / structural changes (no observable behavior change).
+3. **Internal utility without external contract change** — every affected file is internal:
+   not exported from the module's public API surface (not under `exports/` or equivalent,
+   not a `public` class/function in the module manifest, not an HTTP/RPC endpoint, not
+   a published library symbol).
+4. **Single-task decompose with low complexity** — `decompose-feature` produced ≤ 2 tasks
+   AND every task is complexity `S` (small). Taken straight from the decomposition
+   artifact's complexity column.
+5. **`bugfix-flow` invocation** — the pipeline type is `bug` (determined from the parent
+   orchestrator: `feature-flow` is never invoked from `bugfix-flow`, but if the user
+   manually invokes `feature-flow` with a "bug" framing — e.g. slug contains `bugfix-` or
+   user flags the profile as bug during Phase 0.3 — the stage is skipped).
+
+When the detector triggers, announce the reason on the stage transition, e.g.:
+
+> **Stage: PlanReview → Implement. Reason: TestPlan skipped — single-file change with no
+> new AC (skip condition #1).**
+
+## Override: --skip-test-plan
+
+The user can force the TestPlan stage off via a slash-argument on the `feature-flow` call:
+
+```
+/feature-flow --skip-test-plan "task description"
+```
+
+Semantics: **force-off**. Even if the skip detector would return `false` (TestPlan would
+normally run), the stage is **not** executed — neither TestPlan nor TestPlanReview. The
+orchestrator transitions directly to Implement.
+
+Use case: rare cases where the user is certain test-plan effort is not justified —
+experimental prototype, throwaway demo feature, exploratory spike. Announce it explicitly:
+
+> **Stage: PlanReview → Implement. Reason: TestPlan skipped — `--skip-test-plan` override.**
+
+## Test Plan Regeneration
+
+The permanent artifact `docs/testplans/<slug>-test-plan.md` can be modified after the
+initial TestPlan stage in two scenarios:
+
+**On rollback Acceptance → Implement (bugs discovered):**
+- When bugs of **P0 / P1** severity are found — append a new `## Regression TC` section to
+  the permanent file covering the new bugs. No wholesale regeneration.
+- When bugs of **P2 / P3** severity are found and the user decides to fix them — same
+  behavior: append `## Regression TC`.
+- The receipt keeps its existing `review_verdict` (no re-review required for appended
+  regression TCs); only the `updated` timestamp is refreshed.
+
+**On spec change (full regeneration):**
+- Full regeneration happens only through an **explicit** re-invocation of `/feature-flow`
+  with a `--regenerate-test-plan` flag. The orchestrator does NOT regenerate silently.
+- Before overwriting, the previous permanent file is renamed to
+  `docs/testplans/<slug>-test-plan.md.prev` for fast diff.
+- The receipt is rewritten with `status: Draft`, `review_verdict: pending`, and updated
+  `source_spec` / `phase_coverage` / `updated` fields. The next TestPlanReview run sets a
+  fresh verdict.
+
+## TestPlanReview Verdict Handling
+
+The TestPlanReview stage maps `plan-review` verdicts (test-plan branch — see
+`plugins/developer-workflow/skills/plan-review/SKILL.md` §Test-Plan Review Branch) to
+pipeline transitions:
+
+- **PASS** — all five checklist items satisfied. Unconditional transition to Implement.
+  Receipt: `review_verdict: PASS`, `status: Ready`.
+- **WARN** — items (a)–(c) satisfied, but (d) or (e) violated. **Does not block.**
+  Transition to Implement. Receipt: `review_verdict: WARN`, warnings list enumerating the
+  violated items — preserved for downstream review and acceptance context. No revise-loop.
+- **FAIL** — any of (a), (b), (c) violated. Run the revise-loop: **TestPlan ← TestPlanReview**
+  up to 3 cycles. Each cycle patches the permanent test-plan file, re-reviews with the
+  same agents, and appends to the receipt's `Verdict History`. After 3 failed cycles →
+  **escalate to the user** with three options: (a) accept WARN manually and proceed,
+  (b) revise the spec and restart the pipeline, (c) use `--skip-test-plan` to bypass the
+  stage for this run.
+
 ---
 
 ## Phase 2: Implement and Verify (per task)
@@ -144,6 +282,11 @@ Wait for `swarm-report/<slug>-implement.md` + `swarm-report/<slug>-quality.md`.
 Invoke `developer-workflow:acceptance` with:
 - Spec source: requirements from the task / plan / decomposition
 - The running app
+- Test-plan receipt path (when TestPlan stage ran): `swarm-report/<slug>-test-plan.md` —
+  the acceptance skill reads `permanent_path` from the receipt and feeds the permanent
+  test plan to `manual-tester` as the primary source (see `acceptance/SKILL.md` Step 1).
+  When the TestPlan stage was skipped and no receipt exists, acceptance falls back to its
+  existing mount-as-existing or on-the-fly generation logic.
 
 The acceptance skill saves an E2E scenario to `swarm-report/<slug>-e2e-scenario.md`.
 This file uses checkboxes for each verification step — completed steps (`[x]`) survive
@@ -155,6 +298,9 @@ Wait for `swarm-report/<slug>-acceptance.md`.
 - VERIFIED → **Stage: Acceptance → PR**
 - FAILED (P0/P1, obvious cause) → **Stage: Acceptance → Implement.** Max 3 round-trips.
 - FAILED (P0/P1, unclear cause) → **Stage: Acceptance → Debug.** Then Implement.
+- FAILED (P0/P1, new bugs need test coverage) → **Stage: Acceptance → TestPlan.** Append
+  `## Regression TC` to the permanent test plan (see
+  [Test Plan Regeneration](#test-plan-regeneration)), then continue with Implement.
 - PARTIAL (P2/P3) → ask user: fix now or ship as-is
 - Out-of-scope bugs → create issues, don't block
 
@@ -188,7 +334,9 @@ Implement on the user's instruction.
 | From | To | Trigger | Max |
 |------|----|---------|-----|
 | PlanReview | Research | FAIL — knowledge gaps | 2 |
+| TestPlanReview | TestPlan | FAIL — test-plan revise loop | 3 |
 | Acceptance | Implement | FAILED bugs | 3 |
+| Acceptance | TestPlan | FAILED — append Regression TC for new bugs | 3 |
 | Acceptance | Debug | P0/P1 with unclear cause | 1 |
 | PR | Implement | Significant code changes requested | 2 |
 
@@ -209,4 +357,17 @@ The orchestrator **stops and waits for the user** at:
   feedback arrives and decides whether to resume at `implement` with FIXABLE items;
   CI monitoring and merge execution are outside this pipeline.
 - PARTIAL acceptance verdict (user decides: fix or ship)
+- TestPlanReview FAIL after 3 revise cycles — user picks: accept WARN manually, revise
+  spec, or rerun with `--skip-test-plan`.
 - Escalation (scope explosion, repeated failures, architectural decision needed)
+
+---
+
+## Self-reference Skip Note
+
+This PR (v0.10.0), which introduces the TestPlan stage itself, has no user-facing
+behavior — all changes are skill-markdown edits inside the `developer-workflow` plugin.
+It matches skip condition #3 (**internal utility without external contract change**): no
+new public API surface, no exported symbols, no endpoints. The TestPlan stage therefore
+does **not** apply to PR v0.10.0 — this is an intentional self-skip recorded here so
+future maintainers understand the decision.

--- a/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
@@ -25,11 +25,27 @@ for a human QA engineer or the `manual-tester` agent to pick up later.
 Save every test plan to the repository:
 
 ```
-docs/testplans/<feature-name>-test-plan.md
+docs/testplans/<slug>-test-plan.md
 ```
 
-Create the `docs/testplans/` directory if it doesn't exist. Use kebab-case for the feature name.
-Examples: `user-authentication-test-plan.md`, `cart-checkout-test-plan.md`.
+Create the `docs/testplans/` directory if it doesn't exist. The slug is the canonical
+filename anchor — downstream stages (`feature-flow` Phase 1.5, `acceptance` Branch 2)
+mount by exact slug match, so the filename must be slug-based regardless of invocation
+mode.
+
+Slug resolution rules (apply in order):
+
+1. **Orchestrator invocation** — when this skill is invoked from `feature-flow`, a
+   `slug` argument is passed explicitly. Use it as-is.
+2. **Standalone invocation, slug provided inline** — the user or caller may supply
+   a slug directly (e.g. `"slug: login-flow"`). Use it as-is.
+3. **Standalone invocation, no slug** — derive one from the feature name with the
+   stable kebab-case convention used elsewhere in workflow docs: lowercase the
+   name, replace runs of spaces or punctuation with `-`, trim leading/trailing `-`.
+
+Examples of derivation (rule 3): `"User authentication"` → `user-authentication-test-plan.md`,
+`"Cart & checkout"` → `cart-checkout-test-plan.md`, `"Token refresh (auth)"` →
+`token-refresh-auth-test-plan.md`.
 
 ### Receipt (when invoked from orchestrator with a slug)
 
@@ -89,17 +105,21 @@ Field conventions:
 ### Backward compatibility — standalone invocation without slug
 
 When a user invokes this skill directly (e.g. "create a test plan for X") without the
-orchestrator passing a `slug`, the receipt is **not** produced. Behavior matches the
-pre-orchestration flow exactly:
+orchestrator passing a `slug`, the receipt is **not** produced. The permanent file is
+still saved under the canonical slug-based filename:
 
-- Permanent file generated at `docs/testplans/<feature-name>-test-plan.md` as described above.
-- No `swarm-report/<slug>-test-plan.md` is written.
+- Permanent file generated at `docs/testplans/<slug>-test-plan.md`, where `<slug>` is
+  either provided inline or derived from the feature name per the Slug resolution rules
+  above. If the plan may later be consumed by another workflow that mounts an existing
+  plan (e.g. `bugfix-flow` → `acceptance` Branch 2), use the eventual orchestrator slug
+  at creation time so the file is deterministically mountable without renaming.
+- No `swarm-report/<slug>-test-plan.md` receipt is written.
 - No `phase_coverage` or receipt metadata tracked elsewhere.
 
-The `slug` parameter is therefore **mandatory only when invoked from the `feature-flow`
-orchestrator**. Standalone usage continues to work unchanged — existing callers,
-documentation references, and QA workflows that treat `docs/testplans/*-test-plan.md` as
-the single artifact are not broken by this change.
+Standalone callers continue to work: the slug-based filename is the single canonical
+artifact. Pre-existing `docs/testplans/*-test-plan.md` files authored before this
+convention are not auto-migrated — they remain readable by humans, but mount logic
+matches only on the exact `<slug>-test-plan.md` path.
 
 ## Input Discovery
 

--- a/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
@@ -48,10 +48,10 @@ name: test-plan-receipt
 description: Test plan artifact for <slug>
 slug: <slug>
 type: test-plan-receipt
-status: Draft | Ready | Approved
+status: Draft | Ready | Approved | Mounted
 permanent_path: docs/testplans/<slug>-test-plan.md
 source_spec: <path to spec if any, or "inline spec">
-review_verdict: pending | PASS | WARN | FAIL
+review_verdict: pending | PASS | WARN | FAIL | skipped
 phase_coverage: [Phase 1, Phase 2, ...]
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
@@ -74,8 +74,10 @@ updated: YYYY-MM-DD
 
 Field conventions:
 - `status`: `Draft` right after generation; `Ready` after plan-review returns PASS/WARN;
-  `Approved` when the user explicitly signs off.
-- `review_verdict`: `pending` at creation. Updated by `plan-review` to `PASS | WARN | FAIL`.
+  `Approved` when the user explicitly signs off; `Mounted` when a user-authored permanent
+  file is adopted without regeneration (see `feature-flow/SKILL.md` §1.5 Pre-check).
+- `review_verdict`: `pending` at creation; updated by `plan-review` to
+  `PASS | WARN | FAIL`; `skipped` on mount (no review occurs).
 - `phase_coverage`: list of phase labels present in the permanent file. Empty list if the
   feature has no phase segmentation.
 - `created` / `updated`: ISO dates (`YYYY-MM-DD`). `updated` must change whenever either the

--- a/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
@@ -31,6 +31,73 @@ docs/testplans/<feature-name>-test-plan.md
 Create the `docs/testplans/` directory if it doesn't exist. Use kebab-case for the feature name.
 Examples: `user-authentication-test-plan.md`, `cart-checkout-test-plan.md`.
 
+### Receipt (when invoked from orchestrator with a slug)
+
+When this skill is invoked from the `feature-flow` orchestrator, a `slug` argument is passed
+explicitly. In that case, in addition to the permanent document above, produce a **receipt**
+at `swarm-report/<slug>-test-plan.md` that the orchestrator and downstream stages
+(`plan-review`, `acceptance`) can consume for receipt-based gating.
+
+The permanent file remains the source of truth. The receipt is metadata + pointer.
+
+Receipt format:
+
+```markdown
+---
+name: test-plan-receipt
+description: Test plan artifact for <slug>
+slug: <slug>
+type: test-plan-receipt
+status: Draft | Ready | Approved
+permanent_path: docs/testplans/<slug>-test-plan.md
+source_spec: <path to spec if any, or "inline spec">
+review_verdict: pending | PASS | WARN | FAIL
+phase_coverage: [Phase 1, Phase 2, ...]
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+
+# Test Plan Receipt: <slug>
+
+**Status:** <status>
+**Permanent artifact:** [`docs/testplans/<slug>-test-plan.md`](../docs/testplans/<slug>-test-plan.md)
+**Source spec:** <path or description>
+**Review verdict:** <verdict>
+
+## Phase Coverage
+- Phase 1 — TCs covered: TC-1..TC-N
+- Phase 2 — TCs covered: TC-N+1..TC-M
+
+## Review Findings
+(populated by plan-review stage; WARN items listed here)
+```
+
+Field conventions:
+- `status`: `Draft` right after generation; `Ready` after plan-review returns PASS/WARN;
+  `Approved` when the user explicitly signs off.
+- `review_verdict`: `pending` at creation. Updated by `plan-review` to `PASS | WARN | FAIL`.
+- `phase_coverage`: list of phase labels present in the permanent file. Empty list if the
+  feature has no phase segmentation.
+- `created` / `updated`: ISO dates (`YYYY-MM-DD`). `updated` must change whenever either the
+  permanent file or any receipt field is modified.
+- Relative path in the markdown link assumes the conventional `swarm-report/` ↔ `docs/`
+  sibling layout at the repo root.
+
+### Backward compatibility — standalone invocation without slug
+
+When a user invokes this skill directly (e.g. "create a test plan for X") without the
+orchestrator passing a `slug`, the receipt is **not** produced. Behavior matches the
+pre-orchestration flow exactly:
+
+- Permanent file generated at `docs/testplans/<feature-name>-test-plan.md` as described above.
+- No `swarm-report/<slug>-test-plan.md` is written.
+- No `phase_coverage` or receipt metadata tracked elsewhere.
+
+The `slug` parameter is therefore **mandatory only when invoked from the `feature-flow`
+orchestrator**. Standalone usage continues to work unchanged — existing callers,
+documentation references, and QA workflows that treat `docs/testplans/*-test-plan.md` as
+the single artifact are not broken by this change.
+
 ## Input Discovery
 
 Determine what the user has provided and gather context accordingly.
@@ -71,6 +138,27 @@ Often the user provides more than one source. Cross-reference them:
 - Spec says X, but code implements Y → flag the discrepancy as a finding, write test cases for both
 - Design shows a state the spec doesn't mention → note it, write a test case
 - Code handles an edge case not in the spec → include it with `[inferred from code]`
+
+### Non-UI detector — when to use the lightweight template
+
+Not every feature has a user interface. Pure backend services, CLI tools, internal libraries,
+and data pipelines should use a reduced TC format where the full Steps / Expected Result
+columns add noise without signal — the behavior is fully captured by Given/When/Then.
+
+**Detector (all must hold to trigger lightweight mode):**
+- The spec or input contains **no** references to any of: mockups, wireframes, Figma frames,
+  screens, screen states, UI components, Jetpack Compose composables, SwiftUI views, React /
+  Vue / Svelte / HTML components, CSS selectors, navigation flows, or visible user actions
+  (tap, click, scroll, swipe, type in field).
+- The feature surface is API / library / CLI / background job / data transformation.
+- No `ux-expert` or front-end agent was consulted during research.
+
+If any one of the signals above **is** present, use the standard Test Plan Format
+(with full Steps and Expected Result). Mixed features (backend + thin UI) default to the
+standard format.
+
+When the detector triggers, note it in the Findings section of the permanent file:
+`**Lightweight template applied** — no UI surface detected; TCs use Given/When/Then only.`
 
 ## Analysis
 
@@ -168,6 +256,94 @@ Test cases that are good candidates for automated testing.
 
 > Omit this section if no test cases are suitable for automation.
 ```
+
+### Phase Segmentation
+
+When the feature reaches this skill via `decompose-feature` with phases (e.g. T-1..T-3 in
+Phase 1, T-4..T-6 in Phase 2), the permanent file splits the `## Test Cases` section by
+phase so each phase can ship and be re-verified independently. One permanent document per
+feature remains the rule — phases are sections inside it, not separate files.
+
+Apply segmentation when the decomposition artifact contains two or more phases **and** test
+cases can be grouped by which phase introduces the behavior they cover. Otherwise keep a
+single flat `## Test Cases` section.
+
+Example for a feature with two phases:
+
+```markdown
+## Test Cases
+
+### Phase 1 (T-1..T-3) — Core login flow
+
+#### TC-1: Successful login with valid credentials
+| Field | Value |
+|-------|-------|
+| **Priority** | P0 Critical |
+| **Tier** | Smoke |
+| **Preconditions** | User account exists, email is verified |
+| **Steps** | 1. Open login screen  2. Enter email  3. Enter password  4. Tap Login |
+| **Expected Result** | Home screen is shown, session token stored |
+| **Source** | Spec §2.1 |
+
+#### TC-2: Invalid password shows inline error
+...
+
+#### TC-3: Rate-limit after 5 failed attempts
+...
+
+### Phase 2 (T-4..T-6) — Password reset flow
+
+#### TC-4: Request reset email from login screen
+| Field | Value |
+|-------|-------|
+| **Priority** | P0 Critical |
+| **Tier** | Feature |
+| **Preconditions** | User account exists |
+| **Steps** | 1. Tap "Forgot password?"  2. Enter email  3. Submit |
+| **Expected Result** | Confirmation screen shown, reset email dispatched |
+| **Source** | Spec §3.2 |
+
+#### TC-5: Reset link expires after 15 minutes
+...
+
+#### TC-6: Reset flow rejects reused link
+...
+```
+
+When segmentation is applied, the receipt's `phase_coverage` field lists the phase labels
+present (e.g. `[Phase 1, Phase 2]`), and the TC ranges covered by each phase appear in the
+receipt's Phase Coverage section.
+
+### Lightweight template (non-UI features)
+
+When the non-UI detector triggers (see Input Discovery), use this reduced TC format in place
+of the standard one. The entire behavior of each TC is captured in Given/When/Then — no
+numbered Steps, no separate Expected Result field, since both collapse into the Then clause
+for non-interactive surfaces.
+
+```markdown
+#### TC-[N]: [Short title]
+| **Priority** | P0/P1/P2/P3 |
+| **Tier** | Smoke/Feature/Regression |
+| **Preconditions** | [state] |
+| **Scenario (Given/When/Then)** | Given X, When Y, Then Z |
+| **Source** | [Spec §section / inferred from code] |
+```
+
+Example:
+
+```markdown
+#### TC-3: Token refresh succeeds before expiry
+| **Priority** | P0 Critical |
+| **Tier** | Feature |
+| **Preconditions** | Valid refresh token stored, access token within 60s of expiry |
+| **Scenario (Given/When/Then)** | Given an access token with <60s TTL, When the client calls `refresh()`, Then a new access token is returned with the original refresh-token scope preserved |
+| **Source** | `src/auth/TokenManager.kt:142` |
+```
+
+All other sections of the Test Plan Format (front-matter table, Findings, Risk Areas,
+Coverage Matrix, Suggested Automation Candidates, Phase Segmentation when applicable) are
+used unchanged — only the TC blocks switch to this reduced form.
 
 ## Field Definitions
 

--- a/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
@@ -52,6 +52,8 @@ status: Draft | Ready | Approved | Mounted
 permanent_path: docs/testplans/<slug>-test-plan.md
 source_spec: <path to spec if any, or "inline spec">
 review_verdict: pending | PASS | WARN | FAIL | skipped
+review_warnings: []            # populated by plan-review on WARN — list of short strings
+review_blockers: []            # populated by plan-review on FAIL — list of short strings
 phase_coverage: [Phase 1, Phase 2, ...]
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
@@ -63,13 +65,6 @@ updated: YYYY-MM-DD
 **Permanent artifact:** [`docs/testplans/<slug>-test-plan.md`](../docs/testplans/<slug>-test-plan.md)
 **Source spec:** <path or description>
 **Review verdict:** <verdict>
-
-## Phase Coverage
-- Phase 1 — TCs covered: TC-1..TC-N
-- Phase 2 — TCs covered: TC-N+1..TC-M
-
-## Review Findings
-(populated by plan-review stage; WARN items listed here)
 ```
 
 Field conventions:
@@ -78,6 +73,12 @@ Field conventions:
   file is adopted without regeneration (see `feature-flow/SKILL.md` §1.5 Pre-check).
 - `review_verdict`: `pending` at creation; updated by `plan-review` to
   `PASS | WARN | FAIL`; `skipped` on mount (no review occurs).
+- `review_warnings` / `review_blockers`: arrays of short strings populated by `plan-review`.
+  `review_warnings` is written on WARN verdicts (items d or e of the checklist violated —
+  non-blocking); `review_blockers` is written on FAIL (items a, b, or c violated —
+  blocks transition to Implement). Both remain empty arrays on PASS / pending / skipped.
+  Frontmatter is the single source of truth for review findings — the receipt body does
+  not re-list them, keeping downstream YAML parsers authoritative.
 - `phase_coverage`: list of phase labels present in the permanent file. Empty list if the
   feature has no phase segmentation.
 - `created` / `updated`: ISO dates (`YYYY-MM-DD`). `updated` must change whenever either the
@@ -181,6 +182,12 @@ Before writing test cases, identify:
 Every generated test plan must follow this exact structure:
 
 ```markdown
+---
+type: test-plan
+slug: <feature-slug>
+generated: YYYY-MM-DD
+---
+
 # Test Plan: [Feature Name]
 
 | Field | Value |
@@ -189,6 +196,10 @@ Every generated test plan must follow this exact structure:
 | **Generated** | [YYYY-MM-DD] |
 | **Scope** | [one-line summary of what is covered] |
 | **Status** | Draft / Ready for Review / Approved |
+
+The `type: test-plan` frontmatter lets `plan-review` and `acceptance` identify the
+artifact deterministically (Signal #1 of the classifier). `slug` matches the receipt and
+any decomposition artifact for the same feature.
 
 ---
 

--- a/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
@@ -43,9 +43,10 @@ Slug resolution rules (apply in order):
    stable kebab-case convention used elsewhere in workflow docs: lowercase the
    name, replace runs of spaces or punctuation with `-`, trim leading/trailing `-`.
 
-Examples of derivation (rule 3): `"User authentication"` → `user-authentication-test-plan.md`,
-`"Cart & checkout"` → `cart-checkout-test-plan.md`, `"Token refresh (auth)"` →
-`token-refresh-auth-test-plan.md`.
+Examples of derivation (rule 3): `"User authentication"` → `user-authentication`,
+`"Cart & checkout"` → `cart-checkout`, `"Token refresh (auth)"` → `token-refresh-auth`.
+The resulting filename is then `docs/testplans/<slug>-test-plan.md` (for example,
+`docs/testplans/user-authentication-test-plan.md`).
 
 ### Receipt (when invoked from orchestrator with a slug)
 

--- a/plugins/developer-workflow/skills/plan-review/SKILL.md
+++ b/plugins/developer-workflow/skills/plan-review/SKILL.md
@@ -97,6 +97,7 @@ context compaction. Use `./swarm-report/plan-review-state.md` with this structur
 ```markdown
 # Plan Review State
 Source: {plan_mode | file:<path> | conversation}
+Review type: {implementation-plan | test-plan}
 Cycle: {1 | 2 | 3} of 3
 Status: {discovering | reviewing | synthesizing | fixing | done}
 
@@ -112,12 +113,17 @@ Status: {discovering | reviewing | synthesizing | fixing | done}
 - [ ] {agent2} — pending
 
 ## Verdict History
-### Cycle 1: {PASS | CONDITIONAL | FAIL}
+### Cycle 1: {PASS | CONDITIONAL | FAIL | WARN}
 - Blockers: {list}
 - Improvements: {list}
 
 ### Cycle 2: ...
 ```
+
+The `Review type` field records which protocol branch applies:
+- `implementation-plan` — default behavior (Steps 1–5 below, verdicts PASS/CONDITIONAL/FAIL)
+- `test-plan` — test-plan branch (see [Test-Plan Review Branch](#test-plan-review-branch)),
+  verdicts PASS/WARN/FAIL
 
 **Rules:**
 - Create this file at the start of Step 2 (after plan is read and source is tracked)
@@ -143,6 +149,24 @@ Extract from the plan:
 - **Scope** — which modules, layers, or systems are affected
 - **Key decisions** — architectural choices made in the plan
 
+### Classify the plan — implementation-plan vs test-plan
+
+Before moving to Step 2, determine whether the input is a **test-plan** artifact. Two signals,
+combined with OR — any one is enough:
+
+1. **YAML frontmatter type field** — the document starts with frontmatter that declares
+   `type: test-plan` (the permanent artifact at `docs/testplans/<slug>-test-plan.md`) or
+   `type: test-plan-receipt` (the receipt at `swarm-report/<slug>-test-plan.md`).
+2. **Structural signature** — the document contains a `## Test Cases` section AND discrete
+   TC blocks identifiable by TC-ID (e.g. `### TC-1`, `### TC-042`) AND explicit priority
+   labels from the set `P0` / `P1` / `P2` / `P3`. All three structural markers must be
+   present to count this signal.
+
+If either signal fires → the plan is a **test-plan**. Record `Review type: test-plan` in the
+state file and follow the [Test-Plan Review Branch](#test-plan-review-branch) instead of the
+default flow. Otherwise record `Review type: implementation-plan` and proceed with Step 2
+unchanged.
+
 ## Step 2 — Discover and Select Agents
 
 ### Discovery
@@ -165,6 +189,23 @@ Score each discovered agent's relevance **to the specific content of this plan**
 - **Gap coverage** — does this agent cover a blind spot that the other recommended agents miss?
 
 Mark the top-scoring agents as `recommended`. Prefer 2–3 agents, but quality over quantity — if only 1 agent is genuinely relevant, recommend just 1. Do not pad recommendations to reach a number. `general-purpose` is a fallback only when no specialist covers a genuine gap.
+
+### Recommended agents for test-plan input
+
+When `Review type: test-plan` was set in Step 1, pre-select these agents by default (they
+replace the usual technology-based pre-selection heuristic because test-plan relevance is
+driven by coverage/requirements logic, not by the tech stack):
+
+- **`business-analyst`** (recommended) — primary reviewer for test-plan artifacts. Validates
+  that every Acceptance Criterion from the spec is reflected in ≥1 Test Case, flags
+  ambiguous or missing AC coverage, and catches requirement drift between spec and plan.
+- **Domain specialist** (optional) — add at most one if the feature genuinely touches a
+  specialist's domain: `security-expert` when spec mentions auth/encryption/tokens/PII,
+  `performance-expert` when spec defines SLA/latency budget, `ux-expert` when spec covers
+  a11y or user-facing flows. Do not pad — only if the spec concretely invokes that domain.
+
+The orchestrator still uses `AskUserQuestion` to confirm the selection; the user can
+override. If the user explicitly named agents, use theirs instead (same rule as default flow).
 
 ### Present Agent Selection
 
@@ -328,3 +369,86 @@ Confirm the plan is ready. Say so explicitly and proceed to implementation.
 6. If still FAIL after 3 cycles — stop and tell the user: "The plan has failed review {N} times.
    The remaining issues may require a fundamentally different approach. Let's discuss before
    another iteration."
+
+## Test-Plan Review Branch
+
+This branch activates **only** when Step 1's detector classified the input as a test-plan
+(`Review type: test-plan`). For implementation plans the branch is inert — the default flow
+(Steps 2–5 above) runs unchanged. This preserves backward compatibility: nothing changes for
+existing implementation-plan reviews.
+
+### Scope
+
+When this branch is active:
+- Step 2's agent pre-selection uses the test-plan roster (see [Recommended agents for
+  test-plan input](#recommended-agents-for-test-plan-input)) instead of the tech-stack
+  heuristic.
+- Step 3's review prompt is augmented with the checklist below — each agent must answer
+  every checklist item in addition to its own perspective.
+- Step 4's synthesis uses PASS / WARN / FAIL verdicts (see [Verdict policy](#verdict-policy-test-plan))
+  instead of PASS / CONDITIONAL / FAIL.
+- Step 5 routes the receipt update accordingly and drives the revise-loop on FAIL.
+
+### Inline Checklist (5 items)
+
+Every agent reviewing a test-plan MUST evaluate the document against these five items and
+report the status of each one explicitly in their response. Copy the items verbatim into the
+review prompt so findings are comparable across agents:
+
+- **(a) AC coverage** — every Acceptance Criterion from the linked spec has ≥1 Test Case
+  that verifies it. Missing or weak mapping is a violation.
+- **(b) Negative balance** — every happy-path (positive) TC has ≥2 unhappy/negative TCs
+  covering the same flow (invalid input, error states, boundary violations, concurrent or
+  race conditions). A plan that is mostly happy paths violates this item.
+- **(c) Edge cases present** — at least one TC is explicitly tagged as an edge case
+  (boundary value, empty/null, maximum size, timezone/locale boundaries, concurrency,
+  resource exhaustion, etc.). If the plan has no edge-case TC at all, this item is
+  violated.
+- **(d) Non-functional scenarios where applicable** — if the linked spec mentions any of
+  {SLA, latency budget, throughput, a11y, auth, encryption, PII, resource limits, rate
+  limits}, there must be ≥1 non-functional TC covering that concern (performance,
+  accessibility, security). Applicability is driven by spec content — if the spec mentions
+  none of these triggers, this item is trivially satisfied.
+- **(e) Priority-risk alignment** — priorities (P0–P3) are consistent with risk assessment:
+  any high-risk flow (data loss, auth, payment, destructive actions) is at P0–P1; any
+  user-facing critical path is at P0–P1; trivial/informational cases are at P2–P3.
+  Mismatch between stated risk and assigned priority violates this item.
+
+### Verdict policy (test-plan)
+
+| Verdict | Trigger | Exit condition |
+|---------|---------|----------------|
+| **FAIL** (blocker) | Any of items **(a)**, **(b)**, **(c)** is violated | Plan MUST be revised. Drive the revise-loop up to 3 cycles. After 3 cycles still FAIL → escalate to the user (same wording as default flow). Pipeline is blocked. |
+| **WARN** (non-blocking) | Items (a)–(c) all satisfied, but **(d)** or **(e)** is violated | Pipeline continues. Record `review_verdict: WARN` in the receipt along with the explicit list of violated items. No revise-loop required. |
+| **PASS** (clean) | All five items satisfied | Pipeline continues unconditionally. Record `review_verdict: PASS` in the receipt. |
+
+**Severity mapping inside a single agent's output:**
+- A violated item from {(a), (b), (c)} surfaces as `severity: critical`
+- A violated item from {(d), (e)} surfaces as `severity: major`
+
+The orchestrator derives the overall verdict from the aggregated severities using the table
+above. A single critical from any agent with medium-or-higher confidence is enough to
+trigger FAIL, matching the Aggregation Rules in Step 4.
+
+### Receipt integration
+
+After Step 4 synthesis, the orchestrator updates the test-plan receipt at
+`swarm-report/<slug>-test-plan.md` with:
+
+- `review_verdict: PASS | WARN | FAIL`
+- On WARN: a `review_warnings:` list enumerating the violated items (e.g. `(d)`, `(e)`)
+  with one-line rationale each
+- On FAIL: a `review_blockers:` list enumerating the violated items from (a)–(c) with the
+  blocking finding and suggested fix (same payload as the default `## Issues to Resolve`
+  section)
+
+The receipt format itself is owned by the `generate-test-plan` skill — this skill only
+writes the three fields above.
+
+### Revise-loop (FAIL only)
+
+Same state machine as the default flow: Verdict:FAIL → Fix Plan → Re-review, max 3 cycles.
+The "Fix Plan" action edits the permanent test-plan file (the source is always the `file:`
+variant for test-plan — it lives at `docs/testplans/<slug>-test-plan.md`). Each cycle
+appends to `Verdict History` in the state file with the new verdict and the remaining
+blockers.

--- a/plugins/developer-workflow/skills/plan-review/SKILL.md
+++ b/plugins/developer-workflow/skills/plan-review/SKILL.md
@@ -75,6 +75,7 @@ Review       → Synthesize
 Synthesize   → Verdict
 Verdict:PASS → Done
 Verdict:COND → Fix Plan
+Verdict:WARN → Done          (test-plan branch only — see Test-Plan Review Branch)
 Verdict:FAIL → Fix Plan
 Fix Plan     → Re-review (back to Parallel Review with same agents)
 Re-review    → Synthesize → Verdict (same cycle)
@@ -158,9 +159,10 @@ combined with OR — any one is enough:
    `type: test-plan` (the permanent artifact at `docs/testplans/<slug>-test-plan.md`) or
    `type: test-plan-receipt` (the receipt at `swarm-report/<slug>-test-plan.md`).
 2. **Structural signature** — the document contains a `## Test Cases` section AND discrete
-   TC blocks identifiable by TC-ID (e.g. `### TC-1`, `### TC-042`) AND explicit priority
-   labels from the set `P0` / `P1` / `P2` / `P3`. All three structural markers must be
-   present to count this signal.
+   TC blocks identifiable by TC-ID at any heading level (regex `^#{1,6}\s+TC-[\w-]+`, e.g.
+   `### TC-1`, `#### TC-042`, `## TC-auth-01`) AND explicit priority labels from the set
+   `P0` / `P1` / `P2` / `P3`. All three structural markers must be present to count this
+   signal.
 
 If either signal fires → the plan is a **test-plan**. Record `Review type: test-plan` in the
 state file and follow the [Test-Plan Review Branch](#test-plan-review-branch) instead of the

--- a/plugins/maven-mcp/package-lock.json
+++ b/plugins/maven-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.8.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@krozov/maven-central-mcp",
-      "version": "0.8.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/plugins/maven-mcp/package.json
+++ b/plugins/maven-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "MCP server for Maven Central dependency intelligence",
   "main": "./dist/index.js",
   "type": "module",

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "maven-mcp",
-  "version": "0.9.1",
-  "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps, /latest-version, and /dependency-changes skills",
+  "version": "0.10.0",
+  "description": "Maven dependency intelligence \u2014 auto-registers MCP server, provides /check-deps, /latest-version, and /dependency-changes skills",
   "author": {
     "name": "kirich1409"
   },

--- a/plugins/sensitive-guard/.claude-plugin/plugin.json
+++ b/plugins/sensitive-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sensitive-guard",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "Prevents sensitive data (secrets, PII) from reaching AI servers by scanning files before they are read into conversation",
   "author": {
     "name": "kirich1409"


### PR DESCRIPTION
## Summary

Встраивает стадию **TestPlan + TestPlanReview** в `feature-flow` pipeline плагина `developer-workflow`. Pipeline теперь генерирует, ревьюит и сохраняет test-plan между plan-review и implement; `acceptance` потребляет его как primary source. Bugfix-flow не получает свою стадию — документируется ручной путь через `/generate-test-plan` + mount-as-existing. Один релиз v0.10.0 — bump всех 6 плагинов семейства.

Pipeline до:
```
research → [decompose] → [plan-review] → implement → acceptance → PR
```
Pipeline после:
```
research → [decompose] → [plan-review] → [TestPlan → TestPlanReview] → implement → acceptance → PR
                                                ↓ skip (trivial/refactor/internal/small)
                                                └───────────────────────────→ implement
```

Детальное исследование и декомпозиция — в `swarm-report/test-plan-integration-research.md` и `swarm-report/test-plan-integration-decomposition.md` (gitignored).

## Breaking Changes

Нет. Стадия default-on с автоматическим skip для trivial-изменений:
- single-file change без behavior change (AC delta = 0)
- pure refactor (нет новых AC)
- internal utility без внешнего контракта
- single-task decompose ≤2 S-задачи

Override: `--skip-test-plan` для force-off. Bug-профили уходят в `bugfix-flow` в Phase 0.2 до TestPlan gate — отдельное skip-условие не требуется.

Существующие `docs/testplans/*` файлы автоматически монтируются через Pre-check в feature-flow Phase 1.5 без регенерации.

## Release Notes — v0.10.0

**Новые возможности `developer-workflow`:**
- Receipt-based test-plan артефакты: `swarm-report/<slug>-test-plan.md` (receipt) + `docs/testplans/<slug>-test-plan.md` (permanent)
- Phase segmentation permanent-файла при наличии decomposition
- Lightweight TC-формат (Given/When/Then) для non-UI features
- Inline чек-лист ревью test-plan в `plan-review` (5 пунктов: AC coverage, unhappy paths, edge cases, non-functional, priority alignment)
- Primary-source потребление test-plan в `acceptance` с fallback на on-the-fly генерацию
- Mount-as-existing для pre-orchestration файлов (orchestrator owns the write; acceptance Branch 2 — standalone fallback)
- Re-generation policy: rollback → append `## Regression TC` (любая severity когда происходит fix); spec change → explicit `--regenerate-test-plan`
- FAIL review → 3-cycle revise loop → эскалация с 3 опциями
- Документирован ручной путь test-plan для bugfix-flow через mount-as-existing (Phase 3)

**Миграция:** пользователи с существующими `docs/testplans/*` файлами ничего не делают — feature-flow автоматически монтирует их при следующем запуске. Для явной перегенерации — `--regenerate-test-plan`.

**Unified version bump:** все 6 плагинов семейства подняты на 0.10.0 (поверх 0.9.1 из #89). Family semver ranges расширены с `^0.9.1` на `^0.10.0` (caret при 0.x привязан к minor).

## Self-reference Note

PR v0.10.0 вводит test-plan механизм, но сам для себя его не применяет — срабатывает skip-условие #3 (internal utility without external contract change): изменения в SKILL.md и docs не затрагивают public API/endpoints. Self-skip намеренный; в SKILL.md заметка не сохраняется (per-PR meta не место в долгоживущем prompt) — фиксируется только здесь.

## Rebased onto 0.9.1

Ветка rebased на свежий main (включая PR #89 "Fix invalid plugin.json component paths"). Наши ранее bumped manifests унаследовали clean structure без `../skills` / `../agents` полей — kotlin-validator в изначальном smoke test был прав, main это подтвердил. Force-with-lease push выполнен.

## Known Limitations (pre-existing, not introduced by this PR)

- `developer-workflow/docs/ORCHESTRATION.md` — устаревшие упоминания скиллов `implement-task`, `test-feature`, `exploratory-test`
- `developer-workflow/docs/WORKFLOW.md §8` — не перечислены `write-spec` и `bug-hunt` в skill map
- `developer-workflow-swift` README — не упоминает `swiftui-design-system.md`
- `extend` — отсутствует README

Follow-up PR для чистки documentation — отдельной задачей.

## Test Plan (smoke test)

Метод: text-inspection (runtime-запуск через Skill tool невозможен — плагин кэширован, правки в worktree не подгрузятся).

6 сценариев прогнаны (`swarm-report/test-plan-integration-smoke-test.md`):

| # | Сценарий | Verdict |
|---|----------|---------|
| 1 | Default-on activation | PASS |
| 2 | Skip detection (trivial) | PASS |
| 3 | FAIL revise loop (≤3 циклов) | PASS |
| 4 | Mount-as-existing | PASS (после fix Pre-check в Phase 1.5) |
| 5 | Override `--skip-test-plan` | PASS |
| 6 | bugfix-flow fallback | PASS |

Automated validation: `bash scripts/validate.sh` зелёный; `plugin-dev:plugin-validator` PASS на всех 6 плагинах.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
