### PR TITLE
Fix invalid plugin.json component paths (0.9.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.9.0",
+      "version": "0.9.1",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/maven-mcp/plugin"
@@ -23,7 +23,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.9.0",
+      "version": "0.9.1",
       "category": "security",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/sensitive-guard"
@@ -34,7 +34,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.9.0",
+      "version": "0.9.1",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow"
@@ -45,7 +45,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.9.0",
+      "version": "0.9.1",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-experts"
@@ -56,7 +56,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.9.0",
+      "version": "0.9.1",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-kotlin"
@@ -67,7 +67,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.9.0",
+      "version": "0.9.1",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-swift"
@@ -78,7 +78,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.9.0",
+      "version": "0.9.1",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/extend"

--- a/docs/PLUGIN-STANDARDS.md
+++ b/docs/PLUGIN-STANDARDS.md
@@ -29,12 +29,14 @@
 Запрещено:
 
 - `hooks`, `mcpServers`, `permissionMode` **внутри agent frontmatter** — эти поля запрещены в plugin-shipped агентах (security). Допускаются только в проектных агентах.
-- Пути с `../` outside plugin root — не работают после установки (cache не копирует внешние файлы). Валидный путь может использовать `..` внутри плагина, если он не выходит за корень, но лучше избегать — см. п. 2.
+- **Любые пути с `../`** в `plugin.json` (`skills`, `agents`, `commands`, `hooks`, `mcpServers`, `outputStyles`, `monitors`, `lspServers`) — traversal наружу плагина запрещён схемой Claude Code. Плагин не загрузится: `Plugin has an invalid manifest file … Validation errors: <field>: Invalid input`.
+- Пути, **не начинающиеся с `./`** — схема требует explicit relative paths.
 
 ## 2. Paths
 
-- Пути к компонентам (`skills`, `agents`, `commands`, `hooks` и т.д.) в `plugin.json` **резолвятся относительно `.claude-plugin/` директории**, не от корня плагина. Чтобы указать на `<plugin-root>/skills`, нужно писать `"../skills"`.
-- Если директория лежит в корне плагина со стандартным именем (`skills/`, `agents/`, `commands/`, `hooks/`) — поле **можно не указывать вообще**, автодискавер работает. Это предпочтительнее явного `"../skills"`.
+- Пути к компонентам (`skills`, `agents`, `commands`, `hooks`, `mcpServers`, `outputStyles`, `monitors`, `lspServers`) в `plugin.json` **резолвятся от корня плагина**, не от `.claude-plugin/`. Корректно: `"./skills/"`, `"./agents/"`, `"./custom/tool.md"`.
+- **Auto-discovery**: если директория лежит в корне плагина со стандартным именем (`skills/`, `agents/`, `commands/`, `hooks/`, `output-styles/`, `monitors/`) — поле **можно не указывать вообще**. Это дефолтный и предпочтительный путь, убирает лишний источник ошибок.
+- **Никаких `../`**: путь не может выходить за корень плагина. Claude Code при установке копирует в cache только содержимое корня плагина (`~/.claude/plugins/cache/...`), `../` ссылается наружу и ломает плагин после установки. Частая ошибка — написать `"../skills"` из уверенности, что пути резолвятся относительно `.claude-plugin/`. Это не так, раньше так было, сейчас — нет.
 - В скриптах хуков и в references используй `${CLAUDE_PLUGIN_ROOT}` вместо абсолютных или `dirname $0`. Это кросс-платформенно и стабильно при symlink-резолюции.
 - В SKILL.md и агентах ссылайся на `references/` через `${CLAUDE_PLUGIN_ROOT}/agents/references/foo.md`.
 
@@ -130,7 +132,7 @@ Frontmatter:
 - [ ] Описания skills (`description` frontmatter) ≤ 1024 символа
 - [ ] SKILL.md ≤ 500 строк или имеет `references/`
 - [ ] Никаких `hooks`/`mcpServers`/`permissionMode` внутри agent frontmatter
-- [ ] Пути в `plugin.json` не выходят за корень плагина через `..`
+- [ ] Пути в `plugin.json` начинаются с `./` и не содержат `../` (`skills`, `agents`, `commands`, `hooks`, `mcpServers`, `outputStyles`, `monitors`, `lspServers`). Для стандартных директорий в корне плагина — предпочтительно auto-discovery (поле не указывать)
 - [ ] Все referenced файлы существуют
 
 ## 11. Что автоматизируется (`validate.sh`)
@@ -144,5 +146,5 @@ Frontmatter:
 - `description` length ≤ 1024 для skills
 - SKILL.md size warning при > 500 строк без `references/`
 - Forbidden fields в agent frontmatter (`hooks`, `mcpServers`, `permissionMode`)
-- Path traversal (`../` outside plugin root) в `plugin.json`
-- Существование файлов, на которые ссылаются manifests
+- Path traversal (`../`) и invalid prefixes (не `./`) в component-path полях `plugin.json`
+- Существование файлов, на которые ссылаются manifests (относительно корня плагина)

--- a/plugins/developer-workflow-experts/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-experts/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-experts",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Reusable expert agents for code review, architecture, security, performance, UX, build, DevOps, business analysis, and debugging. Safe to install standalone — no skills, no hooks, no MCP servers.",
   "author": {
     "name": "kirich1409"
@@ -14,6 +14,5 @@
     "security",
     "performance",
     "ux"
-  ],
-  "agents": "../agents"
+  ]
 }

--- a/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-kotlin",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Kotlin, Android, and KMP specialist agents and migration skills — kotlin-engineer, compose-developer, code-migration, kmp-migration, migrate-to-compose. Extends developer-workflow for Kotlin/Android projects.",
   "author": {
     "name": "kirich1409"
@@ -18,13 +18,11 @@
   "dependencies": [
     {
       "name": "developer-workflow",
-      "version": "^0.9.0"
+      "version": "^0.9.1"
     },
     {
       "name": "developer-workflow-experts",
-      "version": "^0.9.0"
+      "version": "^0.9.1"
     }
-  ],
-  "skills": "../skills",
-  "agents": "../agents"
+  ]
 }

--- a/plugins/developer-workflow-swift/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-swift/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-swift",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Swift, iOS, and macOS specialist agents — swift-engineer and swiftui-developer, with references covering Swift concurrency, testing, and SwiftUI patterns/state/performance. Extends developer-workflow for Apple platforms.",
   "author": {
     "name": "kirich1409"
@@ -17,12 +17,11 @@
   "dependencies": [
     {
       "name": "developer-workflow",
-      "version": "^0.9.0"
+      "version": "^0.9.1"
     },
     {
       "name": "developer-workflow-experts",
-      "version": "^0.9.0"
+      "version": "^0.9.1"
     }
-  ],
-  "agents": "../agents"
+  ]
 }

--- a/plugins/developer-workflow/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Developer workflow pipeline — research, decomposition, specification, plan review, implementation, debugging, QA (test plans, acceptance, bug hunt, retroactive tests), PR creation and review-feedback triage, feature-flow and bugfix-flow orchestrators. Platform-neutral; platform-specific engineers live in developer-workflow-kotlin and developer-workflow-swift.",
   "author": {
     "name": "kirich1409"
@@ -18,9 +18,7 @@
   "dependencies": [
     {
       "name": "developer-workflow-experts",
-      "version": "^0.9.0"
+      "version": "^0.9.1"
     }
-  ],
-  "skills": "../skills",
-  "agents": "../agents"
+  ]
 }

--- a/plugins/extend/.claude-plugin/plugin.json
+++ b/plugins/extend/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "extend",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Extend Claude Code built-in features: agent review, skill optimization, configuration audit",
   "author": {
     "name": "kirich1409"
@@ -11,6 +11,5 @@
     "claude-code",
     "meta",
     "agent-review"
-  ],
-  "skills": "../skills"
+  ]
 }

--- a/plugins/maven-mcp/package.json
+++ b/plugins/maven-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "MCP server for Maven Central dependency intelligence",
   "main": "./dist/index.js",
   "type": "module",

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maven-mcp",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps, /latest-version, and /dependency-changes skills",
   "author": {
     "name": "kirich1409"
@@ -22,6 +22,5 @@
         "@krozov/maven-central-mcp"
       ]
     }
-  },
-  "skills": "../skills"
+  }
 }

--- a/plugins/sensitive-guard/.claude-plugin/plugin.json
+++ b/plugins/sensitive-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sensitive-guard",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Prevents sensitive data (secrets, PII) from reaching AI servers by scanning files before they are read into conversation",
   "author": {
     "name": "kirich1409"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -190,37 +190,70 @@ check_tag_versions() {
   done < <(jq -r '.plugins[] | [.name, .version] | @tsv' "$MARKETPLACE")
 }
 
-# ---------- L5: Skills / agents directories ----------
+# ---------- L5: plugin.json component paths ----------
+#
+# Claude Code schema rules for component-path fields:
+#   - Path is resolved from the plugin ROOT (not from .claude-plugin/)
+#   - Must start with "./"
+#   - Must not contain "../" — path traversal outside plugin root is rejected
+#     by the manifest validator ("Validation errors: <field>: Invalid input").
+#   - For standard directories (skills/, agents/, commands/, hooks/,
+#     output-styles/, monitors/), auto-discovery works when the field is
+#     omitted entirely; that is the preferred form.
 
-check_skills_dirs() {
-  echo "--- L5: Skills directories exist ---"
-  while IFS=$'\t' read -r name source; do
-    plugin_json="${source}/.claude-plugin/plugin.json"
-    [ -f "$plugin_json" ] || continue
-    skills_rel=$(jq -r '.skills // empty' "$plugin_json")
-    [ -n "$skills_rel" ] || continue
-    skills_path=$(python3 -c "import os; print(os.path.normpath(os.path.join('${source}/.claude-plugin', '${skills_rel}')))")
-    if [ ! -d "$skills_path" ]; then
-      fail "'$name' skills path does not exist: $skills_path"
-    else
-      ok "'$name' skills at $skills_path"
-    fi
-  done < <(jq -r '.plugins[] | [.name, .source] | @tsv' "$MARKETPLACE")
+PATH_FIELDS=(skills agents commands outputStyles hooks mcpServers lspServers monitors)
+
+# Validates a single path string against the schema rules.
+# Args: plugin_name field path_value
+_check_path_shape() {
+  local name="$1" field="$2" p="$3"
+  case "$p" in
+    ../*|*/../*|*/..)
+      fail "'$name' $field path contains '../' — Claude Code rejects path traversal: $p"
+      return 1
+      ;;
+  esac
+  case "$p" in
+    ./*) return 0 ;;
+    *)
+      fail "'$name' $field path must start with './' (got: $p)"
+      return 1
+      ;;
+  esac
 }
 
-check_agents_dirs() {
-  echo "--- L5: Agents directories exist ---"
+# Emits each path string from a plugin.json field. Accepts string or array.
+# Inline objects (hooks/mcpServers/lspServers configs) emit nothing.
+_emit_paths() {
+  local plugin_json="$1" field="$2"
+  jq -r --arg f "$field" '
+    .[$f] as $v
+    | if   $v == null             then empty
+      elif ($v | type) == "string" then $v
+      elif ($v | type) == "array"  then $v[] | select(type == "string")
+      else empty
+      end
+  ' "$plugin_json"
+}
+
+check_component_paths() {
+  echo "--- L5: plugin.json component paths (shape + existence) ---"
   while IFS=$'\t' read -r name source; do
     plugin_json="${source}/.claude-plugin/plugin.json"
     [ -f "$plugin_json" ] || continue
-    agents_rel=$(jq -r '.agents // empty' "$plugin_json")
-    [ -n "$agents_rel" ] || continue
-    agents_path=$(python3 -c "import os; print(os.path.normpath(os.path.join('${source}/.claude-plugin', '${agents_rel}')))")
-    if [ ! -d "$agents_path" ]; then
-      fail "'$name' agents path does not exist: $agents_path"
-    else
-      ok "'$name' agents at $agents_path"
-    fi
+
+    for field in "${PATH_FIELDS[@]}"; do
+      while IFS= read -r p; do
+        [ -n "$p" ] || continue
+        _check_path_shape "$name" "$field" "$p" || continue
+        abs=$(python3 -c "import os; print(os.path.normpath(os.path.join('${source}', '${p}')))")
+        if [ ! -e "$abs" ]; then
+          fail "'$name' $field path does not exist: $abs"
+        else
+          ok "'$name' $field -> $abs"
+        fi
+      done < <(_emit_paths "$plugin_json" "$field")
+    done
   done < <(jq -r '.plugins[] | [.name, .source] | @tsv' "$MARKETPLACE")
 }
 
@@ -278,8 +311,7 @@ main() {
   check_name_consistency
   check_version_consistency
   check_semver
-  check_skills_dirs
-  check_agents_dirs
+  check_component_paths
   check_hook_scripts
   check_frontmatter
 


### PR DESCRIPTION
## Problem

Six of seven plugins failed to load with:

```
Plugin has an invalid manifest file at …/plugin.json.
Validation errors: agents: Invalid input, skills: Invalid input
```

`plugin.json` manifests used `"skills": "../skills"` / `"agents": "../agents"` because `docs/PLUGIN-STANDARDS.md` §2 stated paths resolve relative to `.claude-plugin/`. That was wrong — in current Claude Code, component paths (`skills`, `agents`, `commands`, `hooks`, `mcpServers`, `outputStyles`, `monitors`, `lspServers`) resolve **from the plugin root** and:

- must start with `./`
- must not contain `../` (path traversal outside plugin root is rejected by the schema — installed cache does not copy files from outside the root)

`scripts/validate.sh` mirrored the same incorrect assumption (it joined paths against `<plugin>/.claude-plugin/`), so the misconfig silently passed every pre-release validation.

## Fix

- Remove `skills` / `agents` fields from all 6 affected `plugin.json` files — auto-discovery handles standard directories at plugin root (`skills/`, `agents/`).
- Bump unified version to **0.9.1** in all `plugin.json`, `marketplace.json` and `plugins/maven-mcp/package.json`; update inter-plugin `dependencies` ranges.
- Correct `docs/PLUGIN-STANDARDS.md` §2 (paths are plugin-root relative; `../` is forbidden) and update the pre-release checklist wording accordingly.

## Regression guard (validate.sh)

Replaced `check_skills_dirs` / `check_agents_dirs` with one `check_component_paths` that, for every component-path field:

1. Rejects any value containing `../` with a clear error message.
2. Requires the `./` prefix.
3. Resolves the path **from the plugin root** (not `.claude-plugin/`) and verifies existence.

Verified by injecting `"skills": "../skills"` into `plugins/extend/plugin.json` — validator now fails with:

```
ERROR: 'extend' skills path contains '../' — Claude Code rejects path traversal: ../skills
```

## Test plan

- [x] `bash scripts/validate.sh --check-tag 0.9.1` — all checks passed
- [x] Regression test: inject `"../"` into a plugin.json — validator fails as expected
- [ ] After merge: tag `v0.9.1` → release workflow publishes per-plugin tags, installation loads manifests cleanly