### PR TITLE
Add --draft / --refresh / --promote modes to create-pr

### DIFF
--- a/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
@@ -124,6 +124,16 @@ Invoke `developer-workflow:implement` with:
 
 Wait for `swarm-report/<slug>-implement.md` + `swarm-report/<slug>-quality.md`.
 
+### 2.1 Create draft PR (early)
+
+After `implement` returns a clean Quality Loop result and the branch has been pushed, invoke `developer-workflow:create-pr` with the `--draft` argument:
+
+> Stage: Implement → Acceptance (draft PR created)
+
+The draft PR body references the debug artifact (root cause + reproduction steps) and the fix summary. Acceptance runs against the pushed PR branch, keeping remote state in sync.
+
+If a draft PR already exists for this branch (re-entry on rollback), `--draft` is idempotent — it refreshes the body instead of failing.
+
 ---
 
 ## Phase 3: Acceptance
@@ -160,9 +170,15 @@ Wait for `swarm-report/<slug>-acceptance.md`.
 
 ## Phase 4: PR
 
-### 4.1 Create PR
+### 4.1 Promote to ready for review
 
-Invoke `developer-workflow:create-pr`.
+The draft PR already exists (created at 2.1) and has been updated via fix cycles and acceptance. Now mark it ready:
+
+Invoke `developer-workflow:create-pr` with the `--promote` argument.
+
+`--promote` refreshes the PR body with the final summary (root cause, fix, validation results, status table) and then marks the PR ready for review.
+
+> Stage: Acceptance → PR (promoted to ready)
 
 ### 4.2 Hand-off to user
 

--- a/plugins/developer-workflow/skills/create-pr/SKILL.md
+++ b/plugins/developer-workflow/skills/create-pr/SKILL.md
@@ -105,16 +105,18 @@ git diff $BASE...HEAD                  # full diff (for description reasoning)
 
 Look for artifacts in `./swarm-report/` that match the current branch/task slug. Read those that exist:
 
-| Artifact | Purpose in body |
-|---|---|
-| `<slug>-research.md` | Link + 1-sentence abstract in "Context" section |
-| `<slug>-spec.md` | Reference as "Specification" |
-| `<slug>-plan.md` | Reference as "Plan"; acceptance criteria extracted for "How to test" |
-| `<slug>-test-plan.md` | Reference; test cases become checklist in "How to test" |
-| `<slug>-implement.md` | Summary of implementation goes into "What changed" |
-| `<slug>-quality.md` | Gate pass/fail summary for status table |
-| `<slug>-finalize.md` | Round-by-round summary for status table (when finalize skill exists) |
-| `<slug>-acceptance.md` | Pass/fail + verified scenarios for "Verification" section |
+| Artifact | Location | Purpose in body |
+|---|---|---|
+| research | `swarm-report/<slug>-research.md` | Link + 1-sentence abstract in "Context" section |
+| spec | `docs/specs/<YYYY-MM-DD>-<slug>.md` (written by `write-spec`) | Reference as "Specification" |
+| plan | `swarm-report/<slug>-plan.md` | Reference as "Plan"; acceptance criteria extracted for "How to test" |
+| decomposition | `swarm-report/<slug>-decomposition.md` | Reference as "Task breakdown" when present |
+| debug | `swarm-report/<slug>-debug.md` | Root cause + reproduction steps — primary context for bugfix PRs |
+| test plan | `swarm-report/<slug>-test-plan.md` | Reference; test cases become checklist in "How to test" |
+| implement | `swarm-report/<slug>-implement.md` | Summary of implementation goes into "What changed" |
+| quality | `swarm-report/<slug>-quality.md` | Gate pass/fail summary for status table |
+| finalize | `swarm-report/<slug>-finalize.md` | Round-by-round summary for status table (available once the `finalize` skill is installed) |
+| acceptance | `swarm-report/<slug>-acceptance.md` | Pass/fail + verified scenarios for "Verification" section |
 
 Slug resolution:
 1. Prefer slug if orchestrator passed it as argument
@@ -266,7 +268,7 @@ glab mr update --description "<body>"
 ```
 
 Output:
-> Draft PR: `<url>`
+> Draft PR created: `<url>`
 
 ### 9b. Mode `--refresh`
 
@@ -310,7 +312,7 @@ Output differs by status (see "Output templates" below).
 
 **Draft (`--draft` or default → draft):**
 > Draft PR created: `<url>`
-> Next: complete implementation → invoke `/finalize` → `/acceptance` → `/create-pr --promote` to mark ready.
+> Next: complete implementation and local quality checks → `/acceptance` → `/create-pr --promote` to mark ready. (If the `finalize` skill is installed, the orchestrator will also run it between implement and acceptance.)
 
 **Refreshed (`--refresh`):**
 > PR body refreshed: `<url>`
@@ -332,9 +334,12 @@ Orchestrators (`feature-flow`, `bugfix-flow`) invoke this skill at these milesto
 ```
 implement first pass → push → /create-pr --draft
 implement fix loop pushes → (optional) /create-pr --refresh on major fixes
-finalize round complete → push → /create-pr --refresh
 acceptance complete → /create-pr --refresh (adds acceptance results to body)
 all local checks PASS → /create-pr --promote
+
+(When the `finalize` skill is installed, the orchestrator inserts a
+`/finalize` stage between implement and acceptance; it pushes commits
+between rounds and may call /create-pr --refresh at round boundaries.)
 ```
 
 The orchestrator owns deciding *when* to invoke; this skill owns *how*.

--- a/plugins/developer-workflow/skills/create-pr/SKILL.md
+++ b/plugins/developer-workflow/skills/create-pr/SKILL.md
@@ -1,255 +1,350 @@
 ---
 name: create-pr
 description: >
-  Use when creating a new pull request (GitHub) or merge request (GitLab) for the current branch.
-  Handles branch push, draft/ready decision, title and description generation, label selection,
-  reviewer suggestions from git history, and PR creation.
-  Invoke whenever the user says "create a PR", "open a PR", "make a PR", "create a draft PR",
-  "submit for review", "push a PR", "open an MR", or any variation — draft or not.
+  Manage the pull request (GitHub) / merge request (GitLab) for the current branch through its
+  lifecycle. Four modes: `--draft` creates or refreshes a draft PR early in the pipeline,
+  `--refresh` updates the body of an existing PR without touching its status, `--promote`
+  refreshes body and marks a draft PR ready for review, and default (no flag) creates a new PR
+  with a draft-or-ready prompt. Composes description from available swarm-report artifacts
+  (research, plan, test-plan, finalize, acceptance) and falls back to git log + diff. Invoke
+  when the user says "create PR", "open draft PR", "refresh PR description", "promote to ready",
+  "mark PR ready for review", "обнови PR", "переведи в ready", or when feature-flow /
+  bugfix-flow orchestrators call this skill at a lifecycle step.
 ---
 
 # Create PR
 
-Creates a pull request (GitHub) or merge request (GitLab) for the current branch,
-with a rich description, appropriate labels, and reviewers derived from git history.
+Manage a pull request (GitHub) or merge request (GitLab) across its lifecycle — draft creation, in-flight body refreshes, and final promotion to ready for review. Composes description dynamically from available artifacts.
 
 ---
 
-## Step 1: Setup
+## Modes overview
+
+| Mode | When | What it does | Fails if |
+|---|---|---|---|
+| `--draft` | After first implement commit in a pipeline | Creates draft PR if none exists; refreshes body if a draft already exists | PR exists and is already ready for review |
+| `--refresh` | After major lifecycle steps (finalize round complete, acceptance passed) | Updates body of existing PR (draft or ready) — no status change | No PR exists |
+| `--promote` | After all local quality passes (finalize + acceptance) | Refreshes body with final summary, then marks draft PR as ready for review | No PR exists, or PR is already ready |
+| default | Manual invocation outside pipeline | Asks draft-or-ready if unclear, then creates | PR already exists |
+
+Mode is passed via arguments: `/create-pr --draft`, `/create-pr --refresh`, `/create-pr --promote`, or `/create-pr` for default.
+
+---
+
+## Step 1: Setup (all modes)
 
 ```bash
-# Platform: check remote URL
+# Platform detect
 git remote get-url origin
-# Contains github.com → use gh; contains gitlab → use glab
+# contains github.com → use gh; contains gitlab → use glab
 
 # Base branch
 BASE=$(git remote show origin 2>/dev/null | grep "HEAD branch" | awk '{print $NF}')
 # Fallback order: main → master → develop
 
-# Current branch and author
 BRANCH=$(git branch --show-current)
 CURRENT_EMAIL=$(git config user.email)
 CURRENT_NAME=$(git config user.name)
 ```
 
-**Check if a PR already exists** for this branch — if so, show its URL and stop:
-
-```bash
-gh pr view --json url,isDraft 2>/dev/null   # GitHub
-glab mr view 2>/dev/null                    # GitLab
-```
-
 ---
 
-## Step 2: Push branch if needed
-
-```bash
-git rev-parse --abbrev-ref @{u} 2>/dev/null || git push -u origin "$BRANCH"
-```
-
----
-
-## Step 3: Draft decision
-
-Look for a clear signal in the current conversation:
-
-| Signal | Decision |
-|--------|----------|
-| User said "draft", "WIP", "work in progress" | **Draft** |
-| User said "ready for review", "not draft", "final", "ready" | **Not draft** |
-| Invoked right after quality checks completed cleanly | Lean **not draft** — confirm |
-| No clear signal | **Ask the user** |
-
-If unclear, ask exactly this — one question, nothing else:
-
-> Draft PR or ready for review?
-
-Wait for the answer before continuing.
-
----
-
-## Step 4: Analyse the branch
-
-Run these in parallel to gather all the material needed for labels, reviewers, and description:
-
-```bash
-# 1. Commits on this branch
-git log $BASE..HEAD --oneline
-
-# 2. Changed files
-git diff --name-only $BASE...HEAD
-
-# 3. Full diff stat
-git diff $BASE...HEAD --stat
-
-# 4. Full diff (for understanding what changed)
-git diff $BASE...HEAD
-```
-
----
-
-## Step 5: Labels
-
-Fetch all labels that exist in the remote repo:
+## Step 2: Check for existing PR (all modes)
 
 ```bash
 # GitHub
-gh label list --json name,description --limit 100
-
+gh pr view --json url,isDraft,number,body 2>/dev/null
 # GitLab
-glab api /projects/:fullpath/labels --jq '[.[] | {name, description}]'
+glab mr view --output json 2>/dev/null
 ```
 
-Read the available labels and select the ones that fit the changes. Base the decision on:
-- Changed file paths (e.g. `src/ui/` → ui label, `src/test/` → testing label)
-- Commit message types (`feat` → enhancement/feature, `fix` → bug, `docs` → documentation)
-- Scope of impact (e.g. `breaking-change` if public API is modified)
+Capture:
+- `PR_EXISTS` — true/false
+- `PR_IS_DRAFT` — true/false (if exists)
+- `PR_URL` — for output
+- `PR_BODY` — current body, used by refresh/promote to preserve manual edits (see Step 7.4)
 
-Do not invent labels — only pick from what exists. If nothing clearly fits, apply no labels.
+### Mode preconditions
+
+| Mode | Precondition | On failure |
+|---|---|---|
+| `--draft` | PR does not exist, or exists AND `isDraft: true` | If PR exists AND not draft: abort with "PR is already ready for review. Use `--refresh` to update body or `--promote` is a no-op." |
+| `--refresh` | PR exists | If no PR: abort with "No PR found for this branch. Use `--draft` or default to create one first." |
+| `--promote` | PR exists AND `isDraft: true` | If no PR: abort with "No PR to promote." If already ready: abort with "PR is already ready for review." |
+| default | PR does not exist | If PR exists: print URL, abort. Suggest `--refresh` or `--promote`. |
 
 ---
 
-## Step 6: Reviewers
-
-Find the people most familiar with the changed code by looking at who has touched those files recently:
+## Step 3: Push branch (all modes — if local has new commits)
 
 ```bash
-# For each changed file, collect recent commit authors (last 20 commits per file)
-git diff --name-only -z "$BASE"...HEAD | while IFS= read -r -d '' file; do
-  git log --follow -n 20 --format="%ae %an" -- "$file" 2>/dev/null
-done | sort | uniq -c | sort -rn
+# Ensure upstream + push
+git rev-parse --abbrev-ref @{u} 2>/dev/null || git push -u origin "$BRANCH"
+# If upstream set but local is ahead
+git push
 ```
 
-Filter out the current author (`$CURRENT_EMAIL`). Take the top 3 candidates by commit count.
-
-**Map emails to platform usernames:**
-
-```bash
-# GitHub — search by email
-gh api "/search/users?q=EMAIL+in:email" --jq '.items[0].login' 2>/dev/null
-
-# GitHub — fallback: look up recent commits on the repo by name
-REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
-gh api /repos/$REPO/commits --jq '.[].author.login' 2>/dev/null | sort | uniq
-
-# GitLab — search by email or name
-glab api "/users?search=EMAIL" --jq '.[0].username' 2>/dev/null
-```
-
-Present the suggested reviewers to the user before adding them — don't add silently.
-The user may accept, change, or skip.
+Never force-push here. If the push fails due to non-fast-forward — abort and ask the user to resolve.
 
 ---
 
-## Step 7: Generate title and description
+## Step 4: Analyse branch state (all modes — needed for body)
 
-**Title:**
-- Derive from branch name + most meaningful commit message
-- Strip prefixes: `feat/`, `fix/`, `chore/`, `refactor/`, `docs/`
-- Convert `kebab-case` to sentence case
-- Keep under 70 characters
-- Do not add "WIP:" or "Draft:" — the draft state on the PR conveys this
+Run in parallel:
 
-**Detect visual changes** — look at changed file paths for any of:
-- Android/Compose: `*Screen.kt`, `*Composable.kt`, `res/layout/`, `res/drawable/`
-- Compose Multiplatform: same Kotlin patterns, plus `commonMain` UI directories
-- Web: `*.tsx`, `*.jsx`, `*.css`, `*.scss`, `*.html`
-- iOS: `*.swift` (SwiftUI), `*.xib`, `*.storyboard`
+```bash
+git log $BASE..HEAD --oneline          # commits on the branch
+git diff --name-only $BASE...HEAD      # changed files
+git diff $BASE...HEAD --stat           # diff stat
+git diff $BASE...HEAD                  # full diff (for description reasoning)
+```
 
-If visual changes are detected, the description must include a Screenshots / Demo section (see template below). Prompt the user to provide screenshots or a screen recording if they haven't already — a PR with visual changes but no visuals is hard to review.
+---
 
-**Description template — ready-for-review PR:**
+## Step 5: Discover pipeline artifacts
+
+Look for artifacts in `./swarm-report/` that match the current branch/task slug. Read those that exist:
+
+| Artifact | Purpose in body |
+|---|---|
+| `<slug>-research.md` | Link + 1-sentence abstract in "Context" section |
+| `<slug>-spec.md` | Reference as "Specification" |
+| `<slug>-plan.md` | Reference as "Plan"; acceptance criteria extracted for "How to test" |
+| `<slug>-test-plan.md` | Reference; test cases become checklist in "How to test" |
+| `<slug>-implement.md` | Summary of implementation goes into "What changed" |
+| `<slug>-quality.md` | Gate pass/fail summary for status table |
+| `<slug>-finalize.md` | Round-by-round summary for status table (when finalize skill exists) |
+| `<slug>-acceptance.md` | Pass/fail + verified scenarios for "Verification" section |
+
+Slug resolution:
+1. Prefer slug if orchestrator passed it as argument
+2. Fallback to branch name with `feature/` / `fix/` / `chore/` prefix stripped
+
+Artifacts are gitignored (in `swarm-report/`), so they won't appear in diff — include them as *references* in the body (e.g., "See `swarm-report/my-slug-plan.md`"), not as inlined content. Reviewers working on the PR locally can read them; CI cannot, but the body remains readable without them.
+
+---
+
+## Step 6: Labels and reviewers (skip for `--refresh`)
+
+Only set labels/reviewers when **creating** (draft or default) or when **promoting** — these rarely need to change mid-flight. `--refresh` does NOT touch labels/reviewers to avoid clobbering user edits.
+
+### 6.1 Labels
+
+Fetch available labels (GitHub: `gh label list --json name,description --limit 100`; GitLab: `glab api /projects/:fullpath/labels`). Select from existing only, based on changed file paths, commit types, and scope. Do not invent labels.
+
+### 6.2 Reviewers
+
+For `--draft` **and** `--promote` modes, skip reviewer assignment — reviewers go on only in default mode or when explicitly requested by the caller. Rationale: draft PRs do not need reviewers yet; when promoting to ready, the pipeline normally has already determined reviewers (or the user assigns manually).
+
+For the default mode: top 3 authors who touched the changed files recently, filtered to exclude `$CURRENT_EMAIL`, mapped to platform usernames, presented to the user before adding.
+
+---
+
+## Step 7: Compose body
+
+Body composition is mode-aware.
+
+### 7.1 Section bank
+
+Available sections (include only those that apply):
 
 ```markdown
 ## What changed
-<!-- Concise technical description of the changes: what was added, removed, or modified -->
+<!-- Technical description from commit log + diff -->
 
 ## Why / motivation
-<!-- Context: the requirement, issue, or problem this solves. Link to ticket if applicable -->
+<!-- From task description or plan artifact; link ticket if URL in commits -->
+
+## Artifacts
+<!-- Bullet list of swarm-report/ paths that exist -->
+- Plan: swarm-report/<slug>-plan.md
+- Test plan: swarm-report/<slug>-test-plan.md
+- ...
 
 ## How to test
-<!-- Step-by-step instructions for a reviewer to verify the change works as intended -->
-- [ ] Step 1
-- [ ] Step 2
+<!-- From test-plan.md or plan.md acceptance criteria; checkbox list -->
+- [ ] Scenario 1
+- [ ] Scenario 2
+
+## Status
+<!-- Table: Implement / Finalize / Acceptance stages, pass/fail/pending from artifacts -->
+| Stage | Result | Notes |
+|---|---|---|
+| Implement | ✅ PASS | all gates green |
+| Finalize  | ⏳ in progress | round 2/3 |
+| Acceptance | ⏸ pending | waits for finalize |
+
+## Screenshots / demo
+<!-- For visual changes; prompt user -->
 
 ## Checklist
 - [ ] Tests added or updated
-- [ ] No breaking changes (or breaking changes are documented in this PR)
-- [ ] Relevant documentation updated
-
-## Screenshots / demo
-<!-- For visual changes: before/after screenshots or a short screen recording.
-     Delete this section if there are no visual changes. -->
+- [ ] No breaking changes (or documented)
+- [ ] Relevant docs updated
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 ```
 
-Fill every section from the diff and commit log — no placeholder comments left in the final text. The description must be self-contained: a reviewer who has no context about the task should be able to understand what changed, why, and how to verify it.
+### 7.2 Section selection per mode
 
-**Description template — draft PR (early, work in progress):**
+| Section | `--draft` | `--refresh` | `--promote` | default |
+|---|---|---|---|---|
+| What changed | short (plan/task-based, code may be incomplete) | updated from current diff | final, full | full |
+| Why / motivation | ✅ | ✅ | ✅ | ✅ |
+| Artifacts | ✅ (as they appear) | ✅ (keeps current) | ✅ | ✅ if exist |
+| How to test | from plan if exists | from test-plan if exists | full | ✅ |
+| Status | "Implement: in progress" | updated from latest artifacts | all PASS | optional |
+| Screenshots | placeholder + prompt user | keep as-is | verify filled | prompt |
+| Checklist | unchecked | keep user edits | verify items consistent | unchecked |
 
-```markdown
-## What this PR is about
-<!-- Brief statement of intent — even one line is fine -->
+### 7.3 Detect visual changes
 
-## Status
-<!-- What's done, what's still in progress -->
+Look at changed file paths for:
+- Android/Compose: `*Screen.kt`, `*Composable.kt`, `res/layout/`, `res/drawable/`
+- Compose Multiplatform: Kotlin UI patterns + `commonMain` UI dirs
+- Web: `*.tsx`, `*.jsx`, `*.css`, `*.scss`, `*.html`
+- iOS: `*.swift` (SwiftUI), `*.xib`, `*.storyboard`
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-```
+If visual changes detected — include "Screenshots / demo" section and prompt the user (in `--draft` and `--promote` modes) for attachments. `--refresh` preserves existing Screenshots content.
 
-A draft description can be minimal. It will be updated when the PR is marked ready.
+### 7.4 Preserve user edits on refresh/promote
+
+When `--refresh` or `--promote` runs and `PR_BODY` is non-empty:
+
+1. Detect manual-edit markers — any content between `<!-- user-edit-start -->` and `<!-- user-edit-end -->` is preserved verbatim
+2. Content in Screenshots / demo section preserved verbatim (users paste images there)
+3. Checklist items that are **checked** are preserved as checked — assume the user or reviewer ticked them
+
+Everything else is regenerated from artifacts + git state.
 
 ---
 
-## Step 8: Create
+## Step 8: Generate title
+
+Title generation is mode-aware:
+
+- **`--draft`** — derive from branch name + first commit message; prefix optional `[WIP] ` **only** if the user explicitly asks (draft state itself conveys WIP)
+- **`--refresh`** — keep existing title unchanged
+- **`--promote`** — keep existing title; if user asks for a new title, use the task description or spec
+- **default** — derive from branch + most meaningful commit
+
+Rules (apply on mode creating or changing title):
+- Strip prefixes: `feature/`, `fix/`, `chore/`, `refactor/`, `docs/`
+- Convert `kebab-case` to sentence case
+- Keep under 70 characters
+- Do not add "WIP:" or "Draft:" — draft state conveys this
+
+---
+
+## Step 9: Execute per mode
+
+### 9a. Mode `--draft`
+
+If no PR exists:
 
 ```bash
-# GitHub — draft
+# GitHub
 gh pr create --draft \
   --title "<title>" \
   --body "<body>" \
   --base "$BASE" \
-  --label "<label1>" --label "<label2>" \
-  --reviewer "<username1>" --reviewer "<username2>"
+  --label "<label>" ...
+# Labels optional; no reviewers for draft
 
-# GitHub — ready for review
-gh pr create \
-  --title "<title>" \
-  --body "<body>" \
-  --base "$BASE" \
-  --label "<label1>" --label "<label2>" \
-  --reviewer "<username1>" --reviewer "<username2>"
-
-# GitLab — draft
+# GitLab
 glab mr create --draft \
   --title "<title>" \
   --description "<body>" \
-  --target-branch "$BASE" \
-  --label "<label1>,<label2>" \
-  --reviewer "<username1>"
-
-# GitLab — ready for review
-glab mr create \
-  --title "<title>" \
-  --description "<body>" \
-  --target-branch "$BASE" \
-  --label "<label1>,<label2>" \
-  --reviewer "<username1>"
+  --target-branch "$BASE"
 ```
 
-Omit `--label` and `--reviewer` flags entirely if there are no applicable labels or reviewers — don't pass empty values.
+If draft already exists → edit body:
+
+```bash
+gh pr edit --body "<body>"
+glab mr update --description "<body>"
+```
+
+Output:
+> Draft PR: `<url>`
+
+### 9b. Mode `--refresh`
+
+```bash
+# GitHub
+gh pr edit --body "<new-body>"
+# GitLab
+glab mr update --description "<new-body>"
+```
+
+Labels, reviewers, title are **not** touched.
+
+Output:
+> PR body refreshed: `<url>`
+
+### 9c. Mode `--promote`
+
+Two sequential operations:
+
+```bash
+# 1. Refresh body with final summary
+gh pr edit --body "<final-body>"      # or glab mr update --description
+
+# 2. Mark ready
+gh pr ready                           # GitHub
+glab mr update --ready                # GitLab (flag varies — also: --unwip; verify in glab version)
+```
+
+Output:
+> PR promoted to ready for review: `<url>`
+
+### 9d. Default mode
+
+Same as current behaviour: ask draft-or-ready if not inferable from conversation, then create with full body + labels + reviewers.
+
+Output differs by status (see "Output templates" below).
 
 ---
 
-## Output
+## Output templates
 
-Print the PR/MR URL immediately after creation.
+**Draft (`--draft` or default → draft):**
+> Draft PR created: `<url>`
+> Next: complete implementation → invoke `/finalize` → `/acceptance` → `/create-pr --promote` to mark ready.
 
-**Draft PR:**
-> Draft PR created: \<url\>
-> When implementation is complete, invoke `simplify`, then run Quality Loop gates (build, static analysis, tests) from `~/.claude/rules/dev-workflow-orchestration.md`, then mark it ready for review.
+**Refreshed (`--refresh`):**
+> PR body refreshed: `<url>`
 
-**Ready-for-review PR:**
-> PR created: \<url\>
-> Monitor CI/CD via the platform UI. When reviewer feedback arrives, run `triage-feedback` to categorize and prioritize the comments; then decide what to act on based on the produced triage report.
+**Promoted (`--promote`):**
+> PR promoted to ready for review: `<url>`
+> Monitor CI and reviewer feedback. Use `/triage-feedback` on review comments when they arrive.
+
+**Default ready:**
+> PR created: `<url>`
+> Monitor CI. Use `/triage-feedback` on review comments when they arrive.
+
+---
+
+## Lifecycle integration (informational)
+
+Orchestrators (`feature-flow`, `bugfix-flow`) invoke this skill at these milestones:
+
+```
+implement first pass → push → /create-pr --draft
+implement fix loop pushes → (optional) /create-pr --refresh on major fixes
+finalize round complete → push → /create-pr --refresh
+acceptance complete → /create-pr --refresh (adds acceptance results to body)
+all local checks PASS → /create-pr --promote
+```
+
+The orchestrator owns deciding *when* to invoke; this skill owns *how*.
+
+---
+
+## Scope rules
+
+- **In scope:** PR create/edit/ready status transitions; body composition; labels and reviewers on create/promote; title generation on create.
+- **Out of scope:** editing code, running tests, running `/check`, managing commits (caller pushes beforehand), merging.
+- **Do not** force-push or rewrite history here. If push fails — report and let caller resolve.
+- **Do not** remove labels or reviewers set by humans. Only add missing ones on `--promote` if the pipeline determined additional reviewers.
+- **Do not** strip manually-added content when refreshing — respect `<!-- user-edit-start/end -->` markers and Screenshots section.

--- a/plugins/developer-workflow/skills/feature-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/feature-flow/SKILL.md
@@ -319,7 +319,7 @@ Invoke `developer-workflow:create-pr` with the `--promote` argument.
 
 `--promote` will:
 1. Refresh the PR body with the final summary (what changed, how to test, artifacts, status table showing all stages PASS).
-2. Mark the PR ready for review (`gh pr ready` / `glab mr update --ready`).
+2. Mark the PR ready for review. The exact platform command (`gh pr ready`, version-specific `glab` flag, etc.) is `create-pr`'s responsibility — the orchestrator does not repeat it here.
 
 > Stage: Acceptance → PR (promoted to ready)
 

--- a/plugins/developer-workflow/skills/feature-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/feature-flow/SKILL.md
@@ -270,6 +270,16 @@ Invoke `developer-workflow:implement` with:
 
 Wait for `swarm-report/<slug>-implement.md` + `swarm-report/<slug>-quality.md`.
 
+### 2.1a Create draft PR (early)
+
+After `implement` returns a clean Quality Loop result and the branch has been pushed, invoke `developer-workflow:create-pr` with the `--draft` argument:
+
+> Stage: Implement → Acceptance (draft PR created)
+
+Rationale: the remote branch + draft PR become the source of truth for the work in progress. Reviewers can inspect the code online, the description carries the plan and available artifacts, and later stages push refinements to the same PR rather than accumulating local-only changes.
+
+If a draft PR already exists for this branch (e.g., re-entry on rollback), `create-pr --draft` refreshes the body instead of creating a new PR — idempotent by design.
+
 ### 2.2 Acceptance
 
 Invoke `developer-workflow:acceptance` with:
@@ -301,13 +311,21 @@ Wait for `swarm-report/<slug>-acceptance.md`.
 
 ## Phase 3: PR
 
-### 3.1 Create PR
+### 3.1 Promote to ready for review
 
-Invoke `developer-workflow:create-pr`.
+The draft PR already exists (created at 2.1a) and has been pushed with fix cycles and acceptance updates. Now mark it ready:
+
+Invoke `developer-workflow:create-pr` with the `--promote` argument.
+
+`--promote` will:
+1. Refresh the PR body with the final summary (what changed, how to test, artifacts, status table showing all stages PASS).
+2. Mark the PR ready for review (`gh pr ready` / `glab mr update --ready`).
+
+> Stage: Acceptance → PR (promoted to ready)
 
 **PR granularity** (when decomposed):
-- Independent tasks → one PR per task (invoke create-pr after each task's acceptance)
-- Tightly coupled tasks → bundled PR after all tasks pass acceptance
+- Independent tasks → one PR per task (create + promote per task's acceptance)
+- Tightly coupled tasks → single bundled PR; promote only after all tasks pass acceptance
 
 ### 3.2 Hand-off to user
 


### PR DESCRIPTION
## Summary

Turn \`create-pr\` into a lifecycle manager for the PR, not just a one-shot creator. Four explicit modes:

| Mode | Purpose | Idempotent? |
|---|---|---|
| \`--draft\` | Create draft PR early (pipeline step). If draft already exists — refresh body. | Yes |
| \`--refresh\` | Update body of existing PR, keep status unchanged. Preserves user edits (\`<!-- user-edit-start/end -->\` markers + Screenshots section + checked checklist items). | — |
| \`--promote\` | Refresh body with final summary, then \`gh pr ready\` / \`glab mr update --ready\`. | No — promotes once |
| default | Create PR, ask draft-or-ready if unclear. For manual invocation outside orchestrators. | — |

Body composition is artifact-aware: reads \`swarm-report/<slug>-{research,plan,test-plan,implement,quality,finalize,acceptance}.md\` when they exist, plus git log + diff, and composes the body accordingly. Artifacts are referenced by path (since \`swarm-report/\` is gitignored), not inlined.

## Orchestrator integration

- **\`feature-flow\`** — new step 2.1a: after \`implement\` succeeds and branch is pushed, call \`/create-pr --draft\`. Phase 3 now calls \`/create-pr --promote\` after acceptance passes.
- **\`bugfix-flow\`** — mirror: 2.1 draft, 4.1 promote.

Remote branch + draft PR become the source of truth from the first clean implement pass. Reviewers can watch the code evolve; acceptance and any subsequent rounds push to the same PR.

## What's NOT in this PR

- \`--refresh\` is implemented in the skill but NOT yet called by orchestrators. It will be wired in when the \`finalize\` stage lands (each finalize round ends with a refresh).
- No changes to \`create-pr\`'s platform detection (GitHub / GitLab), push logic, label selection, or reviewer logic — those remain exactly as before, only gated on mode.

## Test plan

- [x] \`bash scripts/validate.sh\` — green (description shortened to fit 1024-char limit).
- [ ] Manual: \`/create-pr --draft\` on a fresh branch — creates draft.
- [ ] Manual: \`/create-pr --draft\` again — refreshes draft body, no duplicate PR.
- [ ] Manual: \`/create-pr --refresh\` after new commits — body updates, status stays draft.
- [ ] Manual: \`/create-pr --promote\` — body gets final summary, PR marked ready.
- [ ] Manual: \`/create-pr\` (no flag) — still prompts draft-or-ready.
- [ ] Manual: Try \`--promote\` on non-existent PR — aborts with clear message.
- [ ] Manual: Try \`--draft\` on already-ready PR — aborts, suggests \`--refresh\`.