### PR TITLE
Add finalize stage; slim implement to mechanical + intent

### DIFF
--- a/plugins/developer-workflow/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow/.claude-plugin/plugin.json
@@ -19,6 +19,11 @@
     {
       "name": "developer-workflow-experts",
       "version": "^0.10.0"
+    },
+    {
+      "name": "pr-review-toolkit",
+      "marketplace": "claude-plugins-official",
+      "version": "*"
     }
   ]
 }

--- a/plugins/developer-workflow/CLAUDE.md
+++ b/plugins/developer-workflow/CLAUDE.md
@@ -38,11 +38,12 @@ Skills in this plugin delegate to engineer agents (kotlin-engineer / compose-dev
 - Pipeline orchestration rules (task profiling, Research Consortium, Quality Loop gates, State Machine, receipt-based gating) ship with this plugin at [`docs/ORCHESTRATION.md`](docs/ORCHESTRATION.md) — skills and the core feature-flow/bugfix-flow orchestrators read from there.
 - Quality Loop gates are defined in `docs/ORCHESTRATION.md`, not in any individual skill.
 
-## Skills roster (15)
+## Skills roster (16)
 
 - Planning/research: `research`, `decompose-feature`, `write-spec`, `plan-review`, `design-options` (optional pre-plan-review stage — generates 2-3 architectural alternatives for high-arch-risk tasks)
 - Implementation: `implement`, `write-tests`, `debug`
-- Verification utility: `check` — reusable mechanical-check runner (build + lint + typecheck + tests), invoked by `implement` and any code-modifying skill
+- Verification utility: `check` — reusable mechanical-check runner (build + lint + typecheck + tests), invoked by `implement`, `finalize`, and any code-modifying skill
+- Code-quality pass: `finalize` — multi-round review-and-fix loop (code-reviewer → /simplify → pr-review-toolkit trio → expert reviews) that runs between `implement` and `acceptance`
 - QA: `generate-test-plan`, `acceptance`, `bug-hunt`
 - PR: `create-pr`, `triage-feedback`
 - Orchestrators: `feature-flow`, `bugfix-flow`

--- a/plugins/developer-workflow/README.md
+++ b/plugins/developer-workflow/README.md
@@ -22,7 +22,7 @@ developer-workflow-kotlin          developer-workflow-swift
 
 Installing this plugin automatically pulls `developer-workflow-experts`. Installing `-kotlin` or `-swift` additionally pulls this plugin.
 
-## Skills (15)
+## Skills (16)
 
 ### Planning / research
 | Skill | Purpose |
@@ -36,8 +36,9 @@ Installing this plugin automatically pulls `developer-workflow-experts`. Install
 ### Implementation
 | Skill | Purpose |
 |---|---|
-| `/implement` | Master orchestrator — delegates to engineers, runs quality loop |
-| `/check` | Mechanical verification utility — auto-detects project tooling (Gradle/Node/Cargo/Swift/Python/Go), runs build + lint + typecheck + tests, reports pass/fail. Called by `implement`, `finalize`, migration skills, or directly by user |
+| `/implement` | Writes code to meet the plan; mechanical checks via `/check` + intent check only. Semantic review, simplify, and expert review live in `/finalize`. |
+| `/check` | Mechanical verification utility — auto-detects project tooling (Gradle/Node/Cargo/Swift/Python/Go), runs build + lint + typecheck + tests. Called by `implement`, `finalize`, migration skills, or user. |
+| `/finalize` | Code-quality pass between `implement` and `acceptance`. Multi-round loop: `code-reviewer` → `/simplify` → `pr-review-toolkit` trio → conditional expert reviews, with `/check` between fixes. Max 3 rounds. |
 | `/debug` | Read-only root cause analysis (via `debugging-expert` from `-experts`) |
 | `/write-tests` | Retroactive tests for existing code — delegates test generation to engineers |
 

--- a/plugins/developer-workflow/docs/ORCHESTRATION.md
+++ b/plugins/developer-workflow/docs/ORCHESTRATION.md
@@ -99,11 +99,23 @@ Each stage produces an artifact in `swarm-report/`. The next stage reads it befo
 
 If a stage artifact is missing — the previous stage did not complete. Do not skip ahead.
 
-## Quality Loop
+## Quality Pipeline
+
+Three stages cover the full quality picture. Each stage answers a different question.
+
+| Stage | Skill | Question | Gate type |
+|---|---|---|---|
+| Mechanical + intent | `implement` | Does it compile, lint, test, and match the plan? | Two-gate Quality Loop |
+| Code quality | `finalize` | Is the code written well? | Multi-round review-and-fix loop |
+| Functional correctness | `acceptance` | Does the feature solve the user's problem? | Manual or automated QA |
+
+The orchestrator sequences them: **implement → finalize → acceptance → PR**. Each stage consumes the previous stage's artifact as a receipt.
+
+---
+
+## Implement — Quality Loop (2 gates)
 
 When the user asks to "prepare for PR", "quality check the branch", "run the quality loop", or "make it PR-ready" — run these gates on the current branch.
-
-After implementation completes and before PR creation, run a mandatory quality loop. Each gate runs in order; a failure triggers a fix cycle before advancing.
 
 ### Build system detection
 
@@ -172,37 +184,60 @@ default like `library`.
 | # | Gate | Action | Agent |
 |---|------|--------|-------|
 | 1 | Mechanical checks | Invoke `/check` — detects project tooling and runs build + lint + typecheck + tests with fail-fast; fix reported issues, re-invoke until PASS | Implementation agent + `/check` skill |
-| 2 | Semantic self-review | Compare original intent ↔ actual `git diff` | `code-reviewer` agent |
-| 3 | Expert reviews | Parallel domain-specific reviews (only when triggered) | Specialist agents |
-| 4 | Intent check | Re-read original task + plan, verify the diff addresses them | Orchestrator |
+| 2 | Intent check | Re-read original task + plan, verify the diff addresses them; scope creep or drift → fix or flag | Orchestrator |
 
-### Separation of author and reviewer
+### Iteration cap
 
-The agent that wrote the code must NOT perform the semantic self-review (gate 2). Launch the `code-reviewer` agent that receives only:
+- **Per gate:** max 3 fix attempts. If still failing after 3 — stop and escalate to user with the failure details and what was tried.
+- **Total quality loop:** max 3 full iterations (gate 1–2 cycles). If the loop does not converge — escalate.
+
+### Quality report artifact
+
+After the loop completes (pass or escalation), save `swarm-report/<slug>-quality.md` with:
+
+- Gate results (mechanical checks, intent check)
+- Issues found and fixes applied
+- Notes for `finalize` — anything surfaced during implement that the finalize stage should investigate (test coverage gaps, security concerns, structural concerns that did not block mechanical checks)
+
+This artifact is the receipt for the Finalize stage — Finalize must not start without it.
+
+---
+
+## Finalize — Code-quality loop
+
+Between `implement` and `acceptance`, the orchestrator runs the `finalize` skill. See [`skills/finalize/SKILL.md`](../skills/finalize/SKILL.md) for full details. Summary of the contract:
+
+### Phases per round (A → B → C → D)
+
+| Phase | Agent / skill | Purpose |
+|---|---|---|
+| A | `code-reviewer` (from `developer-workflow-experts`) | Semantic review: plan conformance, CLAUDE.md, bug detection. Confidence-scored 0/25/50/75/100. |
+| B | `/simplify` (built-in) | Reuse / quality / efficiency pass with auto-fix (3 parallel review agents + direct fix) |
+| C | `pr-review-toolkit:pr-test-analyzer`, `pr-review-toolkit:silent-failure-hunter`, `pr-review-toolkit:type-design-analyzer` — parallel | Test quality, silent failures, type design invariants |
+| D | `security-expert`, `performance-expert`, `architecture-expert` — conditional, parallel | Domain-specific deep review |
+
+Between phases and after any auto-fix, the orchestrator invokes `/check` to confirm mechanical pass.
+
+### Separation of author and reviewer (Phase A)
+
+The agent that wrote the code must NOT perform the Phase A semantic review. Launch the `code-reviewer` agent with only:
 
 1. The original task description (verbatim)
-2. The plan artifact (`swarm-report/<slug>-plan.md`) — if exists
+2. The plan artifact (`swarm-report/<slug>-plan.md`) — or `swarm-report/<slug>-debug.md` for bugfix-flow — if exists
 3. The `git diff` of all changes
 
-Nothing else. No implementation context, no conversation history. This prevents the author's assumptions from leaking into the review.
-
-Questions the reviewer must answer:
+Nothing else. No implementation context. Questions the reviewer must answer:
 - Does the code solve the original problem?
 - Is there scope creep beyond the plan?
 - Are acceptance criteria from the plan met?
 
-### Invocation template for gate 2
-
-The orchestrator prepares the diff before launching the agent:
-1. `git diff $(git merge-base origin/main HEAD)..HEAD > swarm-report/<slug>-diff.txt`
-2. Launch `code-reviewer` agent with this prompt structure:
-
+Invocation template:
 ```
 ## Task description
 {original task description verbatim}
 
-## Plan
-Read the plan at: {path to swarm-report/<slug>-plan.md, or "No plan for this task"}
+## Plan or debug context
+Read: {path to swarm-report/<slug>-plan.md or -debug.md, or "No context document"}
 
 ## Changes to review
 Read the diff at: {path to swarm-report/<slug>-diff.txt}
@@ -210,9 +245,7 @@ Read the diff at: {path to swarm-report/<slug>-diff.txt}
 Review these changes and produce a structured verdict.
 ```
 
-### Expert review triggers
-
-Not every change needs all expert reviews. Launch only the relevant ones, in parallel.
+### Phase D expert-review triggers
 
 | Expert | Trigger — files touch any of: |
 |--------|-------------------------------|
@@ -220,32 +253,16 @@ Not every change needs all expert reviews. Launch only the relevant ones, in par
 | `performance-expert` | RecyclerView/LazyColumn adapters, database queries, image loading, coroutine dispatchers, hot loops, large collections |
 | `architecture-expert` | New modules created, dependency direction changed, public API modified, new abstractions introduced |
 
-If no trigger matches — skip expert reviews entirely.
+If no trigger matches — skip Phase D entirely.
 
-### Iteration cap
+### Exit criteria
 
-- **Per gate:** max 3 fix attempts. If still failing after 3 — stop and escalate to user with the failure details and what was tried.
-- **Total quality loop:** max 5 full iterations (gate 1–4 cycles). If the loop does not converge — escalate. This prevents infinite fix-break-fix loops.
+- **PASS** — no BLOCK-severity findings remain. WARN and NIT surface in the report but do not block progression to acceptance.
+- **ESCALATE** — after 3 rounds, BLOCK findings remain. Orchestrator stops and reports to the user.
 
-### Quality report artifact
+### Finalize report artifact
 
-After the loop completes (pass or escalation), save `swarm-report/<slug>-quality.md` with:
-
-- Gates passed / failed (with attempt counts)
-- Issues found and fixes applied
-- Expert review findings (per expert, if any ran)
-- Semantic self-review verdict
-- Intent check result: PASS or DRIFT (with explanation)
-
-This artifact is the receipt for the Verify stage — Verify must not start without it.
-
-### Verdict handling (gate 2)
-
-| Verdict | Orchestrator action |
-|---------|---------------------|
-| PASS | Proceed to gate 3 (expert reviews) |
-| WARN | Proceed, but include major issues in `swarm-report/<slug>-quality.md` under "Acknowledged risks". If creating a PR, add these to the PR description. |
-| FAIL | Backward transition → Implement. Fix critical issues, re-run gate 1 (`/check`) after edits, then gate 2 (max 3 cycles). |
+Save `swarm-report/<slug>-finalize.md` with round-by-round findings (see `skills/finalize/SKILL.md` for the full schema). This artifact is the receipt for the Acceptance stage — Acceptance must not start without it.
 
 ## Testing Strategy in Planning
 

--- a/plugins/developer-workflow/docs/WORKFLOW.md
+++ b/plugins/developer-workflow/docs/WORKFLOW.md
@@ -14,12 +14,15 @@ working independently in its own domain (codebase, web, documentation, dependenc
 architecture). Results are reviewed and validated by `business-analyst`.
 This ensures decisions are made based on data, not solely on the model's training data.
 
-Quality is enforced by the Quality Loop — four sequential gates from mechanical checks to
-intent verification. Key principle: the author of the code never reviews their own code —
-gate 2 launches a separate `code-reviewer` agent that receives only the task description,
-plan, and git diff, without any implementation context. Mechanical verification (build,
-lint, typecheck, tests) is delegated to the reusable `/check` skill, which auto-detects
-the project stack. Receipt-based gating ensures no stage
+Quality is split into three stages, each answering a different question:
+**implement** (does the code work and match the plan?) → **finalize** (is the code written
+well?) → **acceptance** (does the feature solve the user's problem?). `implement` runs a
+2-gate Quality Loop: mechanical checks via `/check` (build/lint/typecheck/tests) and intent
+check. `finalize` runs a multi-round review-and-fix loop (code-reviewer → /simplify →
+pr-review-toolkit trio → conditional expert reviews) with `/check` between each fix. Key
+principle: the author of the code never reviews their own code — `finalize` Phase A
+launches a separate `code-reviewer` agent that receives only the task description, plan,
+and git diff, without any implementation context. Receipt-based gating ensures no stage
 starts without the previous stage's artifact. Re-anchoring at every stage transition prevents
 drift from the original intent.
 
@@ -52,11 +55,18 @@ IDEA / FEATURE REQUEST
   |   ┌────────────── for each task ──────────────┐
   |   │                                            │
   |   v                                            │
-  | [implement] ---- Code + simplify + Quality Loop
+  | [implement] ---- Write code + Quality Loop (2 gates)
   |   |  |-- specialist agents                     │
-  |   |  '-- Quality Loop (4 gates)                │
+  |   |  '-- /check + intent check                 │
   |   |        Artifacts: <slug>-implement.md      │
   |   |                   <slug>-quality.md        │
+  |   v                                            │
+  | [finalize] ---- Code-quality pass (3-round loop)│
+  |   |  |-- Phase A: code-reviewer               │
+  |   |  |-- Phase B: /simplify                    │
+  |   |  |-- Phase C: pr-review-toolkit trio       │
+  |   |  '-- Phase D: experts (conditional)        │
+  |   |        Artifact: <slug>-finalize.md        │
   |   v                                            │
   | [acceptance] ---- Verify against spec          │
   |   |  '-- manual-tester agent                   │
@@ -84,9 +94,12 @@ BUG REPORT / ISSUE
 [debug] ---- Reproduce -> Binary search -> Hypothesis -> Confirm root cause
   |             Artifact: swarm-report/<slug>-debug.md
   v
-[implement] ---- Fix based on root cause + simplify + Quality Loop
+[implement] ---- Fix based on root cause + Quality Loop (2 gates)
   |                Artifacts: swarm-report/<slug>-implement.md
   |                           swarm-report/<slug>-quality.md
+  v
+[finalize] ---- Code-quality pass (3-round loop)
+  |                Artifact: swarm-report/<slug>-finalize.md
   v
 [acceptance] ---- Verify bug no longer reproduces on live app
   |                Artifact: swarm-report/<slug>-acceptance.md
@@ -112,39 +125,58 @@ Auto-detection is based on keywords and context. When ambiguous — ask the user
 before starting work.
 
 
-## 4. Quality Loop
+## 4. Quality pipeline — three stages
+
+Quality is enforced across three stages, each answering a different question:
+
+| Stage | Skill | Question |
+|---|---|---|
+| 1. Mechanical + intent | `implement` | Does it compile, lint, test, and match the plan? |
+| 2. Code quality | `finalize` | Is the code written well? |
+| 3. Functional correctness | `acceptance` | Does the feature solve the user's problem? |
+
+### 4.1 Implement — 2-gate Quality Loop
 
 ```
-                              Iteration cap: max 5 full cycles
-                              Per gate: max 3 fix attempts
-     _________________________________________________________
-    |                                                         |
-    v                                                         |
-+------------+    +-------------+    +--------+    +--------+ |
-|  Gate 1    |--->|   Gate 2    |--->| Gate 3 |--->| Gate 4 | |
-| /check     |    | code-       |    | Expert |    | Intent | |
-| (mech.)    |    | reviewer    |    | Reviews|    | Check  | |
-+------------+    +-------------+    +--------+    +--------+ |
-     |fail             |                  |            |      |
-     v                 v                  v            v      |
-  [fix cycle:      PASS: gate 3      (by trigger    [fix, if   |
-   re-invoke        WARN: gate 3 +    only)          drift]   |
-   /check]          acknowledged      fix -> /check   |        |
-     |              risks, gate 4                    v        |
-     |              FAIL: --> Implement        (loop closes)  |
-     '---------------------------------------------------------'
+     __________________________________________
+    |                                          |
+    v                                          |
++----------+   +--------------+                |
+| Gate 1   |-->| Gate 2       |                |
+| /check   |   | Intent Check |                |
++----------+   +--------------+                |
+    |fail          |fail                       |
+    v              v                           |
+ [fix cycle] -- re-run /check ------------------'
+ max 3 iterations total; per-gate 3 fix attempts
 ```
-
-### Gates
 
 | # | Gate | Action | Executor |
 |---|------|--------|----------|
 | 1 | Mechanical checks | Invoke `/check` — build + lint + typecheck + tests (fail-fast); fix reported issues, re-invoke until PASS | Implementation agent + `/check` skill |
-| 2 | Semantic Self-Review | Compare intent vs. `git diff` | `code-reviewer` agent |
-| 3 | Expert Reviews | Parallel domain-specific reviews (by trigger) | Specialist agents |
-| 4 | Intent Check | Re-read task + plan, verify correspondence | Orchestrator |
+| 2 | Intent Check | Re-read task + plan, verify correspondence | Orchestrator |
 
-### Expert Review Triggers (gate 3)
+### 4.2 Finalize — multi-round code-quality loop
+
+After implement PASSes both gates, orchestrator invokes `/finalize`:
+
+```
+Round N  (max 3 rounds):
+  Phase A  code-reviewer       -> fix BLOCK -> /check
+  Phase B  /simplify (auto-fix)                -> /check
+  Phase C  pr-review-toolkit trio (parallel)  -> fix BLOCK -> /check
+  Phase D  experts (conditional, parallel)    -> fix BLOCK -> /check
+  end round: any BLOCK? yes -> next round. no -> PASS, exit.
+```
+
+| Phase | Agent / skill | Purpose |
+|---|---|---|
+| A | `code-reviewer` (from `developer-workflow-experts`) | Plan conformance, CLAUDE.md, bugs — confidence 0/25/50/75/100 rubric |
+| B | `/simplify` (built-in) | Reuse / quality / efficiency with auto-fix |
+| C | `pr-review-toolkit:pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer` (parallel) | Test quality, silent failures, type design invariants |
+| D | `security-expert`, `performance-expert`, `architecture-expert` (conditional, parallel) | Domain-specific deep review |
+
+### Phase D trigger table
 
 | Expert | Trigger — changed files touch any of: |
 |--------|---------------------------------------|
@@ -152,15 +184,20 @@ before starting work.
 | `performance-expert` | RecyclerView/LazyColumn, DB queries, image loading, hot loops |
 | `architecture-expert` | New modules, changed dependency direction, public API |
 
-If no trigger fired — gate 3 is skipped.
+If no trigger fired — Phase D is skipped for that round.
 
-### Verdict Handling (gate 2)
+### Verdict handling (Phase A code-reviewer)
 
 | Verdict | Orchestrator action |
 |---------|---------------------|
-| **PASS** | Advance to gate 3 (expert reviews) |
-| **WARN** | Advance to gate 3; major issues recorded in `<slug>-quality.md` as "Acknowledged risks" |
-| **FAIL** | Backward transition -> Implement; fix critical issues, re-run gate 1 (`/check`) after edits, then gate 2 (max 3 cycles) |
+| **PASS** | Continue to Phase B (/simplify) |
+| **WARN** | Continue to Phase B; items listed in the finalize report as "Acknowledged risks" |
+| **FAIL** | Apply BLOCK fixes, re-run `/check`, then re-run Phase A in next round; after 3 rounds with FAIL — escalate to user |
+
+### Finalize exit criteria
+
+- **PASS** — no BLOCK-severity findings across A/B/C/D. WARN and NIT surface in `<slug>-finalize.md`.
+- **ESCALATE** — 3 rounds complete, BLOCK findings remain. Stop and report to user.
 
 ### Build System Detection
 
@@ -366,19 +403,27 @@ research/debug ──→ implement ──→ acceptance ──→ create-pr ─�
 - PARTIAL (P2/P3 only) → orchestrator asks user: fix now or ship with known issues
 
 **Implement inner loop:**
-- Quality gates (mechanical checks via `/check` → code-reviewer → expert reviews → intent check) run inside `implement`
-- Gate failure → fix → re-run gate (max 3 attempts per gate, max 5 full cycles)
+- Two quality gates inside `implement`: mechanical checks via `/check`, then intent check
+- Gate failure → fix → re-run gate (max 3 attempts per gate, max 3 full cycles)
 - If not converging → escalate to user
+
+**Finalize loop:**
+- Runs after `implement` passes both gates, before `acceptance`
+- Four phases per round: code-reviewer → /simplify → pr-review-toolkit trio → conditional expert reviews
+- `/check` invoked between fixes
+- Max 3 rounds; PASS when no BLOCK remains; ESCALATE otherwise
 
 **PR review loop:**
 - `triage-feedback` categorizes and prioritizes the reviewer comments into a
   structured report. FIXABLE items feed back into `implement` on user's call.
-- If review requires significant code changes → back to `implement` → `acceptance` → update PR
+- If review requires significant code changes, the full quality path still applies:
+  `implement` → `finalize` → `acceptance` → update PR. Do not skip `finalize` on review-driven fixes; the code-quality gates apply to fix commits too.
 - CI monitoring and merge execution are done by the user outside this pipeline.
 
 **Loop limits:**
 - Acceptance → Implement: max 3 round-trips. After that → escalate
-- Quality gates: max 3 attempts per gate, max 5 full cycles
+- Implement quality gates: max 3 attempts per gate, max 3 full cycles
+- Finalize: max 3 rounds (A → D per round)
 - PR review: no hard limit, but escalate if same feedback repeats
 
 ### Artifact Contents
@@ -409,12 +454,14 @@ Each artifact includes:
 | `migrate-to-compose` | Implement (Migration) | View -> Compose migration with visual baseline |
 | `create-pr` | PR | PR/MR creation: title, description, labels, reviewers |
 | `triage-feedback` | Post-PR | Analyze, categorize, and prioritize feedback (PR comments or pasted text). Produces action plan. Optionally posts replies + resolves threads via an editable manifest on explicit apply trigger for terminal-verdict items (PRAISE / OUT_OF_SCOPE / NO_ACTION, plus NIT with NO_ACTION); never edits code |
-| `generate-test-plan` | Plan / Verify | Structured test plan from specification |
-| `acceptance` | Verify | Acceptance verification on live app — features and bug fixes |
-| `bug-hunt` | Verify | Undirected bug hunting without a specification |
+| `generate-test-plan` | Plan / Acceptance | Structured test plan from specification |
+| `acceptance` | Acceptance | Acceptance verification on live app — features and bug fixes |
+| `bug-hunt` | Acceptance | Undirected bug hunting without a specification |
 | `decompose-feature` | Research / Plan | Feature decomposition into tasks |
 | `write-tests` | Implement | Retroactive test writing |
-| `simplify`* | Quality | Code review for reuse, quality, and efficiency |
+| `simplify`* | Finalize Phase B | Reuse, quality, and efficiency review with auto-fix |
+| `finalize` | Finalize | Multi-round code-quality loop (A/B/C/D phases) |
+| `check` | Implement (gate 1), Finalize | Mechanical verification — build, lint, typecheck, tests |
 
 *Skill from another plugin / built-in.
 
@@ -423,16 +470,16 @@ Each artifact includes:
 
 | Agent | Stage | Role |
 |-------|-------|------|
-| `code-reviewer` | Quality (gate 2) | Independent review: intent vs. diff |
+| `code-reviewer` | Finalize Phase A | Independent review: intent vs. diff |
 | `kotlin-engineer` | Implement | Kotlin business logic, data/domain layer, ViewModel |
 | `compose-developer` | Implement | Compose UI: screens, components, themes, navigation |
-| `architecture-expert` | Research, Quality (gate 3) | Module structure, dependency direction, API design |
+| `architecture-expert` | Research, Finalize Phase D | Module structure, dependency direction, API design |
 | `business-analyst` | Research (auto-review) | Completeness, product sense, practicality |
-| `security-expert` | Quality (gate 3) | Auth, encryption, token storage, OWASP |
-| `performance-expert` | Quality (gate 3) | N+1, memory leaks, UI jank, hot loops |
-| `build-engineer` | Quality (gate 3) | Gradle config, build performance, module structure |
-| `manual-tester` | Verify | QA on live app: test cases, bug reports |
-| `ux-expert` | Quality (gate 3) | UX review, accessibility, platform conventions |
+| `security-expert` | Finalize Phase D | Auth, encryption, token storage, OWASP |
+| `performance-expert` | Finalize Phase D | N+1, memory leaks, UI jank, hot loops |
+| `build-engineer` | Finalize Phase D | Gradle config, build performance, module structure |
+| `manual-tester` | Acceptance | QA on live app: test cases, bug reports |
+| `ux-expert` | Finalize Phase D | UX review, accessibility, platform conventions |
 | `devops-expert` | PR / Merge | CI/CD, deployment, release automation |
 
 

--- a/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
@@ -38,7 +38,10 @@ Debug      -> Implement        (simple fix — root cause diagnosed, fix is clea
 Debug      -> Report           (not reproducible or escalated)
 Plan       -> Implement
 Plan       -> Debug            (plan review FAIL — need more diagnostic context)
-Implement  -> Acceptance
+Implement  -> Finalize
+Finalize   -> Acceptance       (PASS — no BLOCKs remain)
+Finalize   -> Implement        (ESCALATE after 3 rounds; user routes back)
+Finalize   -> escalate         (ESCALATE after 3 rounds; user picks non-implement path)
 Acceptance -> PR               (VERIFIED — bug gone)
 Acceptance -> Implement        (FAILED — bug still reproduces or new bugs)
 Acceptance -> Debug            (FAILED — fix didn't address root cause)
@@ -128,11 +131,27 @@ Wait for `swarm-report/<slug>-implement.md` + `swarm-report/<slug>-quality.md`.
 
 After `implement` returns a clean Quality Loop result and the branch has been pushed, invoke `developer-workflow:create-pr` with the `--draft` argument:
 
-> Stage: Implement → Acceptance (draft PR created)
+> Stage: Implement → Finalize (draft PR created)
 
-The draft PR body references the debug artifact (root cause + reproduction steps) and the fix summary. Acceptance runs against the pushed PR branch, keeping remote state in sync.
+The draft PR body references the debug artifact (root cause + reproduction steps) and the fix summary. Subsequent stages run against the pushed PR branch, keeping remote state in sync.
 
 If a draft PR already exists for this branch (re-entry on rollback), `--draft` is idempotent — it refreshes the body instead of failing.
+
+---
+
+## Phase 2.5: Finalize (code-quality pass)
+
+After `implement` passes its two gates (mechanical checks + intent check), invoke `developer-workflow:finalize` with:
+- Slug
+- Path to `swarm-report/<slug>-debug.md` (serves as the plan anchor for bugfix-flow — describes root cause and fix direction)
+
+`finalize` runs a multi-round loop (max 3): code-reviewer → /simplify → pr-review-toolkit trio → conditional expert reviews, with `/check` between fixes.
+
+Wait for `swarm-report/<slug>-finalize.md`.
+
+**Route by result:**
+- **PASS** → **Stage: Finalize → Acceptance**
+- **ESCALATE** → stop, report to user. User decides whether to accept risks, route back to implement for deeper fix, or re-scope.
 
 ---
 
@@ -196,6 +215,7 @@ exist.
 
 | From | To | Trigger | Max |
 |------|----|---------|-----|
+| Finalize | Implement | ESCALATE — user routes back to fix root issues | 1 |
 | Acceptance | Implement | Bug still reproduces or new bugs | 3 |
 | Acceptance | Debug | Fix didn't address root cause (2 failed implementations) | 1 |
 | PR | Implement | Review feedback requires code changes | 2 |

--- a/plugins/developer-workflow/skills/feature-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/feature-flow/SKILL.md
@@ -50,9 +50,12 @@ TestPlan       -> TestPlanReview
 TestPlanReview -> Implement        (PASS or WARN)
 TestPlanReview -> TestPlan         (FAIL — revise loop, max 3 cycles)
 TestPlanReview -> escalate         (after 3 failed revise cycles)
-Implement      -> Acceptance
+Implement      -> Finalize
+Finalize       -> Acceptance       (PASS — no BLOCKs remain)
+Finalize       -> Implement        (ESCALATE after 3 rounds; user routes back to implement)
+Finalize       -> escalate         (ESCALATE after 3 rounds; user picks non-implement path)
 Acceptance     -> PR               (VERIFIED)
-Acceptance     -> Implement        (FAILED — bugs to fix)
+Acceptance     -> Implement        (FAILED — bugs to fix; Implement then re-runs Finalize)
 Acceptance     -> TestPlan         (FAILED — add Regression TC for new bugs)
 Acceptance     -> Debug            (FAILED — unclear root cause)
 PR             -> Merge
@@ -296,13 +299,27 @@ Wait for `swarm-report/<slug>-implement.md` + `swarm-report/<slug>-quality.md`.
 
 After `implement` returns a clean Quality Loop result and the branch has been pushed, invoke `developer-workflow:create-pr` with the `--draft` argument:
 
-> Stage: Implement → Acceptance (draft PR created)
+> Stage: Implement → Finalize (draft PR created)
 
 Rationale: the remote branch + draft PR become the source of truth for the work in progress. Reviewers can inspect the code online, the description carries the plan and available artifacts, and later stages push refinements to the same PR rather than accumulating local-only changes.
 
 If a draft PR already exists for this branch (e.g., re-entry on rollback), `create-pr --draft` refreshes the body instead of creating a new PR — idempotent by design.
 
-### 2.2 Acceptance
+### 2.2 Finalize (code-quality pass)
+
+After `implement` passes its two gates (mechanical checks + intent check), invoke `developer-workflow:finalize` with:
+- Slug
+- Path to `swarm-report/<slug>-plan.md` (for Phase A code-reviewer anchor)
+
+`finalize` runs a multi-round loop (max 3 rounds): code-reviewer → /simplify → pr-review-toolkit trio → conditional expert reviews, with `/check` between fixes.
+
+Wait for `swarm-report/<slug>-finalize.md`.
+
+**Route by result:**
+- **PASS** (no BLOCKs remain) → **Stage: Finalize → Acceptance**
+- **ESCALATE** (3 rounds with BLOCKs) — orchestrator stops and reports to user. User decides: (a) accept the risks and go to acceptance manually; (b) route back to `implement` to address root issues; (c) escalate as a task-level re-scope.
+
+### 2.3 Acceptance
 
 Invoke `developer-workflow:acceptance` with:
 - Spec source: requirements from the task / plan / decomposition
@@ -368,6 +385,7 @@ Implement on the user's instruction.
 |------|----|---------|-----|
 | PlanReview | Research | FAIL — knowledge gaps | 2 |
 | TestPlanReview | TestPlan | FAIL — test-plan revise loop | 3 |
+| Finalize | Implement | ESCALATE — user routes back to fix root issues | 1 |
 | Acceptance | Implement | FAILED bugs | 3 |
 | Acceptance | TestPlan | FAILED — append Regression TC for new bugs | 3 |
 | Acceptance | Debug | P0/P1 with unclear cause | 1 |

--- a/plugins/developer-workflow/skills/finalize/SKILL.md
+++ b/plugins/developer-workflow/skills/finalize/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: finalize
+description: >
+  Code-quality pass over the current branch changes. Runs multi-round review-and-fix loop:
+  code-reviewer (plan conformance, CLAUDE.md, bugs) → /simplify (reuse, quality, efficiency) →
+  pr-review-toolkit agents (test quality, silent failures, type design) → conditional expert
+  reviews (security, performance, architecture). Between each fix and each phase the /check
+  skill verifies the code still builds, lints, and tests pass. Exits PASS when no BLOCK-level
+  findings remain (WARN and NIT items are surfaced in the report but do not block), or
+  ESCALATE after 3 rounds. Does NOT verify functional correctness — that's
+  acceptance. Does NOT verify plan conformance at a logic level — that's handled by
+  code-reviewer in Phase A. Invoke when the user says "finalize", "run code quality pass",
+  "clean up the code", "prepare for review", "доведи код", "почисти", or when an orchestrator
+  (feature-flow, bugfix-flow) runs this stage between implement and acceptance.
+---
+
+# Finalize
+
+Code-quality pass between implement and acceptance. Multi-round review-and-fix loop focused on **how** the code is written (quality, clarity, robustness), not **what** it does (that's acceptance) or **whether it works** (that's implement + `/check`).
+
+This skill exists because agent-written code carries recurring patterns worth polishing: over-engineered abstractions, silent failures in catch blocks, weak test coverage, fragile type designs, redundant utilities. `/check` doesn't catch these; `code-reviewer` alone is too narrow; `/simplify` alone is too narrow. `finalize` orchestrates the whole pass.
+
+---
+
+## Three quality layers — where `finalize` fits
+
+| Stage | Answers | Provenance |
+|---|---|---|
+| `implement` | Does the code work and match the plan? | build/lint/tests via `/check`, intent check |
+| **`finalize`** | Is the code written well? | this skill |
+| `acceptance` | Does the feature solve the user's problem? | functional verification via `manual-tester` |
+
+---
+
+## Inputs
+
+The caller (orchestrator or user) provides:
+- **`slug`** — the task slug used for artifact naming
+- **Branch state** — finalize reads the current branch; it does not switch branches
+- **Context artifact path (optional)** — Phase A's `code-reviewer` anchor. Accepts either a feature plan (`swarm-report/<slug>-plan.md`) or, for bugfix-flow invocations, the debug artifact (`swarm-report/<slug>-debug.md`). Either works — `code-reviewer` treats whichever is provided as the "what was supposed to happen" document.
+- **Tolerance flags (optional):**
+  - `--allow-warn` — stop after 1 round even if WARN findings remain (default: still exit PASS on WARN-only, but keep iterating BLOCKs until resolved or round budget runs out)
+  - `--skip-experts` — omit Phase D (rarely useful; experts auto-skip if no triggers match)
+
+---
+
+## Round structure
+
+Each round runs four phases A → B → C → D sequentially. Between phases and after any auto-fix, invoke `/check` to confirm the build still works. Accumulate findings. At the end of the round, decide: exit, or continue to next round.
+
+```
+Round N:
+  Phase A  → code-reviewer          → fix BLOCK → /check → continue
+  Phase B  → /simplify (auto-fixes) → /check               → continue
+  Phase C  → pr-review-toolkit trio (parallel) → fix BLOCK → /check → continue
+  Phase D  → expert reviews (conditional, parallel) → fix BLOCK → /check → continue
+  Round end: did any BLOCK remain unfixed?
+    yes → go to round N+1 (max 3 rounds total)
+    no  → exit with PASS
+```
+
+### Exit criteria
+
+- **PASS (exit):** no BLOCK severity findings from any phase. WARN and NIT findings listed in the report but do not block.
+- **ESCALATE (stop and report to caller):** after 3 rounds, BLOCK findings still present. Dump unresolved findings, caller decides whether to override or loop back to `implement`.
+
+### Max round budget
+
+`max_rounds = 3`. Total budget (per round: 4 phases + fixes + `/check` after each fix) can take non-trivial wall time on large diffs. If a project regularly hits round 3, the BLOCK threshold may be too strict for the project's conventions — tune Phase A's `code-reviewer` confidence threshold (see `developer-workflow-experts/agents/code-reviewer.md`).
+
+---
+
+## Phase A — Semantic review (code-reviewer)
+
+Launch the `code-reviewer` agent (from `developer-workflow-experts`) with:
+- Original task description (verbatim)
+- Plan artifact path (`swarm-report/<slug>-plan.md`) if it exists
+- `git diff` of all branch changes
+
+The agent returns a structured verdict: PASS / WARN / FAIL with findings scored on the 0/25/50/75/100 confidence rubric. Only findings passing the reporting threshold surface.
+
+### Handling findings
+
+| Severity × confidence | Action |
+|---|---|
+| critical ≥ 75 | Fix immediately. After fix, re-run `/check`. If the fix does not converge, the finding stays BLOCK — the round ends without exiting PASS; counted against the 3-round budget. Do not silently downgrade a critical finding to "acknowledged risk". |
+| major ≥ 75 | Fix if tractable. If fix requires refactoring beyond the diff scope → escalate to caller. Remains BLOCK until resolved or escalated. |
+| minor ≥ 50 | Include in report as NIT. Don't fix automatically; caller/user decides. NIT never blocks PASS. |
+
+If `code-reviewer` returns FAIL verdict → this phase has BLOCKs that must be addressed before continuing.
+
+### Output
+
+Summary of this phase's findings goes into the round's log.
+
+---
+
+## Phase B — Built-in simplification (`/simplify`)
+
+Invoke the built-in Claude Code skill `/simplify`. It runs three parallel review agents (reuse, quality, efficiency) and **applies fixes directly** for the findings it considers real.
+
+`/simplify` focuses on:
+- **Reuse**: duplicated logic that should use an existing utility
+- **Quality**: redundant state, parameter sprawl, copy-paste, leaky abstractions, stringly-typed code, unnecessary comments
+- **Efficiency**: redundant work, missed concurrency, hot-path bloat, TOCTOU, memory leaks
+
+Because `/simplify` is fix-oriented, do not pre-review its output — trust the built-in, then run `/check` to confirm the project still builds and tests pass.
+
+### If `/check` fails after `/simplify`
+
+Revert the simplify commits (or the last commit if unambiguously from `/simplify`), log the failure, continue to Phase C. Do not re-invoke `/simplify` in the same round — if it broke something once, it's likely to repeat.
+
+---
+
+## Phase C — PR review toolkit (parallel)
+
+Invoke three agents from the `pr-review-toolkit` plugin in **parallel**:
+
+| Agent | Focus |
+|---|---|
+| `pr-review-toolkit:pr-test-analyzer` | Quality of tests added in the diff: are edge cases covered? Behavioral vs. implementation testing? |
+| `pr-review-toolkit:silent-failure-hunter` | Empty catch blocks, swallowed errors, catches too broad, errors logged but not surfaced |
+| `pr-review-toolkit:type-design-analyzer` | Can invalid states be represented? Are invariants encoded in types? Missing nullability markers, unsafe unions |
+
+Each agent returns findings graded by the same 0–100 confidence rubric used by our `code-reviewer` (the plugin is hard-dep'd via `plugin.json`; agents inherit the convention through prompt sharing).
+
+### Handling Phase C findings
+
+Apply fix-loop rules identical to Phase A:
+- BLOCK (critical/major + confidence ≥ 75) → fix → `/check`
+- WARN (minor ≥ 50) → report, don't auto-fix
+- Below threshold → drop
+
+Fixes for test-quality findings (e.g., "this test doesn't cover the failure path") may require writing new test code — delegate that to the appropriate engineer agent (`kotlin-engineer`, `swift-engineer`, etc.) with the finding as input.
+
+---
+
+## Phase D — Expert reviews (conditional, parallel)
+
+Trigger experts only when the diff matches their domain. Launch the matching ones in **parallel**.
+
+| Expert | Trigger — files touch any of: |
+|---|---|
+| `security-expert` | Auth, encryption, token/secret storage, network requests, permissions, user data handling, crypto libraries |
+| `performance-expert` | RecyclerView / LazyColumn adapters, DB queries, image loading, coroutine dispatchers, hot loops, large collections, N+1 patterns |
+| `architecture-expert` | New modules created, dependency direction changed, public API modified, new abstractions introduced |
+
+No trigger matched → skip Phase D entirely for this round.
+
+### Handling expert findings
+
+Experts typically produce deeper, higher-risk findings. Apply the same severity × confidence gate, but with a lower bar for fix urgency:
+
+- security + critical: **always fix** before continuing, even at confidence 50 (security rarely benefits from optimism)
+- performance / architecture + critical at confidence ≥ 75: fix if local to the diff; escalate if requires broader rework
+
+---
+
+## Mechanical verification between phases
+
+After **any** code modification within a round (Phase A fix, Phase B auto-fix, Phase C fix, Phase D fix), re-invoke `/check`. If `/check` returns FAIL:
+
+1. Log which phase's fix introduced the failure.
+2. Attempt a narrow repair (1 attempt max).
+3. If still failing → revert the fix and keep the originating finding **as BLOCK** on the round's list — the finding is not resolved, so it counts against the round budget. Continue with the remaining phases of the round (they may still find other issues), but do not mark the reverted finding as "acknowledged risk" — that label is reserved for items the user knowingly accepts at the end.
+4. If the round ends with any such unresolved BLOCK, go to the next round. If round 3 ends with unresolved BLOCKs, exit with ESCALATE.
+
+Do not let `/check` failures cascade — a broken build blocks further review and creates noise. But also do not use "revert + continue" as a way to silently ship a BLOCK.
+
+---
+
+## Report
+
+Save `swarm-report/<slug>-finalize.md` on exit (PASS or ESCALATE):
+
+```markdown
+# Finalize: <slug>
+
+**Date:** <date>
+**Rounds run:** N (of 3 max)
+**Exit:** PASS | ESCALATE
+**Escalation reason:** <only if ESCALATE>
+
+## Rounds
+
+### Round 1
+- Phase A (code-reviewer): verdict, N findings (K BLOCK, M WARN, L NIT). Fixes applied: X.
+- Phase B (/simplify): Y files changed, auto-fixed.
+- Phase C (pr-review-toolkit): breakdown per agent.
+- Phase D (experts): triggered: [security-expert, ...]; findings, fixes.
+- `/check` after round: PASS | FAIL (reason)
+
+### Round 2
+...
+
+## Remaining findings (not auto-fixed)
+
+| Severity | Confidence | Category | Finding | Phase | File:Line |
+|---|---|---|---|---|---|
+| WARN | 60 | quality | Inconsistent error logging | A | src/foo/Bar.kt:142 |
+| NIT  | 75 | consistency | Unused import of X in new file | B | ... |
+
+## Acknowledged risks
+
+Findings that were not fixed because fix was non-trivial and they do not block merge.
+Reviewer should be aware of them.
+
+## Commits added during finalize
+
+- <hash> <message>
+```
+
+---
+
+## Scope rules
+
+- **In scope:** reviewing and improving the quality of code *related to the current diff*. Delegating fixes to engineer agents. Invoking `/check` after each mutation.
+- **Out of scope:** writing new features, changing task scope, verifying functional correctness (acceptance), architectural redesign (escalate — this is a new task).
+- **Prefer** to keep fixes inside the files touched by `implement`. Minimal, necessary edits in adjacent files are allowed when a finding explicitly requires them — e.g., Phase C's `pr-test-analyzer` may demand adding tests in a sibling test file, and Phase B's `/simplify` may extract a duplicated helper into an existing utility module. In every such case, keep the edit narrowly scoped to what the finding requires.
+- **Never** re-scope the task under the guise of "cleanup". If a finding points to a structural issue beyond narrow-fix reach → escalate, do not refactor.
+- **Never** silently skip Phase A — `code-reviewer`'s plan-conformance check is the anchor. If the agent fails to launch for infrastructure reasons, stop and escalate.
+- **Never** run forever. 3 rounds, then report.
+
+---
+
+## Escalation
+
+Stop and report to caller when:
+
+- After 3 rounds, BLOCK findings remain unresolved
+- `/check` fails and the fix doesn't converge after 1 retry
+- A BLOCK finding requires refactoring beyond the diff scope
+- An expert finding demands architectural changes (new modules, dependency reorg)
+- Required engineer agent (e.g., `kotlin-engineer`) is not installed but needed for a fix
+
+When escalating: state which phase escalated, what the unresolved findings are, and what the caller needs to decide (accept risks, loop to implement with new task, architectural redesign, etc.).
+
+---
+
+## Integration notes
+
+- **`feature-flow`** and **`bugfix-flow`** invoke this skill between `implement` and `acceptance`.
+- **Manual invocation** is useful for: pre-PR cleanup on a branch that didn't come through an orchestrator, periodic quality audit on an old branch that wasn't finalized, review of a branch before marking draft PR ready (even though orchestrators already do this automatically).
+- The skill assumes `code-reviewer` and `pr-review-toolkit` agents are installed. `code-reviewer` comes from `developer-workflow-experts` (sibling dependency). `pr-review-toolkit` comes from `claude-plugins-official` (hard dep in `plugin.json`).
+
+---
+
+## Dependencies this skill requires
+
+- Hard deps (declared in `plugins/developer-workflow/.claude-plugin/plugin.json`):
+  - `developer-workflow-experts` — for `code-reviewer`, `security-expert`, `performance-expert`, `architecture-expert`
+  - `pr-review-toolkit` (marketplace: `claude-plugins-official`) — for `pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer`
+- Built-in skills:
+  - `/simplify` — Claude Code's built-in reuse/quality/efficiency pass
+  - `/check` — this plugin's mechanical verification utility

--- a/plugins/developer-workflow/skills/implement/SKILL.md
+++ b/plugins/developer-workflow/skills/implement/SKILL.md
@@ -6,8 +6,10 @@ description: >-
   plain text description, GitHub/Jira/Linear issue URL, or a reference to an existing artifact
   (research.md, debug.md, plan.md).
 
-  Pipeline: understand task → implement → simplify → quality loop → produce artifacts.
-  Does NOT create worktrees, PRs, or run live QA — those are separate stages.
+  Pipeline: understand task → write code → quality loop (/check + intent check) → produce artifacts.
+  Semantic review, simplification, expert review, and PR-level quality checks live in the
+  separate `finalize` stage. Does NOT create worktrees, PRs, or run live QA — those are
+  separate stages.
 
   Use when: "implement", "write the code", "fix this", "сделай", "реализуй", "напиши код",
   "пофикси", or when an orchestrator delegates the implementation stage.
@@ -97,24 +99,17 @@ stage (e.g., model, repository, UI layer). Stage specific files, never `git add 
 
 ---
 
-## Phase 3: Simplify
+## Phase 3: Quality Loop
 
-After implementation is complete, invoke the `simplify` skill on changed files.
-This reviews for reuse opportunities, code quality, and efficiency — then fixes issues found.
+Run two quality gates sequentially. A failure triggers a fix cycle before advancing.
 
-If simplify produces changes — commit them separately.
+Semantic review, simplification, expert review, and PR-level code-quality analysis live in the separate `finalize` stage, which the orchestrator runs after `implement`. `implement` is now strictly focused on *getting the code written and working according to the plan* — nothing more.
 
----
-
-## Phase 4: Quality Loop
-
-After code is written, run the Quality Loop defined in [`docs/ORCHESTRATION.md`](../../docs/ORCHESTRATION.md#quality-loop) — that document is the single source of truth for gate definitions, verdict handling, expert-review triggers, and iteration limits.
+After code is written, run the Quality Loop defined in [`docs/ORCHESTRATION.md`](../../docs/ORCHESTRATION.md#implement--quality-loop-2-gates) — that document is the single source of truth for gate definitions, verdict handling, and iteration limits.
 
 Summary for this skill's callers:
 - Gate 1 invokes `/check` (mechanical: build + lint + typecheck + tests)
-- Gate 2 is the semantic self-review by `code-reviewer`
-- Gate 3 launches domain experts only when triggers match the diff
-- Gate 4 is the intent check
+- Gate 2 is the intent check — re-read task + plan, verify the diff addresses them; scope creep or drift → fix or flag
 - A gate failure triggers a fix cycle; total loop is capped per ORCHESTRATION.md
 
 Do not duplicate gate details here — read ORCHESTRATION.md before executing. If ORCHESTRATION.md is missing, escalate rather than guessing the current rules.
@@ -161,18 +156,16 @@ Save to `swarm-report/<slug>-quality.md`:
 | # | Gate | Result | Attempts |
 |---|------|--------|----------|
 | 1 | Mechanical checks (`/check`) | PASS/FAIL | N |
-| 2 | Semantic review | PASS/WARN/FAIL | N |
-| 3 | Expert reviews | PASS/SKIP | — |
-| 4 | Intent check | PASS/DRIFT | — |
+| 2 | Intent check | PASS/DRIFT | — |
 
 ## Issues Found and Fixed
 - <issue> — <fix applied>
 
-## Expert Review Findings
-<per expert, if any ran>
+## Intent Check
+<PASS / DRIFT with explanation>
 
-## Acknowledged Risks
-<WARN items from semantic review, if any>
+## Notes for finalize
+<anything surfaced during implement that the finalize stage should know about: test gaps, security concerns, structural concerns that did not block mechanical checks>
 ```
 
 ---


### PR DESCRIPTION
## Summary

Introduces the third stage of the quality pipeline, separating **code quality** from **plan conformance** and **functional correctness**. After merging, a task flows through:

\`\`\`
implement   (code works + matches plan)
  ↓
finalize    (code is written well)         ← NEW
  ↓
acceptance  (feature solves the problem)
\`\`\`

## Stacked PR

**Based on \`feature/check-skill\`** (PR #95), not \`main\`. Merge PR #95 first, then this one will target \`main\` cleanly.

## New skill: \`finalize\`

\`plugins/developer-workflow/skills/finalize/SKILL.md\`. Multi-round review-and-fix loop, max 3 rounds:

| Phase | Agent / skill | Purpose |
|---|---|---|
| A | \`code-reviewer\` (from \`-experts\`) | Plan conformance, CLAUDE.md, bugs — 0/25/50/75/100 confidence rubric from PR #94 |
| B | \`/simplify\` (built-in) | Reuse, quality, efficiency with auto-fix |
| C | \`pr-review-toolkit:pr-test-analyzer\` + \`silent-failure-hunter\` + \`type-design-analyzer\` — parallel | Test quality, silent failures, type invariants |
| D | \`security-expert\`, \`performance-expert\`, \`architecture-expert\` — conditional, parallel | Domain deep review |

\`/check\` runs between each fix. Exit PASS when no BLOCKs remain; ESCALATE after 3 rounds.

## Hard dep

\`developer-workflow/plugin.json\` declares a new dep on \`pr-review-toolkit\` from \`claude-plugins-official\` marketplace. **Per the revised dependency policy (feedback memory updated in PR #94), external hard deps require explicit per-plugin user approval — this was given during the design discussion.**

If the cross-marketplace dep syntax in \`plugin.json\` needs adjustment for the current Claude Code plugin spec, that's a follow-up.

## implement refactor

Previously 4 Quality Loop gates (after PR #95). Now 2:

| Before (post-#95) | After |
|---|---|
| Gate 1: Mechanical checks (\`/check\`) | 1. Mechanical checks (\`/check\`) — unchanged |
| Gate 2: Semantic self-review | → moved to Finalize Phase A |
| Gate 3: Expert reviews | → moved to Finalize Phase D |
| Gate 4: Intent check | 2. Intent check — unchanged |
| Phase 3: Simplify | → moved to Finalize Phase B |

\`implement\` is now strictly "write code and verify it works per the plan."

## Orchestrator changes

Both \`feature-flow\` and \`bugfix-flow\`:

- State machine: \`Implement → Finalize → Acceptance\` (was \`Implement → Acceptance\`)
- New section for Finalize invocation with route-by-result (PASS / ESCALATE)
- Backward Transitions table: added \`Finalize → Implement\` (max 1)

## Docs

\`docs/ORCHESTRATION.md\` and \`docs/WORKFLOW.md\` rewritten to the three-stage model. Full phase tables, trigger matrices, exit criteria, artifact receipts.

\`CLAUDE.md\` skill roster: 15 → 16. README skills list updated.

## Test plan

- [x] \`bash scripts/validate.sh\` — green
- [ ] Manual: install the built plugin, invoke \`/finalize --slug foo\` on a test branch with intentional issues in each phase
- [ ] Manual: verify Phase A runs \`code-reviewer\` with new 0/25/50/75/100 rubric (requires PR #94)
- [ ] Manual: verify Phase B invokes \`/simplify\`
- [ ] Manual: verify Phase C launches \`pr-review-toolkit\` agents in parallel (requires marketplace \`claude-plugins-official\` and this plugin installed)
- [ ] Manual: verify Phase D only triggers for matching file patterns
- [ ] Manual: verify 3-round escalation fires correctly
- [ ] Verify \`feature-flow\` calls \`finalize\` between implement and acceptance in a real task
- [ ] Verify \`bugfix-flow\` does the same

## Open follow-ups (not in this PR)

- \`feature/design-options-stage\` — variability on research + plan (optional \`design-options\` pre-stage that generates 2-3 architecture alternatives for user selection)
- PR #96 wires \`create-pr --refresh\` calls at major milestones; after this lands, orchestrators should add \`--refresh\` after each finalize round (currently they don't)