### PR TITLE
acceptance iteration 2: conditional expert fan-out + PoLL aggregation

### DIFF
--- a/plugins/developer-workflow/docs/ORCHESTRATION.md
+++ b/plugins/developer-workflow/docs/ORCHESTRATION.md
@@ -121,6 +121,36 @@ Use the highest-priority match when multiple build files are present:
 
 Monorepo: if all changed files are under a single subdirectory with its own build file, use that subdirectory's build system.
 
+### Project type detection
+
+Orthogonal to build-system detection: build system answers "how to build/test",
+project type answers "what kind of product is this". Drives which acceptance checks are
+meaningful (e.g., manual UI QA only on UI surfaces). Consumed by `acceptance`, and may be
+consumed by `research`, `generate-test-plan`, `create-pr` as those skills evolve.
+
+Cheap heuristic over the repository root plus a few well-known paths (e.g. `app/`, `android/`,
+`ios/`) — no external tools required, no exhaustive tree walk:
+
+| Signal found at repo root or a well-known subdirectory | `project_type` | `has_ui_surface` | `ecosystem` |
+|---|---|---|---|
+| `AndroidManifest.xml` under `app/` / `android/`, or `build.gradle*` with `com.android.application` | `android` | true | `gradle` |
+| `*.xcodeproj` / `*.xcworkspace`, `Package.swift` iOS/macOS target, or `Podfile` iOS pods | `ios` | true | `xcode` |
+| `package.json` with a frontend framework (`react`, `vue`, `svelte`, `next`, `vite`, `astro`) or root `index.html` | `web` | true | `node` |
+| `package.json` with `electron`, or Compose Desktop / Swift AppKit entrypoint | `desktop` | true | `node` / `gradle` / `xcode` |
+| `build.gradle*` with Spring / Ktor / Micronaut / Quarkus / `application` plugin (not Android) | `backend-jvm` | false | `gradle` |
+| `package.json` with a Node server (`express`, `fastify`, `koa`, `nest`) and no frontend framework | `backend-node` | false | `node` |
+| `Cargo.toml`, `pyproject.toml`, `go.mod` without web/GUI frameworks; or `bin/` entrypoints | `cli` | false | `rust` / `python` / `go` |
+| `.claude-plugin/` directory (or `.claude-plugin/plugin.json`), Gradle/Maven library packaging without application plugin | `library` | false | `gradle` / `node` |
+| None of the above matches unambiguously | `generic` | ask user | ask user |
+
+**Override policy.** When `write-spec` records `platform:` in the spec frontmatter or the user
+explicitly corrects a detection, that value takes precedence over the heuristic and is recorded
+as `project_type_override` in the consuming skill's receipt.
+
+**Scope.** Root-level glance plus the listed subdirectories is enough. Do not recurse. If the
+detection is ambiguous (`generic`), ask the user once — do not guess and do not fall back to a
+default like `library`.
+
 ### Scope decision
 
 - **In current changes** (`git diff $BASE...HEAD`) — fix autonomously

--- a/plugins/developer-workflow/docs/ORCHESTRATION.md
+++ b/plugins/developer-workflow/docs/ORCHESTRATION.md
@@ -131,16 +131,23 @@ consumed by `research`, `generate-test-plan`, `create-pr` as those skills evolve
 Cheap heuristic over the repository root plus a few well-known paths (e.g. `app/`, `android/`,
 `ios/`) — no external tools required, no exhaustive tree walk:
 
+Each row resolves to exactly one `ecosystem` value — downstream steps (e.g. acceptance build-smoke command selection) assume a single value. Split cases where the same `project_type` has multiple possible stacks into distinct rows.
+
 | Signal found at repo root or a well-known subdirectory | `project_type` | `has_ui_surface` | `ecosystem` |
 |---|---|---|---|
 | `AndroidManifest.xml` under `app/` / `android/`, or `build.gradle*` with `com.android.application` | `android` | true | `gradle` |
 | `*.xcodeproj` / `*.xcworkspace`, `Package.swift` iOS/macOS target, or `Podfile` iOS pods | `ios` | true | `xcode` |
 | `package.json` with a frontend framework (`react`, `vue`, `svelte`, `next`, `vite`, `astro`) or root `index.html` | `web` | true | `node` |
-| `package.json` with `electron`, or Compose Desktop / Swift AppKit entrypoint | `desktop` | true | `node` / `gradle` / `xcode` |
+| `package.json` with `electron` | `desktop` | true | `node` |
+| Compose Desktop entrypoint (Gradle with `org.jetbrains.compose` applied to a JVM target) | `desktop` | true | `gradle` |
+| Swift AppKit entrypoint (`NSApplication` main or `@main App` targeting macOS) | `desktop` | true | `xcode` |
 | `build.gradle*` with Spring / Ktor / Micronaut / Quarkus / `application` plugin (not Android) | `backend-jvm` | false | `gradle` |
 | `package.json` with a Node server (`express`, `fastify`, `koa`, `nest`) and no frontend framework | `backend-node` | false | `node` |
-| `Cargo.toml`, `pyproject.toml`, `go.mod` without web/GUI frameworks; or `bin/` entrypoints | `cli` | false | `rust` / `python` / `go` |
-| `.claude-plugin/` directory (or `.claude-plugin/plugin.json`), Gradle/Maven library packaging without application plugin | `library` | false | `gradle` / `node` |
+| `Cargo.toml` without web/GUI frameworks, or Rust `bin/` entrypoints | `cli` | false | `rust` |
+| `pyproject.toml` without web/GUI frameworks, or Python `bin/` entrypoints | `cli` | false | `python` |
+| `go.mod` without web/GUI frameworks, or Go `bin/` entrypoints | `cli` | false | `go` |
+| `.claude-plugin/` directory (or `.claude-plugin/plugin.json`) | `library` | false | `node` |
+| Gradle/Maven library packaging without application plugin | `library` | false | `gradle` |
 | None of the above matches unambiguously | `generic` | ask user | ask user |
 
 **Override policy.** When `write-spec` records `platform:` in the spec frontmatter or the user

--- a/plugins/developer-workflow/skills/acceptance/SKILL.md
+++ b/plugins/developer-workflow/skills/acceptance/SKILL.md
@@ -3,403 +3,413 @@ name: acceptance
 description: >
   Acceptance verification — confirm implementation meets spec (feature) or that a bug no longer
   reproduces (bug fix). Orchestrator: detects project type, verifies a source exists (spec AC,
-  test plan, or debug.md), fans out parallel checks to `manual-tester` (UI + scenario) and
-  `code-reviewer` (delta), then aggregates into a single receipt. No improvisation — without a
-  source, proposes `/write-spec`, `/generate-test-plan`, or `/debug`. Trigger on: "test this",
-  "verify against spec", "QA the implementation", "run the test plan", "validate acceptance
-  criteria", "verify the PR", "verify the fix", "confirm bug is gone", "acceptance", "приёмка",
-  "проверь", "протестируй", or when implementation is finished and wants verification before PR.
+  test plan, or debug.md), fans out parallel checks to `manual-tester` (UI + scenario),
+  `code-reviewer` (delta), plus `business-analyst` / `ux-expert` / `security-expert` /
+  `performance-expert` and a build smoke as triggered by spec frontmatter and project type,
+  then aggregates via PoLL rules. Without a source, proposes `/write-spec`,
+  `/generate-test-plan`, or `/debug`. Trigger on: "test this", "verify against spec",
+  "QA the implementation", "run the test plan", "validate acceptance criteria",
+  "verify the PR", "verify the fix", "confirm bug is gone", "acceptance", "приёмка",
+  "проверь", "протестируй".
 disable-model-invocation: true
 ---
 
 # Acceptance
 
-Verify that an implementation meets its acceptance contract. This skill is a **choreographer**:
-it detects the project type, confirms that a verification source exists, then fans out parallel
-checks to specialized agents and aggregates their verdicts into a single receipt.
+Choreographer skill. Detects project type, confirms a verification source exists, fans out
+parallel checks to specialized agents, aggregates verdicts into one receipt. Acceptance
+executes a pre-existing verification contract — it does not invent checks. When no contract
+is available, it halts and proposes the correct upstream skill.
 
-Acceptance is an **executor of a pre-existing verification contract**, not a generator of
-checks. The contract comes from upstream skills (`/write-spec`, `/generate-test-plan`,
-`/debug`). Without a contract, acceptance does not improvise — it stops and proposes the
-correct upstream skill.
+---
+
+## Vocabulary
+
+Canonical values used throughout this skill. Downstream consumers (feature-flow, bugfix-flow,
+create-pr) read these from the receipt.
+
+- **`project_type`** — one of: `android`, `ios`, `web`, `desktop`, `backend-jvm`,
+  `backend-node`, `cli`, `library`, `generic`. Source of truth: ORCHESTRATION.md §Project
+  type detection.
+- **`has_ui_surface`** — boolean derived from `project_type`. True for `android`, `ios`,
+  `web`, `desktop`. False otherwise (`generic` → ask user).
+- **`ecosystem`** — build stack: `gradle`, `node`, `rust`, `go`, `python`, `xcode`. Used for
+  build-smoke command selection only; orthogonal to `project_type`.
+- **Per-check verdict** — each sub-check reports `PASS | WARN | FAIL | SKIPPED`, plus
+  `severity` (`critical | major | minor`), `confidence` (`high | medium | low`), and
+  `domain_relevance` (`high | medium | low`) for aggregation.
+- **Bug severity** — `P0 | P1 | P2 | P3`. Unchanged from prior receipt schema, primary axis
+  for `feature-flow`/`bugfix-flow` routing.
+- **Aggregated Status** — `VERIFIED | FAILED | PARTIAL`. Derived; see §Aggregation.
 
 ---
 
 ## Step 0: Detect Project Type
 
-Determine what kind of project this is. The result drives which checks are even meaningful:
-UI projects get `manual-tester`; non-UI projects skip it and rely on static review plus build
-smoke.
+Follow the canonical heuristic in `plugins/developer-workflow/docs/ORCHESTRATION.md` §Project
+type detection. Output: `project_type`, `has_ui_surface`, `ecosystem`.
 
-Run a cheap heuristic over repository root files — no external tools required:
+**Override policy.** If the spec frontmatter `platform:` list is non-empty, **spec wins** —
+take the first platform value as `project_type` (or mark multi-platform when the list has
+more than one), and record `project_type_override: spec` in the receipt. If the user corrects
+detection mid-run, record `project_type_override: user`.
 
-| Signal found at repo root | Project type |
-|---|---|
-| `AndroidManifest.xml` anywhere under `app/`, `android/`, or `build.gradle*` with `com.android.application` plugin | `android` (UI) |
-| `*.xcodeproj` / `*.xcworkspace`, `Package.swift` with iOS/macOS target, or `Podfile` with iOS pods | `ios` (UI) |
-| `package.json` with a frontend framework (`react`, `vue`, `svelte`, `next`, `vite`, `astro`) or `index.html` in project root | `web` (UI) |
-| `package.json` with `electron`, or native desktop entrypoint (Compose Desktop, Swift AppKit main) | `desktop` (UI) |
-| `build.gradle*` with Spring / Ktor / Micronaut / Quarkus / `application` plugin without Android | `backend-jvm` (non-UI) |
-| `package.json` with pure Node server (`express`, `fastify`, `koa`, `nest`) and no frontend framework | `backend-node` (non-UI) |
-| `Cargo.toml`, `pyproject.toml`, `go.mod` without web/GUI frameworks; or `bin/` entrypoints | `cli` (non-UI) |
-| `*.claude-plugin`, Gradle/Maven library packaging without application plugin | `library` (non-UI) |
-| None of the above matches unambiguously | `generic` (ask user) |
-
-Set `project_type` and `has_ui_surface` (bool) for downstream steps. If the heuristic returns
-`generic`, ask the user once: "project type is ambiguous — is this a UI app, a backend/CLI/library,
-or something else?" then record the answer.
-
-**Do not read build files exhaustively** — a root-level glance is enough for iteration 1.
-If the user disagrees with the detection at any point, record the override and proceed.
+Step 0 file reads and Step 1 file reads are disjoint. You MAY issue both sets in one batched
+Read call set to avoid serial round-trips.
 
 ---
 
 ## Step 1: Gather Inputs
 
-At least one verification source is required. If none are available, Step 1.5 (Source-missing
-gate) halts execution and proposes the correct upstream skill — acceptance never improvises.
+Acceptance requires at least one verification source. If none is available, Step 1.5 halts.
 
 ### 1.1 Spec Source (optional if a test plan or debug.md is provided)
 
-The specification defines what "correct" looks like. Accept any combination of:
-- **Figma mockups** — URLs or exported frames
-- **PRD / requirements document** — file path, URL, or inline text
-- **Acceptance criteria** — bullet list, user stories, or a checklist
-- **PR description** — when verifying a PR, the description itself is a spec
-- **Issue / ticket** — GitHub issue, Linear ticket, or similar
+Accept any combination of: Figma mockups, PRD / requirements, acceptance criteria list, PR
+description, GitHub/Linear issue. Read all provided sources.
 
-Read all provided spec sources.
+**Read the spec frontmatter.** If present, load `platform`, `surfaces`, `risk_areas`,
+`non_functional`, `acceptance_criteria_ids`, `design.figma`. These drive the conditional
+triggers in Step 3. If the spec has no frontmatter (pre-iteration-2 specs, external specs,
+or plain-text issues) — every conditional defaults to "not triggered"; only the base checks
+run. This preserves backward compatibility.
 
-### 1.2 Test Plan — Source Priority
+### 1.2 Probe available artifacts (parallel)
 
-Select the test-plan source by walking the four branches below in order. The first branch
-whose condition holds is the one used; record which branch fired so the verification report
-can set `test_plan_source` accordingly.
+Before branching, read the following in a single batched Read call set. Each may error-as-absent
+— that is expected:
+
+- `swarm-report/<slug>-test-plan.md` (receipt)
+- `docs/testplans/<slug>-test-plan.md` (permanent)
+- `swarm-report/<slug>-debug.md` (bug-fix reproduction steps)
+
+Combined with inline inputs and spec sources, one of the branches below fires. Record the
+selected branch as `test_plan_source` in the receipt.
 
 #### Branch 1 — Receipt present (`test_plan_source: receipt`)
 
-**Condition:** `swarm-report/<slug>-test-plan.md` exists (produced by `generate-test-plan`
-when invoked from the orchestrator).
+**Condition:** `swarm-report/<slug>-test-plan.md` exists.
 
-**Actions:**
-1. Read the receipt's YAML frontmatter and load `permanent_path`.
-2. Read `review_verdict`:
-   - `PASS` — proceed.
-   - `WARN` — proceed; carry WARN findings forward into the verification report as context.
-   - `skipped` — proceed. The receipt was written as a mount (pre-orchestration permanent
-     file adopted without regeneration — see `feature-flow/SKILL.md` §1.5 Pre-check or
-     Branch 2 below). No review was performed; treat the plan as user-authored and
-     authoritative.
-   - `FAIL` — do not execute. Stop and escalate back to `feature-flow`: the plan must be
-     revised via `plan-review` before acceptance runs.
-   - `pending` — treat as not-yet-reviewed; escalate to `feature-flow` to run plan-review
-     first instead of proceeding blindly.
-3. Pass the **permanent file** (resolved via `permanent_path`, not the receipt itself) to
-   the `manual-tester` agent as the primary test-plan source.
-4. In the verification report set `test_plan_source: receipt`.
+Read the receipt's YAML frontmatter and load `permanent_path`. Interpret `review_verdict` per
+the canonical definition in `generate-test-plan/SKILL.md` §Receipt: treat `PASS` / `WARN` /
+`skipped` as proceed; `FAIL` and `pending` as blockers that escalate back to the orchestrator.
+Pass the **permanent file** to `manual-tester` as the primary test-plan source. If the
+receipt has a `platform:` field, use it as an additional input to Step 0's override policy.
 
 #### Branch 2 — Permanent file exists without receipt (`test_plan_source: mounted`)
 
 **Condition:** Branch 1 did not fire **and** `docs/testplans/<slug>-test-plan.md` exists on
-disk without a matching receipt in `swarm-report/`.
+disk without a matching receipt.
 
-**Ownership:** the `feature-flow` orchestrator normally emits the mount-receipt in its
-Phase 1.5 Pre-check. This branch runs only when `acceptance` is invoked outside of
-`feature-flow` (standalone QA session, `bugfix-flow`, user-triggered mid-flow), so the
-receipt has not been produced yet.
-
-**Actions:**
-
-1. Emit a mount-receipt at `swarm-report/<slug>-test-plan.md` following the canonical
-   format in `plugins/developer-workflow/skills/generate-test-plan/SKILL.md` §Receipt
-   with the mount overrides: `status: Mounted`, `review_verdict: skipped`,
-   `source_spec: existing (pre-orchestration)`, and `phase_coverage` derived from the
-   permanent file's phase labels when present (scan for `### Phase N ...` headings
-   under `## Test Cases`). Do **not** hardcode `phase_coverage: []`; use the empty
-   list only when the permanent file genuinely has no phase segmentation. When phase
-   coverage cannot be determined reliably from the permanent file (malformed headings,
-   mixed conventions), omit the `phase_coverage` field entirely rather than recording
-   an incorrect value.
-2. Pass the **permanent file** to the `manual-tester` agent as the primary test-plan source.
-3. In the verification report set `test_plan_source: mounted`.
+Acceptance owns the mount-receipt when invoked outside `feature-flow`. Emit a mount-receipt
+at `swarm-report/<slug>-test-plan.md` following the canonical format in
+`generate-test-plan/SKILL.md` §Receipt with mount overrides: `status: Mounted`,
+`review_verdict: skipped`, `source_spec: existing (pre-orchestration)`. Derive
+`phase_coverage` from the permanent file's phase headings; omit the field if coverage cannot
+be determined reliably. Pass the permanent file to `manual-tester`.
 
 #### Branch 3 — Inline test plan or spec available (`test_plan_source: on-the-fly`)
 
 **Condition:** Branches 1 and 2 did not fire **and** the invocation provides a test plan
 inline, a spec source, or both.
 
-The test plan defines what to check. Three modes:
+Three modes:
 
-**Test plan only (no spec)** — the test plan is the single source of truth. Execute it as-is.
-The verification result will be based entirely on whether the test cases pass or fail.
+- **Test plan only (no spec)** — execute as-is; verdict depends on TC pass/fail.
+- **Test plan + spec** — execute the plan, cross-reference against the spec, flag obvious gaps
+  to the user ("spec mentions X but the test plan doesn't cover it — add a TC?").
+- **Spec only (no test plan)** — generate a test plan from the spec: identify testable flows,
+  write TC-prefixed cases with tiers/steps/expected results, present for approval, adjust per
+  feedback.
 
-**Test plan + spec** — accept the plan as-is, but cross-reference it against the spec. If the
-plan has obvious gaps (spec mentions flows the plan doesn't cover), flag them: "The spec
-mentions X but the test plan doesn't cover it — should I add test cases for that?" Let the
-user decide.
+#### Branch 4 — Nothing available (`test_plan_source: absent`)
 
-**Spec only (no test plan)** — generate a test plan from the spec:
-1. Read the spec source thoroughly
-2. Identify all testable flows: happy paths, edge cases, error states, empty states
-3. Write test cases in the manual-tester format (TC-prefixed, with tiers, steps, expected results)
-4. Present the generated plan to the user for approval before executing
-5. Adjust based on their feedback
+**Condition:** no receipt, no permanent file, no inline test plan, no spec source, no
+`swarm-report/<slug>-debug.md` (bug-fix path).
 
-In the verification report set `test_plan_source: on-the-fly`.
-
-#### Branch 4 — Nothing available → Source-missing gate
-
-**Condition:** no receipt, no permanent file, no inline test plan, no spec source, and no
-`swarm-report/<slug>-debug.md` for bug-fix flows.
-
-**Behavior:** proceed to Step 1.5 — do not attempt to run checks without a contract.
+Proceed to Step 1.5. Do not run any checks.
 
 ---
 
 ## Step 1.5: Source-Missing Gate
 
-Acceptance does not improvise checks. When no verification source is available, halt and
-propose the correct upstream skill.
-
-### Decision table
+### Proposal table
 
 | Situation | Proposal |
 |---|---|
-| No spec, no test plan, implement receipt exists (feature path) | "Verification source is missing. Run `/write-spec` (if you need a requirements document) or `/generate-test-plan` (if only a test plan is needed), then re-run acceptance." |
-| Spec present but has no acceptance criteria and no test plan; UI project | "Spec exists but lacks acceptance criteria. Run `/generate-test-plan` to produce executable test cases, or add acceptance criteria to the spec, then re-run acceptance." |
-| Bugfix path: no `swarm-report/<slug>-debug.md` | "Bug-fix acceptance requires reproduction steps. Run `/debug` first to capture the reproduction scenario, then re-run acceptance." |
-| Only `design.figma` in spec, no test plan, UI project | "Only a design source is available. A design-review check is possible in a later iteration; for functional acceptance run `/generate-test-plan` first." |
+| No spec, no test plan, implement receipt exists (feature) | Run `/write-spec` (requirements doc) or `/generate-test-plan` (tests only), then re-run acceptance. |
+| Spec exists without acceptance criteria, no test plan, UI project | Run `/generate-test-plan` to produce executable TCs, or add acceptance criteria to the spec. |
+| Bugfix path with no `swarm-report/<slug>-debug.md` | Run `/debug` to capture reproduction steps, then re-run acceptance. |
+| Only `design.figma` in spec, no test plan, UI project | Design-only review possible via ux-expert; for functional acceptance also run `/generate-test-plan`. |
 
-### Options presented to the user
+### Options
 
-1. **Create the missing source** (primary) — invoke the proposed upstream skill, then re-run
-   acceptance.
-2. **Abort acceptance** — exit without a receipt; the user addresses the gap and re-invokes
-   when ready.
+1. **Create the missing source** — invoke the proposed upstream skill, then re-run acceptance.
+2. **Abort acceptance** — exit without a receipt; user re-invokes when ready.
 
-**Do not offer a third option.** Exploratory QA without a scenario is the `bug-hunt` skill's
-responsibility — a sibling, not a fallback inside acceptance. Mixing verification and
-exploration erodes the contract boundary between the two skills.
+Exploratory QA without a scenario is the `bug-hunt` skill's responsibility. Do not offer it as
+a fallback inside acceptance.
 
-When invoked from `feature-flow` or `bugfix-flow`, this gate should rarely fire — upstream
-skills in those orchestrators guarantee a source. The gate exists primarily for standalone
-invocation.
+From `feature-flow` / `bugfix-flow` this gate rarely fires — upstream skills guarantee a
+source. Standalone invocations are the main user.
 
 ---
 
-## Step 2: Ensure the App is Running
-
-**Only relevant if `has_ui_surface == true`.** For non-UI projects skip directly to Step 3.
-
-Before launching QA, verify the app is accessible. The approach depends on what's being tested:
-
-### Mobile / Desktop App
-
-1. Check if a device/simulator/emulator is already connected — call `list_devices` via the mobile MCP
-2. If a device is available and the app is installed, try launching it
-3. If no device is available or the app isn't installed:
-   - Look for a run configuration in the project (Gradle `installDebug`, Xcode build, etc.)
-   - Build and install: pick the appropriate command for the project
-   - If the build system isn't obvious, ask the user how to build and deploy
-
-### Web App
-
-1. Check if a dev server is already running (look for running processes on common ports, or check if the URL responds)
-2. If not running, look for a start command in the project (`npm start`, `npm run dev`, `./gradlew bootRun`, etc.)
-3. Start the dev server and wait for it to be ready
-4. If the start command isn't obvious, ask the user
-
-### Already Running
-
-If the user says the app is already running or provides a URL / device target, skip the launch
-step and proceed directly.
-
----
-
-## Step 2.5: Persist E2E Scenario
+## Step 2: Persist E2E Scenario
 
 **Only relevant if `has_ui_surface == true` and a scenario source exists** (test plan, spec
-with AC, or debug.md). This file is the persistent state of manual QA — it survives context
-compaction.
+with AC, or debug.md). Re-anchoring against this file is enforced by `manual-tester` —
+acceptance writes it once here; re-reads during aggregation only.
+
+The running-app environment (device, simulator, emulator, browser) is **owned by
+`manual-tester` itself** — see its Step 0 Environment Setup. This skill does not probe
+devices, run `gradlew installDebug`, or start dev servers; it delegates that responsibility
+wholesale to the agent.
 
 Save to `swarm-report/<slug>-e2e-scenario.md`:
 
 ```markdown
 # E2E Scenario: <task name>
 Type: Feature / Bug fix
-Project type: <android | ios | web | desktop>
+Project type: <project_type>
 Spec source: <what was used>
 
 ## Steps
 - [ ] 1. <concrete user action> → Expected: <result>
 - [ ] 2. <concrete user action> → Expected: <result>
-- [ ] 3. <concrete user action> → Expected: <result>
-...
 ```
 
-For bug fixes, the steps come from `debug.md` reproduction steps — inverted:
-- Original: "Step X triggers the bug"
-- E2E: "Step X no longer triggers the bug"
+For bug fixes, steps come from `debug.md` reproduction steps inverted:
+- Original: "Step X triggers the bug" → E2E: "Step X no longer triggers the bug".
 
-**Compaction resilience rules:**
-- Before EVERY verification action — re-read this file via Read tool
-- After each step passes — update the file, mark as `[x]`:
-  ```
-  - [x] 1. Open screen X → Expected: shows data ✅
-  - [ ] 2. Tap button Y → Expected: navigates to Z
-  ```
-- Completed steps (`[x]`) — do NOT re-check
-- Resume from the first incomplete step (`[ ]`)
-- This guarantees no wasted work after compaction
+Compaction-resilience (enforced by `manual-tester`, not by this skill): checkbox marks survive
+compaction; completed steps (`[x]`) are not repeated; resume from the first incomplete step.
+
+---
+
+## Step 2.5: Dedup Probe
+
+Read `swarm-report/<slug>-quality.md` (produced by `implement`'s Quality Loop). If its
+`Status:` is `PASS`, `code-reviewer` is skipped in Step 3. Field name matches `implement`'s
+receipt schema — this skill does **not** rely on any `diff_hash` or similar field, and will
+not skip on that basis alone.
+
+When `code-reviewer` is skipped, write a stub artifact at
+`swarm-report/<slug>-acceptance-code.md` with the per-check schema, `verdict: SKIPPED`, and a
+one-line body. This preserves the one-file-per-check invariant the aggregation in Step 4
+depends on.
+
+If `<slug>-quality.md` does not exist or `Status:` is `FAIL`, run `code-reviewer` normally.
+
+This probe is synchronous — it decides the Step 3 fan-out composition and emits the stub
+before fan-out.
 
 ---
 
 ## Step 3: Run Checks (parallel fan-out)
 
-Based on `project_type` and `has_ui_surface`, pick the check plan and spawn agents in parallel
-via the `Agent` tool. **All agent calls must go out in a single message** to maximize
-parallelism.
+Pick the check plan by `has_ui_surface` plus conditional triggers read from spec frontmatter.
+Emit **one** message containing all tool calls simultaneously (Agent calls + Bash smoke). Do
+not wait for any to return before dispatching the others.
 
-### Check-plan branches (iteration 1 — hardcoded)
+### Base check plan
 
-| Inputs | Checks to run |
+| `has_ui_surface` | Base fan-out |
 |---|---|
-| `has_ui_surface == true` AND scenario source present | `manual-tester` (scenario-driven) + `code-reviewer` (delta) |
-| `has_ui_surface == false` | `code-reviewer` (delta) + build smoke (Bash) |
-| `has_ui_surface == true` AND no scenario source | impossible — Step 1.5 would have halted execution |
+| `true` | `manual-tester` + `code-reviewer` (unless skipped by Step 2.5) |
+| `false` | `code-reviewer` (unless skipped by Step 2.5) + build smoke (Bash) |
 
-Future iterations will add conditional checks (`security-expert`, `ux-expert` design review,
-`business-analyst` AC coverage, `performance-expert`, `build-engineer`). Iteration 1 is
-intentionally minimal: the primary goal is to stop producing false PASS for non-UI projects.
+### Conditional triggers (iteration 2)
 
-### 3.1 Spawn `manual-tester` (UI branch only)
+Add to the fan-out only when the trigger fires. Each trigger maps to a specialist agent with a
+narrow prompt. When no trigger fires for an agent, the agent is not spawned.
 
-The agent prompt must include:
+| Trigger (in spec frontmatter) | Agent | Role |
+|---|---|---|
+| `acceptance_criteria_ids` is a non-empty list | `business-analyst` | AC coverage — every `AC-N` has evidence in the diff, TC list, or manual-tester report |
+| `design.figma` is set, `has_ui_surface == true` | `ux-expert` | Design-review mode — verify UI matches the referenced mockup + project design system |
+| `risk_areas` includes any of `auth`, `payment`, `pii`, `data-migration` | `security-expert` | Security review against diff and any persisted state changes |
+| `non_functional.sla` set, **or** `risk_areas` includes `perf-critical` | `performance-expert` | Bench/regress check against the declared SLA |
+| `non_functional.a11y` set, `has_ui_surface == true` | `ux-expert` in a11y focus | Accessibility audit against the declared WCAG level |
 
-1. **Spec context** — the full spec content or clear pointers to where the spec lives (URLs, file paths)
-2. **Test plan** — the complete set of test cases to execute
-3. **Target** — how to reach the app (device name, URL, etc.)
-4. **Scope** — which test tiers to run (default: Smoke + Feature)
-5. **Output path** — "Write your Test Execution Summary to
-   `swarm-report/<slug>-acceptance-manual.md` when done."
+When both design-review and a11y triggers fire, combine into one `ux-expert` invocation with
+mode `both`. When no trigger fires, acceptance runs the base plan only — preserving
+backward compatibility with specs written before iteration 2.
 
-Example agent prompt structure:
+**Future iterations** will add `architecture-expert` (API contract), `build-engineer` (when
+build files changed), `devops-expert` (when CI config changed).
 
-```
-You are testing a feature against its specification.
+### Per-check artifact schema (shared by all sub-checks)
 
-## Spec
-[Paste or reference the spec source here]
+Each sub-check writes `swarm-report/<slug>-acceptance-<check>.md` with this frontmatter:
 
-## Test Plan
-[Paste the test cases here]
-
-## Target
-[Device/URL/connection details]
-
-## Scope
-Run Smoke + Feature tiers. Report all bugs with severity and evidence.
-
-## Output
-Save your Test Execution Summary to swarm-report/<slug>-acceptance-manual.md with frontmatter:
+```yaml
 ---
 type: acceptance-check
-check: manual
-agent: manual-tester
-verdict: PASS | WARN | FAIL
+check: manual | code | build | ac-coverage | design | security | performance | a11y
+agent: <agent-name or "bash">
+verdict: PASS | WARN | FAIL | SKIPPED
+severity: critical | major | minor | null
+confidence: high | medium | low | null
+domain_relevance: high | medium | low | null
+blocked_on: <optional — what the user must resolve>
 ---
-Then produce a ship/no-ship recommendation inline.
 ```
 
-Do not interfere with the agent's process unless it asks a question or reports a P0 blocker.
+`severity`, `confidence`, `domain_relevance` are required when `verdict` is `WARN` or `FAIL`;
+null for `PASS` / `SKIPPED`. These drive the PoLL aggregation in Step 4.
 
-### 3.2 Spawn `code-reviewer` (always — delta review)
+### 3.1 Spawn `manual-tester` (UI branch)
 
-Check first whether a quality-loop review already passed on the current diff by reading
-`swarm-report/<slug>-quality.md` (produced by the `implement` skill's quality loop). If the
-receipt's verdict is PASS **and** the recorded diff matches the current diff, skip this check
-and record `verdict: SKIPPED (quality-loop already passed)` in the receipt section for the
-`code-reviewer` line.
+`manual-tester` owns the runtime environment end-to-end per its Step 0 Environment Setup.
+Acceptance does not pre-launch — that is intentional delegation.
 
-Otherwise, spawn `code-reviewer` via the `Agent` tool with:
+Prompt contents:
+1. **Spec context** — full text or clear pointers.
+2. **Test plan** — the complete set of test cases.
+3. **Target hints** (optional) — device/URL if the user already named one.
+4. **Scope** — which tiers (default: Smoke + Feature).
+5. **Output path** — `swarm-report/<slug>-acceptance-manual.md` with the per-check schema.
 
-1. **Task description** — one sentence from the spec / PR title
-2. **Plan pointer** — path to the implement receipt or research report if present
-3. **Git diff** — the current diff under review (`git diff <base-branch>...HEAD` or the
-   staged/unstaged changes on the working branch)
-4. **Output path** — "Save your review to `swarm-report/<slug>-acceptance-code.md`."
+If the agent returns `WARN` with `blocked_on`, surface that text to the user as the primary
+next-step requirement before re-running acceptance.
 
-Example prompt:
+### 3.2 Spawn `code-reviewer` (delta review, skipped if Step 2.5 matched)
 
-```
-Independent code review of the current changes.
+Prompt contents:
+1. **Task description** — one sentence from spec or PR title.
+2. **Plan pointer** — path to implement receipt or research report if present.
+3. **Git diff** — current diff.
+4. **Output path** — `swarm-report/<slug>-acceptance-code.md`.
 
-## Task
-[One-line task description]
+Verdict rules: `PASS` if no semantic bugs, logic errors, or security issues; `WARN` for
+style/minor; `FAIL` for blockers.
 
-## Plan / Spec
-[Path or content]
+### 3.3 Build smoke (non-UI branch)
 
-## Diff
-[Full git diff]
+Pick the command by `ecosystem` (see ORCHESTRATION.md §Build system detection):
 
-## Output
-Save your findings to swarm-report/<slug>-acceptance-code.md with frontmatter:
----
-type: acceptance-check
-check: code
-agent: code-reviewer
-verdict: PASS | WARN | FAIL
----
-Then list issues with severity (critical/major/minor). PASS if no semantic bugs, logic errors,
-or security issues; WARN for style/minor; FAIL for blockers.
-```
-
-### 3.3 Build smoke (non-UI branch only)
-
-For non-UI projects run a build smoke via Bash. Pick the command by `project_type`:
-
-| Project type | Smoke command |
+| `ecosystem` | Command |
 |---|---|
-| `backend-jvm` / `library` (Gradle) | `./gradlew build -x test --no-daemon --quiet` — adjust project path if multi-module |
-| `backend-node` / `cli` (Node) | `npm run build` (or `pnpm build` / `yarn build`) |
-| `cli` (Rust) | `cargo build --release --quiet` |
-| `cli` (Go) | `go build ./...` |
-| `cli` (Python) | `python -m compileall .` or package-specific build |
+| `gradle` | `./gradlew build -x test --quiet` (single-module) or `./gradlew :check` (multi-module) |
+| `node` | `npm run build` (or `pnpm build` / `yarn build`) |
+| `rust` | `cargo build --release --quiet` |
+| `go` | `go build ./...` |
+| `python` | `python -m compileall .` or package-specific build |
 
-If the command succeeds, treat it as `PASS`. If it fails, capture the last ~50 lines of output
-and treat the check as `FAIL`. Record the result in `swarm-report/<slug>-acceptance-build.md`
-with the same frontmatter shape as the agent checks.
+Multi-module detection: scan `settings.gradle*` for `include(` statements. If subprojects are
+declared and the user did not specify a target module, ask which module is the smoke target
+**before** entering Step 3 (do not block the fan-out message with a question).
 
-If the project type is `generic` or the build command isn't obvious, ask the user once for the
-smoke command, then run it.
+If the `ecosystem` or command is not resolvable, skip with `verdict: SKIPPED` and
+`blocked_on: build command unknown`. On success write `verdict: PASS`; on failure capture the
+last ~50 lines and write `verdict: FAIL`. Receipt at
+`swarm-report/<slug>-acceptance-build.md`.
+
+### 3.4 Spawn `business-analyst` (conditional — AC coverage)
+
+Fires when `acceptance_criteria_ids` in spec frontmatter is a non-empty list.
+
+Prompt contents:
+1. **Spec** — the spec file path.
+2. **Diff / implement receipt** — evidence for each AC.
+3. **Test plan** (if any) — TC list mapped to AC by `AC-ref:` fields.
+4. **manual-tester output** (if running) — pointer to
+   `swarm-report/<slug>-acceptance-manual.md`.
+5. **Output path** — `swarm-report/<slug>-acceptance-ac-coverage.md`.
+
+Verdict rules: `PASS` if every `AC-N` has at least one evidence pointer; `WARN` for weak
+coverage (single witness on high-risk AC); `FAIL` for any missing AC. Severity: `FAIL` on
+missing AC is `critical`; weak coverage is `major`.
+
+### 3.5 Spawn `ux-expert` (conditional — design-review or a11y)
+
+Fires when `design.figma` is set (design-review mode) **or** `non_functional.a11y` is set
+(a11y mode). Either mode runs in one agent invocation; combine prompts if both triggers fire.
+
+Prompt contents:
+1. **Mode** — `design-review` / `a11y` / `both`.
+2. **Spec** — file path.
+3. **Design source** — `design.figma` URL (design-review mode).
+4. **a11y target** — value of `non_functional.a11y` (e.g. `wcag-aa`).
+5. **Running app pointer** (if `has_ui_surface`) — target hints; the agent reads running-app
+   state via MCP only when the environment is already prepared, otherwise works from
+   screenshots/code.
+6. **Output path** — `swarm-report/<slug>-acceptance-ux.md`.
+
+Verdict rules: `PASS` if design matches reference and a11y criteria met; `WARN` for minor
+spacing/color deviations or AA soft failures; `FAIL` for missing components, broken
+interaction paths, or hard a11y violations (keyboard trap, contrast below threshold).
+
+### 3.6 Spawn `security-expert` (conditional)
+
+Fires when `risk_areas` intersects `{auth, payment, pii, data-migration}`.
+
+Prompt contents:
+1. **Risk list** — the intersection subset.
+2. **Diff** — full git diff.
+3. **Spec** — file path.
+4. **Output path** — `swarm-report/<slug>-acceptance-security.md`.
+
+Verdict rules: `PASS` if no applicable OWASP / project-security-rule violations; `WARN` for
+minor hardening opportunities; `FAIL` for exploitable issues, secret leaks, or regulation
+breaches.
+
+### 3.7 Spawn `performance-expert` (conditional)
+
+Fires when `non_functional.sla` is set **or** `risk_areas` contains `perf-critical`.
+
+Prompt contents:
+1. **SLA target** — from `non_functional.sla`, or implicit `perf-critical` baseline.
+2. **Diff** — full git diff.
+3. **Output path** — `swarm-report/<slug>-acceptance-performance.md`.
+
+Verdict rules: `PASS` if no regression; `WARN` for borderline; `FAIL` for violations.
 
 ---
 
 ## Step 4: Aggregate and Write Receipt
 
-When all parallel checks complete, read each `swarm-report/<slug>-acceptance-<check>.md` file
-and aggregate into a single receipt.
+Read frontmatter of each `swarm-report/<slug>-acceptance-<check>.md` first (verdict +
+severity + confidence + domain_relevance + blocked_on). Read the body only if
+`verdict != PASS`. Do not inline artifact bodies — link them.
 
-### Aggregation rules (iteration 1 — simple)
+**Missing per-check artifact.** Step 2.5 writes a stub for skipped `code-reviewer`; Step 3.3
+writes an artifact even on build-smoke failure. If a planned per-check artifact is
+nonetheless missing at aggregation time, treat the check as `verdict: FAIL` with
+`error: per-check artifact missing` — do not silently drop it.
 
-| Inputs | Final Status |
+### Aggregation — PoLL rules
+
+Acceptance uses the same aggregation protocol as `plan-review` (see `plan-review/SKILL.md`
+§"Aggregation Rules"). Input shape is per-check (not per-reviewer), reduction logic identical:
+
+| Signal | Action |
 |---|---|
-| Every check reports `PASS` (or `SKIPPED` for quality-loop dedup) | `VERIFIED` |
-| Any check reports `FAIL` | `FAILED` |
-| At least one `WARN`, no `FAIL` | `PARTIAL` |
+| **`critical` severity** from any sub-check with `confidence: high` | → Blocker. Aggregated Status = `FAILED`. |
+| **Same issue** (same file:line or same AC id) raised by 2+ sub-checks independently | → Escalate to `critical` regardless of individual severity. Multiple specialists seeing the same problem = real problem. |
+| **`major` severity** from a sub-check with `domain_relevance: high` | → Important. Aggregated Status = `PARTIAL` if not already escalated. |
+| **Contradicting verdicts** (one `PASS`, another `FAIL` on the same item) | → "Uncertainty — requires decision". Aggregated Status = `PARTIAL`, contradiction listed in the receipt. |
+| **`minor` severity** or **`low` confidence** from a single check | → Note, not blocker. Does not affect aggregated Status. |
+| **`low` domain_relevance** check flagging an issue | → Note, weight lower. |
 
-Future iterations will replace this with the full PoLL aggregation rules from `plan-review`
-(critical-from-any-agent, 2+ agents on same issue, contradicting opinions). Iteration 1 keeps
-it minimal.
+**Bug severities (P0–P3) remain the primary routing axis** for
+`feature-flow`/`bugfix-flow`. Any P0/P1 bug reported by any sub-check maps directly to
+`FAILED` regardless of the PoLL above; PoLL layers additional rules on top for cases not
+covered by bug severity alone (e.g. AC coverage FAIL without an associated P0 bug).
 
-### Verification Report
+### Aggregated Status — final table
 
-Save the report to `swarm-report/<slug>-acceptance.md` — this artifact is the receipt for
-the PR stage. `create-pr` references it for the PR description.
+| Input | Aggregated Status |
+|---|---|
+| All checks `PASS` or `SKIPPED`, no P0–P3 bugs, no PoLL blocker | `VERIFIED` |
+| Any P0 / P1 bug **or** PoLL blocker (critical high-confidence, or 2+-agent escalation) | `FAILED` |
+| P2 / P3 bugs only, **or** PoLL important, **or** contradicting verdicts, **or** any `WARN` not otherwise classified | `PARTIAL` |
+| `manual-tester` returned `WARN` with `blocked_on` | `PARTIAL` with `blocked_on` surfaced in Summary |
 
-The schema is **additive**: all fields from prior versions remain; new fields (`Project type`,
-`Check plan`, `Check results`) are appended as new sections.
+### Receipt format
+
+Save to `swarm-report/<slug>-acceptance.md`. Legacy fields preserved; new sections appended.
 
 ```markdown
 # Acceptance: <slug>
@@ -407,33 +417,45 @@ The schema is **additive**: all fields from prior versions remain; new fields (`
 **Status:** VERIFIED / FAILED / PARTIAL
 **Date:** <date>
 **Type:** Feature / Bug fix
-**Project type:** <android | ios | web | desktop | backend-jvm | backend-node | cli | library | generic>
-**Spec source:** [what was used — requirements, debug.md reproduction steps, etc.]
-**Test plan:** [resolved permanent path if sourced via receipt or mounted receipt | generated on-the-fly from spec | none]
+**Project type:** <project_type>
+**Project type override:** <spec | user | none>
+**Ecosystem:** <ecosystem>
+**Spec source:** [what was used]
+**Test plan:** [resolved permanent path / generated on-the-fly / none]
 **test_plan_source:** receipt | mounted | on-the-fly | absent
-**Context artifacts:** [paths to research.md, debug.md, implement.md used as input]
+**Context artifacts:** [paths to research.md, debug.md, implement.md, quality.md used as input]
 
 ## Check Plan
-- List of checks that ran, one per line (e.g., `manual-tester`, `code-reviewer`, `build smoke`)
-- Include `SKIPPED` checks with the reason (e.g., `code-reviewer: SKIPPED — quality-loop passed`)
+- list of checks that ran, one per line, with their trigger
+- e.g. `business-analyst` (AC coverage) — triggered by spec.acceptance_criteria_ids
+- e.g. `ux-expert` — not triggered (no design.figma)
 
 ## Check Results
 
-| Check | Agent / Tool | Verdict | Artifact |
-|---|---|---|---|
-| Manual QA | manual-tester | PASS / WARN / FAIL | swarm-report/<slug>-acceptance-manual.md |
-| Code review | code-reviewer | PASS / WARN / FAIL / SKIPPED | swarm-report/<slug>-acceptance-code.md |
-| Build smoke | bash | PASS / FAIL | swarm-report/<slug>-acceptance-build.md |
+| Check | Agent / Tool | Verdict | Severity | Confidence | Artifact |
+|---|---|---|---|---|---|
+| Manual QA | manual-tester | … | … | … | swarm-report/<slug>-acceptance-manual.md |
+| Code review | code-reviewer | … | … | … | swarm-report/<slug>-acceptance-code.md |
+| AC coverage | business-analyst | … | … | … | swarm-report/<slug>-acceptance-ac-coverage.md |
+| Design / a11y | ux-expert | … | … | … | swarm-report/<slug>-acceptance-ux.md |
+| Security | security-expert | … | … | … | swarm-report/<slug>-acceptance-security.md |
+| Performance | performance-expert | … | … | … | swarm-report/<slug>-acceptance-performance.md |
+| Build smoke | bash | … | … | … | swarm-report/<slug>-acceptance-build.md |
+
+## Convergence signals
+Issues raised by 2+ sub-checks independently. Strongest signal of real problems.
+List one line each with the file:line or AC id and the list of checks that flagged it.
 
 ## Summary
-[1-3 sentences on the overall state]
+[1–3 sentences. If PARTIAL with blocked_on — state the blocker first. If any convergence
+signal — mention it in the first sentence.]
 
 ## Test Results
 - Total: [n] | Passed: [n] | Failed: [n] | Blocked: [n]
 
 ## Bugs Found
-[List bugs by severity — P0 first, then P1, P2, P3]
-[Each with a one-line summary and link to full bug report]
+[List by severity — P0 first, then P1, P2, P3. Link each to the per-check artifact that
+reported it.]
 
 ## Bug Reproduction Check (bug fix only)
 - Reproduction steps from debug.md: [executed / not applicable]
@@ -443,30 +465,34 @@ The schema is **additive**: all fields from prior versions remain; new fields (`
 [Ship / Do not ship / Ship with known issues — and why]
 ```
 
-### What Happens Next
+### Routing (consumed by orchestrators)
 
-Based on the verification state, the orchestrator decides the next transition:
-
-- **VERIFIED** → proceed to `create-pr` (or mark existing PR as ready for review)
-- **FAILED** → back to `implement` with the bug list from `<slug>-acceptance.md` as input.
-  After fix, re-run `acceptance`. Max 3 round-trips before escalating to the user.
-- **PARTIAL** (WARN-level findings only) → orchestrator asks the user: fix now (back to
-  `implement`) or ship with known issues (proceed to `create-pr`, include issues in PR
-  description).
+- **VERIFIED** → `create-pr` (or mark existing PR ready for review).
+- **FAILED** with P0/P1 and obvious cause → `implement` with the bug list as input. Max 3
+  round-trips.
+- **FAILED** with P0/P1 and unclear cause → `debug` first, then `implement`.
+- **FAILED** with P0/P1 requiring regression coverage → `test-plan` append `## Regression TC`,
+  then `implement`.
+- **PARTIAL** with P2/P3 only or WARN — orchestrator asks the user: fix now or ship with
+  known issues (continue to `create-pr`, include in PR description).
+- **PARTIAL** with `blocked_on` — surface the blocker; do not continue until resolved.
 
 ---
 
 ## Re-verification Loop
 
-When the user fixes bugs and wants to re-test:
+On fix-loop re-entry:
 
-1. Re-use the same test plan and project-type detection (unless the user changed repo
-   structure)
-2. Tell `manual-tester` to focus on previously failed test cases + a smoke pass
-3. Re-run `code-reviewer` against the updated diff
-4. Re-run build smoke if it was the failure signal
-5. Aggregate into a fresh `<slug>-acceptance.md`, overwriting the previous one
-6. Repeat until VERIFIED or the user decides to ship as-is
+1. Re-probe Step 0 and Step 1 (project type rarely changes; inputs may).
+2. Re-run checks with this policy:
+   - **Failed checks** — re-run in full.
+   - **Passed checks** — re-run only if the current diff touches files the check inspected
+     (`code-reviewer`, `security-expert`, `performance-expert`), or build inputs changed
+     (`build smoke`), or the spec changed (`business-analyst`, `ux-expert`).
+     `manual-tester` re-runs previously-failed TCs plus a Smoke tier by default.
+   - Record `re-used previous verdict` in the new per-check receipt for skipped re-runs.
+3. Aggregate into a fresh `swarm-report/<slug>-acceptance.md`, overwriting the previous one.
+4. Repeat until VERIFIED or the user decides to ship as-is.
 
-Future iterations will add `diff_hash`-based idempotency to skip checks whose inputs did not
-change between runs; for iteration 1 every cycle re-runs all relevant checks.
+Full `diff_hash`-based idempotency will be added in a later iteration; the policy above is
+the cheap interim.

--- a/plugins/developer-workflow/skills/acceptance/SKILL.md
+++ b/plugins/developer-workflow/skills/acceptance/SKILL.md
@@ -50,9 +50,10 @@ Follow the canonical heuristic in `plugins/developer-workflow/docs/ORCHESTRATION
 type detection. Output: `project_type`, `has_ui_surface`, `ecosystem`.
 
 **Override policy.** If the spec frontmatter `platform:` list is non-empty, **spec wins** —
-take the first platform value as `project_type` (or mark multi-platform when the list has
-more than one), and record `project_type_override: spec` in the receipt. If the user corrects
-detection mid-run, record `project_type_override: user`.
+take the first platform value as the canonical `project_type`. If the list has more than one
+entry, record the full list separately as `platforms: [...]` in the receipt; do not invent a
+`multi-platform` `project_type`. Record `project_type_override: spec` in the receipt. If the
+user corrects detection mid-run, record `project_type_override: user`.
 
 Step 0 file reads and Step 1 file reads are disjoint. You MAY issue both sets in one batched
 Read call set to avoid serial round-trips.
@@ -70,9 +71,18 @@ description, GitHub/Linear issue. Read all provided sources.
 
 **Read the spec frontmatter.** If present, load `platform`, `surfaces`, `risk_areas`,
 `non_functional`, `acceptance_criteria_ids`, `design.figma`. These drive the conditional
-triggers in Step 3. If the spec has no frontmatter (pre-iteration-2 specs, external specs,
-or plain-text issues) — every conditional defaults to "not triggered"; only the base checks
-run. This preserves backward compatibility.
+triggers in Step 3 plus two invariant guards on the base plan:
+
+- `ui ∈ surfaces` forces `manual-tester` into the fan-out when a scenario source exists,
+  even if Step 0 detected a non-UI project (hybrid products with both UI and non-UI
+  surfaces).
+- `surfaces` set and does not contain `ui` on a UI-detected project means the spec
+  explicitly excludes UI — skip `manual-tester` even if `has_ui_surface` is true, and note
+  this in the Check Plan section of the receipt.
+
+If the spec has no frontmatter (pre-iteration-2 specs, external specs, or plain-text issues)
+— every conditional defaults to "not triggered" and `surfaces` is treated as unspecified;
+only the base checks keyed off `has_ui_surface` run. This preserves backward compatibility.
 
 ### 1.2 Probe available artifacts (parallel)
 
@@ -189,17 +199,22 @@ compaction; completed steps (`[x]`) are not repeated; resume from the first inco
 
 ## Step 2.5: Dedup Probe
 
-Read `swarm-report/<slug>-quality.md` (produced by `implement`'s Quality Loop). If its
-`Status:` is `PASS`, `code-reviewer` is skipped in Step 3. Field name matches `implement`'s
-receipt schema — this skill does **not** rely on any `diff_hash` or similar field, and will
-not skip on that basis alone.
+Read `swarm-report/<slug>-quality.md` (produced by `implement`'s Quality Loop). Three cases:
 
-When `code-reviewer` is skipped, write a stub artifact at
-`swarm-report/<slug>-acceptance-code.md` with the per-check schema, `verdict: SKIPPED`, and a
-one-line body. This preserves the one-file-per-check invariant the aggregation in Step 4
-depends on.
+- **`Status: PASS`, receipt is from the current branch head** — `code-reviewer` is skipped.
+  Freshness is inferred from the receipt's `Date:` field vs the branch commit window; if it
+  cannot be confirmed (e.g. receipt significantly older than the latest commit), do **not**
+  skip — run `code-reviewer` normally. On skip, write a stub artifact at
+  `swarm-report/<slug>-acceptance-code.md` with `verdict: SKIPPED`, `blocked_on: null`, and a
+  one-line body referencing `<slug>-quality.md`.
+- **`Status: FAIL`** — Quality Loop failed upstream; do not silently proceed. Run
+  `code-reviewer` anyway, and surface `blocked_on: quality-loop failed — see <slug>-quality.md`
+  in the Step 4 Summary. The aggregated Status is forced to `PARTIAL` at minimum (or
+  `FAILED` if `code-reviewer` itself returns `FAIL`).
+- **Receipt missing** — run `code-reviewer` normally. No skip.
 
-If `<slug>-quality.md` does not exist or `Status:` is `FAIL`, run `code-reviewer` normally.
+Field name matches `implement`'s receipt schema — this skill does **not** rely on any
+`diff_hash` or similar field; full diff-based idempotency is deferred.
 
 This probe is synchronous — it decides the Step 3 fan-out composition and emits the stub
 before fan-out.
@@ -246,15 +261,20 @@ Each sub-check writes `swarm-report/<slug>-acceptance-<check>.md` with this fron
 ```yaml
 ---
 type: acceptance-check
-check: manual | code | build | ac-coverage | design | security | performance | a11y
+check: manual | code | build | ac-coverage | design | a11y | security | performance
 agent: <agent-name or "bash">
 verdict: PASS | WARN | FAIL | SKIPPED
 severity: critical | major | minor | null
 confidence: high | medium | low | null
 domain_relevance: high | medium | low | null
-blocked_on: <optional — what the user must resolve>
+blocked_on: <optional — what the user must resolve; also used when a planned per-check artifact is missing>
 ---
 ```
+
+File naming is **one file per `check` value**: `swarm-report/<slug>-acceptance-<check>.md`
+(e.g. `-manual.md`, `-code.md`, `-design.md`, `-a11y.md`). When a single agent invocation
+covers multiple concerns (see `ux-expert` below), it writes separate files per concern to
+keep the one-file-per-check invariant intact.
 
 `severity`, `confidence`, `domain_relevance` are required when `verdict` is `WARN` or `FAIL`;
 null for `PASS` / `SKIPPED`. These drive the PoLL aggregation in Step 4.
@@ -313,7 +333,9 @@ Fires when `acceptance_criteria_ids` in spec frontmatter is a non-empty list.
 Prompt contents:
 1. **Spec** — the spec file path.
 2. **Diff / implement receipt** — evidence for each AC.
-3. **Test plan** (if any) — TC list mapped to AC by `AC-ref:` fields.
+3. **Test plan** (if any) — TC list mapped to AC via each test case's `Source:` field
+   (e.g. `Source: AC-1` or `Source: AC-2, AC-3`). This is the canonical mapping used by
+   `generate-test-plan`; do not invent a new `AC-ref:` field.
 4. **manual-tester output** (if running) — pointer to
    `swarm-report/<slug>-acceptance-manual.md`.
 5. **Output path** — `swarm-report/<slug>-acceptance-ac-coverage.md`.
@@ -324,18 +346,27 @@ missing AC is `critical`; weak coverage is `major`.
 
 ### 3.5 Spawn `ux-expert` (conditional — design-review or a11y)
 
-Fires when `design.figma` is set (design-review mode) **or** `non_functional.a11y` is set
-(a11y mode). Either mode runs in one agent invocation; combine prompts if both triggers fire.
+Fires when **`has_ui_surface == true`** AND (`design.figma` is set for design-review mode
+**or** `non_functional.a11y` is set for a11y mode). Non-UI projects never trigger this even
+if `non_functional.a11y` is present — a11y on backend/library/CLI has no surface to audit.
+
+Design-review and a11y can both fire in one invocation. When both trigger, spawn `ux-expert`
+once with mode `both`; the agent writes **two** artifacts (one per concern) so aggregation in
+Step 4 treats them as independent checks:
+
+- `swarm-report/<slug>-acceptance-design.md` with `check: design`
+- `swarm-report/<slug>-acceptance-a11y.md` with `check: a11y`
+
+When only one mode fires, only the corresponding artifact is written.
 
 Prompt contents:
 1. **Mode** — `design-review` / `a11y` / `both`.
 2. **Spec** — file path.
 3. **Design source** — `design.figma` URL (design-review mode).
 4. **a11y target** — value of `non_functional.a11y` (e.g. `wcag-aa`).
-5. **Running app pointer** (if `has_ui_surface`) — target hints; the agent reads running-app
-   state via MCP only when the environment is already prepared, otherwise works from
-   screenshots/code.
-6. **Output path** — `swarm-report/<slug>-acceptance-ux.md`.
+5. **Running app pointer** — target hints; the agent reads running-app state via MCP only
+   when the environment is already prepared, otherwise works from screenshots/code.
+6. **Output paths** — one or both of the filenames listed above, matching the mode.
 
 Verdict rules: `PASS` if design matches reference and a11y criteria met; `WARN` for minor
 spacing/color deviations or AA soft failures; `FAIL` for missing components, broken
@@ -377,7 +408,9 @@ severity + confidence + domain_relevance + blocked_on). Read the body only if
 **Missing per-check artifact.** Step 2.5 writes a stub for skipped `code-reviewer`; Step 3.3
 writes an artifact even on build-smoke failure. If a planned per-check artifact is
 nonetheless missing at aggregation time, treat the check as `verdict: FAIL` with
-`error: per-check artifact missing` — do not silently drop it.
+`blocked_on: per-check artifact missing` — do not silently drop it. `blocked_on` is the
+canonical field for surfacing unresolved conditions per the per-check schema; no separate
+`error:` field exists.
 
 ### Aggregation — PoLL rules
 
@@ -437,7 +470,8 @@ Save to `swarm-report/<slug>-acceptance.md`. Legacy fields preserved; new sectio
 | Manual QA | manual-tester | … | … | … | swarm-report/<slug>-acceptance-manual.md |
 | Code review | code-reviewer | … | … | … | swarm-report/<slug>-acceptance-code.md |
 | AC coverage | business-analyst | … | … | … | swarm-report/<slug>-acceptance-ac-coverage.md |
-| Design / a11y | ux-expert | … | … | … | swarm-report/<slug>-acceptance-ux.md |
+| Design | ux-expert | … | … | … | swarm-report/<slug>-acceptance-design.md |
+| A11y | ux-expert | … | … | … | swarm-report/<slug>-acceptance-a11y.md |
 | Security | security-expert | … | … | … | swarm-report/<slug>-acceptance-security.md |
 | Performance | performance-expert | … | … | … | swarm-report/<slug>-acceptance-performance.md |
 | Build smoke | bash | … | … | … | swarm-report/<slug>-acceptance-build.md |

--- a/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
@@ -138,6 +138,13 @@ Read the document. Extract:
 - Acceptance criteria (explicit pass/fail conditions)
 - User roles and permissions mentioned
 
+**Spec frontmatter (when the source is a file with YAML frontmatter).** Read the frontmatter
+block first. If it contains a `platform:` list, copy that list verbatim into the receipt's
+`platform:` field (same canonical values as `write-spec` and ORCHESTRATION.md §Project type
+detection). When the orchestrator invokes this skill without a file-based spec, or the spec
+has no frontmatter, leave `platform:` empty in the receipt — `acceptance` will fall back to
+its project-type heuristic.
+
 ### 2. Figma mockup
 
 Use Figma MCP tools (`get_design_context`, `get_screenshot`) to retrieve the design.

--- a/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
@@ -72,6 +72,10 @@ review_verdict: pending | PASS | WARN | FAIL | skipped
 review_warnings: []            # populated by plan-review on WARN — list of short strings
 review_blockers: []            # populated by plan-review on FAIL — list of short strings
 phase_coverage: [Phase 1, Phase 2, ...]
+platform: []                   # optional; inherited from the source spec's `platform:` field when present.
+                               # Drives platform-aware TC generation and downstream acceptance checks (e.g.,
+                               # skip mobile-only TCs on a backend-only target). Leave empty when the spec
+                               # did not set it; acceptance falls back to its project-type heuristic.
 created: YYYY-MM-DD
 updated: YYYY-MM-DD
 ---

--- a/plugins/developer-workflow/skills/write-spec/SKILL.md
+++ b/plugins/developer-workflow/skills/write-spec/SKILL.md
@@ -417,7 +417,7 @@ date: {YYYY-MM-DD}
 status: draft
 # Optional fields — leave blank when not applicable. Consumed by `acceptance`
 # (choreography) and by `generate-test-plan` (platform-aware coverage).
-platform: []                     # e.g. [android], [ios], [web], [backend-jvm], [cli], [library], [desktop]. May be multi-value for cross-platform features.
+platform: []                     # Canonical values from ORCHESTRATION.md §Project type detection: [android], [ios], [web], [desktop], [backend-jvm], [backend-node], [cli], [library], [generic]. May be multi-value for cross-platform features.
 surfaces: []                     # e.g. [ui], [api], [cli], [background-job]. Drives which acceptance checks run.
 risk_areas: []                   # e.g. [auth], [payment], [pii], [data-migration], [perf-critical]. Each entry triggers a conditional expert in acceptance.
 non_functional:                  # Optional block. Each present entry triggers an expert check.
@@ -445,8 +445,10 @@ Write the "why" that will still make sense in 6 months.}
 ## Acceptance Criteria
 
 The feature is complete when ALL of the following are true. Each criterion is assigned a
-stable `AC-N` id that MUST appear in the frontmatter `acceptance_criteria_ids` list; this is
-what `acceptance` uses to drive AC-coverage checks via `business-analyst`.
+stable `AC-N` id. The frontmatter `acceptance_criteria_ids` list is **optional** for
+back-compat, but when it is provided, it MUST include every `AC-N` id listed here and nothing
+else; that is what `acceptance` uses to drive AC-coverage checks via `business-analyst`.
+Leaving `acceptance_criteria_ids` empty disables the business-analyst conditional.
 
 - [ ] **AC-1** — {Concrete, observable behavior — not internal state}
 - [ ] **AC-2** — {Another criterion}

--- a/plugins/developer-workflow/skills/write-spec/SKILL.md
+++ b/plugins/developer-workflow/skills/write-spec/SKILL.md
@@ -410,6 +410,25 @@ Nothing can be left to inference. Every requirement is verifiable. Every decisio
 explicit with its rationale.
 
 ```markdown
+---
+type: spec
+slug: {slug}
+date: {YYYY-MM-DD}
+status: draft
+# Optional fields — leave blank when not applicable. Consumed by `acceptance`
+# (choreography) and by `generate-test-plan` (platform-aware coverage).
+platform: []                     # e.g. [android], [ios], [web], [backend-jvm], [cli], [library], [desktop]. May be multi-value for cross-platform features.
+surfaces: []                     # e.g. [ui], [api], [cli], [background-job]. Drives which acceptance checks run.
+risk_areas: []                   # e.g. [auth], [payment], [pii], [data-migration], [perf-critical]. Each entry triggers a conditional expert in acceptance.
+non_functional:                  # Optional block. Each present entry triggers an expert check.
+  sla:                           # e.g. p99 < 150ms. Triggers performance-expert.
+  a11y:                          # e.g. wcag-aa. Triggers ux-expert a11y mode.
+acceptance_criteria_ids: []      # e.g. [AC-1, AC-2, AC-3]. Each AC in the list MUST appear as a bullet in §Acceptance Criteria.
+design:                          # Optional.
+  figma:                         # e.g. https://www.figma.com/file/XXX. Triggers ux-expert design-review.
+  design_system:                 # Optional reference to a design system doc.
+---
+
 # Spec: {Feature Name}
 
 Date: {YYYY-MM-DD}
@@ -425,13 +444,15 @@ Write the "why" that will still make sense in 6 months.}
 
 ## Acceptance Criteria
 
-The feature is complete when ALL of the following are true:
+The feature is complete when ALL of the following are true. Each criterion is assigned a
+stable `AC-N` id that MUST appear in the frontmatter `acceptance_criteria_ids` list; this is
+what `acceptance` uses to drive AC-coverage checks via `business-analyst`.
 
-- [ ] {Concrete, observable behavior — not internal state}
-- [ ] {Another criterion}
-- [ ] {Error / edge case criterion}
-- [ ] {Performance criterion with specific numbers, if relevant}
-- [ ] {Compatibility criterion, if relevant}
+- [ ] **AC-1** — {Concrete, observable behavior — not internal state}
+- [ ] **AC-2** — {Another criterion}
+- [ ] **AC-3** — {Error / edge case criterion}
+- [ ] **AC-4** — {Performance criterion with specific numbers, if relevant}
+- [ ] **AC-5** — {Compatibility criterion, if relevant}
 
 **Authoritative definition of done.** The implementing agent validates against this
 list before marking any task complete.


### PR DESCRIPTION
## Summary

Iteration 2 of the acceptance redesign. Adds four conditional specialist agents to the fan-out, aligns aggregation with the PoLL protocol from `plan-review`, centralizes project-type detection in `ORCHESTRATION.md`, and extends `write-spec` / `generate-test-plan` with optional frontmatter fields that drive conditional triggers.

Back-compat: every new frontmatter field is optional. Specs written before iter 2 continue to work verbatim — conditional agents simply do not fire, and the base check plan (manual-tester + code-reviewer or code-reviewer + build smoke) runs unchanged.

## Conditional fan-out (new in iter 2)

| Trigger (spec frontmatter) | Agent | Role |
|---|---|---|
| `acceptance_criteria_ids` non-empty | `business-analyst` | AC coverage — every AC-N has evidence |
| `design.figma` set, UI project | `ux-expert` | Design-review against Figma + design system |
| `risk_areas` ∩ {auth, payment, pii, data-migration} | `security-expert` | Security review of diff |
| `non_functional.sla` set or `risk_areas` has `perf-critical` | `performance-expert` | Bench / regress against SLA |
| `non_functional.a11y` set, UI project | `ux-expert` in a11y mode | WCAG audit at declared level |

Design-review + a11y combine into one `ux-expert` invocation when both trigger.

## PoLL aggregation

Mirrors `plan-review/SKILL.md` §Aggregation Rules:
- critical + high-confidence from any check → FAILED
- same issue raised by 2+ checks independently → escalate to critical
- contradicting verdicts → PARTIAL with "Uncertainty" section
- P0/P1 bugs remain the primary routing axis regardless of PoLL

## Other changes

- `ORCHESTRATION.md` gains **§Project type detection** next to **§Build system detection** — canonical source of truth, consumed by acceptance, extensible to other skills (research, generate-test-plan, create-pr).
- `write-spec` spec template: optional frontmatter `platform`, `surfaces`, `risk_areas`, `non_functional`, `acceptance_criteria_ids`, `design.figma`. Acceptance criteria bullets now carry stable `AC-N` ids.
- `generate-test-plan` receipt: optional `platform:` field inherited from spec.
- Removed leftover `Step 2: Ensure the App is Running` in `acceptance/SKILL.md` that had resurfaced during iter-1 simplify — manual-tester still owns the runtime environment end-to-end.

## Deferred to iteration 3+

- `architecture-expert` conditional (public API / cross-module changes)
- `build-engineer` conditional (build-file changes)
- `devops-expert` conditional (CI config changes)
- `diff_hash`-based idempotency in re-verification loop
- Visual regression as a separate skill

## Test plan

- [ ] `bash scripts/validate.sh` — ✅ passes locally
- [ ] Spec without new frontmatter → only base fan-out runs (back-compat)
- [ ] Spec with `acceptance_criteria_ids` → `business-analyst` spawned, AC coverage in receipt
- [ ] Spec with `risk_areas: [auth]` → `security-expert` in fan-out
- [ ] Spec with `design.figma` + `non_functional.a11y: wcag-aa` on Android project → single `ux-expert` invocation with mode `both`
- [ ] Two checks independently flag same file:line → Convergence signals section populated; aggregated Status escalates
- [ ] P0 bug from `manual-tester` → FAILED regardless of other PASS checks
- [ ] Contradicting PASS/FAIL on same item → PARTIAL with Uncertainty section

🤖 Generated with [Claude Code](https://claude.com/claude-code)