### PR TITLE
Post-release cleanup: doc drift + review findings

### DIFF
--- a/plugins/developer-workflow/CLAUDE.md
+++ b/plugins/developer-workflow/CLAUDE.md
@@ -3,7 +3,7 @@
 ## Structure
 
 ```
-skills/<name>/SKILL.md    # 15 lifecycle skills, each a directory with YAML frontmatter
+skills/<name>/SKILL.md    # 17 lifecycle skills, each a directory with YAML frontmatter
 agents/manual-tester.md   # only agent in core (QA executor)
 docs/WORKFLOW.md          # Full pipeline documentation with diagrams
 docs/ORCHESTRATORS.md     # feature-flow and bugfix-flow diagrams
@@ -15,7 +15,7 @@ This plugin is part of a split family. Depending on the task, Claude Code will h
 
 | Plugin | Contributes |
 |---|---|
-| `developer-workflow` (this) | 14 lifecycle skills + `manual-tester` |
+| `developer-workflow` (this) | 17 lifecycle skills + `manual-tester` |
 | `developer-workflow-experts` | `code-reviewer`, `architecture-expert`, `security-expert`, `performance-expert`, `ux-expert`, `build-engineer`, `devops-expert`, `business-analyst`, `debugging-expert` — required, auto-installed as a dependency |
 | `developer-workflow-kotlin` | `kotlin-engineer`, `compose-developer`; skills `code-migration`, `kmp-migration`, `migrate-to-compose` — install for Kotlin/Android/KMP work |
 | `developer-workflow-swift` | `swift-engineer`, `swiftui-developer` — install for Swift/iOS/macOS work |
@@ -38,7 +38,7 @@ Skills in this plugin delegate to engineer agents (kotlin-engineer / compose-dev
 - Pipeline orchestration rules (task profiling, Research Consortium, Quality Loop gates, State Machine, receipt-based gating) ship with this plugin at [`docs/ORCHESTRATION.md`](docs/ORCHESTRATION.md) — skills and the core feature-flow/bugfix-flow orchestrators read from there.
 - Quality Loop gates are defined in `docs/ORCHESTRATION.md`, not in any individual skill.
 
-## Skills roster (16)
+## Skills roster (17)
 
 - Planning/research: `research`, `decompose-feature`, `write-spec`, `plan-review`, `design-options` (optional pre-plan-review stage — generates 2-3 architectural alternatives for high-arch-risk tasks)
 - Implementation: `implement`, `write-tests`, `debug`

--- a/plugins/developer-workflow/README.md
+++ b/plugins/developer-workflow/README.md
@@ -22,7 +22,7 @@ developer-workflow-kotlin          developer-workflow-swift
 
 Installing this plugin automatically pulls `developer-workflow-experts`. Installing `-kotlin` or `-swift` additionally pulls this plugin.
 
-## Skills (16)
+## Skills (17)
 
 ### Planning / research
 | Skill | Purpose |
@@ -91,17 +91,27 @@ For **most skills**, these integrations are optional enhancements: when present,
 
 ## Installation
 
+**Prerequisite — cross-marketplace dependency.** `developer-workflow` declares a hard dependency on `pr-review-toolkit` from the official Anthropic plugin marketplace. Add that marketplace before installing:
+
+```
+/plugin marketplace add anthropics/claude-plugins-official
+```
+
+Then add ours and install:
+
 ```
 /plugin marketplace add kirich1409/krozov-ai-tools
 /plugin install developer-workflow@krozov-ai-tools
 ```
 
-`developer-workflow-experts` installs automatically as a declared dependency. Add platform plugins as needed:
+`developer-workflow-experts` and `pr-review-toolkit` install automatically as declared dependencies. Add platform plugins as needed:
 
 ```
 /plugin install developer-workflow-kotlin@krozov-ai-tools
 /plugin install developer-workflow-swift@krozov-ai-tools
 ```
+
+If the cross-marketplace dep fails to resolve (e.g., `claude-plugins-official` not added to user's environment), `developer-workflow` installation will abort with a clear message. Add the marketplace and retry.
 
 ## Pipeline documentation
 

--- a/plugins/developer-workflow/README.md
+++ b/plugins/developer-workflow/README.md
@@ -91,13 +91,15 @@ For **most skills**, these integrations are optional enhancements: when present,
 
 ## Installation
 
-**Prerequisite — cross-marketplace dependency.** `developer-workflow` declares a hard dependency on `pr-review-toolkit` from the official Anthropic plugin marketplace. Add that marketplace before installing:
+**Prerequisite — cross-marketplace dependency.** `developer-workflow` declares a hard dependency on `pr-review-toolkit` from Anthropic's official plugin marketplace. That marketplace's name is `claude-plugins-official` (see [`.claude-plugin/marketplace.json`](https://github.com/anthropics/claude-plugins-official/blob/main/.claude-plugin/marketplace.json)) and it is added by giving Claude Code the GitHub repo path `anthropics/claude-plugins-official`:
 
 ```
 /plugin marketplace add anthropics/claude-plugins-official
 ```
 
-Then add ours and install:
+After that, the marketplace is registered under its declared name `claude-plugins-official`, which matches the `marketplace` field in our `plugin.json` dependency entry.
+
+Then add our marketplace and install the plugin:
 
 ```
 /plugin marketplace add kirich1409/krozov-ai-tools
@@ -111,7 +113,7 @@ Then add ours and install:
 /plugin install developer-workflow-swift@krozov-ai-tools
 ```
 
-If the cross-marketplace dep fails to resolve (e.g., `claude-plugins-official` not added to user's environment), `developer-workflow` installation will abort with a clear message. Add the marketplace and retry.
+If the cross-marketplace dep fails to resolve (e.g., `claude-plugins-official` marketplace not registered in the user's environment), `developer-workflow` installation will abort with a clear message. Add the marketplace and retry.
 
 ## Pipeline documentation
 

--- a/plugins/developer-workflow/docs/ORCHESTRATION.md
+++ b/plugins/developer-workflow/docs/ORCHESTRATION.md
@@ -8,17 +8,17 @@ When receiving a task, classify it by **size and complexity**, then pick the app
 
 | Size | Criteria | Pipeline |
 |------|----------|----------|
-| Small | 1-3 files, clear change, no new APIs | Implement → Quality (build+test only) → done |
-| Medium | Multiple files, one module, known patterns | Plan → Implement → Quality → PR |
-| Large | Cross-module, new APIs, unfamiliar libraries | Research → Plan → Implement → Quality → Verify → PR |
-| Migration | Library/technology swap | Research → Snapshot → Migrate → Verify → PR |
+| Small | 1-3 files, clear change, no new APIs | Implement → done (mechanical + intent only; finalize/acceptance skipped for truly trivial changes) |
+| Medium | Multiple files, one module, known patterns | Plan → Implement → Finalize → Acceptance → PR |
+| Large | Cross-module, new APIs, unfamiliar libraries | Research → Plan → Implement → Finalize → Acceptance → PR |
+| Migration | Library/technology swap | Research → Snapshot → Migrate → Finalize → Acceptance → PR |
 | Research | Investigation only, no code changes | Research → Report |
 
 **Skip stages that add no value for the task at hand.** A one-line bug fix does not need Research or a formal Plan. A large feature with unfamiliar dependencies needs the full pipeline.
 
 Auto-detect from scope and context. If ambiguous — state the assumed profile and ask the user to confirm before proceeding.
 
-Migration tasks use the `code-migration` skill. Feature tasks with explicit `/developer-workflow:implement-task` use that skill's built-in pipeline instead of these rules.
+Migration tasks use the `code-migration` skill.
 
 ## Research Consortium
 
@@ -69,13 +69,15 @@ Plan ──→ Research           (plan review reveals gaps or missing context)
 TestPlan ──→ TestPlanReview
 TestPlanReview ──→ Implement  (PASS or WARN)
 TestPlanReview ──→ TestPlan   (FAIL — revise loop, max 3 cycles, then escalate)
-Implement ──→ Quality
+Implement ──→ Finalize
 Implement ──→ Research      (scope is larger than expected — escalate)
-Quality ──→ Verify
-Quality ──→ Implement       (quality loop found issues to fix)
-Verify ──→ PR
-Verify ──→ Implement        (verification fails — fix and re-verify)
-Verify ──→ TestPlan         (new P0/P1 bugs require a `## Regression TC` section appended to the permanent test plan)
+Finalize ──→ Acceptance     (PASS — no BLOCK remains)
+Finalize ──→ Implement      (ESCALATE after 3 rounds; user routes back to fix root issues)
+Finalize ──→ escalate       (ESCALATE after 3 rounds; user picks non-implement path)
+Acceptance ──→ PR           (VERIFIED)
+Acceptance ──→ Implement    (FAILED — fix bugs, then Implement re-runs Finalize)
+Acceptance ──→ Debug        (FAILED — unclear root cause)
+Acceptance ──→ TestPlan     (new P0/P1 bugs require a `## Regression TC` section appended to the permanent test plan)
 PR ──→ Merge
 PR ──→ Implement            (review feedback requires code changes)
 ```
@@ -92,9 +94,9 @@ Each stage produces an artifact in `swarm-report/`. The next stage reads it befo
 | Plan | `<slug>-plan.md` |
 | TestPlan | `docs/testplans/<slug>-test-plan.md` (permanent, source of truth) + `<slug>-test-plan.md` (receipt: `status`, `permanent_path`, `source_spec`, `review_verdict`, `phase_coverage`). Created by `generate-test-plan` when invoked from the orchestrator with a slug; read by `plan-review` (test-plan branch) and `acceptance`. |
 | TestPlanReview | `<slug>-test-plan.md` receipt updated in place: `review_verdict` set to PASS / WARN / FAIL, `status` advances Draft → Ready on PASS/WARN. |
-| Implement | `<slug>-implement.md` (summary of changes, files touched) |
-| Quality | `<slug>-quality.md` (build/lint/test results, issues found/fixed) |
-| Verify | `<slug>-verify.md` / `<slug>-acceptance.md` (verification result: VERIFIED/FAILED/PARTIAL, evidence, `test_plan_source: receipt / mounted / on-the-fly / absent` when the Acceptance stage consumed a test plan) |
+| Implement | `<slug>-implement.md` (summary of changes, files touched) + `<slug>-quality.md` (mechanical checks / intent check results, notes for finalize) |
+| Finalize | `<slug>-finalize.md` (round-by-round phase A-D findings, unresolved BLOCKs, acknowledged risks, commits added during finalize) |
+| Acceptance | `<slug>-acceptance.md` (verification result: VERIFIED/FAILED/PARTIAL, evidence, `test_plan_source: receipt / mounted / on-the-fly / absent` when the Acceptance stage consumed a test plan) |
 | PR | `<slug>-pr.md` (PR URL, description, reviewers) |
 
 If a stage artifact is missing — the previous stage did not complete. Do not skip ahead.
@@ -287,15 +289,18 @@ Route implementation to the right specialist:
 | View → Compose migration | `migrate-to-compose` skill |
 | Library / technology swap | `code-migration` skill |
 | Module → KMP | `kmp-migration` skill |
-| Full autonomous cycle | `implement-task` skill (explicit-only) |
-| Quality check before PR | Quality Loop gates (this section) |
-| PR creation | `create-pr` skill |
+| Full autonomous feature cycle | `feature-flow` skill |
+| Full autonomous bug-fix cycle | `bugfix-flow` skill |
+| Architectural variability | `design-options` skill (optional pre-plan-review stage) |
+| Mechanical verification (build/lint/typecheck/tests) | `check` skill |
+| Code-quality pass (review + /simplify + pr-review-toolkit + experts) | `finalize` skill |
+| PR creation and lifecycle management | `create-pr` skill (`--draft` / `--refresh` / `--promote`) |
 | Triage feedback (PR comments or pasted text) — categorize, prioritize, group; optionally post replies / resolve threads for items with terminal verdicts via an editable manifest; never edits code | `triage-feedback` skill |
 | Plan review (PoLL) | `plan-review` skill |
 | Test plan creation | `generate-test-plan` skill |
-| Feature verification on device | `test-feature` skill |
+| Feature verification on device | `acceptance` skill |
 | Retroactive test writing | `write-tests` skill |
-| Undirected QA / bug hunting | `exploratory-test` skill |
+| Undirected QA / bug hunting | `bug-hunt` skill |
 | Research findings review | `business-analyst` agent |
 
 ## Stage Boundary Protocol

--- a/plugins/developer-workflow/docs/ORCHESTRATION.md
+++ b/plugins/developer-workflow/docs/ORCHESTRATION.md
@@ -73,7 +73,7 @@ Implement ──→ Finalize
 Implement ──→ Research      (scope is larger than expected — escalate)
 Finalize ──→ Acceptance     (PASS — no BLOCK remains)
 Finalize ──→ Implement      (ESCALATE after 3 rounds; user routes back to fix root issues)
-Finalize ──→ escalate       (ESCALATE after 3 rounds; user picks non-implement path)
+Finalize ──→ Escalate       (ESCALATE after 3 rounds; user picks non-implement path — stop state, not a stage)
 Acceptance ──→ PR           (VERIFIED)
 Acceptance ──→ Implement    (FAILED — fix bugs, then Implement re-runs Finalize)
 Acceptance ──→ Debug        (FAILED — unclear root cause)

--- a/plugins/developer-workflow/docs/ORCHESTRATORS.md
+++ b/plugins/developer-workflow/docs/ORCHESTRATORS.md
@@ -48,7 +48,12 @@ flowchart TD
     test_plan_review -->|FAIL, cycles>=3| escalate_tp([Escalate: user decides])
 
     subgraph loop ["For each task"]
-        impl[/implement/] --> acceptance[/acceptance/]
+        impl[/implement/] --> draft_pr[/create-pr --draft/]
+        draft_pr --> finalize[/finalize/]
+        finalize -->|PASS| acceptance[/acceptance/]
+        finalize -->|"ESCALATE (3 rounds)"| finalize_decide{User: accept risks or fix?}
+        finalize_decide -->|Fix| impl
+        finalize_decide -->|Accept| acceptance
         acceptance -->|VERIFIED| pr_decision
         acceptance -->|"FAILED (obvious)"| impl
         acceptance -->|"FAILED (unclear)"| debug_mid[/debug/]
@@ -75,6 +80,8 @@ flowchart TD
     style test_plan fill:#e1f5fe
     style test_plan_review fill:#e1f5fe
     style impl fill:#e8f5e9
+    style finalize fill:#fff9c4
+    style draft_pr fill:#f3e5f5
     style acceptance fill:#fff3e0
     style create_pr fill:#f3e5f5
     style triage fill:#f3e5f5
@@ -100,6 +107,7 @@ flowchart TD
 |-----------|-----|-------------|
 | PlanReview → Research | 2 | Escalate |
 | TestPlanReview → TestPlan | 3 | Escalate |
+| Finalize → Implement | 1 | Escalate |
 | Acceptance → Implement | 3 | Escalate |
 | Acceptance → TestPlan | 3 | Escalate |
 | Acceptance → Debug | 1 | Escalate |
@@ -126,7 +134,12 @@ flowchart TD
     plan -->|PASS| impl
     plan -->|FAIL| debug
 
-    impl[/implement/] --> acceptance[/acceptance/]
+    impl[/implement/] --> draft_pr[/create-pr --draft/]
+    draft_pr --> finalize[/finalize/]
+    finalize -->|PASS| acceptance[/acceptance/]
+    finalize -->|"ESCALATE (3 rounds)"| finalize_decide{User: accept risks or fix?}
+    finalize_decide -->|Fix| impl
+    finalize_decide -->|Accept| acceptance
 
     acceptance -->|"VERIFIED (bug gone)"| create_pr
     acceptance -->|"FAILED — same bug"| impl
@@ -148,6 +161,8 @@ flowchart TD
     style debug fill:#e1f5fe
     style plan fill:#e1f5fe
     style impl fill:#e8f5e9
+    style finalize fill:#fff9c4
+    style draft_pr fill:#f3e5f5
     style acceptance fill:#fff3e0
     style create_pr fill:#f3e5f5
     style triage fill:#f3e5f5
@@ -172,6 +187,7 @@ flowchart TD
 
 | From → To | Max | After limit |
 |-----------|-----|-------------|
+| Finalize → Implement | 1 | Escalate |
 | Acceptance → Implement | 3 | Escalate |
 | Acceptance → Debug | 1 | Escalate |
 | PR → Implement | 2 | Escalate |
@@ -184,7 +200,8 @@ flowchart TD
 |-------|---------|
 | 🔵 Blue | Research / diagnosis |
 | 🟢 Green | Implementation |
-| 🟠 Orange | Verification |
+| 🟡 Yellow | Finalize (code-quality loop) |
+| 🟠 Orange | Acceptance |
 | 🟣 Purple | PR lifecycle |
 | 🔴 Red | Stop / wait for user |
 | ✅ Green border | Done |

--- a/plugins/developer-workflow/docs/ORCHESTRATORS.md
+++ b/plugins/developer-workflow/docs/ORCHESTRATORS.md
@@ -69,7 +69,7 @@ flowchart TD
     next_task -->|Yes| impl
     next_task -->|No| create_pr
 
-    create_pr[/create-pr/] --> handoff([Hand-off to user])
+    create_pr[/create-pr --promote/] --> handoff([Hand-off to user])
     handoff --> triage[/triage-feedback/]
     triage -->|FIXABLE items| impl
     triage -->|Nothing actionable| done([PR in user's hands])
@@ -153,7 +153,7 @@ flowchart TD
     user_decision -->|Fix| impl
     user_decision -->|Ship| create_pr
 
-    create_pr[/create-pr/] --> handoff([Hand-off to user])
+    create_pr[/create-pr --promote/] --> handoff([Hand-off to user])
     handoff --> triage[/triage-feedback/]
     triage -->|FIXABLE items| impl
     triage -->|Nothing actionable| done([PR in user's hands])

--- a/plugins/developer-workflow/skills/check/SKILL.md
+++ b/plugins/developer-workflow/skills/check/SKILL.md
@@ -30,8 +30,8 @@ Inspect the working tree for marker files to decide which check suite to run. A 
 |---|---|---|
 | `gradlew`, `build.gradle`, `build.gradle.kts`, `settings.gradle*` | Gradle | `./gradlew check` (bundles lint/test/etc as configured) |
 | `package.json` | Node (npm/pnpm/yarn) | Derive from scripts — see §2.2 |
-| `Cargo.toml` | Rust / Cargo | `cargo check --all-targets` + `cargo clippy --all-targets -- -D warnings` + `cargo test` |
-| `Package.swift` | Swift SPM | `swift build` + `swift test` |
+| `Cargo.toml` | Rust / Cargo | `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` + `cargo test --all-features` (clippy already performs type-check; no separate `cargo check` needed) |
+| `Package.swift` | Swift SPM | `swift build` + `swift test` — add `swiftlint` or `swift-format lint` if a config file is present |
 | `*.xcodeproj`, `*.xcworkspace` | Xcode | Requires project-specific commands — see §2.3 |
 | `pyproject.toml`, `setup.py`, `setup.cfg` | Python | Derive from configured tools — see §2.4 |
 | `go.mod` | Go | `go vet ./...` + `go test ./...` + `go build ./...` |
@@ -45,13 +45,21 @@ No marker found → report "no recognized project tooling detected" and ask the 
 
 ### 2.1 Gradle
 
-Prefer `./gradlew check` — it is the Gradle convention for "run all verification tasks". If the project has a separate build step needed for CI parity:
+`./gradlew check` by itself runs the *verification* suite (lint, static analysis, tests) but does **not** compile the project. Build failures in production sources are only surfaced by `assemble`. Always run them together:
 
 ```
 ./gradlew assemble check
 ```
 
-Honor the wrapper — never use system-installed `gradle`. If `gradlew` is not executable, invoke it non-mutatingly via `bash ./gradlew check` rather than changing tracked file mode with `chmod +x`. If the permission issue persists, escalate to the caller with a note to fix the wrapper permission themselves — `/check` does not modify the working tree.
+**Android (AGP) projects** — prefer explicit variant-scoped commands; plain `check` on AGP usually runs only unit tests, and `connectedCheck` requires a device and is out of scope for `/check`:
+
+```
+./gradlew assembleDebug lintDebug testDebug
+```
+
+Detect Android via `android { }` block in `build.gradle*` or `com.android.application` / `com.android.library` plugin.
+
+Honor the wrapper — never use system-installed `gradle`. If `gradlew` is not executable, invoke it non-mutatingly via `sh ./gradlew assemble check` rather than changing tracked file mode with `chmod +x` (the wrapper script is sh-compatible, not bash-specific). If the permission issue persists, escalate to the caller with a note to fix the wrapper permission themselves — `/check` does not modify the working tree.
 
 ### 2.2 Node (package.json)
 
@@ -158,7 +166,17 @@ Always produce a structured report, even on single-command runs.
 - Failed: 1
 - Skipped: 1
 - Total wall time: <seconds>
+
+### Machine-readable summary
 ```
+verdict: FAIL
+passed: [build]
+failed: [lint]
+skipped: [tests]
+```
+```
+
+The machine-readable block is mandatory — orchestrator/skills that loop on `/check` rely on it. Parse the `verdict:` line first; the arrays identify which categories are in each state. Keep the block as the last section of the report so callers can tail the output reliably.
 
 ### Verdict rules
 

--- a/plugins/developer-workflow/skills/check/SKILL.md
+++ b/plugins/developer-workflow/skills/check/SKILL.md
@@ -28,7 +28,7 @@ Inspect the working tree for marker files to decide which check suite to run. A 
 
 | Marker files | Stack | Default check suite |
 |---|---|---|
-| `gradlew`, `build.gradle`, `build.gradle.kts`, `settings.gradle*` | Gradle | `./gradlew check` (bundles lint/test/etc as configured) |
+| `gradlew`, `build.gradle`, `build.gradle.kts`, `settings.gradle*` | Gradle | `./gradlew assemble check` — `check` alone does not compile production sources; AGP projects prefer variant-scoped commands (see §2.1) |
 | `package.json` | Node (npm/pnpm/yarn) | Derive from scripts — see §2.2 |
 | `Cargo.toml` | Rust / Cargo | `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` + `cargo test --all-features` (clippy already performs type-check; no separate `cargo check` needed) |
 | `Package.swift` | Swift SPM | `swift build` + `swift test` — add `swiftlint` or `swift-format lint` if a config file is present |
@@ -135,48 +135,25 @@ Always produce a structured report, even on single-command runs.
 
 ### Format
 
-```
-## Check report
+The report has two parts: a human-readable body and a mandatory machine-readable summary block at the end.
 
-**Stack detected:** Gradle  (+ Node if applicable, etc.)
-**Mode:** sequential fail-fast (default) | --all | --fast | --only X
-**Verdict:** PASS | FAIL | PARTIAL
+**Body (markdown)** — structured with headers, table of results, and per-failure details:
 
-### Results
-| # | Check | Command | Status | Notes |
-|---|---|---|---|---|
-| 1 | Build | `./gradlew assemble` | PASS | 23s |
-| 2 | Lint | `./gradlew check` | FAIL | 4 detekt violations |
-| 3 | Tests | (skipped — prior failure) | SKIP | — |
+- `## Check report` with `Stack detected`, `Mode`, `Verdict` lines
+- `### Results` — one row per check with Command / Status / Notes
+- `### Failures` (only if any) — per failure: command, exit code, stderr excerpt (~50 lines), suggested next step
+- `### Summary` — passed/failed/skipped counts + total wall time
 
-### Failures
-(only if any)
+**Machine-readable summary** — keep as the final fenced block of the output so callers can tail-parse reliably:
 
-**Lint failure:**
-- Command: `./gradlew check`
-- Exit: 1
-- Stderr excerpt:
-  ```
-  <last ~50 lines>
-  ```
-- Suggested next step: inspect detekt config or the 4 violations listed above.
-
-### Summary
-- Passed: 1
-- Failed: 1
-- Skipped: 1
-- Total wall time: <seconds>
-
-### Machine-readable summary
-```
+~~~
 verdict: FAIL
 passed: [build]
 failed: [lint]
 skipped: [tests]
-```
-```
+~~~
 
-The machine-readable block is mandatory — orchestrator/skills that loop on `/check` rely on it. Parse the `verdict:` line first; the arrays identify which categories are in each state. Keep the block as the last section of the report so callers can tail the output reliably.
+The machine-readable block is **mandatory** — orchestrator/skills that loop on `/check` rely on it. Parse the `verdict:` line first; the arrays identify which categories are in each state. `verdict` is one of `PASS`, `FAIL`, or `PARTIAL`.
 
 ### Verdict rules
 

--- a/plugins/developer-workflow/skills/create-pr/SKILL.md
+++ b/plugins/developer-workflow/skills/create-pr/SKILL.md
@@ -68,9 +68,9 @@ Capture:
 
 | Mode | Precondition | On failure |
 |---|---|---|
-| `--draft` | PR does not exist, or exists AND `isDraft: true` | If PR exists AND not draft: abort with "PR is already ready for review. Use `--refresh` to update body or `--promote` is a no-op." |
-| `--refresh` | PR exists | If no PR: abort with "No PR found for this branch. Use `--draft` or default to create one first." |
-| `--promote` | PR exists AND `isDraft: true` | If no PR: abort with "No PR to promote." If already ready: abort with "PR is already ready for review." |
+| `--draft` | PR does not exist, or exists AND `isDraft: true` | If PR exists AND not draft: abort with "PR is already ready for review; use `--refresh` to update the body." |
+| `--refresh` | PR exists (draft or ready — `--refresh` does not change status) | If no PR: abort with "No PR found for this branch. Use `--draft` or default to create one first." |
+| `--promote` | PR exists AND `isDraft: true` | If no PR: abort with "No PR to promote." If already ready: abort with "PR is already ready for review; use `--refresh` if you want to update the body." |
 | default | PR does not exist | If PR exists: print URL, abort. Suggest `--refresh` or `--promote`. |
 
 ---
@@ -312,7 +312,7 @@ Output differs by status (see "Output templates" below).
 
 **Draft (`--draft` or default → draft):**
 > Draft PR created: `<url>`
-> Next: complete implementation and local quality checks → `/acceptance` → `/create-pr --promote` to mark ready. (If the `finalize` skill is installed, the orchestrator will also run it between implement and acceptance.)
+> Next: complete implementation → `/finalize` → `/acceptance` → `/create-pr --promote` to mark ready.
 
 **Refreshed (`--refresh`):**
 > PR body refreshed: `<url>`
@@ -333,14 +333,12 @@ Orchestrators (`feature-flow`, `bugfix-flow`) invoke this skill at these milesto
 
 ```
 implement first pass → push → /create-pr --draft
-implement fix loop pushes → (optional) /create-pr --refresh on major fixes
-acceptance complete → /create-pr --refresh (adds acceptance results to body)
+finalize (runs after implement, before acceptance — multi-round code-quality loop)
+acceptance
 all local checks PASS → /create-pr --promote
-
-(When the `finalize` skill is installed, the orchestrator inserts a
-`/finalize` stage between implement and acceptance; it pushes commits
-between rounds and may call /create-pr --refresh at round boundaries.)
 ```
+
+Both orchestrators (`feature-flow`, `bugfix-flow`) call `/create-pr --draft` after `implement` and `/create-pr --promote` after `acceptance` passes. Mid-flow `--refresh` calls (e.g., after each finalize round, after fix loops) are not currently wired in — user or orchestrator can invoke `/create-pr --refresh` manually if the PR body should reflect intermediate progress.
 
 The orchestrator owns deciding *when* to invoke; this skill owns *how*.
 

--- a/plugins/developer-workflow/skills/design-options/SKILL.md
+++ b/plugins/developer-workflow/skills/design-options/SKILL.md
@@ -21,16 +21,18 @@ Generate and present multiple architectural approaches for a single task before 
 
 ## When to run this stage
 
-Run `design-options` when at least one of:
+Run `design-options` when at least one of (same trigger list as `feature-flow` §1.3a):
 
-1. **High architectural risk** — the task touches module boundaries, introduces new abstractions, or replaces a core pattern; multiple viable approaches exist.
-2. **Explicit user request** — "show me a few options", "what are the alternatives", "I want to choose between approaches".
-3. **Uncertainty in the spec** — the spec acknowledges that the "how" is open while the "what" is settled.
+1. **High architectural risk** — the task touches module boundaries, introduces new abstractions, or replaces a core pattern.
+2. **The plan settles the "what" but leaves the "how" open** — multiple plausible approaches exist, and the plan itself does not commit to one.
+3. **User explicitly asks for alternatives** — "show me a few options", "what are the alternatives", "variants", "разные подходы".
 
 Skip for:
 - Straightforward tasks with a single obvious approach
 - Bug fixes where the debug artifact already names the fix direction
 - Single-file changes
+
+Do NOT trigger when the spec itself is underspecified (no clear constraints, no observable behavior). That is a write-spec problem, not a design-options problem — ask the user to re-invoke `write-spec` first (see Escalation).
 
 If invoked from an orchestrator when none of the triggers apply → orchestrator skips this stage without user prompt.
 
@@ -160,9 +162,11 @@ Present the comparison artifact to the user with a brief summary:
 
 > Generated <N> options (<labels — e.g., "A Minimal / B Clean / C Pragmatic">). Saved to `swarm-report/<slug>-design-options.md`.
 > Summary of trade-offs: <1-2 sentences highlighting the most consequential differences>.
-> Which option do you want to proceed with? You can also: (a) ask for a hybrid, (b) request a re-run with different constraints, (c) go back to write-spec if the options surfaced missing requirements.
+> Which option do you want to proceed with?
 
-Wait for the user's choice before proceeding.
+Accepted replies: `A` / `B` / `C` (pick one), `hybrid` (combine parts), `rerun` (regenerate with different constraints), `re-research` (options surfaced missing requirements — go back to `research` stage, matches feature-flow state machine `DesignOptions → Research` transition).
+
+Wait for the user's choice before proceeding — one question per round, alternatives listed in the line above but not broadcast as additional questions.
 
 ---
 

--- a/plugins/developer-workflow/skills/finalize/SKILL.md
+++ b/plugins/developer-workflow/skills/finalize/SKILL.md
@@ -108,7 +108,9 @@ Because `/simplify` is fix-oriented, do not pre-review its output — trust the 
 
 ### If `/check` fails after `/simplify`
 
-Revert the simplify commits (or the last commit if unambiguously from `/simplify`), log the failure, continue to Phase C. Do not re-invoke `/simplify` in the same round — if it broke something once, it's likely to repeat.
+Revert the simplify commits (or the last commit if unambiguously from `/simplify`), log the failure with `phase: B, reason: revert`, continue to Phase C. Do not re-invoke `/simplify` in the same round — if it broke something once, it's likely to repeat.
+
+**Round-budget semantic.** Phase B is a transformative step, not a finding-generator. A Phase B revert does NOT introduce an unresolved BLOCK and does NOT consume the round budget beyond the single Phase B attempt; the round continues normally through Phases C and D. This is distinct from `/check` failure after a Phase A/C/D fix (§Mechanical verification) — there the originating finding stays BLOCK and counts against the budget.
 
 ---
 
@@ -139,20 +141,17 @@ Fixes for test-quality findings (e.g., "this test doesn't cover the failure path
 
 Trigger experts only when the diff matches their domain. Launch the matching ones in **parallel**.
 
-| Expert | Trigger — files touch any of: |
-|---|---|
-| `security-expert` | Auth, encryption, token/secret storage, network requests, permissions, user data handling, crypto libraries |
-| `performance-expert` | RecyclerView / LazyColumn adapters, DB queries, image loading, coroutine dispatchers, hot loops, large collections, N+1 patterns |
-| `architecture-expert` | New modules created, dependency direction changed, public API modified, new abstractions introduced |
+Trigger matrix lives in [`docs/ORCHESTRATION.md` § Phase D expert-review triggers](../../docs/ORCHESTRATION.md#phase-d-expert-review-triggers) — that document is the single source of truth. Do not duplicate it here; read the matrix before executing.
 
 No trigger matched → skip Phase D entirely for this round.
 
 ### Handling expert findings
 
-Experts typically produce deeper, higher-risk findings. Apply the same severity × confidence gate, but with a lower bar for fix urgency:
+Experts produce deeper, higher-risk findings. Apply the same severity × confidence gate as Phase A:
 
-- security + critical: **always fix** before continuing, even at confidence 50 (security rarely benefits from optimism)
-- performance / architecture + critical at confidence ≥ 75: fix if local to the diff; escalate if requires broader rework
+- For security-critical findings that come in at confidence 50, rely on the code-reviewer's **Critical-risk exception** (see `developer-workflow-experts/agents/code-reviewer.md` § Critical-risk exception): the finding is included with a `[please verify]` marker prefixed to the `issue` field. Treat such findings as BLOCK and attempt a fix; if fix is out-of-scope, escalate.
+- performance / architecture + critical at confidence ≥ 75: fix if local to the diff; escalate if requires broader rework.
+- Do not introduce a parallel "always fix at 50" rule — the rubric is defined once in `code-reviewer.md` and inherited by Phase D experts.
 
 ---
 
@@ -193,7 +192,20 @@ Save `swarm-report/<slug>-finalize.md` on exit (PASS or ESCALATE):
 ### Round 2
 ...
 
+## Unresolved BLOCKs (on ESCALATE only)
+
+Findings that could not be fixed and were NOT downgraded. Populated only when the
+finalize stage exits ESCALATE — lists BLOCKs that remain after 3 rounds, or BLOCKs
+whose fix broke `/check` and was reverted (per §Mechanical verification). The user
+must decide: loop back to `implement`, accept as risk, or re-scope.
+
+| Severity | Confidence | Category | Finding | Phase | Round | File:Line |
+|---|---|---|---|---|---|---|
+| BLOCK (critical) | 75 | security | Token logged in clear | D | 3 | src/auth/Logger.kt:23 |
+
 ## Remaining findings (not auto-fixed)
+
+Non-BLOCK items surfaced for reviewer awareness — they do not block exit with PASS.
 
 | Severity | Confidence | Category | Finding | Phase | File:Line |
 |---|---|---|---|---|---|
@@ -202,8 +214,7 @@ Save `swarm-report/<slug>-finalize.md` on exit (PASS or ESCALATE):
 
 ## Acknowledged risks
 
-Findings that were not fixed because fix was non-trivial and they do not block merge.
-Reviewer should be aware of them.
+Findings that the user explicitly decided to accept (e.g., during escalation). Not auto-populated — the user marks items here when handing control back for the run to continue. Distinct from "Unresolved BLOCKs" (which the finalize stage could not close).
 
 ## Commits added during finalize
 

--- a/plugins/developer-workflow/skills/implement/SKILL.md
+++ b/plugins/developer-workflow/skills/implement/SKILL.md
@@ -116,7 +116,7 @@ Do not duplicate gate details here — read ORCHESTRATION.md before executing. I
 
 ---
 
-## Phase 5: Produce Artifacts
+## Phase 4: Produce Artifacts
 
 ### Implementation artifact
 


### PR DESCRIPTION
Addresses Critical + Major findings from \`plugin-dev:plugin-validator\` and \`plugin-dev:skill-reviewer\` runs on main after PRs #94–#98 landed.

## Summary

### Docs aligned with new 3-stage quality pipeline

- **\`ORCHESTRATION.md\`** — Task Profiling, State Machine, Receipt-Based Gating, Skill Selection all used old \`Verify\`/\`Quality\` labels and referenced non-existent skills (\`implement-task\`, \`test-feature\`, \`exploratory-test\`). Now uses \`Finalize\`/\`Acceptance\` with the new transitions.
- **\`ORCHESTRATORS.md\`** — both mermaid diagrams now show \`implement → create-pr --draft → finalize → acceptance\`. Backward-transition tables include \`Finalize → Implement\` (max 1).
- **\`CLAUDE.md\`** — skill count normalised to 17 in all three places (header, family table, roster).
- **\`README.md\`** — skill count 16 → 17; installation docs now document the cross-marketplace prerequisite on \`pr-review-toolkit\` from \`anthropics/claude-plugins-official\`.

### Skill fixes

- **\`implement\`** — Phase 5 → Phase 4 (filled the gap left by removed Simplify phase).
- **\`create-pr\`** — fixed broken abort message for \`--draft\` on a ready PR; clarified \`--refresh\` precondition covers both draft and ready; output + lifecycle diagram updated since \`finalize\` is now required, not optional.
- **\`check\`** — \`./gradlew check\` does not build; always pair with \`assemble\`. Added AGP variant-scoped commands. Cargo: dropped redundant \`cargo check\` (clippy covers it), added \`cargo fmt --check\`. Swift SPM: note lint if config present. Added mandatory machine-readable summary block at end of report. \`bash ./gradlew\` → \`sh ./gradlew\` (wrapper is sh, not bash).
- **\`finalize\`** — Phase D trigger list points to ORCHESTRATION.md (single source of truth, no more drift). Replaced parallel \"security + critical always fix at 50\" rule with reference to code-reviewer's existing Critical-risk exception. Phase B \`/simplify\` revert now explicitly does not consume round budget. Report schema split \"Unresolved BLOCKs\" (ESCALATE-only, auto) from \"Acknowledged risks\" (user-maintained).
- **\`design-options\`** — triggers reworded to match \`feature-flow\` §1.3a verbatim + explicit negative rule for underspecified specs. Phase 4 presentation follows one-question-per-round with explicit accepted replies (A/B/C/hybrid/rerun/re-research); \`re-research\` matches state machine.

## Not addressed (deferred)

- **\`version: \"*\"\` for \`pr-review-toolkit\`** — upstream is unversioned, so wildcard is intentional. If Claude Code schema validation later rejects it, revisit.
- **Minor findings** (~30 items) — left as technical debt; can batch later.
- **Skill size warnings** (\`triage-feedback\` 1005 lines, \`write-spec\` 613 lines, \`acceptance\` 732 lines) — pre-existing WARN from \`validate.sh\`, needs a separate refactor to extract \`references/\`.

## Test plan

- [x] \`bash scripts/validate.sh\` — green
- [ ] Manual: verify ORCHESTRATORS.md mermaid diagrams render correctly on GitHub
- [ ] Manual: verify skill invocations still resolve after skill-count corrections