### PR TITLE
multiexpert-review smoke-test fixtures + baseline

### DIFF
--- a/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/SMOKE_TEST.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/SMOKE_TEST.md
@@ -43,7 +43,7 @@ This harness checks **structural** properties, not content-level correctness. Be
 - **Profile source:** `frontmatter` (from `type: test-plan`)
 - **Reviewer roster:** `business-analyst` (always); plus `security-expert` if fixture mentions `auth|token|encryption|PII|credential` (this fixture does not); plus `performance-expert` because fixture mentions `latency` and `p99` (matches `SLA|latency|throughput|budget`)
 - **Verdict:** one of `PASS / WARN / FAIL`
-- **Receipt writing:** engine resolves `receipt.path_template` to `swarm-report/smoke-test-test-plan-fixture-test-plan.md` and writes `review_verdict` + optional `review_warnings` / `review_blockers`
+- **Receipt writing:** under engine orchestration, `receipt.path_template` resolves to `swarm-report/smoke-test-test-plan-fixture-test-plan.md` and the engine **creates or updates** that file with `review_verdict` + optional `review_warnings` / `review_blockers`. If you run this fixture via the real engine, expect a new or updated file at that path. If you capture baseline via direct-agent invocation (the mode used in `baseline-results.md`), no receipt is written because the engine is bypassed.
 - **Rubric applied:** 5-item checklist (a)–(e) must be evaluated explicitly
 
 ### `spec.md` (spec)
@@ -67,7 +67,7 @@ This harness checks **structural** properties, not content-level correctness. Be
 - Pre/post structural equivalence against the pre-refactor `plan-review` — this would require a baseline captured before the rename/refactor landed (see PR #101), which was not done. Future refactors should capture baseline first; this harness provides the fixture set to do so.
 - Multi-run modal match (3 runs per fixture) — stochasticity smoothing is out of scope for this lightweight harness.
 - Fail-loud error cases (`UNKNOWN_PROFILE_HINT`, `FORBIDDEN_PROFILE_FIELD`, `NO_REVIEWERS_AVAILABLE`, `PROFILE_INVENTORY_MISMATCH`) — documented in `../profiles/README.md` but not executed here because they would require mutating the live profile set.
-- Actual receipt writing for the `test-plan` profile — the baseline only asserts that the engine resolves `receipt.path_template` correctly; no receipt file is written during smoke-test since there is no live pipeline slug. File-write behavior must be exercised via a real `generate-test-plan → multiexpert-review` run.
+- Actual receipt writing for the `test-plan` profile — the captured baseline was produced via direct-agent invocation that bypasses the engine, so no receipt file is written during that capture. A real engine run on the same fixture (which has a `slug` in frontmatter and a profile with `receipt:` defined) will create or update `swarm-report/smoke-test-test-plan-fixture-test-plan.md`. Full receipt-payload validation must be exercised via a real `generate-test-plan → multiexpert-review` pipeline run.
 - Test-plan receipt consumer flow (acceptance skill reading `review_verdict`) — out of scope.
 
 ## Captured baseline

--- a/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/SMOKE_TEST.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/SMOKE_TEST.md
@@ -18,7 +18,7 @@ This harness checks **structural** properties, not content-level correctness. Be
 ## Running a smoke-test manually
 
 1. Pick a fixture, e.g. `plan.md`.
-2. Invoke `multiexpert-review` in a Claude Code session on the fixture. For `spec.md`, you can either rely on frontmatter detection or prepend `profile: spec\n---\n` hint (the `write-spec` callsite does the latter for in-memory drafts — see `write-spec/SKILL.md:538`).
+2. Invoke `multiexpert-review` in a Claude Code session on the fixture. For `spec.md`, you can either rely on frontmatter detection or prepend `profile: spec\n---\n` hint (the `write-spec` callsite does the latter for in-memory drafts — see `write-spec/SKILL.md` section 4.3 "Run multiexpert-review (spec profile)").
 3. Capture the **structural** properties of the run (not the content of individual issues):
    - Which profile the engine detected (logged in state file under `Profile:` and `Profile source:`)
    - Reviewer roster actually invoked
@@ -64,7 +64,7 @@ This harness checks **structural** properties, not content-level correctness. Be
 
 ## What this harness does NOT cover
 
-- Pre/post structural equivalence against the pre-refactor `plan-review` — this would require a baseline captured before commit `8608cbe`, which was not done. Future refactors should capture baseline first; this harness provides the fixture set to do so.
+- Pre/post structural equivalence against the pre-refactor `plan-review` — this would require a baseline captured before the rename/refactor landed (see PR #101), which was not done. Future refactors should capture baseline first; this harness provides the fixture set to do so.
 - Multi-run modal match (3 runs per fixture) — stochasticity smoothing is out of scope for this lightweight harness.
 - Fail-loud error cases (`UNKNOWN_PROFILE_HINT`, `FORBIDDEN_PROFILE_FIELD`, `NO_REVIEWERS_AVAILABLE`, `PROFILE_INVENTORY_MISMATCH`) — documented in `../profiles/README.md` but not executed here because they would require mutating the live profile set.
 - Actual receipt writing for the `test-plan` profile — the baseline only asserts that the engine resolves `receipt.path_template` correctly; no receipt file is written during smoke-test since there is no live pipeline slug. File-write behavior must be exercised via a real `generate-test-plan → multiexpert-review` run.

--- a/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/SMOKE_TEST.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/SMOKE_TEST.md
@@ -1,0 +1,74 @@
+# multiexpert-review — smoke-test harness
+
+Lightweight manual-run smoke-test for the `multiexpert-review` skill. Verifies that each profile activates correctly and produces structurally valid output.
+
+## Scope
+
+This harness checks **structural** properties, not content-level correctness. Because PoLL is stochastic, content of individual issues will differ run-to-run. Structural invariants are stable and what we assert against.
+
+## Fixtures
+
+| Fixture | Expected profile | Expected behavior |
+|---------|------------------|-------------------|
+| `plan.md` | `implementation-plan` | Tech-match agent selection; verdict alphabet `PASS/CONDITIONAL/FAIL` |
+| `test-plan.md` | `test-plan` | Roster includes `business-analyst`; verdict alphabet `PASS/WARN/FAIL`; review prompt augmented with 5-item checklist (a)–(e) |
+| `spec.md` | `spec` | Roster = `[business-analyst, architecture-expert]`; verdict alphabet `PASS/CONDITIONAL/FAIL`; severity mapping uses rubric-item keys (`acceptance_criteria`, `prerequisites`, `out_of_scope`, etc.) |
+| `unknown-artifact.md` | (none — ask user) | Detector falls through all four stages; engine returns profile-choice prompt to user, does not silently default |
+
+## Running a smoke-test manually
+
+1. Pick a fixture, e.g. `plan.md`.
+2. Invoke `multiexpert-review` in a Claude Code session on the fixture. For `spec.md`, you can either rely on frontmatter detection or prepend `profile: spec\n---\n` hint (the `write-spec` callsite does the latter for in-memory drafts — see `write-spec/SKILL.md:538`).
+3. Capture the **structural** properties of the run (not the content of individual issues):
+   - Which profile the engine detected (logged in state file under `Profile:` and `Profile source:`)
+   - Reviewer roster actually invoked
+   - Verdict label chosen from the profile's alphabet
+   - Whether a receipt was written (only the `test-plan` profile has a `receipt:` section)
+   - Error prefix if any (e.g. `[multiexpert-review ERROR] UNKNOWN_PROFILE_HINT: ...`)
+4. Compare observed structural properties to the expectations table above.
+
+## Expected outcomes per fixture
+
+### `plan.md` (implementation-plan)
+
+- **Profile detected:** `implementation-plan`
+- **Profile source:** `frontmatter` (from `type: plan`)
+- **Reviewer roster:** derived by tech-match selection; for this fixture typically at least one of `architecture-expert` (cache layer → architecture), `build-engineer` (Gradle / Redis client dep), `devops-expert` (Helm / deployment)
+- **Verdict:** one of `PASS / CONDITIONAL / FAIL`
+- **Receipt:** none (implementation-plan profile omits `receipt:`)
+
+### `test-plan.md` (test-plan)
+
+- **Profile detected:** `test-plan`
+- **Profile source:** `frontmatter` (from `type: test-plan`)
+- **Reviewer roster:** `business-analyst` (always); plus `security-expert` if fixture mentions `auth|token|encryption|PII|credential` (this fixture does not); plus `performance-expert` because fixture mentions `latency` and `p99` (matches `SLA|latency|throughput|budget`)
+- **Verdict:** one of `PASS / WARN / FAIL`
+- **Receipt writing:** engine resolves `receipt.path_template` to `swarm-report/smoke-test-test-plan-fixture-test-plan.md` and writes `review_verdict` + optional `review_warnings` / `review_blockers`
+- **Rubric applied:** 5-item checklist (a)–(e) must be evaluated explicitly
+
+### `spec.md` (spec)
+
+- **Profile detected:** `spec`
+- **Profile source:** `frontmatter` (from `type: spec`) OR `path_glob` if placed under `docs/specs/**`
+- **Reviewer roster:** `[business-analyst, architecture-expert]` (mandatory primary per profile)
+- **Verdict:** one of `PASS / CONDITIONAL / FAIL`
+- **Severity mapping:** issues titled with rubric-item keys (`acceptance_criteria`, `prerequisites`, `out_of_scope`, `decisions_made`, `affected_modules`, `open_questions_tagged`, `technical_approach_detail`)
+- **Expected findings:** this synthetic spec is deliberately skeletal → reviewers should find critical violations of `acceptance_criteria` (ACs like "works", "fast enough" are not observable/verifiable) and major violations of `decisions_made` (no rationale) and `affected_modules` (vague)
+
+### `unknown-artifact.md` (no profile)
+
+- **Profile detected:** none
+- **Detector path:** all four stages fall through (no hint, no frontmatter, no path glob match, no structural signatures)
+- **Expected engine behavior:** prompt user with `AskUserQuestion` listing `PROFILE_INVENTORY = [implementation-plan, test-plan, spec]`. **Never** silent fallback to implementation-plan.
+- **Verdict:** N/A until user selects a profile
+
+## What this harness does NOT cover
+
+- Pre/post structural equivalence against the pre-refactor `plan-review` — this would require a baseline captured before commit `8608cbe`, which was not done. Future refactors should capture baseline first; this harness provides the fixture set to do so.
+- Multi-run modal match (3 runs per fixture) — stochasticity smoothing is out of scope for this lightweight harness.
+- Fail-loud error cases (`UNKNOWN_PROFILE_HINT`, `FORBIDDEN_PROFILE_FIELD`, `NO_REVIEWERS_AVAILABLE`, `PROFILE_INVENTORY_MISMATCH`) — documented in `../profiles/README.md` but not executed here because they would require mutating the live profile set.
+- Test-plan receipt consumer flow (acceptance skill reading `review_verdict`) — out of scope.
+
+## Captured baseline
+
+See `baseline-results.md` in the same directory for a one-time capture of actual outputs against these fixtures. Newer runs can be compared against it for structural drift — keeping in mind PoLL stochasticity means exact content match is expected to fail; only structural invariants (profile detected, roster composition, verdict alphabet) are stable.

--- a/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/SMOKE_TEST.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/SMOKE_TEST.md
@@ -67,6 +67,7 @@ This harness checks **structural** properties, not content-level correctness. Be
 - Pre/post structural equivalence against the pre-refactor `plan-review` — this would require a baseline captured before commit `8608cbe`, which was not done. Future refactors should capture baseline first; this harness provides the fixture set to do so.
 - Multi-run modal match (3 runs per fixture) — stochasticity smoothing is out of scope for this lightweight harness.
 - Fail-loud error cases (`UNKNOWN_PROFILE_HINT`, `FORBIDDEN_PROFILE_FIELD`, `NO_REVIEWERS_AVAILABLE`, `PROFILE_INVENTORY_MISMATCH`) — documented in `../profiles/README.md` but not executed here because they would require mutating the live profile set.
+- Actual receipt writing for the `test-plan` profile — the baseline only asserts that the engine resolves `receipt.path_template` correctly; no receipt file is written during smoke-test since there is no live pipeline slug. File-write behavior must be exercised via a real `generate-test-plan → multiexpert-review` run.
 - Test-plan receipt consumer flow (acceptance skill reading `review_verdict`) — out of scope.
 
 ## Captured baseline

--- a/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/baseline-results.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/baseline-results.md
@@ -74,7 +74,7 @@ This path was not fully executed (would require interactive user prompt); behavi
 
 ## What this baseline is NOT
 
-- Not a pre/post comparison — the pre-refactor baseline was not captured before commit `8608cbe`. For future regression testing, use this baseline as the post-reference and capture pre-baseline before the next structural change.
+- Not a pre/post comparison — the pre-refactor baseline was not captured before the rename/refactor landed (see PR #101). For future regression testing, use this baseline as the post-reference and capture pre-baseline before the next structural change.
 - Not a multi-run modal average — PoLL stochasticity means content of individual findings will differ next run. Only the structural properties listed above should be stable across runs.
 - Not a full acceptance of AC-E2/E3 from `docs/specs/2026-04-19-multiexpert-review.md` — that spec required 3 runs per fixture; this is a single-run capture as a lightweight smoke-test. Full compliance would require a test harness not built here.
 

--- a/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/baseline-results.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/baseline-results.md
@@ -1,0 +1,83 @@
+# Smoke-test baseline — captured 2026-04-19
+
+Captured manually via direct agent invocation on the fixtures in this directory. Asserted **structural** properties only; content of individual issues is PoLL-stochastic and not part of the baseline.
+
+## Fixture: `plan.md` (implementation-plan profile)
+
+**Profile detection:** `implementation-plan` via frontmatter `type: plan`
+**Reviewer invoked:** `architecture-expert` (tech-match on cache layer / modules)
+**Verdict alphabet used:** `PASS / CONDITIONAL / FAIL` (per profile `verdicts`)
+**Severity labels in output:** `critical | major | minor` (engine-standard)
+**Structural properties verified:**
+- Output follows engine template (Summary / Domain Relevance / Issues)
+- Issues include all required fields (severity, confidence, issue, suggestion)
+- No engine error prefix (normal review path)
+- No receipt written (profile has no `receipt:` section)
+
+**Sample observed findings:** 6 issues total (2 major, 3 minor, 1 major). Touched: cache invalidation coverage, multi-instance consistency contract, write ordering, domain/infra boundary, fallback contract specificity, latency-budget decomposition. All architecture-domain findings — consistent with invoked agent specialty.
+
+## Fixture: `test-plan.md` (test-plan profile)
+
+**Profile detection:** `test-plan` via frontmatter `type: test-plan` (frontmatter path takes precedence over structural signatures)
+**Reviewer invoked:** `business-analyst` (per profile `reviewer_roster.primary`)
+**Optional_if trigger activated:** `performance-expert` flagged as recommended (artifact mentions `latency`, `p99`, matching `SLA|latency|throughput|budget` regex) — the reviewer noted this in their output but the actual panel was kept to business-analyst for this lightweight smoke-test
+**Verdict alphabet used:** `PASS / WARN / FAIL` (per profile `verdicts`)
+**Severity mapping applied:**
+- (a), (b), (c) items → `critical`
+- (d), (e) items → `major`
+**Structural properties verified:**
+- 5-item checklist evaluated explicitly (each item marked satisfied / violated)
+- Final verdict derived from profile verdict policy: `FAIL` because (b) and (c) violated (critical)
+- Output follows engine template
+- Receipt path resolved to `swarm-report/smoke-test-test-plan-fixture-test-plan.md` (not written in smoke-test since no live pipeline)
+
+**Sample observed findings:** 6 issues total — items (b), (c) flagged critical; items (a), (d), (e) flagged with matching severities; verdict FAIL per profile policy. Reviewer also raised open questions about test infrastructure and PII handling — domain-appropriate.
+
+## Fixture: `spec.md` (spec profile)
+
+**Profile detection:** `spec` via frontmatter `type: spec`
+**Reviewer invoked:** `business-analyst` (first of `reviewer_roster.primary: [business-analyst, architecture-expert]`)
+**Verdict alphabet used:** `PASS / CONDITIONAL / FAIL` (per profile `verdicts`)
+**Severity mapping applied:**
+- items `acceptance_criteria`, `prerequisites` → `critical`
+- items `out_of_scope`, `decisions_made`, `affected_modules` → `major`
+- items `open_questions_tagged`, `technical_approach_detail` → `minor`
+**Structural properties verified:**
+- Issues titled with rubric-item keys (`acceptance_criteria violated`, `prerequisites violated`, etc.) per profile prompt augmentation contract
+- Severities assigned per `severity_mapping` of the profile
+- Final verdict FAIL — both critical items violated
+- No receipt written (profile has no `receipt:` section)
+
+**Sample observed findings:** 7 issues — all rubric items evaluated, two critical (AC + prerequisites), three major (out_of_scope, decisions, modules), two minor (OQ, technical_approach). This is the **expected** output for a deliberately-skeletal spec fixture. Verdict FAIL is correct per profile policy.
+
+## Fixture: `unknown-artifact.md` (no profile)
+
+**Profile detection:** none — all four detection stages fall through:
+1. No hint prefix in invocation args
+2. No YAML frontmatter at all → stage 2 falls through
+3. No path-glob in the inventory matches `test-fixtures/unknown-artifact.md`
+4. Structural signatures: test-plan signatures don't match (no `## Test Cases`, no TC-ID pattern); spec has no structural_signatures; implementation-plan has no structural_signatures
+5. → fallback: engine prompts user with `AskUserQuestion` listing `PROFILE_INVENTORY`
+
+**Structural property verified:** engine does **not** silently default to implementation-plan. Operator must explicitly pick a profile.
+
+This path was not fully executed (would require interactive user prompt); behavior documented per `SKILL.md` Step 1 Detection precedence and spec AC-D3.
+
+## Summary table
+
+| Fixture | Profile detected | Detection source | Verdict alphabet | Verdict | Structural check |
+|---------|------------------|------------------|------------------|---------|------------------|
+| `plan.md` | implementation-plan | frontmatter | PASS/CONDITIONAL/FAIL | CONDITIONAL (implied by 3 major issues) | ✓ |
+| `test-plan.md` | test-plan | frontmatter | PASS/WARN/FAIL | FAIL | ✓ |
+| `spec.md` | spec | frontmatter | PASS/CONDITIONAL/FAIL | FAIL | ✓ |
+| `unknown-artifact.md` | (none — ask user) | fallback stage 5 | N/A | N/A | ✓ (documented) |
+
+## What this baseline is NOT
+
+- Not a pre/post comparison — the pre-refactor baseline was not captured before commit `8608cbe`. For future regression testing, use this baseline as the post-reference and capture pre-baseline before the next structural change.
+- Not a multi-run modal average — PoLL stochasticity means content of individual findings will differ next run. Only the structural properties listed above should be stable across runs.
+- Not a full acceptance of AC-E2/E3 from `docs/specs/2026-04-19-multiexpert-review.md` — that spec required 3 runs per fixture; this is a single-run capture as a lightweight smoke-test. Full compliance would require a test harness not built here.
+
+## Re-running
+
+For future refactors of `multiexpert-review`, re-run each fixture after the change and compare **structural** properties (profile detected, reviewer roster, verdict alphabet, verdict label, engine error prefix presence) against this baseline. Any divergence is a behavioral regression signal.

--- a/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/baseline-results.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/baseline-results.md
@@ -1,6 +1,12 @@
 # Smoke-test baseline — captured 2026-04-19
 
-Captured manually via direct agent invocation on the fixtures in this directory. Asserted **structural** properties only; content of individual issues is PoLL-stochastic and not part of the baseline.
+Captured manually via direct agent invocation on the fixtures in this directory — the baseline bypasses the engine orchestration layer. Asserted **structural** properties only; content of individual issues is PoLL-stochastic and not part of the baseline.
+
+**What this means for engine-level expectations.** Because the capture is agent-level, not engine-level:
+- No receipts are created. A real engine run with `profile.receipt` present and a `slug` in the fixture frontmatter WILL create/update the resolved file per the engine contract (`SKILL.md` → Receipt integration).
+- Panel enforcement is not exercised. A profile with `allow_single_reviewer: false` and multiple primary reviewers would, under engine orchestration, invoke the full primary panel (or fail loud with `NO_REVIEWERS_AVAILABLE`). This baseline captures one reviewer's perspective and records only that — do not read "only X invoked" as "panel policy honored".
+
+Engine-level behavior (receipt writes, panel enforcement, verdict aggregation across reviewers) must be exercised via a real pipeline run; it is deliberately out of scope here.
 
 ## Fixture: `plan.md` (implementation-plan profile)
 
@@ -29,14 +35,14 @@ Captured manually via direct agent invocation on the fixtures in this directory.
 - 5-item checklist evaluated explicitly (each item marked satisfied / violated)
 - Final verdict derived from profile verdict policy: `FAIL` because (b) and (c) violated (critical)
 - Output follows engine template
-- Receipt path resolved to `swarm-report/smoke-test-test-plan-fixture-test-plan.md` (not written in smoke-test since no live pipeline)
+- Receipt path resolved to `swarm-report/smoke-test-test-plan-fixture-test-plan.md`; the file is not created by this direct-agent baseline capture (engine was bypassed), but a real engine run on the same fixture would create or update it per the engine's Receipt integration contract
 
 **Sample observed findings:** 6 issues total — items (b), (c) flagged critical; items (a), (d), (e) flagged with matching severities; verdict FAIL per profile policy. Reviewer also raised open questions about test infrastructure and PII handling — domain-appropriate.
 
 ## Fixture: `spec.md` (spec profile)
 
 **Profile detection:** `spec` via frontmatter `type: spec`
-**Reviewer invoked:** `business-analyst` (first of `reviewer_roster.primary: [business-analyst, architecture-expert]`)
+**Reviewer invoked in this capture:** `business-analyst` only. The spec profile declares `reviewer_roster.primary: [business-analyst, architecture-expert]` with `allow_single_reviewer: false`, so a real engine run would invoke both agents (or fail loud with `NO_REVIEWERS_AVAILABLE` if only one is available). This baseline intentionally captures the single-agent perspective and records that fact; panel-enforcement is engine-level and out of scope for this harness.
 **Verdict alphabet used:** `PASS / CONDITIONAL / FAIL` (per profile `verdicts`)
 **Severity mapping applied:**
 - items `acceptance_criteria`, `prerequisites` → `critical`

--- a/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/baseline-results.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/baseline-results.md
@@ -14,7 +14,7 @@ Captured manually via direct agent invocation on the fixtures in this directory.
 - No engine error prefix (normal review path)
 - No receipt written (profile has no `receipt:` section)
 
-**Sample observed findings:** 6 issues total (2 major, 3 minor, 1 major). Touched: cache invalidation coverage, multi-instance consistency contract, write ordering, domain/infra boundary, fallback contract specificity, latency-budget decomposition. All architecture-domain findings — consistent with invoked agent specialty.
+**Sample observed findings:** 6 issues total (3 major, 3 minor). Touched: cache invalidation coverage, multi-instance consistency contract, write ordering, domain/infra boundary, fallback contract specificity, latency-budget decomposition. All architecture-domain findings — consistent with invoked agent specialty.
 
 ## Fixture: `test-plan.md` (test-plan profile)
 

--- a/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/plan.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/plan.md
@@ -1,0 +1,33 @@
+---
+type: plan
+slug: smoke-test-plan-fixture
+---
+
+# Plan: Add caching layer to user profile API
+
+## Goal
+
+Introduce a Redis-backed cache for the `GET /api/users/:id` endpoint to reduce database load during peak hours. Target: 80% cache hit rate, p99 latency under 50ms.
+
+## Approach
+
+1. Add Redis client dependency (Lettuce) to the user-service module.
+2. Wrap the existing `UserRepository.findById` call with a cache-aside pattern in a new `CachedUserRepository` decorator.
+3. TTL: 5 minutes. Invalidation: on `POST /api/users/:id` update.
+4. Metrics: Micrometer counters for cache-hit / cache-miss, gauge for Redis connection pool usage.
+
+## Affected modules
+
+- `user-service/src/main/kotlin/com/example/user/repository/` — new `CachedUserRepository.kt`, wire via Spring config
+- `user-service/build.gradle.kts` — add `io.lettuce:lettuce-core`
+- `user-service/src/main/resources/application.yml` — Redis connection config
+- `deployment/helm/user-service/values.yaml` — Redis sidecar declaration
+
+## Risks
+
+- Cache coherence on multi-instance deployments — covered by TTL, no pub/sub invalidation.
+- Redis outage degrades latency but must not break reads — fallback to DB if Redis unreachable.
+
+## Open questions
+
+- Should we use Redis AUTH / TLS? (Depends on deployment env — ask infra team.)

--- a/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/spec.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/spec.md
@@ -1,0 +1,33 @@
+---
+type: spec
+slug: smoke-test-spec-fixture
+status: draft
+---
+
+# Spec: Minimal synthetic spec fixture
+
+## Context and Motivation
+
+A tiny synthetic spec used as a smoke-test fixture for the multiexpert-review spec profile. This document is deliberately minimal to make rubric violations easy to spot in the review output.
+
+## Acceptance Criteria
+
+- [ ] The feature works.
+- [ ] No regression.
+- [ ] Fast enough.
+
+## Affected Modules
+
+Some modules in the backend.
+
+## Technical Approach
+
+Use a good pattern. Add some code.
+
+## Decisions Made
+
+We decided to implement it this way.
+
+## Out of Scope
+
+Everything else.

--- a/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/test-plan.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/test-plan.md
@@ -1,0 +1,54 @@
+---
+type: test-plan
+slug: smoke-test-test-plan-fixture
+source_spec: docs/specs/synthetic-user-profile-cache.md
+---
+
+# Test Plan: User profile caching
+
+## Acceptance Criteria (from source spec)
+
+- AC-1: `GET /api/users/:id` returns cached result when cache hit
+- AC-2: Cache hit rate ≥80% under steady state
+- AC-3: p99 latency ≤50ms for cached requests
+- AC-4: Cache invalidates on `POST /api/users/:id` update
+- AC-5: Redis outage: endpoint falls back to DB, returns 200 with degraded latency
+
+## Test Cases
+
+### TC-1: Cache hit on repeated read
+**Priority:** P0
+
+Steps:
+1. Warm cache by calling `GET /api/users/42`
+2. Call `GET /api/users/42` again within 5 minutes
+
+Expected: second call returns `X-Cache: HIT` header, response time <20ms.
+
+### TC-2: Cache miss on cold read
+**Priority:** P1
+
+Steps:
+1. Flush Redis
+2. Call `GET /api/users/42`
+
+Expected: response has `X-Cache: MISS`, user data loaded from DB.
+
+### TC-3: Cache invalidates on user update
+**Priority:** P0
+
+Steps:
+1. Warm cache for user 42
+2. POST user update for 42
+3. GET user 42 again
+
+Expected: response has `X-Cache: MISS` (invalidation occurred), new data reflected.
+
+### TC-4: Redis outage fallback
+**Priority:** P1
+
+Steps:
+1. Stop Redis container
+2. Call `GET /api/users/42`
+
+Expected: 200 OK, response loaded from DB, latency degraded but under 200ms.

--- a/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/test-plan.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/test-plan.md
@@ -1,12 +1,13 @@
 ---
 type: test-plan
 slug: smoke-test-test-plan-fixture
-source_spec: docs/specs/synthetic-user-profile-cache.md
 ---
 
 # Test Plan: User profile caching
 
-## Acceptance Criteria (from source spec)
+_Synthetic fixture for smoke-testing the `test-plan` profile. The acceptance criteria and test cases below are fabricated for detector/roster assertions — no corresponding source spec exists in this repo._
+
+## Acceptance Criteria (fabricated for this fixture)
 
 - AC-1: `GET /api/users/:id` returns cached result when cache hit
 - AC-2: Cache hit rate ≥80% under steady state

--- a/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/unknown-artifact.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/test-fixtures/unknown-artifact.md
@@ -1,0 +1,9 @@
+# Random notes
+
+Just some brainstorming. No frontmatter, no test-case structure, no spec sections.
+
+- Thought about the auth flow
+- Consider retry logic somewhere
+- Maybe refactor later
+
+Not yet a plan, not a spec, not a test-plan. Expected detector behavior: no match → fallback ask-user.


### PR DESCRIPTION
## Summary

Lightweight smoke-test harness for the `multiexpert-review` skill — structural-properties-only validation.

- **5 fixtures** under `plugins/developer-workflow/skills/multiexpert-review/test-fixtures/` — one per profile (plan, test-plan, spec) + an unknown-artifact fixture
- **SMOKE_TEST.md** — manual-run doc explaining which structural invariants to assert per fixture
- **baseline-results.md** — one-time capture of structural outputs, to be used as the post-refactor reference for future regression testing

Rebased onto `main` after #101 (multiexpert-review refactor) merged.

## What this is

- Structural smoke-test: verifies profile detection, reviewer roster, verdict alphabet, severity mapping, and engine error-prefix absence
- Designed for manual invocation in Claude Code sessions — no test automation framework added
- Fixtures chosen to exercise each profile's `detect.*` rules via frontmatter; `unknown-artifact.md` documents the ask-user fallback path

## What this is NOT

- Not a pre/post comparison — the pre-refactor baseline (against the old `plan-review` skill) was not captured before the rename commit in #101. For future regressions, use this baseline as the post-reference; capture pre-baseline before the next structural change.
- Not a multi-run modal-match (spec AC-E2/E3 requires 3 runs per fixture). This is a single-run capture — full compliance would need a test harness not built in this PR.
- Does not cover fail-loud error cases (`UNKNOWN_PROFILE_HINT`, `FORBIDDEN_PROFILE_FIELD`, etc.) — those scenarios are documented in `profiles/README.md` but executing them would require mutating the live profile set.

## Test plan

- [x] All 5 fixtures have valid YAML frontmatter where applicable
- [x] SMOKE_TEST.md lists structural invariants per fixture with expected outcomes
- [x] baseline-results.md captured from actual agent invocations (plan → architecture-expert; test-plan → business-analyst; spec → business-analyst)
- [x] All three executed fixtures produced output in the engine-template format
- [x] Test-plan fixture triggered expected optional_if path (latency keywords → performance-expert recommendation)
- [x] Spec fixture produced rubric-aligned severity mapping (AC / prerequisites → critical, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)