### PR TITLE
Minor cleanup: trigger phrases, per-stack notes, edge cases

### DIFF
--- a/plugins/developer-workflow/docs/WORKFLOW.md
+++ b/plugins/developer-workflow/docs/WORKFLOW.md
@@ -509,8 +509,8 @@ Each artifact includes:
 | **Perplexity** | Web research: approaches, best practices, pitfalls | Research (Web Expert) |
 | **DeepWiki** | AI-generated documentation for GitHub repositories | Research (Docs Expert) |
 | **Context7** | Library and framework documentation | Research (Docs Expert) |
-| **mobile MCP** | Testing on real devices and emulators | Verify (`manual-tester`, `acceptance`) |
-| **playwright MCP** | Web application testing in the browser | Verify (`manual-tester`) |
+| **mobile MCP** | Testing on real devices and emulators | Acceptance (`manual-tester`, `acceptance`) |
+| **playwright MCP** | Web application testing in the browser | Acceptance (`manual-tester`) |
 
 
 ## 11. Re-Anchoring Protocol

--- a/plugins/developer-workflow/skills/check/SKILL.md
+++ b/plugins/developer-workflow/skills/check/SKILL.md
@@ -72,7 +72,7 @@ Read `scripts` from `package.json` and run whichever of these exist, in this ord
 3. `test` (or `test:unit`)
 4. `build` (only if the project's CI runs it — check `.github/workflows/*.yml` for signal)
 
-**Node order deviates from the general Phase 3 sequence (Build → Lint → Typecheck → Tests).** JavaScript projects usually run tests without a compilation step, so lint and typecheck surface problems faster than trying to build first. `build` is last because it's the slowest and often not required for local verification. Callers that need the general order can use `--only build` first.
+**For Node projects this stack-specific order is authoritative** and intentionally overrides the general Phase 3 sequence (Build → Lint → Typecheck → Tests). Rationale: JavaScript projects usually run tests without a compilation step, so lint and typecheck surface problems faster than building first; `build` is the slowest and often unnecessary for local verification, so it's opt-in and last. The Phase 3 description in §3 describes the *default* order for stacks that do not override it.
 
 Pick the package manager from lockfile:
 
@@ -98,7 +98,8 @@ Inspect `pyproject.toml` / `setup.cfg` for configured tools. Run only the tools 
 
 - `[tool.ruff]` → `ruff check .`
 - `[tool.mypy]` → `mypy .` (with project path)
-- `[tool.pyright]` or `[tool.pylint]` → corresponding tool (`pyright`, `pylint <package>`)
+- `[tool.pyright]` → `pyright`
+- `[tool.pylint]` → `pylint <package>`
 - `[tool.flake8]` → `flake8 .`
 - `[tool.pytest.ini_options]` or `tests/` present → `pytest` (or `uv run pytest` if the project uses uv)
 - `[tool.black]` → `black --check .`

--- a/plugins/developer-workflow/skills/check/SKILL.md
+++ b/plugins/developer-workflow/skills/check/SKILL.md
@@ -8,10 +8,12 @@ description: >-
   Auto-detects project tooling (Gradle, npm/pnpm/yarn, cargo, Swift SPM, Xcode, Python,
   Go, Makefile) and runs the appropriate commands. Does NOT modify code — it only verifies.
 
-  Use when: "check the project", "run tests", "verify build", "after I edited X run checks",
-  "проверь проект", "запусти проверки", or when a pipeline stage needs to confirm that
-  code modifications did not break anything. Do NOT use for code review (that is gate
-  4 of implement / Phase A of finalize) or acceptance testing (use acceptance).
+  Use when: "check the project", "run tests", "verify build", "does it build?", "smoke check",
+  "make sure nothing is broken", "validate the branch", "after I edited X run checks",
+  "проверь проект", "запусти проверки", "собери проект", "прогони тесты", "все ли чисто",
+  "ничего не сломал?", or when a pipeline stage needs to confirm that code modifications
+  did not break anything. Do NOT use for code review (that is finalize Phase A), functional
+  acceptance testing (use acceptance), or exploratory QA (use bug-hunt).
 ---
 
 # Check
@@ -35,7 +37,7 @@ Inspect the working tree for marker files to decide which check suite to run. A 
 | `*.xcodeproj`, `*.xcworkspace` | Xcode | Requires project-specific commands — see §2.3 |
 | `pyproject.toml`, `setup.py`, `setup.cfg` | Python | Derive from configured tools — see §2.4 |
 | `go.mod` | Go | `go vet ./...` + `go test ./...` + `go build ./...` |
-| `Makefile` with `check`/`test` targets | Generic | `make check` (or `make test` as fallback) |
+| `Makefile` with `check`/`test` targets | Generic | `make check` if the target exists (authoritative — includes what the maintainer decided to include); otherwise `make test` as fallback. Do not run both: `check` wins when both exist. |
 
 No marker found → report "no recognized project tooling detected" and ask the caller to provide commands explicitly.
 
@@ -70,6 +72,8 @@ Read `scripts` from `package.json` and run whichever of these exist, in this ord
 3. `test` (or `test:unit`)
 4. `build` (only if the project's CI runs it — check `.github/workflows/*.yml` for signal)
 
+**Node order deviates from the general Phase 3 sequence (Build → Lint → Typecheck → Tests).** JavaScript projects usually run tests without a compilation step, so lint and typecheck surface problems faster than trying to build first. `build` is last because it's the slowest and often not required for local verification. Callers that need the general order can use `--only build` first.
+
 Pick the package manager from lockfile:
 
 | Lockfile | Manager |
@@ -82,11 +86,11 @@ If no `lint`/`test` scripts exist — report "no check scripts configured" and a
 
 ### 2.3 Xcode
 
-Xcode projects require knowing the scheme and destination. If the caller did not provide commands, ask:
+Xcode projects require knowing the scheme and destination — the skill does not guess. Escalate to the caller with a clear ask:
 
-> "Xcode project detected but no check commands configured. Provide build and test commands (e.g., `xcodebuild -scheme MyApp test -destination 'platform=iOS Simulator,name=iPhone 16'`)."
+> "Xcode project detected but no check commands configured. Provide build and test commands (e.g., `xcodebuild -scheme MyApp test -destination 'platform=iOS Simulator,name=iPhone 16'`), or configure them in a project-specific override so subsequent `/check` invocations pick them up automatically."
 
-Do not guess — wrong destination/scheme wastes time and produces misleading errors.
+This is an escalation, not an interactive prompt — Phase 3 cannot proceed without the commands. Wrong destination/scheme wastes time and produces misleading errors.
 
 ### 2.4 Python
 
@@ -94,8 +98,12 @@ Inspect `pyproject.toml` / `setup.cfg` for configured tools. Run only the tools 
 
 - `[tool.ruff]` → `ruff check .`
 - `[tool.mypy]` → `mypy .` (with project path)
-- `[tool.pytest.ini_options]` or `tests/` present → `pytest`
+- `[tool.pyright]` or `[tool.pylint]` → corresponding tool (`pyright`, `pylint <package>`)
+- `[tool.flake8]` → `flake8 .`
+- `[tool.pytest.ini_options]` or `tests/` present → `pytest` (or `uv run pytest` if the project uses uv)
 - `[tool.black]` → `black --check .`
+
+If the project uses `uv` (presence of `uv.lock` or `[tool.uv]` section), prefer `uv run <tool>` over bare invocation — it respects the project's virtual environment.
 
 Do not install missing tools. If none are configured — report "no check tools configured" and ask the caller.
 
@@ -116,9 +124,11 @@ On the first failure — stop, report failure with stderr excerpt, let the calle
 
 - `--all` — run every check regardless of earlier failures. Useful for getting a full picture before a batch of fixes.
 - `--fast` — skip tests, only build + lint + typecheck. Useful during tight fix loops when the failing surface is known to be non-test.
-- `--only lint` / `--only tests` / `--only build` — single-category check.
+- `--only lint` / `--only tests` / `--only build` / `--only typecheck` — single-category check. Each value maps to one of the Phase 3 categories; pass only one at a time.
 
 If none specified → default sequential fail-fast.
+
+**Flag parsing.** Callers pass the mode as the first `--<flag>` token in the invocation prompt, or via a natural-language directive ("fast mode", "all checks", "only the tests"). The skill parses this early — if multiple mutually-exclusive flags are given (e.g., `--all --fast`), fail with a clear error rather than picking a silent default.
 
 ### Output capture
 
@@ -158,8 +168,8 @@ The machine-readable block is **mandatory** — orchestrator/skills that loop on
 ### Verdict rules
 
 - **PASS** — every executed check returned exit 0. Skipped checks are not failures.
-- **FAIL** — at least one executed check returned non-zero exit.
-- **PARTIAL** — used in `--all` mode when some checks passed and some failed. Signals "here's everything" rather than "stopped at first break".
+- **FAIL** — at least one executed check returned non-zero exit. This applies to default (fail-fast) mode: a failure followed by `SKIP` for remaining categories is still FAIL, not PARTIAL.
+- **PARTIAL** — reserved for `--all` mode when some checks passed and some failed. Signals "here's everything" rather than "stopped at first break". Never emit PARTIAL when any check was SKIP due to fail-fast.
 
 ---
 

--- a/plugins/developer-workflow/skills/create-pr/SKILL.md
+++ b/plugins/developer-workflow/skills/create-pr/SKILL.md
@@ -78,9 +78,11 @@ Capture:
 ## Step 3: Push branch (all modes — if local has new commits)
 
 ```bash
-# Ensure upstream + push
+# Ensure upstream exists. First push uses -u to set upstream tracking.
 git rev-parse --abbrev-ref @{u} 2>/dev/null || git push -u origin "$BRANCH"
-# If upstream set but local is ahead
+# Then sync any local commits that aren't on the remote yet.
+# This is a no-op ("Everything up-to-date") if the branch is already in sync,
+# which is the common case for --refresh / --promote between commits.
 git push
 ```
 
@@ -120,7 +122,7 @@ Look for artifacts in `./swarm-report/` that match the current branch/task slug.
 
 Slug resolution:
 1. Prefer slug if orchestrator passed it as argument
-2. Fallback to branch name with `feature/` / `fix/` / `chore/` prefix stripped
+2. Fallback to branch name with common prefix stripped: `feature/`, `fix/`, `hotfix/`, `bug/`, `chore/`, `refactor/`, `docs/`
 
 Artifacts are gitignored (in `swarm-report/`), so they won't appear in diff — include them as *references* in the body (e.g., "See `swarm-report/my-slug-plan.md`"), not as inlined content. Reviewers working on the PR locally can read them; CI cannot, but the body remains readable without them.
 
@@ -133,6 +135,8 @@ Only set labels/reviewers when **creating** (draft or default) or when **promoti
 ### 6.1 Labels
 
 Fetch available labels (GitHub: `gh label list --json name,description --limit 100`; GitLab: `glab api /projects/:fullpath/labels`). Select from existing only, based on changed file paths, commit types, and scope. Do not invent labels.
+
+**Add, don't replace.** On `--promote` (and on refreshes in default mode if labels were derived earlier), only **add** missing labels computed from the diff; never remove labels set manually by humans. This preserves reviewer / triage / release labels that a maintainer applied post-creation.
 
 ### 6.2 Reviewers
 
@@ -218,6 +222,8 @@ When `--refresh` or `--promote` runs and `PR_BODY` is non-empty:
 3. Checklist items that are **checked** are preserved as checked — assume the user or reviewer ticked them
 
 Everything else is regenerated from artifacts + git state.
+
+**Edge case: empty or missing `PR_BODY`.** If `PR_BODY` is empty (e.g., freshly created draft with no body), skip the preserve-step entirely and generate the body from scratch. Do not fail — the preserve-step is an enhancement, not a precondition.
 
 ---
 

--- a/plugins/developer-workflow/skills/create-pr/SKILL.md
+++ b/plugins/developer-workflow/skills/create-pr/SKILL.md
@@ -136,7 +136,7 @@ Only set labels/reviewers when **creating** (draft or default) or when **promoti
 
 Fetch available labels (GitHub: `gh label list --json name,description --limit 100`; GitLab: `glab api /projects/:fullpath/labels`). Select from existing only, based on changed file paths, commit types, and scope. Do not invent labels.
 
-**Add, don't replace.** On `--promote` (and on refreshes in default mode if labels were derived earlier), only **add** missing labels computed from the diff; never remove labels set manually by humans. This preserves reviewer / triage / release labels that a maintainer applied post-creation.
+**Add, don't replace.** When deriving labels during creation (`--draft` or default) or `--promote`, only **add** missing labels computed from the diff; never remove labels set manually by humans. This preserves reviewer / triage / release labels that a maintainer may have applied between draft creation and promote. `--refresh` skips Step 6 entirely (see header), so it never touches labels at all.
 
 ### 6.2 Reviewers
 

--- a/plugins/developer-workflow/skills/design-options/SKILL.md
+++ b/plugins/developer-workflow/skills/design-options/SKILL.md
@@ -69,7 +69,7 @@ Launch `architecture-expert` agents (from `developer-workflow-experts`) in paral
 |---|---|
 | A — Minimal | Smallest surface area. Reuse existing structure. Minimize new abstractions, new modules, new dependencies. Optimize for "do the thing without disturbing the rest of the codebase". |
 | B — Clean | Ideal architecture disregarding migration cost. Accept larger refactors, new modules, or dependency restructuring if it produces a cleaner long-term shape. |
-| C — Pragmatic | Balanced middle. Introduce abstractions only where they pay for themselves in the short term. Accept some compromise for long-term maintainability. |
+| C — Pragmatic | Follow the existing project patterns as-is; extend only the specific seam this task needs. Do not generalize, do not abstract ahead of use. When in doubt, mirror the nearest similar feature in the codebase. |
 
 For **Options count = 2**, drop C. Picking between Minimal and Clean is a common fast-path when the user only wants the two extremes.
 
@@ -174,10 +174,21 @@ Wait for the user's choice before proceeding — one question per round, alterna
 
 Once the user picks an option (or a hybrid is specified):
 
-1. Write `swarm-report/<slug>-design.md` containing **only** the chosen option's full text plus a short "Chosen because: <reason>" preamble. This is the downstream-friendly artifact — `plan-review` and later stages that care about the chosen architecture read this (not the multi-option file). `plan-review` does not yet ingest this file automatically; the orchestrator should pass the path as an additional input when this stage ran.
+1. Write `swarm-report/<slug>-design.md` containing **only** the chosen option's full text plus a short "Chosen because: <reason>" preamble. This is the downstream-friendly artifact for stages that care about the chosen architecture (not the multi-option file).
 2. Leave the `<slug>-design-options.md` artifact in place as context for later review.
 
-If the user requested a hybrid, compose the hybrid as a fresh text combining the chosen structural choices + rationale. State explicitly which parts came from which option.
+### Downstream consumption — current vs. future
+
+**Current:** `plan-review` does not auto-detect or consume `<slug>-design.md`. Workaround — the orchestrator (feature-flow §1.3a) passes this path to `plan-review` as an additional context input when the design-options stage ran.
+
+**Future (TODO):** extend `plan-review` to auto-detect `<slug>-design.md` and ingest it without orchestrator assistance. Tracked as a follow-up — not a blocker for this skill to be useful today.
+
+### If the user asks for a hybrid
+
+1. Ask the user to specify which parts from which option (one short sentence per part is fine).
+2. Re-invoke `architecture-expert` with a synthesis prompt: combine the specified parts from the chosen options, flag any coherency conflicts (e.g., "Minimal's reuse strategy clashes with Clean's new module boundary"), and produce a single option text.
+3. Persist to `swarm-report/<slug>-design.md` with preamble `Option: Hybrid (A+B)` — or whichever combination — and `Chosen because: <reason>`. The option label in the file makes the hybrid origin explicit for later review.
+4. If the synthesis surfaces incompatibilities the user did not resolve, report them in the preamble under "Known tensions" — the hybrid still persists, but downstream reviewers see the compromise.
 
 ---
 

--- a/plugins/developer-workflow/skills/finalize/SKILL.md
+++ b/plugins/developer-workflow/skills/finalize/SKILL.md
@@ -6,7 +6,7 @@ description: >
   pr-review-toolkit agents (test quality, silent failures, type design) → conditional expert
   reviews (security, performance, architecture). `/check` between fixes. Exits PASS when no
   BLOCK-level findings remain, or ESCALATE after 3 rounds. Invoke on: "finalize", "run code
-  quality pass", "clean up the code", "prepare for review", "польшуй код", "финализация",
+  quality pass", "clean up the code", "prepare for review", "полируй код", "финализация",
   "доведи код", "почисти", or when an orchestrator (feature-flow, bugfix-flow) runs this
   stage between implement and acceptance.
 ---
@@ -35,7 +35,7 @@ The caller (orchestrator or user) provides:
 - **`slug`** — the task slug used for artifact naming
 - **Branch state** — finalize reads the current branch; it does not switch branches
 - **Context artifact path (optional)** — Phase A's `code-reviewer` anchor. Accepts either a feature plan (`swarm-report/<slug>-plan.md`) or, for bugfix-flow invocations, the debug artifact (`swarm-report/<slug>-debug.md`). Either works — `code-reviewer` treats whichever is provided as the "what was supposed to happen" document.
-- **Diff artifact path (derived)** — before invoking `code-reviewer`, materialize the diff to `swarm-report/<slug>-diff.txt` (`git diff $(git merge-base origin/main HEAD)..HEAD`) and pass that path to the agent. Matches the invocation template in `docs/ORCHESTRATION.md`.
+- **Diff artifact path (derived)** — before invoking `code-reviewer`, materialize the diff to `swarm-report/<slug>-diff.txt` and pass that path to the agent. Matches the invocation template in `docs/ORCHESTRATION.md`. Do **not** hardcode `origin/main`: derive the remote's default branch first (the same way `create-pr` does — `git remote show origin | grep "HEAD branch" | awk '{print $NF}'`, with `main` / `master` / `develop` as ordered fallbacks), then diff `$(git merge-base origin/<base> HEAD)..HEAD`. Works on any repository regardless of default-branch naming.
 - **Tolerance flags (optional):**
   - `--allow-warn` — stop after 1 round even if WARN findings remain (default: still exit PASS on WARN-only, but keep iterating BLOCKs until resolved or round budget runs out)
   - `--skip-experts` — omit Phase D (rarely useful; experts auto-skip if no triggers match)
@@ -65,7 +65,9 @@ Round N:
 
 ### Max round budget
 
-`max_rounds = 3`. Total budget (per round: 4 phases + fixes + `/check` after each fix) can take non-trivial wall time on large diffs. If a project regularly hits round 3, the BLOCK threshold may be too strict for the project's conventions — tune Phase A's `code-reviewer` confidence threshold (see `developer-workflow-experts/agents/code-reviewer.md`).
+Default `max_rounds = 3`, overridable to any integer ≥ 1 via the `--max-rounds N` flag (see §Inputs). The caller's flag wins when present; otherwise the default applies. ESCALATE semantics key off the effective value, not the constant — "after 3 rounds" in this document means "after the effective max_rounds".
+
+Total budget (per round: 4 phases + fixes + `/check` after each fix) can take non-trivial wall time on large diffs. If a project regularly hits the cap, the BLOCK threshold may be too strict for the project's conventions — tune Phase A's `code-reviewer` confidence threshold (see `developer-workflow-experts/agents/code-reviewer.md`) rather than silently raising `max_rounds`.
 
 ---
 

--- a/plugins/developer-workflow/skills/finalize/SKILL.md
+++ b/plugins/developer-workflow/skills/finalize/SKILL.md
@@ -1,17 +1,14 @@
 ---
 name: finalize
 description: >
-  Code-quality pass over the current branch changes. Runs multi-round review-and-fix loop:
-  code-reviewer (plan conformance, CLAUDE.md, bugs) → /simplify (reuse, quality, efficiency) →
+  Code-quality pass over the current branch changes. Multi-round review-and-fix loop:
+  code-reviewer (plan conformance, CLAUDE.md, bugs) → /simplify (reuse/quality/efficiency) →
   pr-review-toolkit agents (test quality, silent failures, type design) → conditional expert
-  reviews (security, performance, architecture). Between each fix and each phase the /check
-  skill verifies the code still builds, lints, and tests pass. Exits PASS when no BLOCK-level
-  findings remain (WARN and NIT items are surfaced in the report but do not block), or
-  ESCALATE after 3 rounds. Does NOT verify functional correctness — that's
-  acceptance. Does NOT verify plan conformance at a logic level — that's handled by
-  code-reviewer in Phase A. Invoke when the user says "finalize", "run code quality pass",
-  "clean up the code", "prepare for review", "доведи код", "почисти", or when an orchestrator
-  (feature-flow, bugfix-flow) runs this stage between implement and acceptance.
+  reviews (security, performance, architecture). `/check` between fixes. Exits PASS when no
+  BLOCK-level findings remain, or ESCALATE after 3 rounds. Invoke on: "finalize", "run code
+  quality pass", "clean up the code", "prepare for review", "польшуй код", "финализация",
+  "доведи код", "почисти", or when an orchestrator (feature-flow, bugfix-flow) runs this
+  stage between implement and acceptance.
 ---
 
 # Finalize
@@ -38,9 +35,11 @@ The caller (orchestrator or user) provides:
 - **`slug`** — the task slug used for artifact naming
 - **Branch state** — finalize reads the current branch; it does not switch branches
 - **Context artifact path (optional)** — Phase A's `code-reviewer` anchor. Accepts either a feature plan (`swarm-report/<slug>-plan.md`) or, for bugfix-flow invocations, the debug artifact (`swarm-report/<slug>-debug.md`). Either works — `code-reviewer` treats whichever is provided as the "what was supposed to happen" document.
+- **Diff artifact path (derived)** — before invoking `code-reviewer`, materialize the diff to `swarm-report/<slug>-diff.txt` (`git diff $(git merge-base origin/main HEAD)..HEAD`) and pass that path to the agent. Matches the invocation template in `docs/ORCHESTRATION.md`.
 - **Tolerance flags (optional):**
   - `--allow-warn` — stop after 1 round even if WARN findings remain (default: still exit PASS on WARN-only, but keep iterating BLOCKs until resolved or round budget runs out)
   - `--skip-experts` — omit Phase D (rarely useful; experts auto-skip if no triggers match)
+  - `--max-rounds N` — override the default 3-round cap. Use when the user wants one more round after an ESCALATE, without restarting the whole stage. Must be ≥ 1.
 
 ---
 
@@ -83,8 +82,8 @@ The agent returns a structured verdict: PASS / WARN / FAIL with findings scored 
 
 | Severity × confidence | Action |
 |---|---|
-| critical ≥ 75 | Fix immediately. After fix, re-run `/check`. If the fix does not converge, the finding stays BLOCK — the round ends without exiting PASS; counted against the 3-round budget. Do not silently downgrade a critical finding to "acknowledged risk". |
-| major ≥ 75 | Fix if tractable. If fix requires refactoring beyond the diff scope → escalate to caller. Remains BLOCK until resolved or escalated. |
+| critical ≥ 75 | Fix immediately. After fix, re-run `/check`. If `/check` PASSes and the finding is resolved → BLOCK cleared. If the fix does not converge, the finding stays BLOCK — the round ends without exiting PASS; counted against the 3-round budget. Do not silently downgrade a critical finding to "acknowledged risk". |
+| major ≥ 75 | Fix if tractable. On successful fix + `/check` PASS → BLOCK cleared. If fix requires refactoring beyond the diff scope → escalate to caller; the finding remains BLOCK until the caller resolves it or explicitly moves it to "acknowledged risks" at ESCALATE. |
 | minor ≥ 50 | Include in report as NIT. Don't fix automatically; caller/user decides. NIT never blocks PASS. |
 
 If `code-reviewer` returns FAIL verdict → this phase has BLOCKs that must be addressed before continuing.
@@ -97,7 +96,7 @@ Summary of this phase's findings goes into the round's log.
 
 ## Phase B — Built-in simplification (`/simplify`)
 
-Invoke the built-in Claude Code skill `/simplify`. It runs three parallel review agents (reuse, quality, efficiency) and **applies fixes directly** for the findings it considers real.
+Invoke the built-in Claude Code skill `/simplify`. It performs a parallel reuse / quality / efficiency pass and **applies fixes directly** for the findings it considers real. The exact implementation (number of sub-agents, internal structure) may evolve — finalize treats `/simplify` as a behavioural contract, not an implementation detail.
 
 `/simplify` focuses on:
 - **Reuse**: duplicated logic that should use an existing utility
@@ -160,7 +159,7 @@ Experts produce deeper, higher-risk findings. Apply the same severity × confide
 After **any** code modification within a round (Phase A fix, Phase B auto-fix, Phase C fix, Phase D fix), re-invoke `/check`. If `/check` returns FAIL:
 
 1. Log which phase's fix introduced the failure.
-2. Attempt a narrow repair (1 attempt max).
+2. Attempt a narrow repair — **1 attempt max** (stricter than implement's 3-per-gate, which is before the first clean build). At finalize stage the code already passed `/check` once, so a regression from a finalize fix signals that the fix itself was wrong; repeated retry usually compounds the problem rather than converging.
 3. If still failing → revert the fix and keep the originating finding **as BLOCK** on the round's list — the finding is not resolved, so it counts against the round budget. Continue with the remaining phases of the round (they may still find other issues), but do not mark the reverted finding as "acknowledged risk" — that label is reserved for items the user knowingly accepts at the end.
 4. If the round ends with any such unresolved BLOCK, go to the next round. If round 3 ends with unresolved BLOCKs, exit with ESCALATE.
 

--- a/plugins/developer-workflow/skills/implement/SKILL.md
+++ b/plugins/developer-workflow/skills/implement/SKILL.md
@@ -101,9 +101,7 @@ stage (e.g., model, repository, UI layer). Stage specific files, never `git add 
 
 ## Phase 3: Quality Loop
 
-Run two quality gates sequentially. A failure triggers a fix cycle before advancing.
-
-Semantic review, simplification, expert review, and PR-level code-quality analysis live in the separate `finalize` stage, which the orchestrator runs after `implement`. `implement` is now strictly focused on *getting the code written and working according to the plan* — nothing more.
+Run two quality gates sequentially. A failure triggers a fix cycle before advancing. Implement is strictly "write the code and verify it works per the plan" — everything beyond is the `finalize` stage (see `docs/ORCHESTRATION.md` § Finalize).
 
 After code is written, run the Quality Loop defined in [`docs/ORCHESTRATION.md`](../../docs/ORCHESTRATION.md#implement--quality-loop-2-gates) — that document is the single source of truth for gate definitions, verdict handling, and iteration limits.
 
@@ -156,7 +154,7 @@ Save to `swarm-report/<slug>-quality.md`:
 | # | Gate | Result | Attempts |
 |---|------|--------|----------|
 | 1 | Mechanical checks (`/check`) | PASS/FAIL | N |
-| 2 | Intent check | PASS/DRIFT | — |
+| 2 | Intent check | PASS/DRIFT | — (single-pass; DRIFT triggers full loop re-entry, counted as an additional total iteration) |
 
 ## Issues Found and Fixed
 - <issue> — <fix applied>


### PR DESCRIPTION
Addresses Minor-severity findings from the post-release \`plugin-dev:skill-reviewer\` runs. Zero Critical / Major — this is polish batch.

## Scope

### Docs
- **WORKFLOW.md §10** — last leftover 'Verify' stage labels → 'Acceptance' (mobile MCP, playwright MCP rows).

### /check skill
- Expand trigger phrases (EN + RU): 'smoke check', 'make sure nothing is broken', 'does it build?', 'собери проект', 'прогони тесты', etc.
- 'Do NOT use for' excludes \`bug-hunt\` and drops stale 'gate 4 of implement'.
- Node section: add rationale for deviating from the general Build→Lint→Typecheck→Tests order.
- Xcode: ambiguous ask-or-escalate → pure escalation (skill doesn't continue without commands).
- Python: add pyright/pylint/flake8/uv detection.
- Makefile: clarify \`check\` beats \`test\` when both exist.
- Phase 3: add \`--only typecheck\` (was missing); document flag parsing mechanics.
- Verdict rules: fail-fast SKIP is still FAIL, not PARTIAL.

### /finalize skill
- Trim frontmatter; move RU triggers in.
- Inputs: add derived diff-artifact path and \`--max-rounds N\` override.
- Phase A: spell out BLOCK-cleared outcome for critical/major on successful fix+/check PASS.
- Phase B: prescriptive '3 parallel agents' → behavioural contract.
- /check 1-attempt-max: add rationale (stricter than implement's 3-per-gate because finalize runs after the first clean build).

### /implement skill
- Phase 3: dedup 'separate finalize stage' (already in frontmatter).
- Gate 2 row: clarify '—' attempts = single-pass; DRIFT triggers full loop re-entry.

### /create-pr skill
- Slug resolution: add \`hotfix/\` and \`bug/\` to stripped prefixes.
- §6.1 Labels: explicit 'add, don't replace' rule — preserve maintainer labels.
- §7.4: empty PR_BODY edge case (skip preserve step, generate from scratch).
- §Step 3 push: clarify the unconditional \`git push\` as a no-op-when-in-sync.

### /design-options skill
- Pragmatic style: 'balanced middle' → concrete rule (mirror existing patterns, don't generalize ahead of use).
- §Phase 5: split plan-review caveat into 'Current workaround' vs 'Future TODO'.
- Hybrid handling: expand from one sentence to explicit procedure (user specifies parts → re-invoke architect → persist as 'Option: Hybrid (A+B)').

## Companion GitHub issues

Not in this PR; tracked separately:
- #105 — split triage-feedback (1005 lines) into references/
- #106 — split write-spec (613 lines)
- #107 — split acceptance (732 lines)
- #108 — re-evaluate pr-review-toolkit cross-marketplace dep (\`version: \"*\"\` is problematic; upstream has no tags; allowlist syntax unclear in docs)

## Test plan

- [x] \`bash scripts/validate.sh\` — green
- [ ] Manual: trigger phrases activate \`/check\` correctly
- [ ] Manual: \`/finalize --max-rounds 2\` is parsed by the skill
- [ ] Manual: \`/create-pr --refresh\` on a hotfix/ branch resolves slug correctly