### PR TITLE
Review skill check

### DIFF
--- a/plugins/developer-workflow/skills/check/SKILL.md
+++ b/plugins/developer-workflow/skills/check/SKILL.md
@@ -1,19 +1,21 @@
 ---
 name: check
 description: >-
-  Run all mechanical verification checks on the project — build, static analysis (lint),
-  tests, and typecheck — in a single command. Reusable utility called by any stage that
+  This skill should be used when the user asks to "check the project", "run tests",
+  "verify build", "does it build?", "smoke check", "make sure nothing is broken",
+  "validate the branch", "after I edited X run checks", "проверь проект",
+  "запусти проверки", "собери проект", "прогони тесты", "все ли чисто",
+  "ничего не сломал?", or when a pipeline stage needs to confirm that code
+  modifications did not break anything.
+
+  Runs mechanical verification checks — build, static analysis (lint), tests, and
+  typecheck — in a single command. Auto-detects project tooling (Gradle, npm/pnpm/yarn,
+  cargo, Swift SPM, Xcode, Python, Go, Makefile) and runs the appropriate commands.
+  Does NOT modify code — it only verifies. Reusable utility called by any stage that
   modifies code: implement, finalize, migration skills, or directly by the user.
 
-  Auto-detects project tooling (Gradle, npm/pnpm/yarn, cargo, Swift SPM, Xcode, Python,
-  Go, Makefile) and runs the appropriate commands. Does NOT modify code — it only verifies.
-
-  Use when: "check the project", "run tests", "verify build", "does it build?", "smoke check",
-  "make sure nothing is broken", "validate the branch", "after I edited X run checks",
-  "проверь проект", "запусти проверки", "собери проект", "прогони тесты", "все ли чисто",
-  "ничего не сломал?", or when a pipeline stage needs to confirm that code modifications
-  did not break anything. Do NOT use for code review (that is finalize Phase A), functional
-  acceptance testing (use acceptance), or exploratory QA (use bug-hunt).
+  Do NOT use for code review (that is finalize Phase A), functional acceptance testing
+  (use acceptance), or exploratory QA (use bug-hunt).
 ---
 
 # Check
@@ -119,7 +121,7 @@ Default behaviour: **sequential, fail-fast**. Run checks in this order (whicheve
 3. Typecheck
 4. Tests
 
-On the first failure — stop, report failure with stderr excerpt, let the caller decide. This matches the typical fix cycle: you cannot meaningfully review test output if the code does not compile.
+On the first failure — stop, report failure with stderr excerpt, let the caller decide. This matches the typical fix cycle: test output cannot be meaningfully reviewed if the code does not compile.
 
 ### Opt-in modes (via caller's input)
 


### PR DESCRIPTION
## Summary

Audit and polish of the `check` skill (`plugins/developer-workflow/skills/check/`) against `/plugin-dev:skill-development` criteria.

### Changes

- **Frontmatter description** — rewritten to lead with the third-person "This skill should be used when the user asks to …" clause (criterion requires third-person). Trigger-phrase list and "Do NOT use for …" clause preserved verbatim; stack/behaviour summary moved below.
- **Body voice** — replaced the one remaining second-person phrase (line 122, "you cannot meaningfully review test output…") with an objective/passive equivalent. Rest of the body was already imperative.

No semantic change. Skill behaviour, agent names, command signatures, and integration notes unchanged.

### Metrics

- Description length: 941 → 961 chars (limit 1024). PASS.
- Body word count: 1740 words (ideal 1,500–2,000). PASS.
- No `references/` extraction performed — body already within ideal band; stack tables are core operational content and splitting them would hurt readability without measurable context win.

### Audit report

`swarm-report/skill-review-check-state.md` (gitignored).

### Validation

- `bash scripts/validate.sh` — green. `check` frontmatter reported as `OK (961ch)`. Unrelated pre-existing `WARN` entries on `acceptance`, `triage-feedback`, `write-spec` (lines-per-SKILL.md over 500 with no references/) — not in scope of this PR.
- `plugin-dev:plugin-validator` agent — not run; the Task/agent tool is not available in this sub-agent execution context. Reviewer should run it before marking ready if required by release checklist.

## Test plan

- [ ] `bash scripts/validate.sh` passes locally
- [ ] Reviewer optionally runs `plugin-dev:plugin-validator` on `developer-workflow`
- [ ] Spot-check that `/check` triggers as expected on phrases like "check the project", "прогони тесты"