### PR TITLE
Review skill debug

### DIFF
--- a/plugins/developer-workflow/skills/debug/SKILL.md
+++ b/plugins/developer-workflow/skills/debug/SKILL.md
@@ -1,17 +1,16 @@
 ---
 name: debug
 description: >-
-  Systematic root cause investigation — stops at diagnosis, does NOT fix.
-  Invoke when user says "debug", "find root cause", "why is X broken", "investigate bug",
-  "что сломалось", "почему не работает", "найди причину", "дебаг", "отладь",
-  "test fails", "build breaks", "crash", "unexpected behavior", "regression",
-  or when a previous fix attempt didn't work.
-
+  This skill should be used when the user asks to "debug", "find root cause",
+  "why is X broken", "investigate bug", "что сломалось", "почему не работает",
+  "найди причину", "дебаг", "отладь", "test fails", "build breaks", "crash",
+  "unexpected behavior", "regression", or when a previous fix attempt didn't work.
+  Performs systematic root cause investigation — stops at diagnosis, does NOT fix.
   Produces a debug report with symptom, reproduction steps, root cause evidence, and
   recommended fix direction — ready to hand off to the implement stage.
-
-  Do NOT use for: feature implementation, code review, performance optimization (unless it's a
-  performance bug), writing new tests from scratch (use write-tests), general research (use research).
+  Do NOT use for: feature implementation, code review, performance optimization (unless
+  it's a performance bug), writing new tests from scratch (use write-tests), general
+  research (use research).
 disable-model-invocation: true
 ---
 
@@ -34,7 +33,7 @@ This skill stops at root cause — the fix is a separate stage.
 - Integration issues
 - Regressions
 - **Especially when:** under time pressure, "just one quick fix" seems obvious, previous fix
-  didn't work, you've tried multiple fixes already
+  didn't work, multiple fixes have already been tried
 
 ## Three Phases
 
@@ -48,7 +47,7 @@ Complete each phase before proceeding to the next.
    - They often contain the exact answer
 
 2. **Reproduce consistently**
-   - Can you trigger it reliably? What are the exact steps?
+   - Confirm the bug can be triggered reliably, and capture the exact steps
    - If not reproducible → gather more data, don't guess
 
 3. **Check recent changes**
@@ -85,7 +84,7 @@ At each step, halve the search space:
 
 **Rules:**
 - Each iteration MUST eliminate ~50% of the remaining search space
-- If you find yourself listing 5+ hypotheses without testing → STOP, switch to binary search
+- If 5+ hypotheses accumulate without being tested → STOP, switch to binary search
 - Document what was eliminated at each step
 
 ### Phase 3: Hypothesis and Confirmation
@@ -117,7 +116,7 @@ If no debugger is available:
 
 ## Red Flags — STOP and Return to Phase 1
 
-If you catch yourself thinking:
+Watch for these thought patterns:
 - "Just try changing X and see if it works"
 - "It's probably X, let me fix that"
 - "I don't fully understand but this might work"
@@ -130,9 +129,9 @@ If you catch yourself thinking:
 
 Escalate to user when:
 - Investigation reveals scope is larger than expected
-- Root cause is in a dependency or external system beyond your control
+- Root cause is in a dependency or external system beyond agent control
 - Multiple valid fix approaches exist with non-obvious trade-offs
-- The bug requires access, credentials, or environment you don't have
+- The bug requires access, credentials, or environment not available to the agent
 - Cannot reproduce after exhausting available information
 
 ## Report


### PR DESCRIPTION
## Summary

Audit and refinement of the `debug` skill in `plugins/developer-workflow/skills/debug/` against plugin-dev:skill-development criteria. Safe, textual-only edits — no semantic, structural, or behavioral changes.

## Changes

- **Description rewritten in third person.** Previously opened with `Systematic root cause investigation — stops at diagnosis, does NOT fix. Invoke when user says ...`. Now opens with the canonical `This skill should be used when the user asks to ...` form. All existing trigger phrases (EN + RU) and the `Do NOT use for` scope guard are preserved. Description length: ~736 chars (well under 1024).
- **Body voice: second person → imperative / neutral.** Converted 5 `you/your` phrasings:
  - `you've tried multiple fixes already` → `multiple fixes have already been tried`
  - `Can you trigger it reliably?` → `Confirm the bug can be triggered reliably`
  - `If you find yourself listing 5+ hypotheses ...` → `If 5+ hypotheses accumulate without being tested ...`
  - `If you catch yourself thinking:` → `Watch for these thought patterns:`
  - `beyond your control` / `environment you don't have` → `beyond agent control` / `environment not available to the agent`
- Post-edit grep confirms 0 remaining `you|your|You|Your` occurrences.

## Fixes NOT applied (and why)

- **No extraction to `references/`.** SKILL.md body is 864 words — well under the 1,500-2,000 target and nowhere near the 3,000 hard cap. Fragmenting would hurt, not help.
- **No semantic, structural, or naming changes.** Three-phase flow, red flags, escalation rules, report template, agent name (`debugging-expert`), and `disable-model-invocation: true` are untouched — per task constraints.
- **No rename or relocation of the skill.**

## Audit report

See `swarm-report/skill-review-debug-state.md` (gitignored, worktree-local).

## Validation

- `bash scripts/validate.sh` — **PASS**. `developer-workflow/debug` frontmatter: 736 chars. Pre-existing unrelated WARNs for `acceptance`, `triage-feedback`, `write-spec` (>500 lines, no references/) — not introduced by this PR.
- `plugin-dev:plugin-validator` subagent — **not runnable from this agent context** (no Task tool available). Manually verified equivalent checks: YAML frontmatter valid, `name: debug` matches directory, all referenced paths resolve, no broken links. Recommend a spot-check via the validator agent from an interactive session before merge.

## Test plan

- [ ] `bash scripts/validate.sh` green on CI
- [ ] Spot-check `plugin-dev:plugin-validator` on `developer-workflow` (interactive)
- [ ] Skim the skill — triggering behavior unchanged (same trigger phrases, same `disable-model-invocation: true`)