### PR TITLE
Review skill design-options

### DIFF
--- a/plugins/developer-workflow/skills/design-options/SKILL.md
+++ b/plugins/developer-workflow/skills/design-options/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: design-options
 description: >
-  Generate 2-3 alternative architectural approaches for a single task before multiexpert-review.
-  Launches architecture-expert agents in parallel, each under a different style constraint
-  (minimal / clean / pragmatic), and presents the options side-by-side so the user can pick
-  one informed choice instead of committing to the first approach that came to mind.
-  Optional stage between write-spec (or decompose-feature for a single-task feature) and
-  multiexpert-review. Trigger when: task is high architectural risk, multiple plausible approaches
-  exist, or user explicitly requests it.
-  Invoke on: "explore design options", "show me alternatives", "предложи варианты архитектуры",
-  "разные подходы", "choose between approaches", or when feature-flow runs this as an
-  opt-in stage for high-arch-risk tasks.
+  This skill should be used when the user asks to "explore design options", "show me alternatives",
+  "choose between approaches", "предложи варианты архитектуры", "разные подходы", or when a task
+  has high architectural risk and multiple plausible approaches exist. Generates 2-3 alternative
+  architectural approaches for a single task by launching architecture-expert agents in parallel,
+  each under a different style constraint (minimal / clean / pragmatic), and presents the options
+  side-by-side so the user can pick one informed choice instead of committing to the first
+  approach that came to mind. Optional stage between write-spec (or decompose-feature for a
+  single-task feature) and multiexpert-review. Also used when feature-flow runs this as an
+  opt-in stage for high-arch-risk tasks. Do NOT use for straightforward tasks, bug fixes with
+  a clear fix direction, or single-file changes.
 ---
 
 # Design Options


### PR DESCRIPTION
## Summary

Audit and cleanup of `plugins/developer-workflow/skills/design-options/` against `/plugin-dev:skill-development` criteria.

**Change:** rewrote the `description` frontmatter to lead with the third-person "This skill should be used when the user asks to…" form required by skill-development guidance, preserving all original trigger phrases (English + Russian) and adding an explicit "Do NOT use for…" negative-trigger clause sourced from the body's "Skip for" list.

## Audit findings

| Criterion | Status |
|---|---|
| Description third person ("This skill should be used when…") | FIXED |
| Specific trigger phrases | OK |
| Description ≤ 1024 chars | OK (886) |
| Body voice imperative/infinitive | OK |
| Body word count ≤ 2000 ideal | OK (1706) |
| File references resolve | OK |
| Progressive disclosure | OK |

No extraction to `references/` was needed — body is 1706 words, already within the ideal 1,500–2,000 range. No voice conversion needed — body already imperative.

Full audit notes: `swarm-report/skill-review-design-options-state.md`.

## Validation

- `bash scripts/validate.sh` — green. `'developer-workflow/design-options' frontmatter (886ch)` listed OK. Pre-existing WARN lines about `acceptance` / `triage-feedback` / `write-spec` being >500 lines are unrelated to this change.
- plugin-validator agent — could not be launched from this sub-agent context (no Task tool available). Performed manual equivalent checks: `plugin.json` valid, skill directory intact, frontmatter well-formed, no critical/major violations introduced.

## Test plan

- [x] First 20 lines of edited SKILL.md — YAML frontmatter valid, `name:` matches directory, `description:` ≤ 1024 chars
- [x] `bash scripts/validate.sh` green
- [x] No skill semantics, agent names, command signatures, or behavior changed