### PR TITLE
Review skill write-tests

### DIFF
--- a/plugins/developer-workflow/skills/write-tests/SKILL.md
+++ b/plugins/developer-workflow/skills/write-tests/SKILL.md
@@ -1,6 +1,17 @@
 ---
 name: write-tests
-description: "Write retroactive tests for existing code — classes, modules, or directories lacking test coverage. Discovers test infrastructure (framework, assertions, mocking, naming), plans test cases, delegates generation to kotlin-engineer or compose-developer for Compose UI, verifies tests compile and pass, reports findings. Use when: \"write tests for\", \"add tests to\", \"test this class\", \"increase coverage\", \"add unit tests\", \"this code has no tests\", \"cover with tests\", \"retroactive tests\". Do NOT use when: user wants a test plan document without code (use generate-test-plan), run tests on live app (use acceptance), exploratory QA (use bug-hunt), or tests are part of a new feature (kotlin-engineer handles within implement). Orchestrator — delegates actual test code to engineer agents. Consumes test plans from generate-test-plan when available."
+description: >-
+  This skill should be used when the user asks to "write tests for", "add tests to",
+  "test this class", "increase coverage", "add unit tests", "this code has no tests",
+  "cover with tests", or "retroactive tests" — generating tests for existing code
+  (classes, modules, or directories) that lacks coverage. Discovers test infrastructure
+  (framework, assertions, mocking, naming), plans test cases, delegates generation to
+  kotlin-engineer or compose-developer for Compose UI, verifies tests compile and pass,
+  and reports findings. Do NOT use when the user wants a test plan document without
+  code (use generate-test-plan), run tests on live app (use acceptance), exploratory
+  QA (use bug-hunt), or tests are part of a new feature (kotlin-engineer handles
+  within implement). Orchestrator — delegates actual test code to engineer agents.
+  Consumes test plans from generate-test-plan when available.
 ---
 
 # Write Tests


### PR DESCRIPTION
## Summary

Audit of `plugins/developer-workflow/skills/write-tests/SKILL.md` against `plugin-dev:skill-development` criteria. One safe fix applied.

## Changes

- **Description rewrite (frontmatter only):** converted from imperative ("Write retroactive tests…") to the required third-person form ("This skill should be used when the user asks to…"). Used YAML folded-block `>-` scalar to match the convention of the sibling `generate-test-plan` skill.
- Trigger phrases, "Do NOT use when" guidance, orchestrator note, and body content preserved verbatim.
- No semantic changes to workflow, agent delegation, phases, or tool usage.

## Audit highlights

| Criterion | Status |
|-----------|--------|
| Third-person description | Fixed |
| Description ≤ 1024 chars | OK (887ch per validator) |
| Specific trigger phrases | OK |
| Imperative body voice, no "You should" | OK |
| Body word count | 2,086 words — above ideal 2,000 but well under 3,000 hard cap |
| File references resolve | OK |
| Progressive disclosure | OK (single-file minimal pattern) |

Full audit report: `swarm-report/skill-review-write-tests-state.md`

## Fixes NOT applied

- Extraction of Phase 4 prompt templates / Phase 2 tables to `references/` — body is within hard cap, tables are fast-reference, and prompt templates are the operational core of the delegation contract. Extracting would risk semantic drift and introduce inconsistency with sibling skills.

## Validation

- `bash scripts/validate.sh` — green. `developer-workflow/write-tests` frontmatter 887ch, no warnings.
- `plugin-dev:plugin-validator` agent — not runnable from this worktree session (Task tool unavailable). Structural validator is green; recommend a follow-up plugin-validator run at main repo level before release.

## Test plan

- [x] `bash scripts/validate.sh` passes
- [x] Frontmatter `name: write-tests` matches directory
- [x] Description < 1024 chars
- [x] No second-person voice introduced in body
- [ ] `plugin-dev:plugin-validator` on `developer-workflow` — pending repo-level run