### PR TITLE
Review skill implement: refine description and dedupe Phase 3

### DIFF
--- a/plugins/developer-workflow/skills/implement/SKILL.md
+++ b/plugins/developer-workflow/skills/implement/SKILL.md
@@ -1,18 +1,15 @@
 ---
 name: implement
 description: >-
-  Implementation stage — takes a task with optional context artifacts and produces working code.
-  Designed to be called by an orchestrator or directly by the user. Accepts any task source:
-  plain text description, GitHub/Jira/Linear issue URL, or a reference to an existing artifact
-  (research.md, debug.md, plan.md).
-
-  Pipeline: understand task → write code → quality loop (/check + intent check) → produce artifacts.
+  Implementation stage — produces working code from a task plus optional context artifacts.
+  Callable by an orchestrator or directly by the user. Accepts any task source: plain text,
+  a GitHub/Jira/Linear issue URL, or existing artifacts (research.md, debug.md, plan.md).
+  Pipeline: understand task → write code → quality loop (/check + intent check) → artifacts.
   Semantic review, simplification, expert review, and PR-level quality checks live in the
-  separate `finalize` stage. Does NOT create worktrees, PRs, or run live QA — those are
-  separate stages.
+  separate `finalize` stage. Does NOT create worktrees, PRs, or run live QA.
 
-  Use when: "implement", "write the code", "fix this", "сделай", "реализуй", "напиши код",
-  "пофикси", or when an orchestrator delegates the implementation stage.
+  Use when the user says: "implement", "write the code", "fix this", "сделай", "реализуй",
+  "напиши код", "пофикси", or when an orchestrator delegates the implementation stage.
   Do NOT use for: debugging/investigation (use debug), research (use research),
   PR creation (use create-pr), live QA (use acceptance).
 disable-model-invocation: true
@@ -101,16 +98,21 @@ stage (e.g., model, repository, UI layer). Stage specific files, never `git add 
 
 ## Phase 3: Quality Loop
 
-Run two quality gates sequentially. A failure triggers a fix cycle before advancing. Implement is strictly "write the code and verify it works per the plan" — everything beyond is the `finalize` stage (see `docs/ORCHESTRATION.md` § Finalize).
+Implement is strictly "write the code and verify it works per the plan" — everything beyond
+is the `finalize` stage (see `docs/ORCHESTRATION.md` § Finalize).
 
-After code is written, run the Quality Loop defined in [`docs/ORCHESTRATION.md`](../../docs/ORCHESTRATION.md#implement--quality-loop-2-gates) — that document is the single source of truth for gate definitions, verdict handling, and iteration limits.
+After code is written, run the Quality Loop defined in [`docs/ORCHESTRATION.md`](../../docs/ORCHESTRATION.md#implement--quality-loop-2-gates)
+— that document is the single source of truth for gate definitions, verdict handling, and
+iteration limits.
 
-Summary for this skill's callers:
-- Gate 1 invokes `/check` (mechanical: build + lint + typecheck + tests)
-- Gate 2 is the intent check — re-read task + plan, verify the diff addresses them; scope creep or drift → fix or flag
-- A gate failure triggers a fix cycle; total loop is capped per ORCHESTRATION.md
+Summary for callers:
+- Gate 1 invokes `/check` (mechanical: build + lint + typecheck + tests).
+- Gate 2 is the intent check — re-read task + plan, verify the diff addresses them;
+  scope creep or drift triggers a fix or an escalation flag.
+- A gate failure triggers a fix cycle; total loop is capped per ORCHESTRATION.md.
 
-Do not duplicate gate details here — read ORCHESTRATION.md before executing. If ORCHESTRATION.md is missing, escalate rather than guessing the current rules.
+Do not duplicate gate details here — read ORCHESTRATION.md before executing.
+If ORCHESTRATION.md is missing, escalate rather than guessing the current rules.
 
 ---
 


### PR DESCRIPTION
## Summary

Audit of `plugins/developer-workflow/skills/implement/` against `/plugin-dev:skill-development` criteria. Skill was already in good shape; two minor prose edits applied.

### Changes

- **Frontmatter description** (921 → 829 chars): tightened the opening sentence, collapsed the duplicated "separate stages" closer, and reframed the trigger line as "Use when the user says:" for clearer third-person phrasing.
- **Phase 3 prose**: removed a redundant "Run two quality gates sequentially. A failure triggers a fix cycle before advancing." sentence — the same information was already covered by the subsequent Summary bullets. Added terminal punctuation and reflowed long lines.

No semantic or behavioral change. All agent names, gate definitions, artifact shapes, escalation rules, and the link to `docs/ORCHESTRATION.md#implement--quality-loop-2-gates` preserved verbatim.

### Audit report

`swarm-report/skill-review-implement-state.md` (gitignored; referenced locally).

### Validation

- `bash scripts/validate.sh` — **green**. New description reported as `'developer-workflow/implement' frontmatter (828ch)`. Pre-existing warnings for `acceptance`, `triage-feedback`, `write-spec` (>500 lines, no references/) are unrelated to this change.
- `plugin-dev:plugin-validator` agent — **not run**: the Task/Agent launcher tool is not available in this isolated worktree environment. Validation script covers structural/frontmatter checks.

### Fixes deliberately NOT applied

- Description still opens with "Implementation stage —" rather than "This skill should be used when..." — sibling skills (`debug`, `finalize`, `research`) share the same compressed plugin-family pattern; switching just this one file would break family consistency.
- No content extraction to `references/` — body is 1012 words, well under the 1,500-2,000 ideal; splitting would hurt progressive disclosure, not help it.

## Test plan

- [ ] `bash scripts/validate.sh` passes
- [ ] Frontmatter `name: implement` matches directory
- [ ] Description ≤ 1024 chars (828ch reported by validator)
- [ ] Link `docs/ORCHESTRATION.md#implement--quality-loop-2-gates` resolves
- [ ] No `you`/`your` second-person voice in body