### PR TITLE
Review skill generate-test-plan

### DIFF
--- a/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
@@ -48,83 +48,16 @@ Examples of derivation (rule 3): `"User authentication"` → `user-authenticatio
 The resulting filename is then `docs/testplans/<slug>-test-plan.md` (for example,
 `docs/testplans/user-authentication-test-plan.md`).
 
-### Receipt (when invoked from orchestrator with a slug)
+### Receipt (orchestrator invocation)
 
-When this skill is invoked from the `feature-flow` orchestrator, a `slug` argument is passed
-explicitly. In that case, in addition to the permanent document above, produce a **receipt**
-at `swarm-report/<slug>-test-plan.md` that the orchestrator and downstream stages
-(`multiexpert-review`, `acceptance`) can consume for receipt-based gating.
+When invoked from `feature-flow` with a slug, produce an additional **receipt** at
+`swarm-report/<slug>-test-plan.md` for receipt-based gating by `multiexpert-review` and
+`acceptance`. Standalone invocation without a slug skips the receipt — the permanent file
+is the only artifact.
 
-The permanent file remains the source of truth. The receipt is metadata + pointer.
-
-Receipt format:
-
-```markdown
----
-name: test-plan-receipt
-description: Test plan artifact for <slug>
-slug: <slug>
-type: test-plan-receipt
-status: Draft | Ready | Approved | Mounted
-permanent_path: docs/testplans/<slug>-test-plan.md
-source_spec: <path to spec if any, or "inline spec">
-review_verdict: pending | PASS | WARN | FAIL | skipped
-review_warnings: []            # populated by multiexpert-review on WARN — list of short strings
-review_blockers: []            # populated by multiexpert-review on FAIL — list of short strings
-phase_coverage: [Phase 1, Phase 2, ...]
-platform: []                   # optional; inherited from the source spec's `platform:` field when present.
-                               # Drives platform-aware TC generation and downstream acceptance checks (e.g.,
-                               # skip mobile-only TCs on a backend-only target). Leave empty when the spec
-                               # did not set it; acceptance falls back to its project-type heuristic.
-created: YYYY-MM-DD
-updated: YYYY-MM-DD
----
-
-# Test Plan Receipt: <slug>
-
-**Status:** <status>
-**Permanent artifact:** [`docs/testplans/<slug>-test-plan.md`](../docs/testplans/<slug>-test-plan.md)
-**Source spec:** <path or description>
-**Review verdict:** <verdict>
-```
-
-Field conventions:
-- `status`: `Draft` right after generation; `Ready` after multiexpert-review returns PASS/WARN;
-  `Approved` when the user explicitly signs off; `Mounted` when a user-authored permanent
-  file is adopted without regeneration (see `feature-flow/SKILL.md` §1.5 Pre-check).
-- `review_verdict`: `pending` at creation; updated by `multiexpert-review` to
-  `PASS | WARN | FAIL`; `skipped` on mount (no review occurs).
-- `review_warnings` / `review_blockers`: arrays of short strings populated by `multiexpert-review`.
-  `review_warnings` is written on WARN verdicts (items d or e of the checklist violated —
-  non-blocking); `review_blockers` is written on FAIL (items a, b, or c violated —
-  blocks transition to Implement). Both remain empty arrays on PASS / pending / skipped.
-  Frontmatter is the single source of truth for review findings — the receipt body does
-  not re-list them, keeping downstream YAML parsers authoritative.
-- `phase_coverage`: list of phase labels present in the permanent file. Empty list if the
-  feature has no phase segmentation.
-- `created` / `updated`: ISO dates (`YYYY-MM-DD`). `updated` must change whenever either the
-  permanent file or any receipt field is modified.
-- Relative path in the markdown link assumes the conventional `swarm-report/` ↔ `docs/`
-  sibling layout at the repo root.
-
-### Backward compatibility — standalone invocation without slug
-
-When a user invokes this skill directly (e.g. "create a test plan for X") without the
-orchestrator passing a `slug`, the receipt is **not** produced. The permanent file is
-still saved under the canonical slug-based filename:
-
-- Permanent file generated at `docs/testplans/<slug>-test-plan.md`, where `<slug>` is
-  either provided inline or derived from the feature name per the Slug resolution rules
-  above. If the plan may later be consumed by another workflow that mounts an existing
-  plan (e.g. `bugfix-flow` → `acceptance` Branch 2), use the eventual orchestrator slug
-  at creation time so the file is deterministically mountable without renaming.
-- No `swarm-report/<slug>-test-plan.md` receipt is written.
-- No `phase_coverage` or receipt metadata tracked elsewhere.
-
-Standalone callers continue to work: the slug-based filename is the single canonical
-artifact. Pre-existing `docs/testplans/*-test-plan.md` files authored before this
-convention are not auto-migrated — they remain readable by humans, but mount logic
-matches only on the exact `<slug>-test-plan.md` path.
+Full receipt frontmatter schema, field conventions, platform inheritance, and standalone
+fallback rules live in [`references/receipt.md`](references/receipt.md). Consult that file
+when generating or updating a receipt.
 
 ## Input Discovery
 
@@ -138,12 +71,9 @@ Read the document. Extract:
 - Acceptance criteria (explicit pass/fail conditions)
 - User roles and permissions mentioned
 
-**Spec frontmatter (when the source is a file with YAML frontmatter).** Read the frontmatter
-block first. If it contains a `platform:` list, copy that list verbatim into the receipt's
-`platform:` field (same canonical values as `write-spec` and ORCHESTRATION.md §Project type
-detection). When the orchestrator invokes this skill without a file-based spec, or the spec
-has no frontmatter, leave `platform:` empty in the receipt — `acceptance` will fall back to
-its project-type heuristic.
+When the source is a file with YAML frontmatter containing a `platform:` list, copy that
+list verbatim into the receipt's `platform:` field (see
+[`references/receipt.md`](references/receipt.md) §Platform inheritance).
 
 ### 2. Figma mockup
 
@@ -194,6 +124,8 @@ standard format.
 
 When the detector triggers, note it in the Findings section of the permanent file:
 `**Lightweight template applied** — no UI surface detected; TCs use Given/When/Then only.`
+For the reduced TC format itself, see
+[`references/templates.md`](references/templates.md) §Lightweight Template.
 
 ## Analysis
 
@@ -302,93 +234,20 @@ Test cases that are good candidates for automated testing.
 > Omit this section if no test cases are suitable for automation.
 ```
 
-### Phase Segmentation
+### Variants — phase segmentation and lightweight TCs
 
-When the feature reaches this skill via `decompose-feature` with phases (e.g. T-1..T-3 in
-Phase 1, T-4..T-6 in Phase 2), the permanent file splits the `## Test Cases` section by
-phase so each phase can ship and be re-verified independently. One permanent document per
-feature remains the rule — phases are sections inside it, not separate files.
+Two variants apply on top of the format above:
 
-Apply segmentation when the decomposition artifact contains two or more phases **and** test
-cases can be grouped by which phase introduces the behavior they cover. Otherwise keep a
-single flat `## Test Cases` section.
+- **Phase segmentation** — when `decompose-feature` produced two or more phases and TCs
+  group cleanly by the phase that introduces the behavior, split `## Test Cases` into
+  per-phase subsections. The permanent file stays as one document.
+- **Lightweight TC template** — when the non-UI detector triggers (see above), TC blocks
+  collapse Steps and Expected Result into a single Given/When/Then row. All other sections
+  remain unchanged.
 
-Example for a feature with two phases:
-
-```markdown
-## Test Cases
-
-### Phase 1 (T-1..T-3) — Core login flow
-
-#### TC-1: Successful login with valid credentials
-| Field | Value |
-|-------|-------|
-| **Priority** | P0 Critical |
-| **Tier** | Smoke |
-| **Preconditions** | User account exists, email is verified |
-| **Steps** | 1. Open login screen  2. Enter email  3. Enter password  4. Tap Login |
-| **Expected Result** | Home screen is shown, session token stored |
-| **Source** | Spec §2.1 |
-
-#### TC-2: Invalid password shows inline error
-...
-
-#### TC-3: Rate-limit after 5 failed attempts
-...
-
-### Phase 2 (T-4..T-6) — Password reset flow
-
-#### TC-4: Request reset email from login screen
-| Field | Value |
-|-------|-------|
-| **Priority** | P0 Critical |
-| **Tier** | Feature |
-| **Preconditions** | User account exists |
-| **Steps** | 1. Tap "Forgot password?"  2. Enter email  3. Submit |
-| **Expected Result** | Confirmation screen shown, reset email dispatched |
-| **Source** | Spec §3.2 |
-
-#### TC-5: Reset link expires after 15 minutes
-...
-
-#### TC-6: Reset flow rejects reused link
-...
-```
-
-When segmentation is applied, the receipt's `phase_coverage` field lists the phase labels
-present (e.g. `[Phase 1, Phase 2]`), and the TC ranges covered by each phase appear in the
-receipt's Phase Coverage section.
-
-### Lightweight template (non-UI features)
-
-When the non-UI detector triggers (see Input Discovery), use this reduced TC format in place
-of the standard one. The entire behavior of each TC is captured in Given/When/Then — no
-numbered Steps, no separate Expected Result field, since both collapse into the Then clause
-for non-interactive surfaces.
-
-```markdown
-#### TC-[N]: [Short title]
-| **Priority** | P0/P1/P2/P3 |
-| **Tier** | Smoke/Feature/Regression |
-| **Preconditions** | [state] |
-| **Scenario (Given/When/Then)** | Given X, When Y, Then Z |
-| **Source** | [Spec §section / inferred from code] |
-```
-
-Example:
-
-```markdown
-#### TC-3: Token refresh succeeds before expiry
-| **Priority** | P0 Critical |
-| **Tier** | Feature |
-| **Preconditions** | Valid refresh token stored, access token within 60s of expiry |
-| **Scenario (Given/When/Then)** | Given an access token with <60s TTL, When the client calls `refresh()`, Then a new access token is returned with the original refresh-token scope preserved |
-| **Source** | `src/auth/TokenManager.kt:142` |
-```
-
-All other sections of the Test Plan Format (front-matter table, Findings, Risk Areas,
-Coverage Matrix, Suggested Automation Candidates, Phase Segmentation when applicable) are
-used unchanged — only the TC blocks switch to this reduced form.
+Full worked examples for both variants live in
+[`references/templates.md`](references/templates.md). Consult it before emitting either
+variant so the TC shape matches what downstream stages expect.
 
 ## Field Definitions
 
@@ -431,3 +290,10 @@ used unchanged — only the TC blocks switch to this reduced form.
   product intent
 - Target 15-30 test cases for a medium feature; fewer for simple changes, more for
   complex flows — every test case should earn its place
+
+## Additional Resources
+
+- [`references/receipt.md`](references/receipt.md) — receipt frontmatter schema, field
+  conventions, platform inheritance, standalone fallback rules.
+- [`references/templates.md`](references/templates.md) — worked examples for phase
+  segmentation and the lightweight (non-UI) TC template.

--- a/plugins/developer-workflow/skills/generate-test-plan/references/receipt.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/references/receipt.md
@@ -1,0 +1,88 @@
+# Test Plan Receipt Format
+
+When this skill is invoked from the `feature-flow` orchestrator, a `slug` argument is passed
+explicitly. In that case, in addition to the permanent document under
+`docs/testplans/<slug>-test-plan.md`, produce a **receipt** at
+`swarm-report/<slug>-test-plan.md` that the orchestrator and downstream stages
+(`multiexpert-review`, `acceptance`) consume for receipt-based gating.
+
+The permanent file remains the source of truth. The receipt is metadata + pointer.
+
+## Receipt format
+
+```markdown
+---
+name: test-plan-receipt
+description: Test plan artifact for <slug>
+slug: <slug>
+type: test-plan-receipt
+status: Draft | Ready | Approved | Mounted
+permanent_path: docs/testplans/<slug>-test-plan.md
+source_spec: <path to spec if any, or "inline spec">
+review_verdict: pending | PASS | WARN | FAIL | skipped
+review_warnings: []            # populated by multiexpert-review on WARN — list of short strings
+review_blockers: []            # populated by multiexpert-review on FAIL — list of short strings
+phase_coverage: [Phase 1, Phase 2, ...]
+platform: []                   # optional; inherited from the source spec's `platform:` field when present.
+                               # Drives platform-aware TC generation and downstream acceptance checks (e.g.,
+                               # skip mobile-only TCs on a backend-only target). Leave empty when the spec
+                               # did not set it; acceptance falls back to its project-type heuristic.
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+
+# Test Plan Receipt: <slug>
+
+**Status:** <status>
+**Permanent artifact:** [`docs/testplans/<slug>-test-plan.md`](../docs/testplans/<slug>-test-plan.md)
+**Source spec:** <path or description>
+**Review verdict:** <verdict>
+```
+
+## Field conventions
+
+- `status`: `Draft` right after generation; `Ready` after multiexpert-review returns PASS/WARN;
+  `Approved` when the user explicitly signs off; `Mounted` when a user-authored permanent
+  file is adopted without regeneration (see `feature-flow/SKILL.md` §1.5 Pre-check).
+- `review_verdict`: `pending` at creation; updated by `multiexpert-review` to
+  `PASS | WARN | FAIL`; `skipped` on mount (no review occurs).
+- `review_warnings` / `review_blockers`: arrays of short strings populated by `multiexpert-review`.
+  `review_warnings` is written on WARN verdicts (items d or e of the checklist violated —
+  non-blocking); `review_blockers` is written on FAIL (items a, b, or c violated —
+  blocks transition to Implement). Both remain empty arrays on PASS / pending / skipped.
+  Frontmatter is the single source of truth for review findings — the receipt body does
+  not re-list them, keeping downstream YAML parsers authoritative.
+- `phase_coverage`: list of phase labels present in the permanent file. Empty list if the
+  feature has no phase segmentation.
+- `created` / `updated`: ISO dates (`YYYY-MM-DD`). `updated` must change whenever either the
+  permanent file or any receipt field is modified.
+- Relative path in the markdown link assumes the conventional `swarm-report/` ↔ `docs/`
+  sibling layout at the repo root.
+
+## Platform inheritance from spec frontmatter
+
+When the source is a file with YAML frontmatter, read the frontmatter block first. If it
+contains a `platform:` list, copy that list verbatim into the receipt's `platform:` field
+(same canonical values as `write-spec` and ORCHESTRATION.md §Project type detection). When
+the orchestrator invokes this skill without a file-based spec, or the spec has no frontmatter,
+leave `platform:` empty in the receipt — `acceptance` falls back to its project-type heuristic.
+
+## Backward compatibility — standalone invocation without slug
+
+When a user invokes this skill directly (e.g. "create a test plan for X") without the
+orchestrator passing a `slug`, the receipt is **not** produced. The permanent file is
+still saved under the canonical slug-based filename:
+
+- Permanent file generated at `docs/testplans/<slug>-test-plan.md`, where `<slug>` is
+  either provided inline or derived from the feature name per the Slug resolution rules
+  in SKILL.md. If the plan may later be consumed by another workflow that mounts an
+  existing plan (e.g. `bugfix-flow` → `acceptance` Branch 2), use the eventual
+  orchestrator slug at creation time so the file is deterministically mountable without
+  renaming.
+- No `swarm-report/<slug>-test-plan.md` receipt is written.
+- No `phase_coverage` or receipt metadata tracked elsewhere.
+
+Standalone callers continue to work: the slug-based filename is the single canonical
+artifact. Pre-existing `docs/testplans/*-test-plan.md` files authored before this
+convention are not auto-migrated — they remain readable by humans, but mount logic
+matches only on the exact `<slug>-test-plan.md` path.

--- a/plugins/developer-workflow/skills/generate-test-plan/references/templates.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/references/templates.md
@@ -1,0 +1,93 @@
+# Test Plan Templates — Extended Examples
+
+Use this reference when applying the phase segmentation or lightweight (non-UI) template
+in a generated test plan. Keep the SKILL.md Test Plan Format as the base — these are
+additive variants.
+
+## Phase Segmentation
+
+When the feature reaches this skill via `decompose-feature` with phases (e.g. T-1..T-3 in
+Phase 1, T-4..T-6 in Phase 2), the permanent file splits the `## Test Cases` section by
+phase so each phase can ship and be re-verified independently. One permanent document per
+feature remains the rule — phases are sections inside it, not separate files.
+
+Apply segmentation when the decomposition artifact contains two or more phases **and** test
+cases can be grouped by which phase introduces the behavior they cover. Otherwise keep a
+single flat `## Test Cases` section.
+
+Example for a feature with two phases:
+
+```markdown
+## Test Cases
+
+### Phase 1 (T-1..T-3) — Core login flow
+
+#### TC-1: Successful login with valid credentials
+| Field | Value |
+|-------|-------|
+| **Priority** | P0 Critical |
+| **Tier** | Smoke |
+| **Preconditions** | User account exists, email is verified |
+| **Steps** | 1. Open login screen  2. Enter email  3. Enter password  4. Tap Login |
+| **Expected Result** | Home screen is shown, session token stored |
+| **Source** | Spec §2.1 |
+
+#### TC-2: Invalid password shows inline error
+...
+
+#### TC-3: Rate-limit after 5 failed attempts
+...
+
+### Phase 2 (T-4..T-6) — Password reset flow
+
+#### TC-4: Request reset email from login screen
+| Field | Value |
+|-------|-------|
+| **Priority** | P0 Critical |
+| **Tier** | Feature |
+| **Preconditions** | User account exists |
+| **Steps** | 1. Tap "Forgot password?"  2. Enter email  3. Submit |
+| **Expected Result** | Confirmation screen shown, reset email dispatched |
+| **Source** | Spec §3.2 |
+
+#### TC-5: Reset link expires after 15 minutes
+...
+
+#### TC-6: Reset flow rejects reused link
+...
+```
+
+When segmentation is applied, the receipt's `phase_coverage` field lists the phase labels
+present (e.g. `[Phase 1, Phase 2]`), and the TC ranges covered by each phase appear in the
+receipt's Phase Coverage section.
+
+## Lightweight Template (Non-UI Features)
+
+When the non-UI detector triggers (see SKILL.md §Input Discovery), use this reduced TC
+format in place of the standard one. The entire behavior of each TC is captured in
+Given/When/Then — no numbered Steps, no separate Expected Result field, since both collapse
+into the Then clause for non-interactive surfaces.
+
+```markdown
+#### TC-[N]: [Short title]
+| **Priority** | P0/P1/P2/P3 |
+| **Tier** | Smoke/Feature/Regression |
+| **Preconditions** | [state] |
+| **Scenario (Given/When/Then)** | Given X, When Y, Then Z |
+| **Source** | [Spec §section / inferred from code] |
+```
+
+Example:
+
+```markdown
+#### TC-3: Token refresh succeeds before expiry
+| **Priority** | P0 Critical |
+| **Tier** | Feature |
+| **Preconditions** | Valid refresh token stored, access token within 60s of expiry |
+| **Scenario (Given/When/Then)** | Given an access token with <60s TTL, When the client calls `refresh()`, Then a new access token is returned with the original refresh-token scope preserved |
+| **Source** | `src/auth/TokenManager.kt:142` |
+```
+
+All other sections of the Test Plan Format (front-matter table, Findings, Risk Areas,
+Coverage Matrix, Suggested Automation Candidates, Phase Segmentation when applicable) are
+used unchanged — only the TC blocks switch to this reduced form.


### PR DESCRIPTION
## Summary

Audit and improvement of `plugins/developer-workflow/skills/generate-test-plan/` against `/plugin-dev:skill-development` criteria.

## Changes

- **SKILL.md trimmed** from 433 lines / 2748 words to ~270 lines / 1831 words (now within the 1500-2000-word ideal band).
- **`references/receipt.md`** (new, 637 words) — receipt frontmatter schema, field conventions (`status`, `review_verdict`, `review_warnings`, `review_blockers`, `phase_coverage`, `platform`, `created`, `updated`), platform-inheritance rules, and the standalone-invocation backward-compatibility rules.
- **`references/templates.md`** (new, 557 words) — full worked examples for phase segmentation (Phase 1 + Phase 2 with TC tables) and the lightweight (non-UI) Given/When/Then TC template.
- SKILL.md gains a condensed `### Receipt (orchestrator invocation)` paragraph plus an `## Additional Resources` section with pointers to both reference files.

## Audit criteria — results

| Criterion | Result |
|-----------|--------|
| Description third person | PASS |
| Description specific trigger phrases | PASS |
| Description ≤ 1024 chars | PASS (999) |
| Frontmatter `name:` matches directory | PASS |
| Body voice imperative (no "you") | PASS (only occurrence is inside a quoted trigger phrase) |
| Body ≤ 2000 words ideal | PASS post-review (1831) |
| File references resolve | PASS |
| Progressive disclosure | PASS post-review |

## What was NOT changed (and why)

- **Test Plan Format block kept inline** — it is the output contract downstream stages (`multiexpert-review`, `acceptance`) match on (`type: test-plan` frontmatter). Must be emitted verbatim on every invocation.
- **Field Definitions (Priority/Tier/Source) kept inline** — compact tables used on every TC emission; extracting would force an extra load every run.
- **Slug resolution rules and Guidelines kept inline** — applied on every invocation, no size win from extraction.
- **Description trigger phrases not reshuffled** — already specific and disambiguates clearly against `acceptance` / `bug-hunt`.

## Audit report

[`swarm-report/skill-review-generate-test-plan-state.md`](../blob/chore/review-skill-generate-test-plan/swarm-report/skill-review-generate-test-plan-state.md) (not committed — gitignored).

## Validation

- `bash scripts/validate.sh` — **green**. `developer-workflow/generate-test-plan` frontmatter OK (999 chars). Pre-existing WARNs on `acceptance`, `triage-feedback`, `write-spec` (>500-line SKILL.md without references/) are unrelated and out of scope for this review.
- `plugin-dev:plugin-validator` agent — **not invoked**: Task/Agent tool not available in this worktree agent environment. Manual criteria check against `/plugin-dev:skill-development` rules passed; no Critical/Major issues introduced.

## Test plan

- [ ] CI green
- [ ] Mark ready for review once CI passes