### PR TITLE
Review skill multiexpert-review

### DIFF
--- a/plugins/developer-workflow/skills/multiexpert-review/SKILL.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/SKILL.md
@@ -1,16 +1,15 @@
 ---
 name: multiexpert-review
 description: >-
-  Review documentation artifacts (plan, spec, test-plan) with a panel of independent expert
-  agents before commit. Use when asked to review a plan, spec, test-plan, or similar
-  documentation artifact. Uses the PoLL (Panel of LLM Evaluators) consensus protocol.
-  Invoke on phrases: "review the plan", "review the spec", "check the plan", "validate the
-  approach", "multi-expert review", "panel review", "план ревью", "проверь план", "оцени план",
-  "check the spec", or after exiting Plan Mode and wanting independent expert evaluation before
-  implementation. Also invoke when the user says "is this plan good?", "what did I miss?",
-  "sanity check this", "review this before I start", "check my approach", or wants multiple
-  viewpoints on an implementation strategy. Do NOT invoke for code review (use code-reviewer
-  agent instead) or PR review.
+  This skill should be used when the user asks to "review the plan", "review the spec",
+  "check the plan", "check the spec", "validate the approach", "multi-expert review",
+  "panel review", "план ревью", "проверь план", "оцени план", "is this plan good?",
+  "what did I miss?", "sanity check this", "review this before I start", or
+  "check my approach" — or after exiting Plan Mode and wanting independent expert
+  evaluation of a plan, spec, or test-plan before implementation. Runs a panel of
+  independent expert agents against a documentation artifact using the PoLL
+  (Panel of LLM Evaluators) consensus protocol. Do NOT invoke for code review
+  (use the code-reviewer agent) or PR review.
 ---
 
 # Multi-Expert Review
@@ -88,48 +87,9 @@ Re-review    → Synthesize → Verdict (same cycle)
 
 ## Persistence (compaction resilience)
 
-Save state to `./swarm-report/multiexpert-review-<slug>-state.md` (or `multiexpert-review-<YYYYMMDD-HHMM>-state.md` if no slug known).
+Save state to `./swarm-report/multiexpert-review-<slug>-state.md` (fallback `multiexpert-review-<YYYYMMDD-HHMM>-state.md` when no slug is known). Update after each significant step; re-read before each action and skip completed steps.
 
-**Slug source** (in priority order):
-1. Explicit caller args (`slug:` field)
-2. Artifact frontmatter `slug:` field
-3. Artifact filename without extension
-4. Timestamp fallback
-
-**Legacy read:** if the slug-qualified file doesn't exist, try `./swarm-report/plan-review-state.md` (legacy from pre-rename era). If found, copy content into the new slug-qualified name and continue on the new file. Do not delete the legacy file — user decides.
-
-**Always write:** new slug-qualified name.
-
-State file structure:
-
-```markdown
-# Multi-Expert Review State
-Source: {plan_mode | file:<path> | conversation}
-Profile: {implementation-plan | test-plan | spec | ...}   # locked at cycle 1
-Profile source: {caller_hint | frontmatter | path | signature | user_prompt}
-Cycle: {1 | 2 | 3} of 3
-Status: {detecting | reviewing | synthesizing | fixing | done}
-
-## Artifact Summary
-{goal, technologies, scope — extracted in Step 1}
-
-## Selected Agents
-- {agent1} (recommended)
-- {agent2} (recommended)
-
-## Reviews Completed
-- [x] {agent1} — {severity counts: N critical, M major, K minor}
-- [ ] {agent2} — pending
-
-## Verdict History
-### Cycle 1: {PASS | CONDITIONAL | FAIL | WARN}
-- Blockers: {list}
-- Improvements: {list}
-
-### Cycle 2: ...
-```
-
-Update after each significant step. Re-read before each action — skip completed steps.
+Full state-file schema, slug precedence, and legacy-file migration — see `references/persistence.md`.
 
 ## Step 1 — Read artifact and detect profile
 
@@ -154,7 +114,7 @@ Cycle-locking, profile validation (negative-list), and inventory-mismatch checks
 
 Find real agents via `Glob("**/agents/*.md")` + built-in subagents from system prompt. Read each agent's frontmatter to confirm. Never invent phantom agents.
 
-**Short-name collision tie-break:** if the same agent short-name resolves to multiple files (e.g., two plugins define `security-expert`), prefer first match in this order: (1) same-plugin as the caller skill, (2) sibling `developer-workflow-*` plugin, (3) any other source. If still ambiguous, fail loud with the dedicated category: `[multiexpert-review ERROR] AMBIGUOUS_REVIEWER: short-name <name> resolves to <paths>`. Distinct from `NO_REVIEWERS_AVAILABLE` (which covers the "agents missing entirely" path) so consumers can branch on intent. In practice the `developer-workflow-*` family guarantees unique short-names — this guard only triggers on non-family plugin conflicts.
+**Short-name collision tie-break:** if the same agent short-name resolves to multiple files, resolve deterministically in this order: (1) same-plugin as the caller skill, (2) sibling `developer-workflow-*` plugin, (3) any other source. If still ambiguous, emit `AMBIGUOUS_REVIEWER`. See `references/error-semantics.md` for full details.
 
 ### Selection per profile
 
@@ -166,11 +126,7 @@ Use `profile.reviewer_roster`:
 
 ### Single-reviewer guard
 
-If exactly 1 agent ended up selected:
-- If `profile.allow_single_reviewer: true` — proceed. Final verdict carries a `## Review Mode: single-perspective` marker in the output text (not in any receipt — receipt schemas are profile-declared and do not include `review_mode`).
-- If `profile.allow_single_reviewer: false` — fail loud `[multiexpert-review ERROR] NO_REVIEWERS_AVAILABLE: profile <name> requires panel, only <agent> available`.
-
-If 0 agents — same `NO_REVIEWERS_AVAILABLE` error regardless of flag.
+If exactly 1 agent remains selected and `profile.allow_single_reviewer: true` — proceed; final verdict carries a `## Review Mode: single-perspective` marker. If `false`, or 0 agents — emit `NO_REVIEWERS_AVAILABLE`. See `references/error-semantics.md` for details.
 
 ### User confirmation
 
@@ -318,19 +274,18 @@ If `profile.receipt` is absent — skip receipt writing.
 
 ## Error semantics
 
-All engine errors produce exactly this prefix on the first line of output:
+All engine errors produce this prefix as the first line of output:
 
 ```
 [multiexpert-review ERROR] <CATEGORY>: <details>
 ```
 
-Categories:
+Consumers (`feature-flow`, `write-spec`, etc.) detect this prefix to distinguish engine errors from ordinary review FAIL verdicts. Full category list and triggering conditions — see `references/error-semantics.md`.
 
-- `UNKNOWN_PROFILE_HINT` — caller hint not in inventory
-- `FORBIDDEN_PROFILE_FIELD` — profile frontmatter contains forbidden field
-- `NO_REVIEWERS_AVAILABLE` — no agents remain after discovery/filtering, or panel required but single
-- `AMBIGUOUS_REVIEWER` — short-name resolves to multiple agent files after the family tie-break
-- `PROFILE_INVENTORY_MISMATCH` — README list vs. `profiles/*.md` presence disagree
-- `ROUTING_NOT_SUPPORTED` — engine reached Step 5 with a source the profile declared `N/A` in `source_routing`
+## Additional resources
 
-Consumers (`feature-flow`, `write-spec`, etc.) detect this prefix to distinguish engine errors from ordinary review FAIL verdicts.
+- `references/persistence.md` — state-file schema, slug precedence, legacy migration
+- `references/error-semantics.md` — engine error categories and tie-break details
+- `profiles/README.md` — profile contract, detection precedence, receipt semantics
+- `profiles/<name>.md` — per-artifact rubric, roster, verdict alphabet, source routing
+- `test-fixtures/` — smoke-test artifacts and baseline reviewer output

--- a/plugins/developer-workflow/skills/multiexpert-review/references/error-semantics.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/references/error-semantics.md
@@ -1,0 +1,29 @@
+# Error semantics
+
+All engine errors produce exactly this prefix on the first line of output:
+
+```
+[multiexpert-review ERROR] <CATEGORY>: <details>
+```
+
+Consumers (`feature-flow`, `write-spec`, etc.) detect this prefix to distinguish engine errors from ordinary review FAIL verdicts.
+
+## Categories
+
+| Category | Condition |
+|----------|-----------|
+| `UNKNOWN_PROFILE_HINT` | Caller hint not in inventory |
+| `FORBIDDEN_PROFILE_FIELD` | Profile frontmatter contains forbidden field (negative-list in `../profiles/README.md`) |
+| `NO_REVIEWERS_AVAILABLE` | No agents remain after discovery/filtering, or panel required but only one agent available |
+| `AMBIGUOUS_REVIEWER` | Short-name resolves to multiple agent files after the family tie-break (see engine Step 2) |
+| `PROFILE_INVENTORY_MISMATCH` | `profiles/README.md` inventory list disagrees with `profiles/*.md` file presence |
+| `ROUTING_NOT_SUPPORTED` | Engine reached Step 5 with a source the profile declared `N/A` in `source_routing` |
+
+## Tie-break and single-reviewer details
+
+- **Short-name collision tie-break (Step 2):** if the same agent short-name resolves to multiple files (e.g., two plugins define `security-expert`), prefer first match in this order: (1) same-plugin as the caller skill, (2) sibling `developer-workflow-*` plugin, (3) any other source. If still ambiguous, emit `AMBIGUOUS_REVIEWER` with paths. Distinct from `NO_REVIEWERS_AVAILABLE` (which covers the "agents missing entirely" path) so consumers can branch on intent. In practice the `developer-workflow-*` family guarantees unique short-names — this guard only triggers on non-family plugin conflicts.
+
+- **Single-reviewer guard (Step 2):**
+  - `profile.allow_single_reviewer: true` — proceed. Final verdict carries a `## Review Mode: single-perspective` marker in the output text (not in any receipt — receipt schemas are profile-declared and do not include `review_mode`).
+  - `profile.allow_single_reviewer: false` — emit `NO_REVIEWERS_AVAILABLE: profile <name> requires panel, only <agent> available`.
+  - 0 agents — same `NO_REVIEWERS_AVAILABLE` error regardless of flag.

--- a/plugins/developer-workflow/skills/multiexpert-review/references/persistence.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/references/persistence.md
@@ -1,0 +1,54 @@
+# Persistence — state file details
+
+This document expands the "Persistence" section of `../SKILL.md`. The engine persists review state to a file so the workflow survives context compaction and can resume mid-cycle.
+
+## State file path
+
+Save to `./swarm-report/multiexpert-review-<slug>-state.md` (or `multiexpert-review-<YYYYMMDD-HHMM>-state.md` if no slug is known).
+
+### Slug source (priority order)
+
+1. Explicit caller args (`slug:` field)
+2. Artifact frontmatter `slug:` field
+3. Artifact filename without extension
+4. Timestamp fallback
+
+### Legacy read
+
+If the slug-qualified file does not exist, try `./swarm-report/plan-review-state.md` (legacy from the pre-rename era). If found, copy content into the new slug-qualified name and continue on the new file. Do not delete the legacy file — that is the user's decision.
+
+**Always write:** the new slug-qualified name.
+
+## State file structure
+
+```markdown
+# Multi-Expert Review State
+Source: {plan_mode | file:<path> | conversation}
+Profile: {implementation-plan | test-plan | spec | ...}   # locked at cycle 1
+Profile source: {caller_hint | frontmatter | path | signature | user_prompt}
+Cycle: {1 | 2 | 3} of 3
+Status: {detecting | reviewing | synthesizing | fixing | done}
+
+## Artifact Summary
+{goal, technologies, scope — extracted in Step 1}
+
+## Selected Agents
+- {agent1} (recommended)
+- {agent2} (recommended)
+
+## Reviews Completed
+- [x] {agent1} — {severity counts: N critical, M major, K minor}
+- [ ] {agent2} — pending
+
+## Verdict History
+### Cycle 1: {PASS | CONDITIONAL | FAIL | WARN}
+- Blockers: {list}
+- Improvements: {list}
+
+### Cycle 2: ...
+```
+
+## Update discipline
+
+- Update after each significant step (profile detected, agents selected, reviews collected, verdict synthesized, fix applied).
+- Re-read before each action — skip completed steps. This is the compaction-resilience contract: any step marked done in the file must not be repeated.


### PR DESCRIPTION
## Summary

Audit of `plugins/developer-workflow/skills/multiexpert-review/SKILL.md` against `/plugin-dev:skill-development` criteria. Safe, behavior-preserving edits only — no changes to semantics, agent names, command signatures, workflow, state machine, or bundled resources (`profiles/`, `test-fixtures/` untouched).

### Changes

- **Frontmatter `description`**: rewritten to third-person form ("This skill should be used when the user asks to…"). All existing trigger phrases preserved; narrative sentences tightened. 803 → 679 chars (well under the 1024 limit).
- **Body word count**: 2128 → 1844 words (now within the 1500–2000 ideal range). 336 → 291 lines.
- **Progressive disclosure**: added `references/` with two new files:
  - `references/persistence.md` — full state-file schema, slug precedence, legacy migration
  - `references/error-semantics.md` — full engine error category list + short-name tie-break details
- SKILL.md now links to `references/`, `profiles/`, and `test-fixtures/` in a new `## Additional resources` section.

### Explicitly NOT changed

- Step 3 review-prompt template stays verbatim in SKILL.md — declared engine-fixed and cross-referenced as invariant by `profiles/README.md` and `profiles/test-plan.md`. Moving it would risk drift.
- Second-person voice inside that template is intentional (it is the prompt sent TO reviewer agents).
- `profiles/` and `test-fixtures/` folders — untouched per task constraints.
- Workflow, state machine, allowed transitions, verdict criteria, error prefix, receipt semantics — all preserved byte-exact.

### Verification

- `bash scripts/validate.sh` — green. `developer-workflow/multiexpert-review` frontmatter reported as 679 chars; line count 291 (no WARN at 500 threshold).
- **plugin-validator subagent NOT run in this session** — the `Task`/`Agent` tool is not available in this agent's environment, so the subagent launch could not be performed. Manual cross-check against plugin-validator's known rubric (frontmatter validity, description 1024-char limit, third-person metadata, imperative body voice, reference link integrity, bundled-resource preservation) all pass. Suggest a human-side `plugin-dev:plugin-validator` run on this plugin before marking ready.
- Pre-existing WARNs unrelated to this change: `acceptance` (736 lines), `triage-feedback` (1005 lines), `write-spec` (664 lines) — not touched here.

### Audit report

`swarm-report/skill-review-multiexpert-review-state.md` (gitignored — local to the worktree).

## Test plan

- [ ] `bash scripts/validate.sh` passes on CI
- [ ] Human runs `plugin-dev:plugin-validator` against `developer-workflow` and confirms PASS / Minor-only
- [ ] Skim `references/persistence.md` and `references/error-semantics.md` for information parity with the deleted SKILL.md paragraphs
- [ ] Confirm `profiles/` and `test-fixtures/` contents unchanged (`git diff main -- plugins/developer-workflow/skills/multiexpert-review/{profiles,test-fixtures}` is empty)