### PR TITLE
fix(developer-workflow): Critical debug STOP + policy compliance

### DIFF
--- a/plugins/developer-workflow/README.md
+++ b/plugins/developer-workflow/README.md
@@ -86,6 +86,7 @@ For **most skills**, these integrations are optional enhancements: when present,
 |---|---|---|---|
 | `mobile` | MCP server | `manual-tester`, `acceptance`, `bug-hunt` | Live mobile QA execution (iOS/Android UI automation + store management). Required to run mobile-QA steps. |
 | `playwright` | MCP server (from `claude-plugins-official`) | `manual-tester`, `acceptance`, `bug-hunt` | Live browser QA execution. Required to run web-QA steps. |
+| `ast-index` | CLI + plugin | `research`, `write-spec`, `write-tests`, `decompose-feature` | Optional. Structured code index for symbol / usages / deps / API lookups — non-QA skills use it when available and fall back to `Grep` + `Read` otherwise. |
 | `/code-review` | Slash command (from `claude-plugins-official`) | optional post-PR review | Optional. Standalone GitHub PR review with confidence-based scoring — separate from in-pipeline `code-reviewer` gate. |
 | `ralph-loop` | Plugin (from `claude-plugins-official`) | ad-hoc use outside pipeline | Optional. While-true iteration on a single prompt until completion marker — alternative to our structured orchestrators for exploratory work. |
 

--- a/plugins/developer-workflow/skills/acceptance/SKILL.md
+++ b/plugins/developer-workflow/skills/acceptance/SKILL.md
@@ -1,16 +1,14 @@
 ---
 name: acceptance
 description: >
-  Acceptance verification — confirm implementation meets spec (feature) or that a bug no longer
-  reproduces (bug fix). Orchestrator: detects project type, verifies a source exists (spec AC,
-  test plan, or debug.md), fans out parallel checks to `manual-tester` (UI + scenario),
-  `code-reviewer` (delta), plus `business-analyst` / `ux-expert` / `security-expert` /
-  `performance-expert` and a build smoke as triggered by spec frontmatter and project type,
-  then aggregates via PoLL rules. Without a source, proposes `/write-spec`,
-  `/generate-test-plan`, or `/debug`. Trigger on: "test this", "verify against spec",
-  "QA the implementation", "run the test plan", "validate acceptance criteria",
-  "verify the PR", "verify the fix", "confirm bug is gone", "acceptance", "приёмка",
-  "проверь", "протестируй".
+  This skill should be used when the user wants to confirm an implementation meets its spec
+  (feature) or that a bug no longer reproduces (bug fix). Fans out parallel checks to
+  manual-tester, code-reviewer, and conditional expert agents (selected by spec frontmatter
+  and project type), then aggregates verdicts into one receipt via PoLL rules. Without a
+  verification source, proposes /write-spec, /generate-test-plan, or /debug. Triggers:
+  "test this", "verify against spec", "QA the implementation", "run the test plan",
+  "validate acceptance criteria", "verify the PR", "verify the fix", "confirm bug is gone",
+  "acceptance", "приёмка", "проверь", "протестируй".
 disable-model-invocation: true
 ---
 

--- a/plugins/developer-workflow/skills/acceptance/SKILL.md
+++ b/plugins/developer-workflow/skills/acceptance/SKILL.md
@@ -2,13 +2,11 @@
 name: acceptance
 description: >
   This skill should be used when the user wants to confirm an implementation meets its spec
-  (feature) or that a bug no longer reproduces (bug fix). Fans out parallel checks to
-  manual-tester, code-reviewer, and conditional expert agents (selected by spec frontmatter
-  and project type), then aggregates verdicts into one receipt via PoLL rules. Without a
-  verification source, proposes /write-spec, /generate-test-plan, or /debug. Triggers:
-  "test this", "verify against spec", "QA the implementation", "run the test plan",
-  "validate acceptance criteria", "verify the PR", "verify the fix", "confirm bug is gone",
-  "acceptance", "приёмка", "проверь", "протестируй".
+  (feature) or that a bug no longer reproduces (bug fix). Fans out parallel checks and
+  aggregates verdicts into one receipt. Triggers: "test this", "verify against spec",
+  "QA the implementation", "run the test plan", "validate acceptance criteria",
+  "verify the PR", "verify the fix", "confirm bug is gone", "acceptance", "приёмка",
+  "проверь", "протестируй".
 disable-model-invocation: true
 ---
 

--- a/plugins/developer-workflow/skills/bug-hunt/SKILL.md
+++ b/plugins/developer-workflow/skills/bug-hunt/SKILL.md
@@ -38,8 +38,27 @@ Ask or infer from context:
 - **Web app** — need a URL
 
 If the user says "the app is already running" or provides a device/URL, use it directly.
-Otherwise, follow the same launch logic as `acceptance` Step 2 (build, install, start
-dev server, etc.).
+Otherwise, follow the standard app-launch sequence:
+
+1. Build the app with the project's default tooling (Gradle, Xcode, `npm run dev`, etc.)
+2. Install on the target device / simulator, or start the dev server for web
+3. Verify the process is reachable (device is visible to the automation MCP, URL responds)
+4. If any step fails, surface the error to the user and stop — do not explore a half-launched app
+
+This mirrors `acceptance`'s launch logic so the two skills behave identically; kept inline
+to avoid silent coupling to that skill's step numbering.
+
+### 1.1.1 Session identifier
+
+Generate a short session ID used for `BUG-[SESSION_ID]-[n]` / `OBSERVATION-[SESSION_ID]-[n]`
+and for the persistent artifact path:
+
+```
+<SESSION_ID> = <YYYY-MM-DD>-<short-target-slug>
+```
+
+Example: `2026-04-20-payments-flow`, `2026-04-20-full-app`. The artifact path (see Step 3) is
+`./swarm-report/bug-hunt-<SESSION_ID>.md`.
 
 ### 1.2 Focus area (optional)
 
@@ -70,6 +89,12 @@ If they say "quick check" or "just the settings screen", use Quick. If they say 
 
 Spawn the `manual-tester` agent with an exploratory prompt. The prompt structure differs from
 `acceptance` — instead of a spec and test plan, it provides heuristics and exploration rules.
+
+**MCP prerequisite (QA-execution exception, see `developer-workflow/CLAUDE.md`):** bug-hunt
+requires real device/browser automation via the `mobile` MCP (mobile targets) or `playwright`
+MCP (web targets). If the required MCP server is not installed or enabled, **stop with a
+clear install/enable message** — do not attempt to continue without automation. Graceful
+degradation is impossible when real interaction is required.
 
 ```
 You are performing exploratory testing — there is no specification to verify against.
@@ -152,13 +177,17 @@ even in exploratory mode).
 
 ## Step 3: Collect and Present Exploration Report
 
-When the manual-tester agent completes, process its output into a structured report.
+When the manual-tester agent completes, process its output into a structured report and
+persist it to `./swarm-report/bug-hunt-<SESSION_ID>.md` (the path registered in Step 1.1.1).
+This file is what `Re-exploration After Fixes` re-reads to verify previously reported bugs
+— the report is not scroll-ephemeral.
 
 ### Report Format
 
 ```
 ## Bug Hunting Report
 
+**Session ID:** [SESSION_ID from Step 1.1.1]
 **Date:** [date]
 **App:** [name, version, or URL]
 **Device / Browser:** [device name + OS version, or browser + viewport]
@@ -222,7 +251,11 @@ on a specific area the team is concerned about, or moving on to spec-based verif
 
 When the user fixes reported bugs and wants to check again:
 
-1. Re-launch with the same focus area (or the area where bugs were found)
-2. The agent verifies previously reported bugs are fixed
-3. The agent continues exploring adjacent areas for regressions
-4. Updated report replaces or appends to the previous one
+1. Load the prior report from `./swarm-report/bug-hunt-<SESSION_ID>.md` and extract the list
+   of previously reported bugs (by BUG-ID)
+2. Re-launch with the same focus area (or the area where bugs were found)
+3. The agent re-verifies each previously reported bug and marks it `Fixed` / `Still present` /
+   `Cannot reproduce` in the new report
+4. The agent continues exploring adjacent areas for regressions
+5. Write the updated report to a new `bug-hunt-<SESSION_ID>-run<N>.md` alongside the original
+   so both are preserved for audit

--- a/plugins/developer-workflow/skills/bug-hunt/SKILL.md
+++ b/plugins/developer-workflow/skills/bug-hunt/SKILL.md
@@ -178,9 +178,19 @@ even in exploratory mode).
 ## Step 3: Collect and Present Exploration Report
 
 When the manual-tester agent completes, process its output into a structured report and
-persist it to `./swarm-report/bug-hunt-<SESSION_ID>.md` (the path registered in Step 1.1.1).
-This file is what `Re-exploration After Fixes` re-reads to verify previously reported bugs
-— the report is not scroll-ephemeral.
+persist it. The write path depends on which run this is:
+
+- **First run for this `<SESSION_ID>`** (no prior `bug-hunt-<SESSION_ID>*.md` exists in
+  `swarm-report/`) → write to `./swarm-report/bug-hunt-<SESSION_ID>.md` (the path
+  registered in Step 1.1.1).
+- **Re-exploration run** (the base file already exists — entered via the
+  `Re-exploration After Fixes` flow below) → write to
+  `./swarm-report/bug-hunt-<SESSION_ID>-run<N>.md`, where `<N>` is the next unused index
+  starting at 2. Leave earlier `run<N>` files and the base file in place; they are the
+  audit trail.
+
+Either way, the latest report is what `Re-exploration After Fixes` reads to verify
+previously reported bugs — the report is not scroll-ephemeral.
 
 ### Report Format
 

--- a/plugins/developer-workflow/skills/create-pr/SKILL.md
+++ b/plugins/developer-workflow/skills/create-pr/SKILL.md
@@ -324,9 +324,17 @@ gh pr edit --body "<final-body>"      # or glab mr update --description
 # 2. Mark ready
 gh pr ready                           # GitHub
 # GitLab: --ready on current glab (≥1.32); older glab used --unwip.
-# Try --ready first; on `unknown flag` stderr fall back to --unwip:
-if ! glab mr update --ready 2> /tmp/glab.err; then
-  grep -q 'unknown flag' /tmp/glab.err && glab mr update --unwip || { cat /tmp/glab.err; exit 1; }
+# Try --ready first; fall back to --unwip ONLY when stderr shows that
+# --ready itself is an unknown flag. Any other error is real — surface it.
+GLAB_ERR=$(mktemp)
+trap 'rm -f "$GLAB_ERR"' EXIT
+if ! glab mr update --ready 2>"$GLAB_ERR"; then
+  if grep -qE 'unknown flag:? --ready|flag provided but not defined: -?ready' "$GLAB_ERR"; then
+    glab mr update --unwip
+  else
+    cat "$GLAB_ERR" >&2
+    exit 1
+  fi
 fi
 ```
 

--- a/plugins/developer-workflow/skills/create-pr/SKILL.md
+++ b/plugins/developer-workflow/skills/create-pr/SKILL.md
@@ -51,14 +51,28 @@ CURRENT_NAME=$(git config user.name)
 
 ## Step 2: Check for existing PR (all modes)
 
+Do NOT use `2>/dev/null` here — it silently conflates "no PR exists" (expected) with
+"CLI unavailable / auth failed" (a real error). Capture stderr and branch on exit code:
+
 ```bash
 # GitHub
-gh pr view --json url,isDraft,number,body 2>/dev/null
+out=$(gh pr view --json url,isDraft,number,body 2>&1); rc=$?
+# Exit code:
+#   0              → PR exists; parse $out as JSON
+#   1 + stderr contains "no pull requests" / "no open pull requests" → no PR (expected)
+#   any other rc or unexpected stderr → real error (CLI missing, unauthenticated, API down)
+
 # GitLab
-glab mr view --output json 2>/dev/null
+out=$(glab mr view --output json 2>&1); rc=$?
+# Same pattern: rc 0 → MR exists; stderr "no open merge request" → no MR; other → real error.
 ```
 
-Capture:
+**On real error (non-zero rc that is not the "no PR" case):** abort with the captured
+stderr and stop. Do not proceed as if no PR exists — that would try to create a duplicate.
+Typical cause inside the sandbox: the proxy-injected token is missing; see
+`CLAUDE.md` (root) → "If `git push` fails with authentication errors".
+
+Capture on success:
 - `PR_EXISTS` — true/false
 - `PR_IS_DRAFT` — true/false (if exists)
 - `PR_URL` — for output
@@ -134,7 +148,15 @@ Only set labels/reviewers when **creating** (draft or default) or when **promoti
 
 ### 6.1 Labels
 
-Fetch available labels (GitHub: `gh label list --json name,description --limit 100`; GitLab: `glab api /projects/:fullpath/labels`). Select from existing only, based on changed file paths, commit types, and scope. Do not invent labels.
+Fetch available labels:
+
+- **GitHub:** `gh label list --json name,description --limit 100`
+- **GitLab:** `glab label list` (fetches labels for the current project resolved from
+  `git remote get-url origin`; do NOT use `glab api /projects/:fullpath/labels` — glab
+  does not substitute `:fullpath` and the call will 404)
+
+Select from existing only, based on changed file paths, commit types, and scope. Do not
+invent labels.
 
 **Add, don't replace.** When deriving labels during creation (`--draft` or default) or `--promote`, only **add** missing labels computed from the diff; never remove labels set manually by humans. This preserves reviewer / triage / release labels that a maintainer may have applied between draft creation and promote. `--refresh` skips Step 6 entirely (see header), so it never touches labels at all.
 
@@ -300,7 +322,11 @@ gh pr edit --body "<final-body>"      # or glab mr update --description
 
 # 2. Mark ready
 gh pr ready                           # GitHub
-glab mr update --ready                # GitLab (flag varies — also: --unwip; verify in glab version)
+# GitLab: --ready on current glab (≥1.32); older glab used --unwip.
+# Try --ready first; on `unknown flag` stderr fall back to --unwip:
+if ! glab mr update --ready 2> /tmp/glab.err; then
+  grep -q 'unknown flag' /tmp/glab.err && glab mr update --unwip || { cat /tmp/glab.err; exit 1; }
+fi
 ```
 
 Output:

--- a/plugins/developer-workflow/skills/create-pr/SKILL.md
+++ b/plugins/developer-workflow/skills/create-pr/SKILL.md
@@ -69,8 +69,9 @@ out=$(glab mr view --output json 2>&1); rc=$?
 
 **On real error (non-zero rc that is not the "no PR" case):** abort with the captured
 stderr and stop. Do not proceed as if no PR exists — that would try to create a duplicate.
-Typical cause inside the sandbox: the proxy-injected token is missing; see
-`CLAUDE.md` (root) → "If `git push` fails with authentication errors".
+Typical causes: `gh` / `glab` not installed or not authenticated (`gh auth status`,
+`glab auth status`), API outage, or a sandbox/proxy environment where the Git provider
+token is missing.
 
 Capture on success:
 - `PR_EXISTS` — true/false

--- a/plugins/developer-workflow/skills/debug/SKILL.md
+++ b/plugins/developer-workflow/skills/debug/SKILL.md
@@ -100,7 +100,7 @@ At each step, halve the search space:
    - Don't test multiple hypotheses simultaneously
 
 3. **Evaluate result**
-   - Confirmed → document root cause and produce artifact
+   - Confirmed → **STOP. Do NOT fix.** Document root cause and produce the artifact. Even if the fix is one obvious line, the fix belongs to the `implement` stage — ending here is the contract of this skill.
    - Refuted → form NEW hypothesis informed by what was learned, return to Phase 2
    - After 3+ failed hypotheses → STOP, likely an architectural issue, escalate to user
 

--- a/plugins/developer-workflow/skills/design-options/SKILL.md
+++ b/plugins/developer-workflow/skills/design-options/SKILL.md
@@ -1,16 +1,12 @@
 ---
 name: design-options
 description: >
-  Generate 2-3 alternative architectural approaches for a single task before multiexpert-review.
-  Launches architecture-expert agents in parallel, each under a different style constraint
-  (minimal / clean / pragmatic), and presents the options side-by-side so the user can pick
-  one informed choice instead of committing to the first approach that came to mind.
-  Optional stage between write-spec (or decompose-feature for a single-task feature) and
-  multiexpert-review. Trigger when: task is high architectural risk, multiple plausible approaches
-  exist, or user explicitly requests it.
-  Invoke on: "explore design options", "show me alternatives", "предложи варианты архитектуры",
-  "разные подходы", "choose between approaches", or when feature-flow runs this as an
-  opt-in stage for high-arch-risk tasks.
+  This skill should be used when the user wants to compare 2-3 alternative architectural
+  approaches for a single task before locking the plan — typically for high-arch-risk work
+  or when multiple plausible designs exist. Launches architecture-expert agents in parallel
+  under different style constraints (minimal / clean / pragmatic) and presents the options
+  side-by-side for an informed pick. Triggers: "explore design options", "show me alternatives",
+  "choose between approaches", "предложи варианты архитектуры", "разные подходы".
 ---
 
 # Design Options
@@ -198,7 +194,7 @@ Once the user picks an option (or a hybrid is specified):
 - **Out of scope:** writing the implementation plan (that is multiexpert-review's input — we produce the *design*, not the steps); writing code; updating the spec.
 - **Never** pick an option for the user silently. Always present, always wait.
 - **Never** generate just one option — if only one survives scoping, there is nothing to choose; skip this stage entirely.
-- **Never** generate more than 4 options — beyond 4, choice fatigue dominates.
+- **Never** generate more than 3 options — the cap declared in Inputs (`maximum 3`); beyond that, choice fatigue dominates.
 
 ---
 

--- a/plugins/developer-workflow/skills/drive-to-merge/SKILL.md
+++ b/plugins/developer-workflow/skills/drive-to-merge/SKILL.md
@@ -1,17 +1,11 @@
 ---
 name: drive-to-merge
 description: >
-  Autonomous orchestrator that takes an existing PR/MR from its current state to merge. Monitors
-  CI/CD, diagnoses failures, fetches review comments, categorizes them inline, proposes concrete
-  fixes (snippet or delegation), delegates to implement/debug, posts replies, resolves threads,
-  re-requests review (Copilot + humans), polls via ScheduleWakeup, loops until merged. Decision
-  tables rendered in-session — no user-editable manifest. Default mode waits for "approve" per
-  round; `--auto` proceeds without waiting; `--dry-run` stops after the first table. Final merge
-  always requires explicit user confirmation. Triggers: "drive this PR to merge", "get this PR
-  merged", "monitor CI and reviews", "ship this PR", "land this PR", "доведи PR до мержа",
-  "веди PR", "замержь этот PR". Autonomous-mode triggers (equivalent to `--auto`): "действуй
-  автономно", "без подтверждений", "auto mode", "не спрашивай", "run autonomously". Do NOT use
-  for creating new PRs (use create-pr) or code written from scratch (use implement).
+  This skill should be used when the user wants an existing PR/MR driven to merge —
+  monitor CI, triage review comments, fix failures, re-request review, loop until merged.
+  Triggers: "drive this PR to merge", "get this PR merged", "monitor CI and reviews",
+  "ship this PR", "land this PR", "доведи PR до мержа", "веди PR", "замержь этот PR".
+  Do NOT use for creating new PRs (use create-pr) or code written from scratch (use implement).
 ---
 
 # Drive to Merge

--- a/plugins/developer-workflow/skills/finalize/SKILL.md
+++ b/plugins/developer-workflow/skills/finalize/SKILL.md
@@ -1,14 +1,12 @@
 ---
 name: finalize
 description: >
-  Code-quality pass over the current branch changes. Multi-round review-and-fix loop:
-  code-reviewer (plan conformance, CLAUDE.md, bugs) → /simplify (reuse/quality/efficiency) →
-  pr-review-toolkit agents (test quality, silent failures, type design) → conditional expert
-  reviews (security, performance, architecture). `/check` between fixes. Exits PASS when no
-  BLOCK-level findings remain, or ESCALATE after 3 rounds. Invoke on: "finalize", "run code
-  quality pass", "clean up the code", "prepare for review", "полируй код", "финализация",
-  "доведи код", "почисти", or when an orchestrator (feature-flow, bugfix-flow) runs this
-  stage between implement and acceptance.
+  This skill should be used when the user wants a code-quality pass over the current branch —
+  multi-round review-and-fix loop that polishes how the code is written, not what it does.
+  Runs code-reviewer, /simplify, pr-review-toolkit, and conditional expert reviews with /check
+  between rounds; exits PASS when no BLOCK findings remain or ESCALATE after max rounds.
+  Triggers: "finalize", "run code quality pass", "clean up the code", "prepare for review",
+  "полируй код", "финализация", "доведи код", "почисти".
 ---
 
 # Finalize
@@ -61,7 +59,7 @@ Round N:
 ### Exit criteria
 
 - **PASS (exit):** no BLOCK severity findings from any phase. WARN and NIT findings listed in the report but do not block.
-- **ESCALATE (stop and report to caller):** after 3 rounds, BLOCK findings still present. Dump unresolved findings, caller decides whether to override or loop back to `implement`.
+- **ESCALATE (stop and report to caller):** after `max_rounds` rounds (default 3, see §Max round budget), BLOCK findings still present. Dump unresolved findings, caller decides whether to override or loop back to `implement`.
 
 ### Max round budget
 
@@ -196,7 +194,7 @@ Save `swarm-report/<slug>-finalize.md` on exit (PASS or ESCALATE):
 ## Unresolved BLOCKs (on ESCALATE only)
 
 Findings that could not be fixed and were NOT downgraded. Populated only when the
-finalize stage exits ESCALATE — lists BLOCKs that remain after 3 rounds, or BLOCKs
+finalize stage exits ESCALATE — lists BLOCKs that remain after `max_rounds` rounds, or BLOCKs
 whose fix broke `/check` and was reverted (per §Mechanical verification). The user
 must decide: loop back to `implement`, accept as risk, or re-scope.
 

--- a/plugins/developer-workflow/skills/finalize/SKILL.md
+++ b/plugins/developer-workflow/skills/finalize/SKILL.md
@@ -52,7 +52,7 @@ Round N:
   Phase C  → pr-review-toolkit trio (parallel) → fix BLOCK → /check → continue
   Phase D  → expert reviews (conditional, parallel) → fix BLOCK → /check → continue
   Round end: did any BLOCK remain unfixed?
-    yes → go to round N+1 (max 3 rounds total)
+    yes → go to round N+1 (up to max_rounds total — default 3, see §Max round budget)
     no  → exit with PASS
 ```
 
@@ -63,7 +63,7 @@ Round N:
 
 ### Max round budget
 
-Default `max_rounds = 3`, overridable to any integer ≥ 1 via the `--max-rounds N` flag (see §Inputs). The caller's flag wins when present; otherwise the default applies. ESCALATE semantics key off the effective value, not the constant — "after 3 rounds" in this document means "after the effective max_rounds".
+Default `max_rounds = 3`, overridable to any integer ≥ 1 via the `--max-rounds N` flag (see §Inputs). The caller's flag wins when present; otherwise the default applies. ESCALATE semantics key off the effective value.
 
 Total budget (per round: 4 phases + fixes + `/check` after each fix) can take non-trivial wall time on large diffs. If a project regularly hits the cap, the BLOCK threshold may be too strict for the project's conventions — tune Phase A's `code-reviewer` confidence threshold (see `developer-workflow-experts/agents/code-reviewer.md`) rather than silently raising `max_rounds`.
 
@@ -229,7 +229,7 @@ Findings that the user explicitly decided to accept (e.g., during escalation). N
 - **Prefer** to keep fixes inside the files touched by `implement`. Minimal, necessary edits in adjacent files are allowed when a finding explicitly requires them — e.g., Phase C's `pr-test-analyzer` may demand adding tests in a sibling test file, and Phase B's `/simplify` may extract a duplicated helper into an existing utility module. In every such case, keep the edit narrowly scoped to what the finding requires.
 - **Never** re-scope the task under the guise of "cleanup". If a finding points to a structural issue beyond narrow-fix reach → escalate, do not refactor.
 - **Never** silently skip Phase A — `code-reviewer`'s plan-conformance check is the anchor. If the agent fails to launch for infrastructure reasons, stop and escalate.
-- **Never** run forever. 3 rounds, then report.
+- **Never** run forever. Stop after `max_rounds` rounds (default 3) and report.
 
 ---
 
@@ -237,7 +237,7 @@ Findings that the user explicitly decided to accept (e.g., during escalation). N
 
 Stop and report to caller when:
 
-- After 3 rounds, BLOCK findings remain unresolved
+- After `max_rounds` rounds (default 3), BLOCK findings remain unresolved
 - `/check` fails and the fix doesn't converge after 1 retry
 - A BLOCK finding requires refactoring beyond the diff scope
 - An expert finding demands architectural changes (new modules, dependency reorg)

--- a/plugins/developer-workflow/skills/multiexpert-review/SKILL.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/SKILL.md
@@ -4,7 +4,8 @@ description: >-
   This skill should be used when the user wants a plan, spec, or test-plan reviewed by a
   panel of independent expert agents (PoLL — Panel of LLM Evaluators — protocol) before
   committing. Triggers: "review the plan", "review the spec", "review the test-plan",
-  "multi-expert review", "panel review", "проверь план", "оцени план", "проверь спецификацию",
+  "multi-expert review", "panel review", "validate the approach", "sanity check this",
+  "what did I miss?", "проверь план", "оцени план", "проверь спецификацию",
   "проверь тест-план". Do NOT use for code review (use code-reviewer) or for generating
   alternative designs (use design-options).
 ---

--- a/plugins/developer-workflow/skills/multiexpert-review/SKILL.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/SKILL.md
@@ -1,16 +1,12 @@
 ---
 name: multiexpert-review
 description: >-
-  Review documentation artifacts (plan, spec, test-plan) with a panel of independent expert
-  agents before commit. Use when asked to review a plan, spec, test-plan, or similar
-  documentation artifact. Uses the PoLL (Panel of LLM Evaluators) consensus protocol.
-  Invoke on phrases: "review the plan", "review the spec", "check the plan", "validate the
-  approach", "multi-expert review", "panel review", "план ревью", "проверь план", "оцени план",
-  "check the spec", or after exiting Plan Mode and wanting independent expert evaluation before
-  implementation. Also invoke when the user says "is this plan good?", "what did I miss?",
-  "sanity check this", "review this before I start", "check my approach", or wants multiple
-  viewpoints on an implementation strategy. Do NOT invoke for code review (use code-reviewer
-  agent instead) or PR review.
+  This skill should be used when the user wants a plan, spec, or test-plan reviewed by a
+  panel of independent expert agents (PoLL — Panel of LLM Evaluators — protocol) before
+  committing. Triggers: "review the plan", "review the spec", "review the test-plan",
+  "multi-expert review", "panel review", "проверь план", "оцени план", "проверь спецификацию",
+  "проверь тест-план". Do NOT use for code review (use code-reviewer) or for generating
+  alternative designs (use design-options).
 ---
 
 # Multi-Expert Review

--- a/plugins/developer-workflow/skills/research/SKILL.md
+++ b/plugins/developer-workflow/skills/research/SKILL.md
@@ -75,11 +75,11 @@ simultaneously). Each agent works independently — never share one agent's find
 **What:** Analyze existing code, patterns, dependencies, and relevant modules related to the
 research topic.
 
-**How:** Launch an Explore subagent with instructions to use:
-- `ast-index search`, `ast-index class`, `ast-index usages` — find relevant code
-- `ast-index deps`, `ast-index dependents` — module relationships
-- `ast-index api` — public API surface of affected modules
-- `Read`, `Grep` — examine specific files and patterns
+**How:** Launch an Explore subagent with instructions to locate symbols, trace module
+relationships, and map public API surface area. Prefer a structured code-index MCP tool
+(for example `ast-index`) when available — it resolves classes, usages, dependencies, and
+API by symbol rather than text. Fall back to `Grep` + `Read` when no index is available;
+the skill must still produce a complete report in that mode.
 
 **Prompt template:**
 ```
@@ -92,7 +92,9 @@ Find and report:
 4. Module boundaries and layers that would be affected
 5. Any existing TODO/FIXME comments related to this topic
 
-Use ast-index for all symbol searches. Use Grep only for string literals and comments.
+Use a code-index tool (e.g. `ast-index search`/`class`/`usages`/`deps`/`dependents`/`api`)
+for symbol resolution when available. If no index is available, use `Grep` for text search
+and `Read` for targeted file inspection — report with the same structure either way.
 Be thorough — check build files, configuration, and test code too.
 
 Respond in the same language as the research topic description. Structure: overview, then findings grouped by category.

--- a/plugins/developer-workflow/skills/research/SKILL.md
+++ b/plugins/developer-workflow/skills/research/SKILL.md
@@ -76,10 +76,10 @@ simultaneously). Each agent works independently — never share one agent's find
 research topic.
 
 **How:** Launch an Explore subagent with instructions to locate symbols, trace module
-relationships, and map public API surface area. Prefer a structured code-index MCP tool
-(for example `ast-index`) when available — it resolves classes, usages, dependencies, and
-API by symbol rather than text. Fall back to `Grep` + `Read` when no index is available;
-the skill must still produce a complete report in that mode.
+relationships, and map public API surface area. Prefer a structured code-index tool when
+available — one that resolves classes, usages, dependencies, and API by symbol rather than
+text. Fall back to `Grep` + `Read` when no index is available; the skill must still produce
+a complete report in that mode. See the project README for any recommended index tooling.
 
 **Prompt template:**
 ```
@@ -92,9 +92,10 @@ Find and report:
 4. Module boundaries and layers that would be affected
 5. Any existing TODO/FIXME comments related to this topic
 
-Use a code-index tool (e.g. `ast-index search`/`class`/`usages`/`deps`/`dependents`/`api`)
-for symbol resolution when available. If no index is available, use `Grep` for text search
-and `Read` for targeted file inspection — report with the same structure either way.
+Use a code-index tool for symbol resolution when one is available in the environment —
+look up classes, usages, dependencies, dependents, and public API surface by symbol rather
+than by text. If no index is available, use `Grep` for text search and `Read` for targeted
+file inspection; produce the same report structure either way.
 Be thorough — check build files, configuration, and test code too.
 
 Respond in the same language as the research topic description. Structure: overview, then findings grouped by category.

--- a/plugins/developer-workflow/skills/write-tests/SKILL.md
+++ b/plugins/developer-workflow/skills/write-tests/SKILL.md
@@ -25,10 +25,9 @@ The user provides one or more of:
 - A module or directory (`feature/auth`, `:core:network`)
 - A vague reference ("the auth module", "this class")
 
-Resolve vague references using a code-index MCP tool (e.g. `ast-index search`,
-`ast-index class`) when available; fall back to `Grep` / `Glob` + `Read` otherwise. If the
-reference remains ambiguous after resolution, ask **one clarifying question** before
-proceeding.
+Resolve vague references using a code-index tool when one is available in the environment;
+fall back to `Grep` / `Glob` + `Read` otherwise. If the reference remains ambiguous after
+resolution, ask **one clarifying question** before proceeding.
 
 ### 1.1.1 Generate slug
 
@@ -49,9 +48,9 @@ Read all source files in the target scope. For each file, identify:
 
 Search for existing tests:
 - Check the corresponding test source set (`src/test/`, `src/androidTest/`, `src/commonTest/`)
-- Prefer a code-index MCP tool when available (e.g. `ast-index search "TargetClass"` or
-  `ast-index usages "TargetClass"`) to find test classes that reference the target; fall
-  back to `Grep "TargetClass" path/to/test-src-set` when no index is available
+- Prefer a code-index tool when one is available in the environment to locate test classes
+  that reference the target by symbol (search / usages / class lookups); fall back to
+  `Grep "TargetClass" path/to/test-src-set` when no index is available
 - Check for `@Test` annotations that exercise target functions
 
 ### 1.4 Identify untested code

--- a/plugins/developer-workflow/skills/write-tests/SKILL.md
+++ b/plugins/developer-workflow/skills/write-tests/SKILL.md
@@ -25,8 +25,10 @@ The user provides one or more of:
 - A module or directory (`feature/auth`, `:core:network`)
 - A vague reference ("the auth module", "this class")
 
-Resolve vague references using `ast-index search` or `ast-index class`. If ambiguous, ask
-**one clarifying question** before proceeding.
+Resolve vague references using a code-index MCP tool (e.g. `ast-index search`,
+`ast-index class`) when available; fall back to `Grep` / `Glob` + `Read` otherwise. If the
+reference remains ambiguous after resolution, ask **one clarifying question** before
+proceeding.
 
 ### 1.1.1 Generate slug
 
@@ -47,7 +49,9 @@ Read all source files in the target scope. For each file, identify:
 
 Search for existing tests:
 - Check the corresponding test source set (`src/test/`, `src/androidTest/`, `src/commonTest/`)
-- Use `ast-index search "TargetClass"` or `ast-index usages "TargetClass"` to find test classes that reference the target classes
+- Prefer a code-index MCP tool when available (e.g. `ast-index search "TargetClass"` or
+  `ast-index usages "TargetClass"`) to find test classes that reference the target; fall
+  back to `Grep "TargetClass" path/to/test-src-set` when no index is available
 - Check for `@Test` annotations that exercise target functions
 
 ### 1.4 Identify untested code


### PR DESCRIPTION
## Summary

Fixes the single Critical finding and six Major findings from the recent skill-reviewer sweep across `developer-workflow` skills.

- **Critical** — `debug` Phase 3: add an explicit `STOP, do not fix` boundary at the confirmed-hypothesis moment so a one-line fix cannot drift across the stage boundary.
- **Policy compliance** — soft-reference the `ast-index` code index in `research` and `write-tests` (the plugin's own CLAUDE.md forbids hardcoding non-QA MCP tool names).
- **Description hygiene** — trim five oversized descriptions (`drive-to-merge`, `design-options`, `finalize`, `acceptance`, `multiexpert-review`) toward the ~500-char sweet spot, adopt the canonical `This skill should be used when…` framing, and strip runtime-mode modifiers / routing hints. Also reconcile contradictions surfaced in the pass (option cap in `design-options`, `max_rounds` vs hard-coded 3 in `finalize`, add `design-options` to the negative guard of `multiexpert-review`, replace closed agent enumeration in `acceptance` with an open description).
- **`bug-hunt`** — persist the "Bug Hunting Report" to `./swarm-report/bug-hunt-<SESSION_ID>.md` so the advertised "Re-exploration After Fixes" flow has something to re-verify; document the fail-fast dependency on the mobile / playwright MCP (per the QA-execution exception); inline the launch sequence instead of the silent coupling to `acceptance` Step 2.
- **`create-pr`** — harden external-CLI error handling so "no PR exists" is not silently conflated with "gh/glab unavailable / auth failed"; fix the `glab api /projects/:fullpath/labels` call that 404s (use `glab label list` instead); resolve the `glab mr update --ready` vs `--unwip` ambiguity with a version-aware fallback.

All changes are SKILL.md edits — no runtime behavior changes beyond the explicit stop / fail-fast contracts above.

## Sibling PRs

This is **PR C** of three logical PRs from the skill-reviewer sweep (scorecard: 1 Critical / 36 Major / 109 Minor across 17 skills). See also:

- **PR B** — feature-flow / bugfix-flow state-machine holes and retry-cap reconciliation.
- **PR A** — progressive disclosure sweep for write-spec, acceptance, generate-test-plan, write-tests (+ Swift support), create-pr.

## Test plan

- [x] `bash scripts/validate.sh` — green
- [ ] Manual: `debug` reads cleanly with the new Phase 3 stop text
- [ ] Manual: each trimmed description still resolves the skill on real invocation phrases (English + Russian)
- [ ] Manual: `bug-hunt` first run writes the expected `swarm-report/bug-hunt-<SESSION_ID>.md`
- [ ] Manual: `create-pr` error path — disconnect `gh` / break auth and confirm the skill aborts with the real error instead of trying to create a duplicate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)