### PR TITLE
fix(developer-workflow): close feature-flow / bugfix-flow state-machine holes

### DIFF
--- a/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
@@ -157,7 +157,10 @@ If a draft PR already exists for this branch (re-entry on rollback), `--draft` i
 
 After `implement` passes its two gates (mechanical checks + intent check), invoke `developer-workflow:finalize` with:
 - Slug
-- Path to `swarm-report/<slug>-debug.md` (serves as the plan anchor for bugfix-flow — describes root cause and fix direction)
+- Plan anchor — pass `swarm-report/<slug>-plan.md` when the Plan stage ran (Phase 1.5);
+  otherwise pass `swarm-report/<slug>-debug.md`. The plan overrides debug.md as the
+  anchor because the plan carries the chosen approach, while debug.md stays authoritative
+  for root cause and reproduction steps (see Phase 1.5).
 
 `finalize` runs a multi-round loop (max 3): code-reviewer → /simplify → pr-review-toolkit trio → conditional expert reviews, with `/check` between fixes.
 
@@ -196,7 +199,7 @@ Wait for `swarm-report/<slug>-acceptance.md`.
 |--------|-----------|--------|
 | VERIFIED (bug gone) | **Acceptance → PR** | Proceed |
 | FAILED — same bug | **Acceptance → Implement** | Fix again (max 2 retries — see Backward Transitions). After the 2nd retry also fails acceptance, route **Acceptance → Debug** (re-diagnose). |
-| FAILED — new bug | Route per bug: trivial → Implement, complex → Debug |
+| FAILED — new bug | Route per bug: trivial → Implement (counted against the `Acceptance → Implement` cap of 2), complex → Debug (counted against the `Acceptance → Debug` cap of 1). If either cap is exhausted, **escalate** — do not loop again. |
 | PARTIAL — bug gone, minor issues | Ask user: fix or ship as-is |
 
 ---

--- a/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: bugfix-flow
 description: >-
-  Thin orchestrator for bug fix tasks — sequences modular skills: debug → implement → acceptance → PR.
-  Invoke when the user reports a bug and wants it fixed end-to-end.
-  Trigger on: "/bugfix-flow", "bugfix flow", "fix this bug", "исправь баг", "почини", "это сломалось, почини",
-  "fix and ship", "find and fix", "debug and fix".
-  Do NOT use for: feature implementation (use feature-flow), investigation without fix (use debug),
-  quick obvious fix that doesn't need diagnosis (invoke implement directly).
+  This skill should be used when the user reports a bug and wants it fixed end-to-end —
+  thin orchestrator sequencing debug → (optional plan) → implement → finalize → acceptance →
+  draft/ready PR → drive-to-merge. Delegates every stage to a separate skill; writes no
+  code itself. Triggers: "/bugfix-flow", "bugfix flow", "fix this bug", "исправь баг",
+  "почини", "это сломалось, почини", "fix and ship", "find and fix", "debug and fix".
+  Do NOT use for: feature implementation (use feature-flow), investigation without fix
+  (use debug), or a quick obvious fix that does not need diagnosis (invoke implement directly).
 ---
 
 # Bugfix Flow — Bug Fix Orchestrator
@@ -45,9 +46,16 @@ Finalize   -> escalate         (ESCALATE after 3 rounds; user picks non-implemen
 Acceptance -> PR               (VERIFIED — bug gone)
 Acceptance -> Implement        (FAILED — bug still reproduces or new bugs)
 Acceptance -> Debug            (FAILED — fix didn't address root cause)
-PR         -> Merge
+PR         -> Merge            (TERMINAL — no further transitions)
 PR         -> Implement        (review feedback requires code changes)
+PR         -> escalate         (drive-to-merge blocker — DISCUSSION on P0/P1,
+                                unresolvable rebase, repeated same-signature CI failure)
 ```
+
+Per-transition maxima for backward edges (Plan → Debug, Finalize → Implement,
+Acceptance → Implement / Debug, PR → Implement) are declared in the
+[Backward Transitions](#backward-transitions-strict-limits) table below. When a cap is
+reached, the orchestrator **escalates** instead of looping again.
 
 **ALL other transitions are FORBIDDEN.** Before every transition, announce:
 
@@ -104,10 +112,16 @@ action that depends on reproduction steps.
 When the debug artifact indicates a complex fix (touches multiple modules, needs architectural
 decisions, or the recommended fix direction has alternatives):
 
-1. Create an implementation plan in Plan Mode based on the debug findings
-2. Invoke `developer-workflow:multiexpert-review` to validate the plan
-3. If FAIL → back to Debug for more context
-4. If PASS/CONDITIONAL → proceed to Implement
+1. Create an implementation plan in Plan Mode based on the debug findings and save it to
+   `swarm-report/<slug>-plan.md` (same convention as `feature-flow` Phase 1.3).
+2. Invoke `developer-workflow:multiexpert-review` on `swarm-report/<slug>-plan.md` with
+   `profile: implementation-plan` to validate.
+3. If FAIL → back to Debug for more context (counted against the Plan → Debug backward cap).
+4. If PASS/CONDITIONAL → proceed to Implement.
+
+When the Plan stage ran, `swarm-report/<slug>-plan.md` **overrides** `swarm-report/<slug>-debug.md`
+as the plan anchor for `finalize` (Phase 2.5) — the plan carries the chosen approach, while
+debug.md stays authoritative for root cause and reproduction steps.
 
 Skip for straightforward fixes where the debug artifact already gives a clear, single-path direction.
 
@@ -181,7 +195,7 @@ Wait for `swarm-report/<slug>-acceptance.md`.
 | Result | Transition | Action |
 |--------|-----------|--------|
 | VERIFIED (bug gone) | **Acceptance → PR** | Proceed |
-| FAILED — same bug | **Acceptance → Implement** | Fix again. If 2nd failure → **Acceptance → Debug** (re-diagnose) |
+| FAILED — same bug | **Acceptance → Implement** | Fix again (max 2 retries — see Backward Transitions). After the 2nd retry also fails acceptance, route **Acceptance → Debug** (re-diagnose). |
 | FAILED — new bug | Route per bug: trivial → Implement, complex → Debug |
 | PARTIAL — bug gone, minor issues | Ask user: fix or ship as-is |
 
@@ -220,9 +234,10 @@ gate always requires explicit confirmation.
 
 | From | To | Trigger | Max |
 |------|----|---------|-----|
+| Plan | Debug | Plan-review FAIL — plan needs more diagnostic context | 1 |
 | Finalize | Implement | ESCALATE — user routes back to fix root issues | 1 |
-| Acceptance | Implement | Bug still reproduces or new bugs | 3 |
-| Acceptance | Debug | Fix didn't address root cause (2 failed implementations) | 1 |
+| Acceptance | Implement | Bug still reproduces or new bugs | 2 |
+| Acceptance | Debug | Fix didn't address root cause (after 2 failed implementations) | 1 |
 | PR | Implement | Review feedback requires code changes | 2 |
 
 Each backward transition:

--- a/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
@@ -46,7 +46,7 @@ Finalize   -> escalate         (ESCALATE after 3 rounds; user picks non-implemen
 Acceptance -> PR               (VERIFIED — bug gone)
 Acceptance -> Implement        (FAILED — bug still reproduces or new bugs)
 Acceptance -> Debug            (FAILED — fix didn't address root cause)
-PR         -> Merge            (TERMINAL — no further transitions)
+PR         -> Merged           (TERMINAL — no further transitions)
 PR         -> Implement        (review feedback requires code changes)
 PR         -> escalate         (drive-to-merge blocker — DISCUSSION on P0/P1,
                                 unresolvable rebase, repeated same-signature CI failure)
@@ -240,7 +240,7 @@ gate always requires explicit confirmation.
 | Plan | Debug | Plan-review FAIL — plan needs more diagnostic context | 1 |
 | Finalize | Implement | ESCALATE — user routes back to fix root issues | 1 |
 | Acceptance | Implement | Bug still reproduces or new bugs | 2 |
-| Acceptance | Debug | Fix didn't address root cause (after 2 failed implementations) | 1 |
+| Acceptance | Debug | Fix didn't address root cause (after 2 failed implementations), or acceptance finds a complex new bug that needs renewed diagnosis | 1 |
 | PR | Implement | Review feedback requires code changes | 2 |
 
 Each backward transition:

--- a/plugins/developer-workflow/skills/feature-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/feature-flow/SKILL.md
@@ -62,7 +62,7 @@ Acceptance     -> TestPlan         (FAILED — add Regression TC for new bugs)
 Acceptance     -> Debug            (FAILED — unclear root cause)
 Debug          -> Implement        (root cause diagnosed — fix follows; forward recovery
                                      edge, not counted against any backward cap)
-PR             -> Merge            (TERMINAL — no further transitions)
+PR             -> Merged           (TERMINAL — no further transitions)
 PR             -> Implement        (review feedback requires code changes)
 PR             -> escalate         (drive-to-merge blocker — DISCUSSION on P0/P1,
                                      unresolvable rebase, repeated same-signature CI failure)
@@ -376,6 +376,38 @@ Wait for `swarm-report/<slug>-acceptance.md`.
   [Test Plan Regeneration](#test-plan-regeneration)), then continue with Implement.
 - PARTIAL (P2/P3) → ask user: fix now or ship as-is
 - Out-of-scope bugs → create issues, don't block
+
+---
+
+### 2.4 Debug (recovery stage)
+
+Entered only as a recovery edge from Acceptance when the failure cause is unclear (see
+the route-by-result list above — "FAILED (P0/P1, unclear cause) → Stage: Acceptance → Debug").
+This stage mirrors `bugfix-flow` Phase 1 but is scoped to diagnosing the acceptance
+regression, not the original feature work.
+
+**Context passing (MANDATORY):** pass the failing acceptance report
+(`swarm-report/<slug>-acceptance.md`), the original plan
+(`swarm-report/<slug>-plan.md` if PlanReview ran), and any reproduction steps
+`manual-tester` recorded.
+
+Invoke `developer-workflow:debug` with the collected context.
+
+Wait for `swarm-report/<slug>-debug.md`. Same convention as bugfix-flow —
+the file includes a **Reproduction Steps** section, is persistent state, and
+survives context compaction. Re-read it before any downstream action.
+
+**Route by status:**
+- **Diagnosed, simple fix** → **Stage: Debug → Implement.** Pass `<slug>-debug.md` as
+  the anchor so the next Implement retry acts on the root cause, not the symptom.
+- **Diagnosed, complex fix** (multiple files, architectural impact) → surface to the
+  user; feature-flow does not have a mid-pipeline Plan stage, so a complex acceptance
+  regression is escalated rather than looped through Plan.
+- **Not Reproducible** → report to user, ask for more info. Stop.
+- **Escalated** → report findings, stop.
+
+The `Acceptance → Debug` backward cap is 1 (see
+[Backward Transitions](#backward-transitions-strict-limits)); if exhausted, escalate.
 
 ---
 

--- a/plugins/developer-workflow/skills/feature-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/feature-flow/SKILL.md
@@ -60,7 +60,8 @@ Acceptance     -> PR               (VERIFIED)
 Acceptance     -> Implement        (FAILED — bugs to fix; Implement then re-runs Finalize)
 Acceptance     -> TestPlan         (FAILED — add Regression TC for new bugs)
 Acceptance     -> Debug            (FAILED — unclear root cause)
-Debug          -> Implement        (root cause diagnosed — fix follows)
+Debug          -> Implement        (root cause diagnosed — fix follows; forward recovery
+                                     edge, not counted against any backward cap)
 PR             -> Merge            (TERMINAL — no further transitions)
 PR             -> Implement        (review feedback requires code changes)
 PR             -> escalate         (drive-to-merge blocker — DISCUSSION on P0/P1,

--- a/plugins/developer-workflow/skills/feature-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/feature-flow/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: feature-flow
 description: >-
-  Thin orchestrator for feature tasks — sequences modular skills through the full pipeline.
-  Invoke when the user gives a feature task and wants it done end-to-end autonomously.
-  Trigger on: "/feature-flow", "implement this feature", "сделай эту фичу от начала до конца",
-  "full cycle", "autonomous implementation".
-  Do NOT use for: bug fixes (use bugfix-flow), research-only (use research), single quick change
-  (invoke implement directly).
+  This skill should be used when the user wants a feature task driven end-to-end autonomously,
+  from research through PR merge — sequencing research, decomposition, planning, multiexpert
+  review, test-plan, implement, finalize, acceptance, draft/ready PR, and drive-to-merge.
+  Thin orchestrator: delegates every stage to a separate skill; writes no code itself.
+  Triggers: "/feature-flow", "implement this feature end-to-end", "run the full pipeline",
+  "сделай эту фичу от начала до конца", "full cycle", "autonomous implementation".
+  Do NOT use for: bug fixes (use bugfix-flow), research-only (use research), or a single
+  quick change that does not need the pipeline (invoke implement directly).
 ---
 
 # Feature Flow — Feature Orchestrator
@@ -58,9 +60,17 @@ Acceptance     -> PR               (VERIFIED)
 Acceptance     -> Implement        (FAILED — bugs to fix; Implement then re-runs Finalize)
 Acceptance     -> TestPlan         (FAILED — add Regression TC for new bugs)
 Acceptance     -> Debug            (FAILED — unclear root cause)
-PR             -> Merge
+Debug          -> Implement        (root cause diagnosed — fix follows)
+PR             -> Merge            (TERMINAL — no further transitions)
 PR             -> Implement        (review feedback requires code changes)
+PR             -> escalate         (drive-to-merge blocker — DISCUSSION on P0/P1,
+                                     unresolvable rebase, repeated same-signature CI failure)
 ```
+
+Per-transition maxima for backward edges (PlanReview → Research, TestPlanReview → TestPlan,
+Finalize → Implement, Acceptance → Implement / TestPlan / Debug, PR → Implement) are declared
+in the [Backward Transitions](#backward-transitions-strict-limits) table below. When a cap is
+reached, the orchestrator **escalates** instead of looping again.
 
 **Decision criteria for skipping stages:**
 - **Skip Research:** task is well-understood, no external APIs, no unfamiliar libraries


### PR DESCRIPTION
## Summary

Fixes five Major findings from the skill-reviewer sweep on the two orchestrator skills.

**`feature-flow`:**
- Add the missing `Debug → Implement` edge to Allowed transitions. It was already referenced in Phase 2.3 (`FAILED unclear cause → Debug. Then Implement`) and the Backward Transitions table — now in the state machine's primary source of truth.
- Add `PR → escalate` for `drive-to-merge` blockers (DISCUSSION on P0/P1, unresolvable rebase, repeated same-signature CI failure). Stop Points already listed these — the state machine now matches.
- Mark `PR → Merge` as TERMINAL explicitly and cross-link per-transition maxima from the state machine to the Backward Transitions table so the inline list does not read as unbounded.
- Tighten the description: emphasize the end-to-end pipeline (`from research through PR merge`) to disambiguate from the single-step `implement` skill. Skill-selection was silently picking `implement` when the user wanted the full cycle.

**`bugfix-flow`:**
- Reconcile the `Acceptance → Implement` cap: Phase 3 route table said "2nd failure → Debug" (implying max 2) but the Backward Transitions table said max 3. Align to **max 2** — a bug that does not yield in two implements needs re-diagnosis, not more retries. Also mirror `PR → Merge` TERMINAL and `PR → escalate` from feature-flow for symmetry.
- Add `Plan → Debug` to the Backward Transitions table with max 1 — the state machine declared this edge (Phase 1.5 multiexpert-review FAIL) but it had no numeric cap and no standard protocol attached.
- Name the Plan-stage artifact path in Phase 1.5 (`swarm-report/<slug>-plan.md`, same convention as feature-flow) and clarify it overrides `debug.md` as the finalize plan anchor when both exist.
- Update the description to include `finalize` in the pipeline summary (previously read "debug → implement → acceptance → PR", missing the code-quality pass).

## Sibling PRs

This is **PR B** of three logical PRs from the skill-reviewer sweep. See also:

- **PR C** (#128) — Critical debug STOP + policy compliance (ast-index soft-refs, trimmed descriptions, bug-hunt persistence, create-pr CLI hardening).
- **PR A** — progressive disclosure sweep for write-spec, acceptance, generate-test-plan, write-tests (+ Swift support), create-pr.

## Test plan

- [x] `bash scripts/validate.sh` — green
- [ ] Manual: walk through every edge in the feature-flow state machine and confirm the new edges / TERMINAL / escalate nodes resolve to matching Backward / Stop Points text
- [ ] Manual: run a simulated bug-fix cycle that fails acceptance twice — confirm the 2nd failure routes to Debug per the new cap
- [ ] Manual: confirm the new feature-flow description actually beats `implement` on the phrase "implement this feature end-to-end"

🤖 Generated with [Claude Code](https://claude.com/claude-code)