### PR TITLE
refactor(developer-workflow): progressive disclosure sweep + Swift in write-tests

### DIFF
--- a/plugins/developer-workflow/skills/acceptance/SKILL.md
+++ b/plugins/developer-workflow/skills/acceptance/SKILL.md
@@ -394,7 +394,7 @@ build-engineer, devops-expert) has a narrow prompt template and verdict rules �
 inputs, output path, and PASS/WARN/FAIL criteria. Spawn each via Agent tool in the same
 fan-out message; build smoke runs via Bash.
 
-See `references/subcheck-prompts.md` for the full prompt template and verdict rules per
+See [`references/subcheck-prompts.md`](references/subcheck-prompts.md) for the full prompt template and verdict rules per
 agent and for the build-smoke command table.
 
 ---
@@ -413,7 +413,7 @@ Missing-artifact invariant: if a planned per-check artifact is missing at aggreg
 treat the check as `verdict: FAIL` with `blocked_on: per-check artifact missing` — do not
 silently drop it.
 
-See `references/aggregation.md` for the PoLL rule table, Aggregated Status table, full
+See [`references/aggregation.md`](references/aggregation.md) for the PoLL rule table, Aggregated Status table, full
 receipt format, and the orchestrator routing table.
 
 ---
@@ -429,6 +429,6 @@ receipt — re-run them regardless of `diff_hash`. Overwrite per-check artifacts
 `diff_hash`, aggregate into a fresh receipt, and repeat until VERIFIED or the user ships
 as-is.
 
-See `references/re-verification.md` for the full per-check decision table, the
+See [`references/re-verification.md`](references/re-verification.md) for the full per-check decision table, the
 spec/test-plan change override rule, the back-compat rule for older receipts, and the
 per-agent re-run scope details.

--- a/plugins/developer-workflow/skills/acceptance/SKILL.md
+++ b/plugins/developer-workflow/skills/acceptance/SKILL.md
@@ -386,347 +386,49 @@ keep the one-file-per-check invariant intact.
 `severity`, `confidence`, `domain_relevance` are required when `verdict` is `WARN` or `FAIL`;
 null for `PASS` / `SKIPPED`. These drive the PoLL aggregation in Step 4.
 
-### 3.1 Spawn `manual-tester` (UI branch)
+### 3.1–3.10 Per-agent sub-check prompts
 
-`manual-tester` owns the runtime environment end-to-end per its Step 0 Environment Setup.
-Acceptance does not pre-launch — that is intentional delegation.
+Each sub-check (manual-tester, code-reviewer, build smoke, business-analyst, ux-expert in
+design-review / a11y / both modes, security-expert, performance-expert, architecture-expert,
+build-engineer, devops-expert) has a narrow prompt template and verdict rules — covering
+inputs, output path, and PASS/WARN/FAIL criteria. Spawn each via Agent tool in the same
+fan-out message; build smoke runs via Bash.
 
-Prompt contents:
-1. **Spec context** — full text or clear pointers.
-2. **Test plan** — the complete set of test cases.
-3. **Target hints** (optional) — device/URL if the user already named one.
-4. **Scope** — which tiers (default: Smoke + Feature).
-5. **Output path** — `swarm-report/<slug>-acceptance-manual.md` with the per-check schema.
-
-If the agent returns `WARN` with `blocked_on`, surface that text to the user as the primary
-next-step requirement before re-running acceptance.
-
-### 3.2 Spawn `code-reviewer` (delta review, skipped if Step 2.5 matched)
-
-Prompt contents:
-1. **Task description** — one sentence from spec or PR title.
-2. **Plan pointer** — path to implement receipt or research report if present.
-3. **Git diff** — current diff.
-4. **Output path** — `swarm-report/<slug>-acceptance-code.md`.
-
-Verdict rules: `PASS` if no semantic bugs, logic errors, or security issues; `WARN` for
-style/minor; `FAIL` for blockers.
-
-### 3.3 Build smoke (non-UI branch)
-
-Pick the command by `ecosystem` (see ORCHESTRATION.md §Build system detection):
-
-| `ecosystem` | Command |
-|---|---|
-| `gradle` | `./gradlew build -x test --quiet` (single-module) or `./gradlew :check` (multi-module) |
-| `node` | `npm run build` (or `pnpm build` / `yarn build`) |
-| `rust` | `cargo build --release --quiet` |
-| `go` | `go build ./...` |
-| `python` | `python -m compileall .` or package-specific build |
-
-Multi-module detection: scan `settings.gradle*` for `include(` statements. If subprojects are
-declared and the user did not specify a target module, ask which module is the smoke target
-**before** entering Step 3 (do not block the fan-out message with a question).
-
-If the `ecosystem` or command is not resolvable, skip with `verdict: SKIPPED` and
-`blocked_on: build command unknown`. On success write `verdict: PASS`; on failure capture the
-last ~50 lines and write `verdict: FAIL`. Receipt at
-`swarm-report/<slug>-acceptance-build.md`.
-
-### 3.4 Spawn `business-analyst` (conditional — AC coverage)
-
-Fires when `acceptance_criteria_ids` in spec frontmatter is a non-empty list.
-
-Prompt contents:
-1. **Spec** — the spec file path.
-2. **Diff / implement receipt** — evidence for each AC.
-3. **Test plan** (if any) — TC list mapped to AC via each test case's `Source:` field
-   (e.g. `Source: AC-1` or `Source: AC-2, AC-3`). This is the canonical mapping used by
-   `generate-test-plan`; do not invent a new `AC-ref:` field.
-4. **manual-tester output** (if running) — pointer to
-   `swarm-report/<slug>-acceptance-manual.md`.
-5. **Output path** — `swarm-report/<slug>-acceptance-ac-coverage.md`.
-
-Verdict rules: `PASS` if every `AC-N` has at least one evidence pointer; `WARN` for weak
-coverage (single witness on high-risk AC); `FAIL` for any missing AC. Severity: `FAIL` on
-missing AC is `critical`; weak coverage is `major`.
-
-### 3.5 Spawn `ux-expert` (conditional — design-review or a11y)
-
-Fires when **`has_ui_surface == true`** AND (`design.figma` is set for design-review mode
-**or** `non_functional.a11y` is set for a11y mode). Non-UI projects never trigger this even
-if `non_functional.a11y` is present — a11y on backend/library/CLI has no surface to audit.
-
-Design-review and a11y can both fire in one invocation. When both trigger, spawn `ux-expert`
-once with mode `both`; the agent writes **two** artifacts (one per concern) so aggregation in
-Step 4 treats them as independent checks:
-
-- `swarm-report/<slug>-acceptance-design.md` with `check: design`
-- `swarm-report/<slug>-acceptance-a11y.md` with `check: a11y`
-
-When only one mode fires, only the corresponding artifact is written.
-
-Prompt contents:
-1. **Mode** — `design-review` / `a11y` / `both`.
-2. **Spec** — file path.
-3. **Design source** — `design.figma` URL (design-review mode).
-4. **a11y target** — value of `non_functional.a11y` (e.g. `wcag-aa`).
-5. **Running app pointer** — target hints; the agent reads running-app state via MCP only
-   when the environment is already prepared, otherwise works from screenshots/code.
-6. **Output paths** — one or both of the filenames listed above, matching the mode.
-
-Verdict rules: `PASS` if design matches reference and a11y criteria met; `WARN` for minor
-spacing/color deviations or AA soft failures; `FAIL` for missing components, broken
-interaction paths, or hard a11y violations (keyboard trap, contrast below threshold).
-
-### 3.6 Spawn `security-expert` (conditional)
-
-Fires when `risk_areas` intersects `{auth, payment, pii, data-migration}`.
-
-Prompt contents:
-1. **Risk list** — the intersection subset.
-2. **Diff** — full git diff.
-3. **Spec** — file path.
-4. **Output path** — `swarm-report/<slug>-acceptance-security.md`.
-
-Verdict rules: `PASS` if no applicable OWASP / project-security-rule violations; `WARN` for
-minor hardening opportunities; `FAIL` for exploitable issues, secret leaks, or regulation
-breaches.
-
-### 3.7 Spawn `performance-expert` (conditional)
-
-Fires when `non_functional.sla` is set **or** `risk_areas` contains `perf-critical`.
-
-Prompt contents:
-1. **SLA target** — from `non_functional.sla`, or implicit `perf-critical` baseline.
-2. **Diff** — full git diff.
-3. **Output path** — `swarm-report/<slug>-acceptance-performance.md`.
-
-Verdict rules: `PASS` if no regression; `WARN` for borderline; `FAIL` for violations.
-
-### 3.8 Spawn `architecture-expert` (conditional — diff-triggered)
-
-Fires when the diff touches a public API symbol **or** spans ≥ 3 top-level modules (see the
-heuristic at §Conditional triggers).
-
-Prompt contents:
-1. **Trigger reason** — `public-api` / `cross-module` / `both` with the specific file list
-   that matched.
-2. **Diff** — full git diff (scoped to triggered files + their immediate neighbours).
-3. **Module map** — list of top-level modules touched, discovered from
-   `settings.gradle*` / `package.json` workspaces / `Cargo.toml` workspace members.
-4. **Output path** — `swarm-report/<slug>-acceptance-architecture.md` with `check: architecture`.
-
-Verdict rules: `PASS` if public contracts are preserved and module dependency direction is
-clean; `WARN` for style issues (e.g., missing deprecation annotation, avoidable coupling);
-`FAIL` for contract breakage, circular dependencies, or leaking internals into a public API.
-
-### 3.9 Spawn `build-engineer` (conditional — diff-triggered)
-
-Fires when the diff touches any build file listed in §Conditional triggers.
-
-Prompt contents:
-1. **Build files changed** — exact file list from the diff.
-2. **Diff** — scoped to those files plus any touched module manifests.
-3. **Ecosystem** — resolved `ecosystem` from Step 0 (drives which toolchain the agent should
-   evaluate against).
-4. **Output path** — `swarm-report/<slug>-acceptance-build-config.md` with
-   `check: build-config`.
-
-Note: `check: build` is already used by the non-UI build smoke (§3.3). The expert review of
-**config changes** uses a distinct check identifier `build-config` so aggregation can treat
-the two axes independently (a project can have a clean smoke and a broken config, or vice
-versa).
-
-Verdict rules: `PASS` if dependency additions are pinned/hash-verified, plugin versions are
-consistent, and task wiring is intact; `WARN` for unpinned version ranges, unused
-dependencies, or minor style issues; `FAIL` for breaking plugin mismatches, missing required
-configuration, or dependency choices that conflict with project policy.
-
-### 3.10 Spawn `devops-expert` (conditional — diff-triggered)
-
-Fires when the diff touches CI / release configuration (see §Conditional triggers).
-
-Prompt contents:
-1. **CI files changed** — exact file list.
-2. **Diff** — scoped to CI/release files.
-3. **Repo context** — `public` vs `private` (affects secret handling guidance),
-   and any related marketplace/deployment manifests if present.
-4. **Output path** — `swarm-report/<slug>-acceptance-devops.md` with `check: devops`.
-
-Verdict rules: `PASS` if pipeline health is preserved, secrets are handled correctly, and
-rollout gates remain sound; `WARN` for minor inefficiencies or missing
-`timeout-minutes` / `concurrency` guards; `FAIL` for leaked secrets, disabled safety gates,
-or breaking workflow syntax.
+See `references/subcheck-prompts.md` for the full prompt template and verdict rules per
+agent and for the build-smoke command table.
 
 ---
 
 ## Step 4: Aggregate and Write Receipt
 
-Read frontmatter of each `swarm-report/<slug>-acceptance-<check>.md` first (verdict +
-severity + confidence + domain_relevance + blocked_on). Read the body only if
-`verdict != PASS`. Do not inline artifact bodies — link them.
+Read each per-check artifact's frontmatter first (body only if `verdict != PASS`), then
+reduce via PoLL rules (same protocol as `multiexpert-review` §"Step 4 — Synthesize verdict").
+Bug severities (P0–P3) remain the primary routing axis; PoLL layers additional rules for
+cases not covered by bug severity alone. Derive Aggregated Status (`VERIFIED | FAILED |
+PARTIAL`), write the aggregated receipt to `swarm-report/<slug>-acceptance.md` (including
+idempotency hashes, Check Plan, Check Results table, Convergence signals, Summary, Bugs
+Found, Recommendation), and route to the invoking orchestrator.
 
-**Missing per-check artifact.** Step 2.5 writes a stub for skipped `code-reviewer`; Step 3.3
-writes an artifact even on build-smoke failure. If a planned per-check artifact is
-nonetheless missing at aggregation time, treat the check as `verdict: FAIL` with
-`blocked_on: per-check artifact missing` — do not silently drop it. `blocked_on` is the
-canonical field for surfacing unresolved conditions per the per-check schema; no separate
-`error:` field exists.
+Missing-artifact invariant: if a planned per-check artifact is missing at aggregation time,
+treat the check as `verdict: FAIL` with `blocked_on: per-check artifact missing` — do not
+silently drop it.
 
-### Aggregation — PoLL rules
-
-Acceptance uses the same aggregation protocol as `multiexpert-review` (see
-`multiexpert-review/SKILL.md` §"Step 4 — Synthesize verdict"). Input shape is per-check
-(not per-reviewer), reduction logic identical:
-
-| Signal | Action |
-|---|---|
-| **`critical` severity** from any sub-check with `confidence: high` | → Blocker. Aggregated Status = `FAILED`. |
-| **Same issue** (same file:line or same AC id) raised by 2+ sub-checks independently | → Escalate to `critical` regardless of individual severity. Multiple specialists seeing the same problem = real problem. |
-| **`major` severity** from a sub-check with `domain_relevance: high` | → Important. Aggregated Status = `PARTIAL` if not already escalated. |
-| **Contradicting verdicts** (one `PASS`, another `FAIL` on the same item) | → "Uncertainty — requires decision". Aggregated Status = `PARTIAL`, contradiction listed in the receipt. |
-| **`minor` severity** or **`low` confidence** from a single check | → Note, not blocker. Does not affect aggregated Status. |
-| **`low` domain_relevance** check flagging an issue | → Note, weight lower. |
-
-**Bug severities (P0–P3) remain the primary routing axis** for
-`feature-flow`/`bugfix-flow`. Any P0/P1 bug reported by any sub-check maps directly to
-`FAILED` regardless of the PoLL above; PoLL layers additional rules on top for cases not
-covered by bug severity alone (e.g. AC coverage FAIL without an associated P0 bug).
-
-### Aggregated Status — final table
-
-| Input | Aggregated Status |
-|---|---|
-| All checks `PASS` or `SKIPPED`, no P0–P3 bugs, no PoLL blocker | `VERIFIED` |
-| Any P0 / P1 bug **or** PoLL blocker (critical high-confidence, or 2+-agent escalation) | `FAILED` |
-| P2 / P3 bugs only, **or** PoLL important, **or** contradicting verdicts, **or** any `WARN` not otherwise classified | `PARTIAL` |
-| `manual-tester` returned `WARN` with `blocked_on` | `PARTIAL` with `blocked_on` surfaced in Summary |
-
-### Receipt format
-
-Save to `swarm-report/<slug>-acceptance.md`. Legacy fields preserved; new sections appended.
-
-```markdown
-# Acceptance: <slug>
-
-**Status:** VERIFIED / FAILED / PARTIAL
-**Date:** <date>
-**Type:** Feature / Bug fix
-**Project type:** <project_type>
-**Project type override:** <spec | user | none>
-**Ecosystem:** <ecosystem>
-**Spec source:** [what was used]
-**Test plan:** [resolved permanent path / generated on-the-fly / none]
-**test_plan_source:** receipt | mounted | on-the-fly | absent
-**Context artifacts:** [paths to research.md, debug.md, implement.md, quality.md used as input]
-
-## Idempotency Hashes
-- `diff_hash`: <sha256 of `git diff <base>...HEAD`>
-- `spec_hash`: <sha256 of the spec file bytes, or `null` if no file spec>
-- `test_plan_hash`: <sha256 of the permanent test plan, or `null`>
-
-These three hashes drive the Re-verification Loop decision table; downstream orchestrators
-don't need to read them.
-
-## Check Plan
-- list of checks that ran, one per line, with their trigger
-- e.g. `business-analyst` (AC coverage) — triggered by spec.acceptance_criteria_ids
-- e.g. `ux-expert` — not triggered (no design.figma)
-
-## Check Results
-
-| Check | Agent / Tool | Verdict | Severity | Confidence | Artifact |
-|---|---|---|---|---|---|
-| Manual QA | manual-tester | … | … | … | swarm-report/<slug>-acceptance-manual.md |
-| Code review | code-reviewer | … | … | … | swarm-report/<slug>-acceptance-code.md |
-| AC coverage | business-analyst | … | … | … | swarm-report/<slug>-acceptance-ac-coverage.md |
-| Design | ux-expert | … | … | … | swarm-report/<slug>-acceptance-design.md |
-| A11y | ux-expert | … | … | … | swarm-report/<slug>-acceptance-a11y.md |
-| Security | security-expert | … | … | … | swarm-report/<slug>-acceptance-security.md |
-| Performance | performance-expert | … | … | … | swarm-report/<slug>-acceptance-performance.md |
-| Architecture | architecture-expert | … | … | … | swarm-report/<slug>-acceptance-architecture.md |
-| Build config | build-engineer | … | … | … | swarm-report/<slug>-acceptance-build-config.md |
-| DevOps | devops-expert | … | … | … | swarm-report/<slug>-acceptance-devops.md |
-| Build smoke | bash | … | … | … | swarm-report/<slug>-acceptance-build.md |
-
-## Convergence signals
-Issues raised by 2+ sub-checks independently. Strongest signal of real problems.
-List one line each with the file:line or AC id and the list of checks that flagged it.
-
-## Summary
-[1–3 sentences. If PARTIAL with blocked_on — state the blocker first. If any convergence
-signal — mention it in the first sentence.]
-
-## Test Results
-- Total: [n] | Passed: [n] | Failed: [n] | Blocked: [n]
-
-## Bugs Found
-[List by severity — P0 first, then P1, P2, P3. Link each to the per-check artifact that
-reported it.]
-
-## Bug Reproduction Check (bug fix only)
-- Reproduction steps from debug.md: [executed / not applicable]
-- Bug reproduces after fix: [yes / no]
-
-## Recommendation
-[Ship / Do not ship / Ship with known issues — and why]
-```
-
-### Routing (consumed by orchestrators)
-
-- **VERIFIED** → `create-pr` (or mark existing PR ready for review).
-- **FAILED** with P0/P1 and obvious cause → `implement` with the bug list as input. Max 3
-  round-trips.
-- **FAILED** with P0/P1 and unclear cause → `debug` first, then `implement`.
-- **FAILED** with P0/P1 requiring regression coverage → `test-plan` append `## Regression TC`,
-  then `implement`.
-- **PARTIAL** with P2/P3 only or WARN — orchestrator asks the user: fix now or ship with
-  known issues (continue to `create-pr`, include in PR description).
-- **PARTIAL** with `blocked_on` — surface the blocker; do not continue until resolved.
+See `references/aggregation.md` for the PoLL rule table, Aggregated Status table, full
+receipt format, and the orchestrator routing table.
 
 ---
 
 ## Re-verification Loop
 
-On fix-loop re-entry (after `FAILED` → `implement` fix → re-run acceptance):
+On fix-loop re-entry (after `FAILED` → `implement` fix → re-run acceptance), re-probe Step 0
+and Step 1, compute `diff_hash_new`, then decide per-check action from the decision table
+(PASS/SKIPPED/WARN with matching `diff_hash` → skip; any FAIL → always re-run; missing or
+`null` prior hash → re-run). `business-analyst` and `manual-tester` get a spec/test-plan
+change override: if `spec_hash` or `test_plan_hash` changed — or is missing from an older
+receipt — re-run them regardless of `diff_hash`. Overwrite per-check artifacts with a fresh
+`diff_hash`, aggregate into a fresh receipt, and repeat until VERIFIED or the user ships
+as-is.
 
-1. Re-probe Step 0 and Step 1 (project type rarely changes; inputs may).
-2. Compute `diff_hash_new` = `sha256(git diff <base>...HEAD)`.
-3. Decide per-check action using the previous per-check artifact and `diff_hash`:
-
-   | Previous verdict | Previous `diff_hash` vs `diff_hash_new` | Action |
-   |---|---|---|
-   | `PASS` or `SKIPPED` | match | **Skip** — reuse the existing artifact as-is. Record `re-used previous verdict` in the aggregated receipt. |
-   | `PASS` or `SKIPPED` | mismatch | Re-run. |
-   | `WARN` | match | Skip. Re-used verdict keeps the WARN; user had the option to ship with it. |
-   | `WARN` | mismatch | Re-run. |
-   | `FAIL` | any | **Always re-run.** A FAIL is the point of the loop; hash match means the fix didn't land in the diff yet — still must re-run to confirm. |
-   | any prior verdict with previous `diff_hash` = `null`, absent, or unreadable | any | Re-run — cannot prove idempotency without a usable hash. |
-
-   An explicit `diff_hash: null` and a missing `diff_hash` field are treated the same way:
-   both mean the prior artifact does not carry enough information to prove idempotency, so
-   the check must be re-run.
-
-4. For checks that are re-run:
-   - Overwrite the per-check artifact with fresh content and a new `diff_hash`.
-   - `manual-tester` specifically re-runs previously-failed TCs plus a Smoke tier by default;
-     the full plan is re-run only on explicit request or when the spec changed.
-5. Aggregate into a fresh `swarm-report/<slug>-acceptance.md`, overwriting the previous one.
-6. Repeat until VERIFIED or the user decides to ship as-is.
-
-**Spec/test-plan change override.** If the spec file or test-plan file changed between runs
-(detected by comparing their `sha256` to values recorded in the previous aggregated receipt
-under `spec_hash` / `test_plan_hash`), `business-analyst` and `manual-tester` are always
-re-run regardless of `diff_hash` — their input is the spec/TC list, not just the code diff.
-Other checks remain subject to the `diff_hash` policy.
-
-**Back-compat rule.** If the previous aggregated receipt does not contain `spec_hash`
-and/or `test_plan_hash` (e.g. a pre-iteration-3 receipt) — or either prior value is unknown
-or unreadable — treat that input as **changed** and re-run the affected checks to be safe:
-missing/unknown `spec_hash` forces `business-analyst`; missing/unknown `test_plan_hash`
-forces `manual-tester`. If both are missing/unknown, re-run both. Other checks remain
-subject to the `diff_hash` policy.
-
-This is the full idempotency pass that iteration 2 parked. Cost saving: on a single-file fix
-after a 5-agent FAIL, typically 2–3 passed checks are re-used instead of re-run.
+See `references/re-verification.md` for the full per-check decision table, the
+spec/test-plan change override rule, the back-compat rule for older receipts, and the
+per-agent re-run scope details.

--- a/plugins/developer-workflow/skills/acceptance/references/aggregation.md
+++ b/plugins/developer-workflow/skills/acceptance/references/aggregation.md
@@ -1,0 +1,125 @@
+Referenced from: `plugins/developer-workflow/skills/acceptance/SKILL.md` (§Step 4: Aggregate and Write Receipt).
+
+# Acceptance — Aggregation, Receipt Format, and Routing
+
+Read frontmatter of each `swarm-report/<slug>-acceptance-<check>.md` first (verdict +
+severity + confidence + domain_relevance + blocked_on). Read the body only if
+`verdict != PASS`. Do not inline artifact bodies — link them.
+
+**Missing per-check artifact.** Step 2.5 writes a stub for skipped `code-reviewer`; Step 3.3
+writes an artifact even on build-smoke failure. If a planned per-check artifact is
+nonetheless missing at aggregation time, treat the check as `verdict: FAIL` with
+`blocked_on: per-check artifact missing` — do not silently drop it. `blocked_on` is the
+canonical field for surfacing unresolved conditions per the per-check schema; no separate
+`error:` field exists.
+
+## Aggregation — PoLL rules
+
+Acceptance uses the same aggregation protocol as `multiexpert-review` (see
+`multiexpert-review/SKILL.md` §"Step 4 — Synthesize verdict"). Input shape is per-check
+(not per-reviewer), reduction logic identical:
+
+| Signal | Action |
+|---|---|
+| **`critical` severity** from any sub-check with `confidence: high` | → Blocker. Aggregated Status = `FAILED`. |
+| **Same issue** (same file:line or same AC id) raised by 2+ sub-checks independently | → Escalate to `critical` regardless of individual severity. Multiple specialists seeing the same problem = real problem. |
+| **`major` severity** from a sub-check with `domain_relevance: high` | → Important. Aggregated Status = `PARTIAL` if not already escalated. |
+| **Contradicting verdicts** (one `PASS`, another `FAIL` on the same item) | → "Uncertainty — requires decision". Aggregated Status = `PARTIAL`, contradiction listed in the receipt. |
+| **`minor` severity** or **`low` confidence** from a single check | → Note, not blocker. Does not affect aggregated Status. |
+| **`low` domain_relevance** check flagging an issue | → Note, weight lower. |
+
+**Bug severities (P0–P3) remain the primary routing axis** for
+`feature-flow`/`bugfix-flow`. Any P0/P1 bug reported by any sub-check maps directly to
+`FAILED` regardless of the PoLL above; PoLL layers additional rules on top for cases not
+covered by bug severity alone (e.g. AC coverage FAIL without an associated P0 bug).
+
+## Aggregated Status — final table
+
+| Input | Aggregated Status |
+|---|---|
+| All checks `PASS` or `SKIPPED`, no P0–P3 bugs, no PoLL blocker | `VERIFIED` |
+| Any P0 / P1 bug **or** PoLL blocker (critical high-confidence, or 2+-agent escalation) | `FAILED` |
+| P2 / P3 bugs only, **or** PoLL important, **or** contradicting verdicts, **or** any `WARN` not otherwise classified | `PARTIAL` |
+| `manual-tester` returned `WARN` with `blocked_on` | `PARTIAL` with `blocked_on` surfaced in Summary |
+
+## Receipt format
+
+Save to `swarm-report/<slug>-acceptance.md`. Legacy fields preserved; new sections appended.
+
+```markdown
+# Acceptance: <slug>
+
+**Status:** VERIFIED / FAILED / PARTIAL
+**Date:** <date>
+**Type:** Feature / Bug fix
+**Project type:** <project_type>
+**Project type override:** <spec | user | none>
+**Ecosystem:** <ecosystem>
+**Spec source:** [what was used]
+**Test plan:** [resolved permanent path / generated on-the-fly / none]
+**test_plan_source:** receipt | mounted | on-the-fly | absent
+**Context artifacts:** [paths to research.md, debug.md, implement.md, quality.md used as input]
+
+## Idempotency Hashes
+- `diff_hash`: <sha256 of `git diff <base>...HEAD`>
+- `spec_hash`: <sha256 of the spec file bytes, or `null` if no file spec>
+- `test_plan_hash`: <sha256 of the permanent test plan, or `null`>
+
+These three hashes drive the Re-verification Loop decision table; downstream orchestrators
+don't need to read them.
+
+## Check Plan
+- list of checks that ran, one per line, with their trigger
+- e.g. `business-analyst` (AC coverage) — triggered by spec.acceptance_criteria_ids
+- e.g. `ux-expert` — not triggered (no design.figma)
+
+## Check Results
+
+| Check | Agent / Tool | Verdict | Severity | Confidence | Artifact |
+|---|---|---|---|---|---|
+| Manual QA | manual-tester | … | … | … | swarm-report/<slug>-acceptance-manual.md |
+| Code review | code-reviewer | … | … | … | swarm-report/<slug>-acceptance-code.md |
+| AC coverage | business-analyst | … | … | … | swarm-report/<slug>-acceptance-ac-coverage.md |
+| Design | ux-expert | … | … | … | swarm-report/<slug>-acceptance-design.md |
+| A11y | ux-expert | … | … | … | swarm-report/<slug>-acceptance-a11y.md |
+| Security | security-expert | … | … | … | swarm-report/<slug>-acceptance-security.md |
+| Performance | performance-expert | … | … | … | swarm-report/<slug>-acceptance-performance.md |
+| Architecture | architecture-expert | … | … | … | swarm-report/<slug>-acceptance-architecture.md |
+| Build config | build-engineer | … | … | … | swarm-report/<slug>-acceptance-build-config.md |
+| DevOps | devops-expert | … | … | … | swarm-report/<slug>-acceptance-devops.md |
+| Build smoke | bash | … | … | … | swarm-report/<slug>-acceptance-build.md |
+
+## Convergence signals
+Issues raised by 2+ sub-checks independently. Strongest signal of real problems.
+List one line each with the file:line or AC id and the list of checks that flagged it.
+
+## Summary
+[1–3 sentences. If PARTIAL with blocked_on — state the blocker first. If any convergence
+signal — mention it in the first sentence.]
+
+## Test Results
+- Total: [n] | Passed: [n] | Failed: [n] | Blocked: [n]
+
+## Bugs Found
+[List by severity — P0 first, then P1, P2, P3. Link each to the per-check artifact that
+reported it.]
+
+## Bug Reproduction Check (bug fix only)
+- Reproduction steps from debug.md: [executed / not applicable]
+- Bug reproduces after fix: [yes / no]
+
+## Recommendation
+[Ship / Do not ship / Ship with known issues — and why]
+```
+
+## Routing (consumed by orchestrators)
+
+- **VERIFIED** → `create-pr` (or mark existing PR ready for review).
+- **FAILED** with P0/P1 and obvious cause → `implement` with the bug list as input. Max 3
+  round-trips.
+- **FAILED** with P0/P1 and unclear cause → `debug` first, then `implement`.
+- **FAILED** with P0/P1 requiring regression coverage → `test-plan` append `## Regression TC`,
+  then `implement`.
+- **PARTIAL** with P2/P3 only or WARN — orchestrator asks the user: fix now or ship with
+  known issues (continue to `create-pr`, include in PR description).
+- **PARTIAL** with `blocked_on` — surface the blocker; do not continue until resolved.

--- a/plugins/developer-workflow/skills/acceptance/references/re-verification.md
+++ b/plugins/developer-workflow/skills/acceptance/references/re-verification.md
@@ -1,0 +1,45 @@
+Referenced from: `plugins/developer-workflow/skills/acceptance/SKILL.md` (§Re-verification Loop).
+
+# Acceptance — Re-verification Loop
+
+On fix-loop re-entry (after `FAILED` → `implement` fix → re-run acceptance):
+
+1. Re-probe Step 0 and Step 1 (project type rarely changes; inputs may).
+2. Compute `diff_hash_new` = `sha256(git diff <base>...HEAD)`.
+3. Decide per-check action using the previous per-check artifact and `diff_hash`:
+
+   | Previous verdict | Previous `diff_hash` vs `diff_hash_new` | Action |
+   |---|---|---|
+   | `PASS` or `SKIPPED` | match | **Skip** — reuse the existing artifact as-is. Record `re-used previous verdict` in the aggregated receipt. |
+   | `PASS` or `SKIPPED` | mismatch | Re-run. |
+   | `WARN` | match | Skip. Re-used verdict keeps the WARN; user had the option to ship with it. |
+   | `WARN` | mismatch | Re-run. |
+   | `FAIL` | any | **Always re-run.** A FAIL is the point of the loop; hash match means the fix didn't land in the diff yet — still must re-run to confirm. |
+   | any prior verdict with previous `diff_hash` = `null`, absent, or unreadable | any | Re-run — cannot prove idempotency without a usable hash. |
+
+   An explicit `diff_hash: null` and a missing `diff_hash` field are treated the same way:
+   both mean the prior artifact does not carry enough information to prove idempotency, so
+   the check must be re-run.
+
+4. For checks that are re-run:
+   - Overwrite the per-check artifact with fresh content and a new `diff_hash`.
+   - `manual-tester` specifically re-runs previously-failed TCs plus a Smoke tier by default;
+     the full plan is re-run only on explicit request or when the spec changed.
+5. Aggregate into a fresh `swarm-report/<slug>-acceptance.md`, overwriting the previous one.
+6. Repeat until VERIFIED or the user decides to ship as-is.
+
+**Spec/test-plan change override.** If the spec file or test-plan file changed between runs
+(detected by comparing their `sha256` to values recorded in the previous aggregated receipt
+under `spec_hash` / `test_plan_hash`), `business-analyst` and `manual-tester` are always
+re-run regardless of `diff_hash` — their input is the spec/TC list, not just the code diff.
+Other checks remain subject to the `diff_hash` policy.
+
+**Back-compat rule.** If the previous aggregated receipt does not contain `spec_hash`
+and/or `test_plan_hash` (e.g. a pre-iteration-3 receipt) — or either prior value is unknown
+or unreadable — treat that input as **changed** and re-run the affected checks to be safe:
+missing/unknown `spec_hash` forces `business-analyst`; missing/unknown `test_plan_hash`
+forces `manual-tester`. If both are missing/unknown, re-run both. Other checks remain
+subject to the `diff_hash` policy.
+
+This is the full idempotency pass that iteration 2 parked. Cost saving: on a single-file fix
+after a 5-agent FAIL, typically 2–3 passed checks are re-used instead of re-run.

--- a/plugins/developer-workflow/skills/acceptance/references/subcheck-prompts.md
+++ b/plugins/developer-workflow/skills/acceptance/references/subcheck-prompts.md
@@ -1,0 +1,176 @@
+Referenced from: `plugins/developer-workflow/skills/acceptance/SKILL.md` (§Step 3: Run Checks — per-agent sub-check prompts).
+
+# Acceptance — Per-Agent Sub-Check Prompts
+
+## Spawn `manual-tester` (UI branch)
+
+`manual-tester` owns the runtime environment end-to-end per its Step 0 Environment Setup.
+Acceptance does not pre-launch — that is intentional delegation.
+
+Prompt contents:
+1. **Spec context** — full text or clear pointers.
+2. **Test plan** — the complete set of test cases.
+3. **Target hints** (optional) — device/URL if the user already named one.
+4. **Scope** — which tiers (default: Smoke + Feature).
+5. **Output path** — `swarm-report/<slug>-acceptance-manual.md` with the per-check schema.
+
+If the agent returns `WARN` with `blocked_on`, surface that text to the user as the primary
+next-step requirement before re-running acceptance.
+
+## Spawn `code-reviewer` (delta review, skipped if Step 2.5 matched)
+
+Prompt contents:
+1. **Task description** — one sentence from spec or PR title.
+2. **Plan pointer** — path to implement receipt or research report if present.
+3. **Git diff** — current diff.
+4. **Output path** — `swarm-report/<slug>-acceptance-code.md`.
+
+Verdict rules: `PASS` if no semantic bugs, logic errors, or security issues; `WARN` for
+style/minor; `FAIL` for blockers.
+
+## Build smoke (non-UI branch)
+
+Pick the command by `ecosystem` (see ORCHESTRATION.md §Build system detection):
+
+| `ecosystem` | Command |
+|---|---|
+| `gradle` | `./gradlew build -x test --quiet` (single-module) or `./gradlew :check` (multi-module) |
+| `node` | `npm run build` (or `pnpm build` / `yarn build`) |
+| `rust` | `cargo build --release --quiet` |
+| `go` | `go build ./...` |
+| `python` | `python -m compileall .` or package-specific build |
+
+Multi-module detection: scan `settings.gradle*` for `include(` statements. If subprojects are
+declared and the user did not specify a target module, ask which module is the smoke target
+**before** entering Step 3 (do not block the fan-out message with a question).
+
+If the `ecosystem` or command is not resolvable, skip with `verdict: SKIPPED` and
+`blocked_on: build command unknown`. On success write `verdict: PASS`; on failure capture the
+last ~50 lines and write `verdict: FAIL`. Receipt at
+`swarm-report/<slug>-acceptance-build.md`.
+
+## Spawn `business-analyst` (conditional — AC coverage)
+
+Fires when `acceptance_criteria_ids` in spec frontmatter is a non-empty list.
+
+Prompt contents:
+1. **Spec** — the spec file path.
+2. **Diff / implement receipt** — evidence for each AC.
+3. **Test plan** (if any) — TC list mapped to AC via each test case's `Source:` field
+   (e.g. `Source: AC-1` or `Source: AC-2, AC-3`). This is the canonical mapping used by
+   `generate-test-plan`; do not invent a new `AC-ref:` field.
+4. **manual-tester output** (if running) — pointer to
+   `swarm-report/<slug>-acceptance-manual.md`.
+5. **Output path** — `swarm-report/<slug>-acceptance-ac-coverage.md`.
+
+Verdict rules: `PASS` if every `AC-N` has at least one evidence pointer; `WARN` for weak
+coverage (single witness on high-risk AC); `FAIL` for any missing AC. Severity: `FAIL` on
+missing AC is `critical`; weak coverage is `major`.
+
+## Spawn `ux-expert` (conditional — design-review or a11y)
+
+Fires when **`has_ui_surface == true`** AND (`design.figma` is set for design-review mode
+**or** `non_functional.a11y` is set for a11y mode). Non-UI projects never trigger this even
+if `non_functional.a11y` is present — a11y on backend/library/CLI has no surface to audit.
+
+Design-review and a11y can both fire in one invocation. When both trigger, spawn `ux-expert`
+once with mode `both`; the agent writes **two** artifacts (one per concern) so aggregation in
+Step 4 treats them as independent checks:
+
+- `swarm-report/<slug>-acceptance-design.md` with `check: design`
+- `swarm-report/<slug>-acceptance-a11y.md` with `check: a11y`
+
+When only one mode fires, only the corresponding artifact is written.
+
+Prompt contents:
+1. **Mode** — `design-review` / `a11y` / `both`.
+2. **Spec** — file path.
+3. **Design source** — `design.figma` URL (design-review mode).
+4. **a11y target** — value of `non_functional.a11y` (e.g. `wcag-aa`).
+5. **Running app pointer** — target hints; the agent reads running-app state via MCP only
+   when the environment is already prepared, otherwise works from screenshots/code.
+6. **Output paths** — one or both of the filenames listed above, matching the mode.
+
+Verdict rules: `PASS` if design matches reference and a11y criteria met; `WARN` for minor
+spacing/color deviations or AA soft failures; `FAIL` for missing components, broken
+interaction paths, or hard a11y violations (keyboard trap, contrast below threshold).
+
+## Spawn `security-expert` (conditional)
+
+Fires when `risk_areas` intersects `{auth, payment, pii, data-migration}`.
+
+Prompt contents:
+1. **Risk list** — the intersection subset.
+2. **Diff** — full git diff.
+3. **Spec** — file path.
+4. **Output path** — `swarm-report/<slug>-acceptance-security.md`.
+
+Verdict rules: `PASS` if no applicable OWASP / project-security-rule violations; `WARN` for
+minor hardening opportunities; `FAIL` for exploitable issues, secret leaks, or regulation
+breaches.
+
+## Spawn `performance-expert` (conditional)
+
+Fires when `non_functional.sla` is set **or** `risk_areas` contains `perf-critical`.
+
+Prompt contents:
+1. **SLA target** — from `non_functional.sla`, or implicit `perf-critical` baseline.
+2. **Diff** — full git diff.
+3. **Output path** — `swarm-report/<slug>-acceptance-performance.md`.
+
+Verdict rules: `PASS` if no regression; `WARN` for borderline; `FAIL` for violations.
+
+## Spawn `architecture-expert` (conditional — diff-triggered)
+
+Fires when the diff touches a public API symbol **or** spans ≥ 3 top-level modules (see the
+heuristic at §Conditional triggers).
+
+Prompt contents:
+1. **Trigger reason** — `public-api` / `cross-module` / `both` with the specific file list
+   that matched.
+2. **Diff** — full git diff (scoped to triggered files + their immediate neighbours).
+3. **Module map** — list of top-level modules touched, discovered from
+   `settings.gradle*` / `package.json` workspaces / `Cargo.toml` workspace members.
+4. **Output path** — `swarm-report/<slug>-acceptance-architecture.md` with `check: architecture`.
+
+Verdict rules: `PASS` if public contracts are preserved and module dependency direction is
+clean; `WARN` for style issues (e.g., missing deprecation annotation, avoidable coupling);
+`FAIL` for contract breakage, circular dependencies, or leaking internals into a public API.
+
+## Spawn `build-engineer` (conditional — diff-triggered)
+
+Fires when the diff touches any build file listed in §Conditional triggers.
+
+Prompt contents:
+1. **Build files changed** — exact file list from the diff.
+2. **Diff** — scoped to those files plus any touched module manifests.
+3. **Ecosystem** — resolved `ecosystem` from Step 0 (drives which toolchain the agent should
+   evaluate against).
+4. **Output path** — `swarm-report/<slug>-acceptance-build-config.md` with
+   `check: build-config`.
+
+Note: `check: build` is already used by the non-UI build smoke (§3.3). The expert review of
+**config changes** uses a distinct check identifier `build-config` so aggregation can treat
+the two axes independently (a project can have a clean smoke and a broken config, or vice
+versa).
+
+Verdict rules: `PASS` if dependency additions are pinned/hash-verified, plugin versions are
+consistent, and task wiring is intact; `WARN` for unpinned version ranges, unused
+dependencies, or minor style issues; `FAIL` for breaking plugin mismatches, missing required
+configuration, or dependency choices that conflict with project policy.
+
+## Spawn `devops-expert` (conditional — diff-triggered)
+
+Fires when the diff touches CI / release configuration (see §Conditional triggers).
+
+Prompt contents:
+1. **CI files changed** — exact file list.
+2. **Diff** — scoped to CI/release files.
+3. **Repo context** — `public` vs `private` (affects secret handling guidance),
+   and any related marketplace/deployment manifests if present.
+4. **Output path** — `swarm-report/<slug>-acceptance-devops.md` with `check: devops`.
+
+Verdict rules: `PASS` if pipeline health is preserved, secrets are handled correctly, and
+rollout gates remain sound; `WARN` for minor inefficiencies or missing
+`timeout-minutes` / `concurrency` guards; `FAIL` for leaked secrets, disabled safety gates,
+or breaking workflow syntax.

--- a/plugins/developer-workflow/skills/create-pr/SKILL.md
+++ b/plugins/developer-workflow/skills/create-pr/SKILL.md
@@ -177,7 +177,7 @@ Body composition is mode-aware.
 
 The body is composed from a catalog of optional sections: What changed, Why / motivation, Artifacts, How to test, Status, Screenshots / demo, Checklist, and a trailing Claude Code footer. Include only the sections that apply for the current mode and available artifacts.
 
-See `references/body-sections.md` for the full section-bank templates with example content and status-table formatting.
+See [`references/body-sections.md`](references/body-sections.md) for the full section-bank templates with example content and status-table formatting.
 
 ### 7.2 Section selection per mode
 
@@ -195,7 +195,7 @@ See `references/body-sections.md` for the full section-bank templates with examp
 
 Scan the changed file paths for platform-specific UI markers (Android/Compose, Compose Multiplatform, Web, iOS/SwiftUI). If any match, include the "Screenshots / demo" section and prompt the user for attachments in `--draft` and `--promote` modes; `--refresh` preserves existing Screenshots content verbatim.
 
-See `references/visual-change-patterns.md` for the full glob patterns per platform.
+See [`references/visual-change-patterns.md`](references/visual-change-patterns.md) for the full glob patterns per platform.
 
 ### 7.4 Preserve user edits on refresh/promote
 

--- a/plugins/developer-workflow/skills/create-pr/SKILL.md
+++ b/plugins/developer-workflow/skills/create-pr/SKILL.md
@@ -175,44 +175,9 @@ Body composition is mode-aware.
 
 ### 7.1 Section bank
 
-Available sections (include only those that apply):
+The body is composed from a catalog of optional sections: What changed, Why / motivation, Artifacts, How to test, Status, Screenshots / demo, Checklist, and a trailing Claude Code footer. Include only the sections that apply for the current mode and available artifacts.
 
-```markdown
-## What changed
-<!-- Technical description from commit log + diff -->
-
-## Why / motivation
-<!-- From task description or plan artifact; link ticket if URL in commits -->
-
-## Artifacts
-<!-- Bullet list of swarm-report/ paths that exist -->
-- Plan: swarm-report/<slug>-plan.md
-- Test plan: swarm-report/<slug>-test-plan.md
-- ...
-
-## How to test
-<!-- From test-plan.md or plan.md acceptance criteria; checkbox list -->
-- [ ] Scenario 1
-- [ ] Scenario 2
-
-## Status
-<!-- Table: Implement / Finalize / Acceptance stages, pass/fail/pending from artifacts -->
-| Stage | Result | Notes |
-|---|---|---|
-| Implement | ✅ PASS | all gates green |
-| Finalize  | ⏳ in progress | round 2/3 |
-| Acceptance | ⏸ pending | waits for finalize |
-
-## Screenshots / demo
-<!-- For visual changes; prompt user -->
-
-## Checklist
-- [ ] Tests added or updated
-- [ ] No breaking changes (or documented)
-- [ ] Relevant docs updated
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-```
+See `references/body-sections.md` for the full section-bank templates with example content and status-table formatting.
 
 ### 7.2 Section selection per mode
 
@@ -228,13 +193,9 @@ Available sections (include only those that apply):
 
 ### 7.3 Detect visual changes
 
-Look at changed file paths for:
-- Android/Compose: `*Screen.kt`, `*Composable.kt`, `res/layout/`, `res/drawable/`
-- Compose Multiplatform: Kotlin UI patterns + `commonMain` UI dirs
-- Web: `*.tsx`, `*.jsx`, `*.css`, `*.scss`, `*.html`
-- iOS: `*.swift` (SwiftUI), `*.xib`, `*.storyboard`
+Scan the changed file paths for platform-specific UI markers (Android/Compose, Compose Multiplatform, Web, iOS/SwiftUI). If any match, include the "Screenshots / demo" section and prompt the user for attachments in `--draft` and `--promote` modes; `--refresh` preserves existing Screenshots content verbatim.
 
-If visual changes detected — include "Screenshots / demo" section and prompt the user (in `--draft` and `--promote` modes) for attachments. `--refresh` preserves existing Screenshots content.
+See `references/visual-change-patterns.md` for the full glob patterns per platform.
 
 ### 7.4 Preserve user edits on refresh/promote
 

--- a/plugins/developer-workflow/skills/create-pr/references/body-sections.md
+++ b/plugins/developer-workflow/skills/create-pr/references/body-sections.md
@@ -1,0 +1,42 @@
+# create-pr — Body Section Bank
+
+Referenced from: `plugins/developer-workflow/skills/create-pr/SKILL.md` (§7.1).
+
+Available sections (include only those that apply):
+
+```markdown
+## What changed
+<!-- Technical description from commit log + diff -->
+
+## Why / motivation
+<!-- From task description or plan artifact; link ticket if URL in commits -->
+
+## Artifacts
+<!-- Bullet list of swarm-report/ paths that exist -->
+- Plan: swarm-report/<slug>-plan.md
+- Test plan: swarm-report/<slug>-test-plan.md
+- ...
+
+## How to test
+<!-- From test-plan.md or plan.md acceptance criteria; checkbox list -->
+- [ ] Scenario 1
+- [ ] Scenario 2
+
+## Status
+<!-- Table: Implement / Finalize / Acceptance stages, pass/fail/pending from artifacts -->
+| Stage | Result | Notes |
+|---|---|---|
+| Implement | ✅ PASS | all gates green |
+| Finalize  | ⏳ in progress | round 2/3 |
+| Acceptance | ⏸ pending | waits for finalize |
+
+## Screenshots / demo
+<!-- For visual changes; prompt user -->
+
+## Checklist
+- [ ] Tests added or updated
+- [ ] No breaking changes (or documented)
+- [ ] Relevant docs updated
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```

--- a/plugins/developer-workflow/skills/create-pr/references/visual-change-patterns.md
+++ b/plugins/developer-workflow/skills/create-pr/references/visual-change-patterns.md
@@ -6,6 +6,7 @@ Look at changed file paths for:
 - Android/Compose: `*Screen.kt`, `*Composable.kt`, `res/layout/`, `res/drawable/`
 - Compose Multiplatform: Kotlin UI patterns + `commonMain` UI dirs
 - Web: `*.tsx`, `*.jsx`, `*.css`, `*.scss`, `*.html`
-- iOS: `*.swift` (SwiftUI), `*.xib`, `*.storyboard`
+- iOS: `*View.swift`, `*Screen.swift`, `Views/`, `Screens/`, `*.xib`, `*.storyboard`
+  (plain `*.swift` is too broad — most Swift files are non-UI; match by suffix/dir)
 
 If visual changes detected — include "Screenshots / demo" section and prompt the user (in `--draft` and `--promote` modes) for attachments. `--refresh` preserves existing Screenshots content.

--- a/plugins/developer-workflow/skills/create-pr/references/visual-change-patterns.md
+++ b/plugins/developer-workflow/skills/create-pr/references/visual-change-patterns.md
@@ -1,0 +1,11 @@
+# create-pr — Visual Change Detection Patterns
+
+Referenced from: `plugins/developer-workflow/skills/create-pr/SKILL.md` (§7.3).
+
+Look at changed file paths for:
+- Android/Compose: `*Screen.kt`, `*Composable.kt`, `res/layout/`, `res/drawable/`
+- Compose Multiplatform: Kotlin UI patterns + `commonMain` UI dirs
+- Web: `*.tsx`, `*.jsx`, `*.css`, `*.scss`, `*.html`
+- iOS: `*.swift` (SwiftUI), `*.xib`, `*.storyboard`
+
+If visual changes detected — include "Screenshots / demo" section and prompt the user (in `--draft` and `--promote` modes) for attachments. `--refresh` preserves existing Screenshots content.

--- a/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
@@ -56,7 +56,7 @@ the artifact via receipt-based gating. The permanent file remains the source of 
 the receipt is metadata + pointer. Standalone invocations (no slug passed) skip the
 receipt entirely and write only the canonical `docs/testplans/<slug>-test-plan.md` file.
 
-See `references/receipt-format.md` for the full YAML schema, field conventions
+See [`references/receipt-format.md`](references/receipt-format.md) for the full YAML schema, field conventions
 (`status`, `review_verdict`, `review_warnings` / `review_blockers`, `phase_coverage`,
 `platform`, `created` / `updated`), and the standalone-without-slug backward-compatibility
 rules.
@@ -164,7 +164,7 @@ be grouped by phase, split the `## Test Cases` section into `### Phase N (T-i..T
 subsections (still one permanent file per feature). The receipt's `phase_coverage` then lists
 the phase labels present.
 
-See `references/format-templates.md` for the full standard and lightweight templates (verbatim
+See [`references/format-templates.md`](references/format-templates.md) for the full standard and lightweight templates (verbatim
 markdown), the phase-segmentation worked example, and the rules for when each variant applies.
 
 ## Field Definitions

--- a/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
@@ -50,81 +50,16 @@ The resulting filename is then `docs/testplans/<slug>-test-plan.md` (for example
 
 ### Receipt (when invoked from orchestrator with a slug)
 
-When this skill is invoked from the `feature-flow` orchestrator, a `slug` argument is passed
-explicitly. In that case, in addition to the permanent document above, produce a **receipt**
-at `swarm-report/<slug>-test-plan.md` that the orchestrator and downstream stages
-(`multiexpert-review`, `acceptance`) can consume for receipt-based gating.
+When invoked from `feature-flow` with a `slug` argument, also emit a receipt at
+`swarm-report/<slug>-test-plan.md` so `multiexpert-review` and `acceptance` can mount
+the artifact via receipt-based gating. The permanent file remains the source of truth;
+the receipt is metadata + pointer. Standalone invocations (no slug passed) skip the
+receipt entirely and write only the canonical `docs/testplans/<slug>-test-plan.md` file.
 
-The permanent file remains the source of truth. The receipt is metadata + pointer.
-
-Receipt format:
-
-```markdown
----
-name: test-plan-receipt
-description: Test plan artifact for <slug>
-slug: <slug>
-type: test-plan-receipt
-status: Draft | Ready | Approved | Mounted
-permanent_path: docs/testplans/<slug>-test-plan.md
-source_spec: <path to spec if any, or "inline spec">
-review_verdict: pending | PASS | WARN | FAIL | skipped
-review_warnings: []            # populated by multiexpert-review on WARN — list of short strings
-review_blockers: []            # populated by multiexpert-review on FAIL — list of short strings
-phase_coverage: [Phase 1, Phase 2, ...]
-platform: []                   # optional; inherited from the source spec's `platform:` field when present.
-                               # Drives platform-aware TC generation and downstream acceptance checks (e.g.,
-                               # skip mobile-only TCs on a backend-only target). Leave empty when the spec
-                               # did not set it; acceptance falls back to its project-type heuristic.
-created: YYYY-MM-DD
-updated: YYYY-MM-DD
----
-
-# Test Plan Receipt: <slug>
-
-**Status:** <status>
-**Permanent artifact:** [`docs/testplans/<slug>-test-plan.md`](../docs/testplans/<slug>-test-plan.md)
-**Source spec:** <path or description>
-**Review verdict:** <verdict>
-```
-
-Field conventions:
-- `status`: `Draft` right after generation; `Ready` after multiexpert-review returns PASS/WARN;
-  `Approved` when the user explicitly signs off; `Mounted` when a user-authored permanent
-  file is adopted without regeneration (see `feature-flow/SKILL.md` §1.5 Pre-check).
-- `review_verdict`: `pending` at creation; updated by `multiexpert-review` to
-  `PASS | WARN | FAIL`; `skipped` on mount (no review occurs).
-- `review_warnings` / `review_blockers`: arrays of short strings populated by `multiexpert-review`.
-  `review_warnings` is written on WARN verdicts (items d or e of the checklist violated —
-  non-blocking); `review_blockers` is written on FAIL (items a, b, or c violated —
-  blocks transition to Implement). Both remain empty arrays on PASS / pending / skipped.
-  Frontmatter is the single source of truth for review findings — the receipt body does
-  not re-list them, keeping downstream YAML parsers authoritative.
-- `phase_coverage`: list of phase labels present in the permanent file. Empty list if the
-  feature has no phase segmentation.
-- `created` / `updated`: ISO dates (`YYYY-MM-DD`). `updated` must change whenever either the
-  permanent file or any receipt field is modified.
-- Relative path in the markdown link assumes the conventional `swarm-report/` ↔ `docs/`
-  sibling layout at the repo root.
-
-### Backward compatibility — standalone invocation without slug
-
-When a user invokes this skill directly (e.g. "create a test plan for X") without the
-orchestrator passing a `slug`, the receipt is **not** produced. The permanent file is
-still saved under the canonical slug-based filename:
-
-- Permanent file generated at `docs/testplans/<slug>-test-plan.md`, where `<slug>` is
-  either provided inline or derived from the feature name per the Slug resolution rules
-  above. If the plan may later be consumed by another workflow that mounts an existing
-  plan (e.g. `bugfix-flow` → `acceptance` Branch 2), use the eventual orchestrator slug
-  at creation time so the file is deterministically mountable without renaming.
-- No `swarm-report/<slug>-test-plan.md` receipt is written.
-- No `phase_coverage` or receipt metadata tracked elsewhere.
-
-Standalone callers continue to work: the slug-based filename is the single canonical
-artifact. Pre-existing `docs/testplans/*-test-plan.md` files authored before this
-convention are not auto-migrated — they remain readable by humans, but mount logic
-matches only on the exact `<slug>-test-plan.md` path.
+See `references/receipt-format.md` for the full YAML schema, field conventions
+(`status`, `review_verdict`, `review_warnings` / `review_blockers`, `phase_coverage`,
+`platform`, `created` / `updated`), and the standalone-without-slug backward-compatibility
+rules.
 
 ## Input Discovery
 
@@ -211,184 +146,26 @@ Before writing test cases, identify:
 
 ## Test Plan Format
 
-Every generated test plan must follow this exact structure:
+Every generated test plan has the same top-level layout: YAML frontmatter with `type: test-plan`
+and `slug`, a header metadata table, then `Findings`, `Risk Areas`, `Test Cases`,
+`Edge Cases & Negative Scenarios`, `Coverage Matrix`, and `Suggested Automation Candidates`.
+Each `TC-[N]` block is itself a table with `Priority`, `Tier`, `Preconditions`, `Steps`,
+`Expected Result`, and `Source` rows.
 
-```markdown
----
-type: test-plan
-slug: <feature-slug>
-generated: YYYY-MM-DD
----
+Two variants exist:
 
-# Test Plan: [Feature Name]
+- **Standard format** — the default; full Steps + Expected Result columns.
+- **Lightweight format (non-UI features)** — when the non-UI detector triggers, TC blocks
+  collapse Steps and Expected Result into a single `Scenario (Given/When/Then)` row.
+  All other sections are unchanged.
 
-| Field | Value |
-|-------|-------|
-| **Source** | [spec link / Figma link / code path — whatever was provided] |
-| **Generated** | [YYYY-MM-DD] |
-| **Scope** | [one-line summary of what is covered] |
-| **Status** | Draft / Ready for Review / Approved |
+When the feature arrives via `decompose-feature` with two or more phases and test cases can
+be grouped by phase, split the `## Test Cases` section into `### Phase N (T-i..T-j) — <label>`
+subsections (still one permanent file per feature). The receipt's `phase_coverage` then lists
+the phase labels present.
 
-The `type: test-plan` frontmatter lets `multiexpert-review` and `acceptance` identify the
-artifact deterministically (Signal #1 of the classifier). `slug` matches the receipt and
-any decomposition artifact for the same feature.
-
----
-
-## Findings
-
-Discrepancies, ambiguities, or assumptions discovered during analysis.
-Each finding has a short title and explanation.
-
-- **[Finding title]** — [explanation]
-
-> Omit this section entirely if there are no findings.
-
----
-
-## Risk Areas
-
-| Area | Risk Level | Reason |
-|------|-----------|--------|
-| [area name] | High / Medium / Low | [why this area is risky] |
-
----
-
-## Test Cases
-
-### [Group Name]
-
-Group related test cases by feature area, screen, or workflow
-(e.g., Authentication, Cart Checkout, Error Handling).
-
-#### TC-[N]: [Short descriptive title]
-
-| Field | Value |
-|-------|-------|
-| **Priority** | P0 Critical / P1 High / P2 Medium / P3 Low |
-| **Tier** | Smoke / Feature / Regression |
-| **Preconditions** | What must be true before starting |
-| **Steps** | 1. First step  2. Second step  3. Third step |
-| **Expected Result** | Observable outcome that means the test passed |
-| **Source** | Spec §section / Figma frame name / `path/to/file.kt:42` / [inferred from code] |
-
----
-
-## Edge Cases & Negative Scenarios
-
-Same TC format as above. Grouped separately for visibility.
-Includes: boundary values, invalid inputs, error states, permission denials,
-network failures, empty/null data, concurrent operations.
-
----
-
-## Coverage Matrix
-
-| Requirement / Screen / Flow | Test Cases | Risk |
-|-----------------------------|-----------|------|
-| [requirement or screen name] | TC-1, TC-3 | High |
-| [another requirement] | TC-2 | Low |
-
----
-
-## Suggested Automation Candidates
-
-Test cases that are good candidates for automated testing.
-
-| Test Case | Rationale |
-|-----------|-----------|
-| TC-[N] | [why this is a good automation candidate] |
-
-> Omit this section if no test cases are suitable for automation.
-```
-
-### Phase Segmentation
-
-When the feature reaches this skill via `decompose-feature` with phases (e.g. T-1..T-3 in
-Phase 1, T-4..T-6 in Phase 2), the permanent file splits the `## Test Cases` section by
-phase so each phase can ship and be re-verified independently. One permanent document per
-feature remains the rule — phases are sections inside it, not separate files.
-
-Apply segmentation when the decomposition artifact contains two or more phases **and** test
-cases can be grouped by which phase introduces the behavior they cover. Otherwise keep a
-single flat `## Test Cases` section.
-
-Example for a feature with two phases:
-
-```markdown
-## Test Cases
-
-### Phase 1 (T-1..T-3) — Core login flow
-
-#### TC-1: Successful login with valid credentials
-| Field | Value |
-|-------|-------|
-| **Priority** | P0 Critical |
-| **Tier** | Smoke |
-| **Preconditions** | User account exists, email is verified |
-| **Steps** | 1. Open login screen  2. Enter email  3. Enter password  4. Tap Login |
-| **Expected Result** | Home screen is shown, session token stored |
-| **Source** | Spec §2.1 |
-
-#### TC-2: Invalid password shows inline error
-...
-
-#### TC-3: Rate-limit after 5 failed attempts
-...
-
-### Phase 2 (T-4..T-6) — Password reset flow
-
-#### TC-4: Request reset email from login screen
-| Field | Value |
-|-------|-------|
-| **Priority** | P0 Critical |
-| **Tier** | Feature |
-| **Preconditions** | User account exists |
-| **Steps** | 1. Tap "Forgot password?"  2. Enter email  3. Submit |
-| **Expected Result** | Confirmation screen shown, reset email dispatched |
-| **Source** | Spec §3.2 |
-
-#### TC-5: Reset link expires after 15 minutes
-...
-
-#### TC-6: Reset flow rejects reused link
-...
-```
-
-When segmentation is applied, the receipt's `phase_coverage` field lists the phase labels
-present (e.g. `[Phase 1, Phase 2]`), and the TC ranges covered by each phase appear in the
-receipt's Phase Coverage section.
-
-### Lightweight template (non-UI features)
-
-When the non-UI detector triggers (see Input Discovery), use this reduced TC format in place
-of the standard one. The entire behavior of each TC is captured in Given/When/Then — no
-numbered Steps, no separate Expected Result field, since both collapse into the Then clause
-for non-interactive surfaces.
-
-```markdown
-#### TC-[N]: [Short title]
-| **Priority** | P0/P1/P2/P3 |
-| **Tier** | Smoke/Feature/Regression |
-| **Preconditions** | [state] |
-| **Scenario (Given/When/Then)** | Given X, When Y, Then Z |
-| **Source** | [Spec §section / inferred from code] |
-```
-
-Example:
-
-```markdown
-#### TC-3: Token refresh succeeds before expiry
-| **Priority** | P0 Critical |
-| **Tier** | Feature |
-| **Preconditions** | Valid refresh token stored, access token within 60s of expiry |
-| **Scenario (Given/When/Then)** | Given an access token with <60s TTL, When the client calls `refresh()`, Then a new access token is returned with the original refresh-token scope preserved |
-| **Source** | `src/auth/TokenManager.kt:142` |
-```
-
-All other sections of the Test Plan Format (front-matter table, Findings, Risk Areas,
-Coverage Matrix, Suggested Automation Candidates, Phase Segmentation when applicable) are
-used unchanged — only the TC blocks switch to this reduced form.
+See `references/format-templates.md` for the full standard and lightweight templates (verbatim
+markdown), the phase-segmentation worked example, and the rules for when each variant applies.
 
 ## Field Definitions
 

--- a/plugins/developer-workflow/skills/generate-test-plan/references/format-templates.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/references/format-templates.md
@@ -1,0 +1,182 @@
+Referenced from: `plugins/developer-workflow/skills/generate-test-plan/SKILL.md` (§Test Plan Format).
+
+# Test Plan Format Templates
+
+Every generated test plan must follow this exact structure:
+
+```markdown
+---
+type: test-plan
+slug: <feature-slug>
+generated: YYYY-MM-DD
+---
+
+# Test Plan: [Feature Name]
+
+| Field | Value |
+|-------|-------|
+| **Source** | [spec link / Figma link / code path — whatever was provided] |
+| **Generated** | [YYYY-MM-DD] |
+| **Scope** | [one-line summary of what is covered] |
+| **Status** | Draft / Ready for Review / Approved |
+
+The `type: test-plan` frontmatter lets `multiexpert-review` and `acceptance` identify the
+artifact deterministically (Signal #1 of the classifier). `slug` matches the receipt and
+any decomposition artifact for the same feature.
+
+---
+
+## Findings
+
+Discrepancies, ambiguities, or assumptions discovered during analysis.
+Each finding has a short title and explanation.
+
+- **[Finding title]** — [explanation]
+
+> Omit this section entirely if there are no findings.
+
+---
+
+## Risk Areas
+
+| Area | Risk Level | Reason |
+|------|-----------|--------|
+| [area name] | High / Medium / Low | [why this area is risky] |
+
+---
+
+## Test Cases
+
+### [Group Name]
+
+Group related test cases by feature area, screen, or workflow
+(e.g., Authentication, Cart Checkout, Error Handling).
+
+#### TC-[N]: [Short descriptive title]
+
+| Field | Value |
+|-------|-------|
+| **Priority** | P0 Critical / P1 High / P2 Medium / P3 Low |
+| **Tier** | Smoke / Feature / Regression |
+| **Preconditions** | What must be true before starting |
+| **Steps** | 1. First step  2. Second step  3. Third step |
+| **Expected Result** | Observable outcome that means the test passed |
+| **Source** | Spec §section / Figma frame name / `path/to/file.kt:42` / [inferred from code] |
+
+---
+
+## Edge Cases & Negative Scenarios
+
+Same TC format as above. Grouped separately for visibility.
+Includes: boundary values, invalid inputs, error states, permission denials,
+network failures, empty/null data, concurrent operations.
+
+---
+
+## Coverage Matrix
+
+| Requirement / Screen / Flow | Test Cases | Risk |
+|-----------------------------|-----------|------|
+| [requirement or screen name] | TC-1, TC-3 | High |
+| [another requirement] | TC-2 | Low |
+
+---
+
+## Suggested Automation Candidates
+
+Test cases that are good candidates for automated testing.
+
+| Test Case | Rationale |
+|-----------|-----------|
+| TC-[N] | [why this is a good automation candidate] |
+
+> Omit this section if no test cases are suitable for automation.
+```
+
+## Phase Segmentation
+
+When the feature reaches this skill via `decompose-feature` with phases (e.g. T-1..T-3 in
+Phase 1, T-4..T-6 in Phase 2), the permanent file splits the `## Test Cases` section by
+phase so each phase can ship and be re-verified independently. One permanent document per
+feature remains the rule — phases are sections inside it, not separate files.
+
+Apply segmentation when the decomposition artifact contains two or more phases **and** test
+cases can be grouped by which phase introduces the behavior they cover. Otherwise keep a
+single flat `## Test Cases` section.
+
+Example for a feature with two phases:
+
+```markdown
+## Test Cases
+
+### Phase 1 (T-1..T-3) — Core login flow
+
+#### TC-1: Successful login with valid credentials
+| Field | Value |
+|-------|-------|
+| **Priority** | P0 Critical |
+| **Tier** | Smoke |
+| **Preconditions** | User account exists, email is verified |
+| **Steps** | 1. Open login screen  2. Enter email  3. Enter password  4. Tap Login |
+| **Expected Result** | Home screen is shown, session token stored |
+| **Source** | Spec §2.1 |
+
+#### TC-2: Invalid password shows inline error
+...
+
+#### TC-3: Rate-limit after 5 failed attempts
+...
+
+### Phase 2 (T-4..T-6) — Password reset flow
+
+#### TC-4: Request reset email from login screen
+| Field | Value |
+|-------|-------|
+| **Priority** | P0 Critical |
+| **Tier** | Feature |
+| **Preconditions** | User account exists |
+| **Steps** | 1. Tap "Forgot password?"  2. Enter email  3. Submit |
+| **Expected Result** | Confirmation screen shown, reset email dispatched |
+| **Source** | Spec §3.2 |
+
+#### TC-5: Reset link expires after 15 minutes
+...
+
+#### TC-6: Reset flow rejects reused link
+...
+```
+
+When segmentation is applied, the receipt's `phase_coverage` field lists the phase labels
+present (e.g. `[Phase 1, Phase 2]`), and the TC ranges covered by each phase appear in the
+receipt's Phase Coverage section.
+
+## Lightweight template (non-UI features)
+
+When the non-UI detector triggers (see Input Discovery), use this reduced TC format in place
+of the standard one. The entire behavior of each TC is captured in Given/When/Then — no
+numbered Steps, no separate Expected Result field, since both collapse into the Then clause
+for non-interactive surfaces.
+
+```markdown
+#### TC-[N]: [Short title]
+| **Priority** | P0/P1/P2/P3 |
+| **Tier** | Smoke/Feature/Regression |
+| **Preconditions** | [state] |
+| **Scenario (Given/When/Then)** | Given X, When Y, Then Z |
+| **Source** | [Spec §section / inferred from code] |
+```
+
+Example:
+
+```markdown
+#### TC-3: Token refresh succeeds before expiry
+| **Priority** | P0 Critical |
+| **Tier** | Feature |
+| **Preconditions** | Valid refresh token stored, access token within 60s of expiry |
+| **Scenario (Given/When/Then)** | Given an access token with <60s TTL, When the client calls `refresh()`, Then a new access token is returned with the original refresh-token scope preserved |
+| **Source** | `src/auth/TokenManager.kt:142` |
+```
+
+All other sections of the Test Plan Format (front-matter table, Findings, Risk Areas,
+Coverage Matrix, Suggested Automation Candidates, Phase Segmentation when applicable) are
+used unchanged — only the TC blocks switch to this reduced form.

--- a/plugins/developer-workflow/skills/generate-test-plan/references/receipt-format.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/references/receipt-format.md
@@ -1,0 +1,80 @@
+Referenced from: `plugins/developer-workflow/skills/generate-test-plan/SKILL.md` (§Receipt).
+
+# Test Plan Receipt Format
+
+When this skill is invoked from the `feature-flow` orchestrator, a `slug` argument is passed
+explicitly. In that case, in addition to the permanent document, produce a **receipt**
+at `swarm-report/<slug>-test-plan.md` that the orchestrator and downstream stages
+(`multiexpert-review`, `acceptance`) can consume for receipt-based gating.
+
+The permanent file remains the source of truth. The receipt is metadata + pointer.
+
+Receipt format:
+
+```markdown
+---
+name: test-plan-receipt
+description: Test plan artifact for <slug>
+slug: <slug>
+type: test-plan-receipt
+status: Draft | Ready | Approved | Mounted
+permanent_path: docs/testplans/<slug>-test-plan.md
+source_spec: <path to spec if any, or "inline spec">
+review_verdict: pending | PASS | WARN | FAIL | skipped
+review_warnings: []            # populated by multiexpert-review on WARN — list of short strings
+review_blockers: []            # populated by multiexpert-review on FAIL — list of short strings
+phase_coverage: [Phase 1, Phase 2, ...]
+platform: []                   # optional; inherited from the source spec's `platform:` field when present.
+                               # Drives platform-aware TC generation and downstream acceptance checks (e.g.,
+                               # skip mobile-only TCs on a backend-only target). Leave empty when the spec
+                               # did not set it; acceptance falls back to its project-type heuristic.
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+
+# Test Plan Receipt: <slug>
+
+**Status:** <status>
+**Permanent artifact:** [`docs/testplans/<slug>-test-plan.md`](../docs/testplans/<slug>-test-plan.md)
+**Source spec:** <path or description>
+**Review verdict:** <verdict>
+```
+
+## Field conventions
+
+- `status`: `Draft` right after generation; `Ready` after multiexpert-review returns PASS/WARN;
+  `Approved` when the user explicitly signs off; `Mounted` when a user-authored permanent
+  file is adopted without regeneration (see `feature-flow/SKILL.md` §1.5 Pre-check).
+- `review_verdict`: `pending` at creation; updated by `multiexpert-review` to
+  `PASS | WARN | FAIL`; `skipped` on mount (no review occurs).
+- `review_warnings` / `review_blockers`: arrays of short strings populated by `multiexpert-review`.
+  `review_warnings` is written on WARN verdicts (items d or e of the checklist violated —
+  non-blocking); `review_blockers` is written on FAIL (items a, b, or c violated —
+  blocks transition to Implement). Both remain empty arrays on PASS / pending / skipped.
+  Frontmatter is the single source of truth for review findings — the receipt body does
+  not re-list them, keeping downstream YAML parsers authoritative.
+- `phase_coverage`: list of phase labels present in the permanent file. Empty list if the
+  feature has no phase segmentation.
+- `created` / `updated`: ISO dates (`YYYY-MM-DD`). `updated` must change whenever either the
+  permanent file or any receipt field is modified.
+- Relative path in the markdown link assumes the conventional `swarm-report/` ↔ `docs/`
+  sibling layout at the repo root.
+
+## Backward compatibility — standalone invocation without slug
+
+When a user invokes this skill directly (e.g. "create a test plan for X") without the
+orchestrator passing a `slug`, the receipt is **not** produced. The permanent file is
+still saved under the canonical slug-based filename:
+
+- Permanent file generated at `docs/testplans/<slug>-test-plan.md`, where `<slug>` is
+  either provided inline or derived from the feature name per the Slug resolution rules
+  in SKILL.md. If the plan may later be consumed by another workflow that mounts an existing
+  plan (e.g. `bugfix-flow` → `acceptance` Branch 2), use the eventual orchestrator slug
+  at creation time so the file is deterministically mountable without renaming.
+- No `swarm-report/<slug>-test-plan.md` receipt is written.
+- No `phase_coverage` or receipt metadata tracked elsewhere.
+
+Standalone callers continue to work: the slug-based filename is the single canonical
+artifact. Pre-existing `docs/testplans/*-test-plan.md` files authored before this
+convention are not auto-migrated — they remain readable by humans, but mount logic
+matches only on the exact `<slug>-test-plan.md` path.

--- a/plugins/developer-workflow/skills/generate-test-plan/references/receipt-format.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/references/receipt-format.md
@@ -17,10 +17,10 @@ name: test-plan-receipt
 description: Test plan artifact for <slug>
 slug: <slug>
 type: test-plan-receipt
-status: Draft | Ready | Approved | Mounted
+status: Draft
 permanent_path: docs/testplans/<slug>-test-plan.md
 source_spec: <path to spec if any, or "inline spec">
-review_verdict: pending | PASS | WARN | FAIL | skipped
+review_verdict: pending
 review_warnings: []            # populated by multiexpert-review on WARN — list of short strings
 review_blockers: []            # populated by multiexpert-review on FAIL — list of short strings
 phase_coverage: [Phase 1, Phase 2, ...]

--- a/plugins/developer-workflow/skills/write-spec/SKILL.md
+++ b/plugins/developer-workflow/skills/write-spec/SKILL.md
@@ -142,7 +142,7 @@ Tracks and their inclusion rules:
 - **Critical Evaluation (general-purpose subagent)** — include when the user proposed a specific technical approach, OR the codebase has established patterns in this area that may be outdated or problematic. Produces 3 approach options (Radical / Classic / Conservative).
 - **Dependency Chain (general-purpose subagent)** — include when the feature integrates with external services, requires OS-level capabilities, touches infrastructure, or the user's request implies a setup phase.
 
-Use these research-agent prompt templates verbatim when launching each expert. See `references/research-prompts.md` for the full per-agent prompt text.
+Use these research-agent prompt templates verbatim when launching each expert. See [`references/research-prompts.md`](references/research-prompts.md) for the full per-agent prompt text.
 
 ### 1.2 State file
 
@@ -296,7 +296,7 @@ explicit with its rationale.
 
 Follow the canonical Markdown spec template — YAML frontmatter with `type`/`slug`/`date`/`status` plus optional `platform`/`surfaces`/`risk_areas`/`non_functional`/`acceptance_criteria_ids`/`design` fields that drive downstream `acceptance` and `generate-test-plan`, followed by body sections: Context and Motivation, Acceptance Criteria (stable `AC-N` ids), Prerequisites, Affected Modules and Files, Technical Approach, Technical Constraints, Decisions Made, Out of Scope, Open Questions, and Future Phases.
 
-See `references/spec-template.md` for the full template (frontmatter fields, section headers, table shapes, and inline instructions) — copy it verbatim into the draft and fill in each placeholder.
+See [`references/spec-template.md`](references/spec-template.md) for the full template (frontmatter fields, section headers, table shapes, and inline instructions) — copy it verbatim into the draft and fill in each placeholder.
 
 ---
 
@@ -329,7 +329,7 @@ profile: spec
 <rest of args: full spec content + original feature goal>
 ```
 
-The hint is defense-in-depth: inline-arg callsites lack the frontmatter the detector would classify on, and the one-line prefix short-circuits detection deterministically and independently of detector internals. See `references/profile-hint-rationale.md` for the full rationale.
+The hint is defense-in-depth: inline-arg callsites lack the frontmatter the detector would classify on, and the one-line prefix short-circuits detection deterministically and independently of detector internals. See [`references/profile-hint-rationale.md`](references/profile-hint-rationale.md) for the full rationale.
 
 **Artifact source:** in-memory draft, so engine classifies source as `conversation` and
 uses the spec profile's `source_routing.conversation: inline-revise` action for FAIL fixes

--- a/plugins/developer-workflow/skills/write-spec/SKILL.md
+++ b/plugins/developer-workflow/skills/write-spec/SKILL.md
@@ -133,131 +133,16 @@ before the research even starts.
 Launch relevant expert agents **in a single message** (parallel). Each works independently.
 Select tracks based on what the feature actually needs — not all every time.
 
-#### Codebase Expert (Explore subagent) — always include
+Tracks and their inclusion rules:
 
-```
-Investigate the codebase for everything related to: {feature goal}
+- **Codebase Expert (Explore subagent)** — always include. Surveys existing code, patterns, deps, module boundaries, integration points, TODOs, test infra.
+- **Architecture Expert (architecture-expert agent)** — include when the feature adds a new module, changes dependency direction, introduces new abstractions, or crosses more than one architectural layer.
+- **Web Research (general-purpose subagent)** — include when the feature involves external protocols, non-trivial algorithms, third-party integration, or unfamiliar domain.
+- **Business Analyst (business-analyst agent)** — include when the feature has user-facing impact, unclear scope, or comes from a vague idea.
+- **Critical Evaluation (general-purpose subagent)** — include when the user proposed a specific technical approach, OR the codebase has established patterns in this area that may be outdated or problematic. Produces 3 approach options (Radical / Classic / Conservative).
+- **Dependency Chain (general-purpose subagent)** — include when the feature integrates with external services, requires OS-level capabilities, touches infrastructure, or the user's request implies a setup phase.
 
-Find and report:
-1. Existing code that relates to this feature — classes, interfaces, modules, files
-2. Current patterns used for similar concerns in this project
-3. Dependencies already in the project that are relevant
-4. Module boundaries and architectural layers that would be affected
-5. Integration points — where would new code connect to existing code?
-6. Any TODO/FIXME comments related to this feature area
-7. Test infrastructure available for the affected areas
-
-Use ast-index for all symbol searches. Use Grep only for string literals and comments.
-Check build files, configuration, and test code too.
-
-Report: overview paragraph, then findings grouped by category with file paths and
-class/function names.
-```
-
-#### Architecture Expert (architecture-expert agent)
-
-Include when: feature adds a new module, changes dependency direction, introduces new
-abstractions, or crosses more than one architectural layer.
-
-```
-Evaluate the architectural implications of: {feature goal}
-
-Analyze:
-1. Which modules and layers would be affected?
-2. Does this align with the current architecture? What structural changes are needed?
-3. Dependency direction — any problematic new dependencies introduced?
-4. API boundaries — what contracts need to change or be created?
-5. Where should new code live (which module, which layer)?
-6. What existing architectural patterns should this follow?
-7. Are there alternative approaches worth comparing?
-
-Read the relevant module structure and build files before making judgments.
-```
-
-#### Web Research (general-purpose subagent)
-
-Include when: feature involves external protocols, non-trivial algorithms, third-party
-integration, or unfamiliar domain.
-
-```
-Research best practices and implementation approaches for: {feature goal}
-
-If Perplexity MCP is available, use it for deep research (perplexity_research or
-perplexity_ask). Otherwise use built-in web search tools.
-
-Investigate:
-1. Common implementation approaches with trade-offs
-2. Known pitfalls and mistakes to avoid
-3. Relevant libraries or standards
-4. Real-world examples from open-source projects
-5. Platform-specific considerations (Android/iOS/KMP if relevant)
-
-Note if web search was unavailable. Include source URLs for key claims.
-```
-
-#### Business Analyst (business-analyst agent)
-
-Include when: feature has user-facing impact, unclear scope, or comes from a vague idea.
-
-```
-Analyze the scope and requirements of: {feature goal}
-
-Assess:
-1. Is the scope well-defined? What's ambiguous?
-2. What is the MVP — smallest version that delivers real value?
-3. What requirements are implicit but not stated?
-4. Edge cases and error scenarios not yet covered?
-5. Where could this feature grow beyond its original intent?
-6. Dependencies on external systems, APIs, or other teams?
-
-Be concrete — list specific scenarios, not abstract concerns.
-```
-
-#### Critical Evaluation (general-purpose subagent)
-
-Include when: the user proposed a specific technical approach, OR the codebase has
-established patterns in this area that may be outdated or problematic.
-
-```
-Critically evaluate the approach for: {feature goal}
-User's proposed approach (if any): {what the user suggested}
-
-Investigate:
-1. Existing patterns in the codebase for this concern — are they good practice or
-   legacy/problematic? If problematic, explain why and what would be better.
-2. Is the user's proposed approach optimal? What are its trade-offs?
-3. What would a modern/industry-recommended approach look like?
-4. Prepare 3 concrete approach options for the user to choose from:
-   - **Radical**: most complete, modern, future-proof — higher upfront cost
-   - **Classic**: follows existing project patterns — familiar but may carry baggage
-   - **Conservative**: minimal change, quickest to ship — simplest but most limited
-5. For each option: trade-offs, estimated complexity, recommended when.
-
-Do NOT recommend blindly following project patterns if they are outdated or problematic.
-Flag bad patterns explicitly — the user should know before committing to them.
-```
-
-#### Dependency Chain (general-purpose subagent)
-
-Include when: feature integrates with external services, requires OS-level capabilities,
-touches infrastructure, or the user's request implies a setup phase.
-
-```
-Map the full dependency chain for: {feature goal}
-
-Identify everything that must exist or be configured BEFORE the feature can work:
-
-1. Infrastructure / services — third-party APIs, cloud services, databases, queues
-2. Platform requirements — OS permissions, capability declarations, entitlements
-3. Console / dashboard setup — developer consoles, API keys, service accounts
-4. Configuration — environment variables, config files, secrets
-5. Code prerequisites — base classes, interfaces, or modules that must exist first
-6. Test prerequisites — what test infrastructure or fixtures are needed
-
-For each dependency: is it already in place, or does it need to be created/configured?
-Flag any dependency that requires manual steps outside of code (e.g., "create FCM project
-in Firebase console") — these become explicit prerequisite steps in the spec.
-```
+Use these research-agent prompt templates verbatim when launching each expert. See `references/research-prompts.md` for the full per-agent prompt text.
 
 ### 1.2 State file
 
@@ -409,134 +294,9 @@ Write the spec as if the reader is an implementing agent with zero additional co
 Nothing can be left to inference. Every requirement is verifiable. Every decision is
 explicit with its rationale.
 
-```markdown
----
-type: spec
-slug: {slug}
-date: {YYYY-MM-DD}
-status: draft
-# Optional fields — leave blank when not applicable. Consumed by `acceptance`
-# (choreography) and by `generate-test-plan` (platform-aware coverage).
-platform: []                     # Canonical values from ORCHESTRATION.md §Project type detection: [android], [ios], [web], [desktop], [backend-jvm], [backend-node], [cli], [library], [generic]. May be multi-value for cross-platform features.
-surfaces: []                     # e.g. [ui], [api], [cli], [background-job]. Drives which acceptance checks run.
-risk_areas: []                   # e.g. [auth], [payment], [pii], [data-migration], [perf-critical]. Each entry triggers a conditional expert in acceptance.
-non_functional:                  # Optional block. Each present entry triggers an expert check.
-  sla:                           # e.g. p99 < 150ms. Triggers performance-expert.
-  a11y:                          # e.g. wcag-aa. Triggers ux-expert a11y mode.
-acceptance_criteria_ids: []      # e.g. [AC-1, AC-2, AC-3]. Each AC in the list MUST appear as a bullet in §Acceptance Criteria.
-design:                          # Optional.
-  figma:                         # e.g. https://www.figma.com/file/XXX. Triggers ux-expert design-review.
-  design_system:                 # Optional reference to a design system doc.
----
+Follow the canonical Markdown spec template — YAML frontmatter with `type`/`slug`/`date`/`status` plus optional `platform`/`surfaces`/`risk_areas`/`non_functional`/`acceptance_criteria_ids`/`design` fields that drive downstream `acceptance` and `generate-test-plan`, followed by body sections: Context and Motivation, Acceptance Criteria (stable `AC-N` ids), Prerequisites, Affected Modules and Files, Technical Approach, Technical Constraints, Decisions Made, Out of Scope, Open Questions, and Future Phases.
 
-# Spec: {Feature Name}
-
-Date: {YYYY-MM-DD}
-Status: draft
-Slug: {slug}
-
----
-
-## Context and Motivation
-
-{2-4 sentences: what this feature does, who benefits, why now.
-Write the "why" that will still make sense in 6 months.}
-
-## Acceptance Criteria
-
-The feature is complete when ALL of the following are true. Each criterion is assigned a
-stable `AC-N` id. The frontmatter `acceptance_criteria_ids` list is **optional** for
-back-compat, but when it is provided, it MUST include every `AC-N` id listed here and nothing
-else; that is what `acceptance` uses to drive AC-coverage checks via `business-analyst`.
-Leaving `acceptance_criteria_ids` empty disables the business-analyst conditional.
-
-- [ ] **AC-1** — {Concrete, observable behavior — not internal state}
-- [ ] **AC-2** — {Another criterion}
-- [ ] **AC-3** — {Error / edge case criterion}
-- [ ] **AC-4** — {Performance criterion with specific numbers, if relevant}
-- [ ] **AC-5** — {Compatibility criterion, if relevant}
-
-**Authoritative definition of done.** The implementing agent validates against this
-list before marking any task complete.
-
-## Prerequisites
-
-Steps that must be completed BEFORE implementation begins. Each item is either
-already done, or is an explicit task for the implementing agent or a human.
-
-| Prerequisite | Status | Owner | Notes |
-|--------------|--------|-------|-------|
-| {e.g., Create FCM project in Firebase console} | ⬜ Todo / ✅ Done | Human / Agent | {how to do it} |
-| {e.g., Add notification entitlement to app} | ⬜ Todo | Agent | {file to modify} |
-
-*(Remove this section if there are no prerequisites outside of code changes.)*
-
-## Affected Modules and Files
-
-| Module / File | Change type | Notes |
-|---------------|-------------|-------|
-| {path or module name} | New / Modified / Deleted | {what changes and why} |
-
-Key integration points:
-- {Interface or class that new code must implement or call}
-- {Existing service or repository that will be extended}
-
-## Technical Approach
-
-{High-level description of HOW the feature will be implemented — not code, but enough
-to guide architecture:
-- Which pattern to follow (existing or new)
-- Data flow: source → transformation → destination
-- Key new abstractions (classes, interfaces, modules)
-- Error handling strategy
-- State management approach (if UI-relevant)}
-
-## Technical Constraints
-
-Rules the implementing agent must follow without deviation:
-
-- {Must use X library — already in project}
-- {Must NOT add new dependencies without approval}
-- {Must follow Y pattern used elsewhere}
-- {Must support API level Z+}
-- {Must be KMP-compatible / Android-only}
-- {No blocking operations on the main thread}
-
-## Decisions Made
-
-Choices locked in during spec. The implementing agent does NOT revisit these.
-
-| Decision | Choice | Rationale |
-|----------|--------|-----------|
-| {What was decided} | {The choice} | {Why this over alternatives} |
-
-## Out of Scope
-
-Will NOT be implemented as part of this spec:
-
-- {Behavior or feature explicitly excluded}
-- {Edge case deferred to a future spec}
-- {Migration or compatibility concern left out}
-
-## Open Questions
-
-Unresolved questions the implementing agent must handle or escalate:
-
-- [ ] {Question} — *blocking / non-blocking*
-  - Options: {A}, {B}
-  - Recommendation: {preferred}
-
-If none: write "None — spec is complete." and remove this section.
-
-## Future Phases
-
-*(Only when feature was split into phases)*
-
-**Phase 2 — {name}:** {brief description, why deferred}
-**Phase 3 — {name}:** {brief description}
-
-Specced separately after Phase 1 is implemented and validated in production.
-```
+See `references/spec-template.md` for the full template (frontmatter fields, section headers, table shapes, and inline instructions) — copy it verbatim into the draft and fill in each placeholder.
 
 ---
 
@@ -569,20 +329,7 @@ profile: spec
 <rest of args: full spec content + original feature goal>
 ```
 
-Why the hint (defense-in-depth, not a single-cause fix): the `spec` profile's detector
-declares `frontmatter_type: [spec]` and `path_globs: ["docs/specs/**"]`. Either path would
-normally classify a draft that carries `type: spec` frontmatter and lives under `docs/specs/`.
-The explicit hint exists because:
-
-1. **Invocation-path robustness** — in some callsites the draft is passed as inline args
-   without the frontmatter block; the engine sees only body prose and can't rely on
-   frontmatter detection.
-2. **Cheapest deterministic route** — Step 1 hint-match short-circuits detection before
-   any YAML parse or path-glob evaluation; cost is a single-line prefix.
-3. **Detector-independence** — removes the orchestrator's dependency on detector internals.
-   Future detector refactors (reordering, different fallback) cannot silently re-open the
-   historical spec → implementation-plan misclassification drift that this profile exists
-   to close.
+The hint is defense-in-depth: inline-arg callsites lack the frontmatter the detector would classify on, and the one-line prefix short-circuits detection deterministically and independently of detector internals. See `references/profile-hint-rationale.md` for the full rationale.
 
 **Artifact source:** in-memory draft, so engine classifies source as `conversation` and
 uses the spec profile's `source_routing.conversation: inline-revise` action for FAIL fixes

--- a/plugins/developer-workflow/skills/write-spec/references/profile-hint-rationale.md
+++ b/plugins/developer-workflow/skills/write-spec/references/profile-hint-rationale.md
@@ -1,0 +1,18 @@
+Referenced from: `plugins/developer-workflow/skills/write-spec/SKILL.md` (§Phase 4.3 Run multiexpert-review).
+
+# Multiexpert-Review `spec` Profile Hint — Rationale
+
+Why the hint (defense-in-depth, not a single-cause fix): the `spec` profile's detector
+declares `frontmatter_type: [spec]` and `path_globs: ["docs/specs/**"]`. Either path would
+normally classify a draft that carries `type: spec` frontmatter and lives under `docs/specs/`.
+The explicit hint exists because:
+
+1. **Invocation-path robustness** — in some callsites the draft is passed as inline args
+   without the frontmatter block; the engine sees only body prose and can't rely on
+   frontmatter detection.
+2. **Cheapest deterministic route** — Step 1 hint-match short-circuits detection before
+   any YAML parse or path-glob evaluation; cost is a single-line prefix.
+3. **Detector-independence** — removes the orchestrator's dependency on detector internals.
+   Future detector refactors (reordering, different fallback) cannot silently re-open the
+   historical spec → implementation-plan misclassification drift that this profile exists
+   to close.

--- a/plugins/developer-workflow/skills/write-spec/references/research-prompts.md
+++ b/plugins/developer-workflow/skills/write-spec/references/research-prompts.md
@@ -51,8 +51,8 @@ integration, or unfamiliar domain.
 ```
 Research best practices and implementation approaches for: {feature goal}
 
-If Perplexity MCP is available, use it for deep research (perplexity_research or
-perplexity_ask). Otherwise use built-in web search tools.
+Prefer a dedicated web research tool when one is available in the environment.
+Otherwise use standard web search.
 
 Investigate:
 1. Common implementation approaches with trade-offs

--- a/plugins/developer-workflow/skills/write-spec/references/research-prompts.md
+++ b/plugins/developer-workflow/skills/write-spec/references/research-prompts.md
@@ -16,8 +16,8 @@ Find and report:
 6. Any TODO/FIXME comments related to this feature area
 7. Test infrastructure available for the affected areas
 
-Use ast-index for all symbol searches. Use Grep only for string literals and comments.
-Check build files, configuration, and test code too.
+Prefer a code-index tool for symbol resolution when one is available in the environment.
+Use Grep for string literals and comments. Check build files, configuration, and test code too.
 
 Report: overview paragraph, then findings grouped by category with file paths and
 class/function names.

--- a/plugins/developer-workflow/skills/write-spec/references/research-prompts.md
+++ b/plugins/developer-workflow/skills/write-spec/references/research-prompts.md
@@ -1,0 +1,129 @@
+Referenced from: `plugins/developer-workflow/skills/write-spec/SKILL.md` (§Phase 1.1 Launch research consortium).
+
+# Research-Agent Prompt Templates
+
+## Codebase Expert (Explore subagent) — always include
+
+```
+Investigate the codebase for everything related to: {feature goal}
+
+Find and report:
+1. Existing code that relates to this feature — classes, interfaces, modules, files
+2. Current patterns used for similar concerns in this project
+3. Dependencies already in the project that are relevant
+4. Module boundaries and architectural layers that would be affected
+5. Integration points — where would new code connect to existing code?
+6. Any TODO/FIXME comments related to this feature area
+7. Test infrastructure available for the affected areas
+
+Use ast-index for all symbol searches. Use Grep only for string literals and comments.
+Check build files, configuration, and test code too.
+
+Report: overview paragraph, then findings grouped by category with file paths and
+class/function names.
+```
+
+## Architecture Expert (architecture-expert agent)
+
+Include when: feature adds a new module, changes dependency direction, introduces new
+abstractions, or crosses more than one architectural layer.
+
+```
+Evaluate the architectural implications of: {feature goal}
+
+Analyze:
+1. Which modules and layers would be affected?
+2. Does this align with the current architecture? What structural changes are needed?
+3. Dependency direction — any problematic new dependencies introduced?
+4. API boundaries — what contracts need to change or be created?
+5. Where should new code live (which module, which layer)?
+6. What existing architectural patterns should this follow?
+7. Are there alternative approaches worth comparing?
+
+Read the relevant module structure and build files before making judgments.
+```
+
+## Web Research (general-purpose subagent)
+
+Include when: feature involves external protocols, non-trivial algorithms, third-party
+integration, or unfamiliar domain.
+
+```
+Research best practices and implementation approaches for: {feature goal}
+
+If Perplexity MCP is available, use it for deep research (perplexity_research or
+perplexity_ask). Otherwise use built-in web search tools.
+
+Investigate:
+1. Common implementation approaches with trade-offs
+2. Known pitfalls and mistakes to avoid
+3. Relevant libraries or standards
+4. Real-world examples from open-source projects
+5. Platform-specific considerations (Android/iOS/KMP if relevant)
+
+Note if web search was unavailable. Include source URLs for key claims.
+```
+
+## Business Analyst (business-analyst agent)
+
+Include when: feature has user-facing impact, unclear scope, or comes from a vague idea.
+
+```
+Analyze the scope and requirements of: {feature goal}
+
+Assess:
+1. Is the scope well-defined? What's ambiguous?
+2. What is the MVP — smallest version that delivers real value?
+3. What requirements are implicit but not stated?
+4. Edge cases and error scenarios not yet covered?
+5. Where could this feature grow beyond its original intent?
+6. Dependencies on external systems, APIs, or other teams?
+
+Be concrete — list specific scenarios, not abstract concerns.
+```
+
+## Critical Evaluation (general-purpose subagent)
+
+Include when: the user proposed a specific technical approach, OR the codebase has
+established patterns in this area that may be outdated or problematic.
+
+```
+Critically evaluate the approach for: {feature goal}
+User's proposed approach (if any): {what the user suggested}
+
+Investigate:
+1. Existing patterns in the codebase for this concern — are they good practice or
+   legacy/problematic? If problematic, explain why and what would be better.
+2. Is the user's proposed approach optimal? What are its trade-offs?
+3. What would a modern/industry-recommended approach look like?
+4. Prepare 3 concrete approach options for the user to choose from:
+   - **Radical**: most complete, modern, future-proof — higher upfront cost
+   - **Classic**: follows existing project patterns — familiar but may carry baggage
+   - **Conservative**: minimal change, quickest to ship — simplest but most limited
+5. For each option: trade-offs, estimated complexity, recommended when.
+
+Do NOT recommend blindly following project patterns if they are outdated or problematic.
+Flag bad patterns explicitly — the user should know before committing to them.
+```
+
+## Dependency Chain (general-purpose subagent)
+
+Include when: feature integrates with external services, requires OS-level capabilities,
+touches infrastructure, or the user's request implies a setup phase.
+
+```
+Map the full dependency chain for: {feature goal}
+
+Identify everything that must exist or be configured BEFORE the feature can work:
+
+1. Infrastructure / services — third-party APIs, cloud services, databases, queues
+2. Platform requirements — OS permissions, capability declarations, entitlements
+3. Console / dashboard setup — developer consoles, API keys, service accounts
+4. Configuration — environment variables, config files, secrets
+5. Code prerequisites — base classes, interfaces, or modules that must exist first
+6. Test prerequisites — what test infrastructure or fixtures are needed
+
+For each dependency: is it already in place, or does it need to be created/configured?
+Flag any dependency that requires manual steps outside of code (e.g., "create FCM project
+in Firebase console") — these become explicit prerequisite steps in the spec.
+```

--- a/plugins/developer-workflow/skills/write-spec/references/spec-template.md
+++ b/plugins/developer-workflow/skills/write-spec/references/spec-template.md
@@ -1,0 +1,132 @@
+Referenced from: `plugins/developer-workflow/skills/write-spec/SKILL.md` (§Phase 3 Write Spec Draft).
+
+# Spec Draft Template
+
+```markdown
+---
+type: spec
+slug: {slug}
+date: {YYYY-MM-DD}
+status: draft
+# Optional fields — leave blank when not applicable. Consumed by `acceptance`
+# (choreography) and by `generate-test-plan` (platform-aware coverage).
+platform: []                     # Canonical values from ORCHESTRATION.md §Project type detection: [android], [ios], [web], [desktop], [backend-jvm], [backend-node], [cli], [library], [generic]. May be multi-value for cross-platform features.
+surfaces: []                     # e.g. [ui], [api], [cli], [background-job]. Drives which acceptance checks run.
+risk_areas: []                   # e.g. [auth], [payment], [pii], [data-migration], [perf-critical]. Each entry triggers a conditional expert in acceptance.
+non_functional:                  # Optional block. Each present entry triggers an expert check.
+  sla:                           # e.g. p99 < 150ms. Triggers performance-expert.
+  a11y:                          # e.g. wcag-aa. Triggers ux-expert a11y mode.
+acceptance_criteria_ids: []      # e.g. [AC-1, AC-2, AC-3]. Each AC in the list MUST appear as a bullet in §Acceptance Criteria.
+design:                          # Optional.
+  figma:                         # e.g. https://www.figma.com/file/XXX. Triggers ux-expert design-review.
+  design_system:                 # Optional reference to a design system doc.
+---
+
+# Spec: {Feature Name}
+
+Date: {YYYY-MM-DD}
+Status: draft
+Slug: {slug}
+
+---
+
+## Context and Motivation
+
+{2-4 sentences: what this feature does, who benefits, why now.
+Write the "why" that will still make sense in 6 months.}
+
+## Acceptance Criteria
+
+The feature is complete when ALL of the following are true. Each criterion is assigned a
+stable `AC-N` id. The frontmatter `acceptance_criteria_ids` list is **optional** for
+back-compat, but when it is provided, it MUST include every `AC-N` id listed here and nothing
+else; that is what `acceptance` uses to drive AC-coverage checks via `business-analyst`.
+Leaving `acceptance_criteria_ids` empty disables the business-analyst conditional.
+
+- [ ] **AC-1** — {Concrete, observable behavior — not internal state}
+- [ ] **AC-2** — {Another criterion}
+- [ ] **AC-3** — {Error / edge case criterion}
+- [ ] **AC-4** — {Performance criterion with specific numbers, if relevant}
+- [ ] **AC-5** — {Compatibility criterion, if relevant}
+
+**Authoritative definition of done.** The implementing agent validates against this
+list before marking any task complete.
+
+## Prerequisites
+
+Steps that must be completed BEFORE implementation begins. Each item is either
+already done, or is an explicit task for the implementing agent or a human.
+
+| Prerequisite | Status | Owner | Notes |
+|--------------|--------|-------|-------|
+| {e.g., Create FCM project in Firebase console} | ⬜ Todo / ✅ Done | Human / Agent | {how to do it} |
+| {e.g., Add notification entitlement to app} | ⬜ Todo | Agent | {file to modify} |
+
+*(Remove this section if there are no prerequisites outside of code changes.)*
+
+## Affected Modules and Files
+
+| Module / File | Change type | Notes |
+|---------------|-------------|-------|
+| {path or module name} | New / Modified / Deleted | {what changes and why} |
+
+Key integration points:
+- {Interface or class that new code must implement or call}
+- {Existing service or repository that will be extended}
+
+## Technical Approach
+
+{High-level description of HOW the feature will be implemented — not code, but enough
+to guide architecture:
+- Which pattern to follow (existing or new)
+- Data flow: source → transformation → destination
+- Key new abstractions (classes, interfaces, modules)
+- Error handling strategy
+- State management approach (if UI-relevant)}
+
+## Technical Constraints
+
+Rules the implementing agent must follow without deviation:
+
+- {Must use X library — already in project}
+- {Must NOT add new dependencies without approval}
+- {Must follow Y pattern used elsewhere}
+- {Must support API level Z+}
+- {Must be KMP-compatible / Android-only}
+- {No blocking operations on the main thread}
+
+## Decisions Made
+
+Choices locked in during spec. The implementing agent does NOT revisit these.
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| {What was decided} | {The choice} | {Why this over alternatives} |
+
+## Out of Scope
+
+Will NOT be implemented as part of this spec:
+
+- {Behavior or feature explicitly excluded}
+- {Edge case deferred to a future spec}
+- {Migration or compatibility concern left out}
+
+## Open Questions
+
+Unresolved questions the implementing agent must handle or escalate:
+
+- [ ] {Question} — *blocking / non-blocking*
+  - Options: {A}, {B}
+  - Recommendation: {preferred}
+
+If none: write "None — spec is complete." and remove this section.
+
+## Future Phases
+
+*(Only when feature was split into phases)*
+
+**Phase 2 — {name}:** {brief description, why deferred}
+**Phase 3 — {name}:** {brief description}
+
+Specced separately after Phase 1 is implemented and validated in production.
+```

--- a/plugins/developer-workflow/skills/write-tests/SKILL.md
+++ b/plugins/developer-workflow/skills/write-tests/SKILL.md
@@ -83,7 +83,7 @@ that the Phase 4 engineer agent consumes verbatim.
 The goal is simple: generated tests must look hand-written. Never introduce a new framework
 or style that isn't already present in the project.
 
-See `references/test-infrastructure-discovery.md` for the detection tables (frameworks,
+See [`references/test-infrastructure-discovery.md`](references/test-infrastructure-discovery.md) for the detection tables (frameworks,
 assertions, mocking, async, UI, DI, naming, placement, setup, assertion style) and the exact
 Test Infrastructure Summary template.
 
@@ -156,7 +156,7 @@ Every delegation prompt must include: target code paths, the Phase 2 Test Infras
 Summary, the Phase 3 test cases, a style-reference test file, and the Phase 1.5 test plan
 if one exists.
 
-See `references/agent-prompts.md` for the full prompt templates for `kotlin-engineer`,
+See [`references/agent-prompts.md`](references/agent-prompts.md) for the full prompt templates for `kotlin-engineer`,
 `compose-developer`, `swift-engineer`, and `swiftui-developer`. Fill in the `{…}`
 placeholders and keep the section headings intact.
 

--- a/plugins/developer-workflow/skills/write-tests/SKILL.md
+++ b/plugins/developer-workflow/skills/write-tests/SKILL.md
@@ -179,7 +179,9 @@ build system:
 
 # Swift — SwiftPM package
 swift test
-# or narrow to one target: swift test --filter <TargetName>Tests
+# Narrow by test-product (test target): swift test --test-product <TestTargetName>
+# Narrow by identifier pattern: swift test --filter <Suite>/<method>  (e.g. LoginTests/testSignIn)
+# Note: --filter matches test identifiers/regex, not targets.
 
 # Swift — Xcode project / workspace (iOS, macOS, etc.)
 xcodebuild test -scheme <Scheme> -destination 'platform=iOS Simulator,name=iPhone 15'

--- a/plugins/developer-workflow/skills/write-tests/SKILL.md
+++ b/plugins/developer-workflow/skills/write-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-tests
-description: "Write retroactive tests for existing code — classes, modules, or directories lacking test coverage. Discovers test infrastructure (framework, assertions, mocking, naming), plans test cases, delegates generation to kotlin-engineer or compose-developer for Compose UI, verifies tests compile and pass, reports findings. Use when: \"write tests for\", \"add tests to\", \"test this class\", \"increase coverage\", \"add unit tests\", \"this code has no tests\", \"cover with tests\", \"retroactive tests\". Do NOT use when: user wants a test plan document without code (use generate-test-plan), run tests on live app (use acceptance), exploratory QA (use bug-hunt), or tests are part of a new feature (kotlin-engineer handles within implement). Orchestrator — delegates actual test code to engineer agents. Consumes test plans from generate-test-plan when available."
+description: "Write retroactive tests for existing code — classes, modules, or directories lacking test coverage. Discovers test infrastructure (framework, assertions, mocking, naming), plans test cases, delegates generation to platform engineer agents (kotlin-engineer, compose-developer, swift-engineer, swiftui-developer) matched to the target code, verifies tests compile and pass, reports findings. Use when: \"write tests for\", \"add tests to\", \"test this class\", \"increase coverage\", \"add unit tests\", \"this code has no tests\", \"cover with tests\", \"retroactive tests\". Do NOT use when: user wants a test plan document without code (use generate-test-plan), run tests on live app (use acceptance), exploratory QA (use bug-hunt), or tests are part of a new feature (the engineer agent handles tests within implement). Orchestrator — delegates actual test code to engineer agents. Consumes test plans from generate-test-plan when available."
 ---
 
 # Write Tests
@@ -10,8 +10,9 @@ discovers what needs testing, understands the project's test infrastructure, pla
 delegates code generation to the appropriate agent, verifies the tests, and reports results.
 
 **Key principle:** this skill is an orchestrator. It never writes test code directly — it
-delegates to `kotlin-engineer` (business logic, data layer, domain) or `compose-developer`
-(Compose UI code). The skill's job is discovery, planning, delegation, and verification.
+delegates to a platform engineer agent: `kotlin-engineer` / `compose-developer` for
+Kotlin/Android targets, or `swift-engineer` / `swiftui-developer` for Swift/iOS targets.
+The skill's job is discovery, planning, delegation, and verification.
 
 ---
 
@@ -20,10 +21,10 @@ delegates to `kotlin-engineer` (business logic, data layer, domain) or `compose-
 ### 1.1 Accept target
 
 The user provides one or more of:
-- A file path (`src/main/kotlin/com/example/UserRepository.kt`)
-- A class name (`UserRepository`)
-- A module or directory (`feature/auth`, `:core:network`)
-- A vague reference ("the auth module", "this class")
+- A file path (`src/main/kotlin/com/example/UserRepository.kt`, `Sources/Auth/LoginService.swift`)
+- A class or type name (`UserRepository`, `LoginService`)
+- A module or directory (`feature/auth`, `:core:network`, `Sources/Auth`, an Xcode target)
+- A vague reference ("the auth module", "this class", "the login view")
 
 Resolve vague references using a code-index tool when one is available in the environment;
 fall back to `Grep` / `Glob` + `Read` otherwise. If the reference remains ambiguous after
@@ -42,16 +43,19 @@ Read all source files in the target scope. For each file, identify:
 - Public API surface (public/internal classes, functions, properties)
 - Dependencies (constructor parameters, injected services)
 - Complexity indicators (branching, state management, error handling)
-- Whether the code is Compose UI or non-UI Kotlin
+- Whether the code is UI (Compose composables, SwiftUI views) or non-UI code (Kotlin business
+  logic / data layer, Swift services / models / repositories)
 
 ### 1.3 Find existing tests
 
 Search for existing tests:
-- Check the corresponding test source set (`src/test/`, `src/androidTest/`, `src/commonTest/`)
+- Check the corresponding test location — Kotlin/Android: `src/test/`, `src/androidTest/`,
+  `src/commonTest/`; Swift: `Tests/<TargetName>Tests/` (SwiftPM) or the Xcode test target
+  (often `<AppName>Tests/` or `<AppName>UITests/`)
 - Prefer a code-index tool when one is available in the environment to locate test classes
   that reference the target by symbol (search / usages / class lookups); fall back to
   `Grep "TargetClass" path/to/test-src-set` when no index is available
-- Check for `@Test` annotations that exercise target functions
+- Check for `@Test` (JUnit / Swift Testing) or `XCTestCase` subclasses that exercise target functions
 
 ### 1.4 Identify untested code
 
@@ -70,51 +74,18 @@ without one — a test plan is helpful but not required.
 
 ## Phase 2: Discover Test Infrastructure
 
-Analyze the project's existing test setup to ensure generated tests match the codebase
-conventions. Inspect existing test files (at least 3-5 if available) and build configuration.
+Inspect 3-5 existing test files plus build configuration (`build.gradle(.kts)`,
+`Package.swift`, Xcode project) to discover the framework, assertion library, mocking /
+test-double approach, async-testing helpers, UI-testing stack, and naming / file-placement
+conventions in use. Compile the results into a structured **Test Infrastructure Summary**
+that the Phase 4 engineer agent consumes verbatim.
 
-### 2.1 Detect frameworks and libraries
+The goal is simple: generated tests must look hand-written. Never introduce a new framework
+or style that isn't already present in the project.
 
-| Category | What to detect | Where to look |
-|----------|---------------|---------------|
-| Test framework | JUnit 4, JUnit 5, Kotest | `build.gradle(.kts)` dependencies, existing test imports |
-| Assertion library | Truth, AssertJ, Kotest matchers, kotlin.test | Existing test imports and assertions |
-| Mocking | MockK, Mockito-Kotlin, fakes (manual) | Existing test imports, `@MockK`, `mock()`, `Fake*` classes |
-| Coroutine testing | `kotlinx-coroutines-test` (`runTest`), Turbine | Existing test imports, `build.gradle(.kts)` |
-| Compose testing | `compose-ui-test`, `createComposeRule` | Existing test imports, `build.gradle(.kts)` |
-| DI in tests | Hilt test, Koin test, manual construction | Existing test setup patterns |
-
-### 2.2 Detect conventions
-
-| Convention | What to detect | How |
-|-----------|---------------|-----|
-| Naming | `should verb`, `test verb`, backtick names, `given_when_then` | Read existing test function names |
-| File placement | Same package as source? Separate test package? | Compare test file locations to source |
-| Test class naming | `ClassNameTest`, `ClassNameSpec`, `ClassNameTests` | Read existing test class names |
-| Setup pattern | `@Before`/`@BeforeEach`, `init {}`, builder/factory | Read existing test setup blocks |
-| Assertion style | Fluent (`assertThat(x).isEqualTo(y)`) vs plain (`assertEquals`) | Read existing assertions |
-
-### 2.3 Produce Test Infrastructure Summary
-
-Compile findings into a structured summary for the code generation agent:
-
-```
-## Test Infrastructure Summary
-
-**Framework:** {JUnit 4 / JUnit 5 / Kotest}
-**Assertions:** {Truth / AssertJ / Kotest matchers / kotlin.test}
-**Mocking:** {MockK / Mockito-Kotlin / fakes / none}
-**Coroutine testing:** {runTest + Turbine / runTest only / runBlocking / none}
-**Compose testing:** {compose-ui-test / none}
-
-**Naming convention:** {description — e.g., "backtick names with 'should' prefix"}
-**Class naming:** {e.g., "ClassNameTest"}
-**File placement:** {e.g., "same package in src/test/kotlin/"}
-**Setup pattern:** {e.g., "@Before with MockK annotations"}
-**Assertion style:** {e.g., "Truth fluent assertions"}
-
-**Example test file:** {path to a representative existing test for reference}
-```
+See `references/test-infrastructure-discovery.md` for the detection tables (frameworks,
+assertions, mocking, async, UI, DI, naming, placement, setup, assertion style) and the exact
+Test Infrastructure Summary template.
 
 ---
 
@@ -168,79 +139,26 @@ the agent writes the code.
 
 | Target code type | Agent |
 |-----------------|-------|
-| Business logic, data layer, domain, ViewModel | `kotlin-engineer` |
+| Kotlin business logic, data layer, domain, ViewModel | `kotlin-engineer` |
 | Compose UI composables | `compose-developer` |
+| Swift business logic, data layer, services, models, repositories | `swift-engineer` |
+| SwiftUI views, screens, modifiers, navigation | `swiftui-developer` |
 
-If the target includes both UI and non-UI code, launch separate agents for each.
+Route by both language and layer: Kotlin/Android targets go to `kotlin-engineer` or
+`compose-developer`; Swift/iOS/macOS targets go to `swift-engineer` or `swiftui-developer`.
+If the target includes both UI and non-UI code, launch separate agents for each. If the
+required platform plugin is not installed, the Task call will fail with a clear message —
+report it and ask the user to install the matching platform plugin.
 
 ### 4.2 Agent prompt
 
-Include in the delegation prompt:
+Every delegation prompt must include: target code paths, the Phase 2 Test Infrastructure
+Summary, the Phase 3 test cases, a style-reference test file, and the Phase 1.5 test plan
+if one exists.
 
-1. **Target code paths** — full file paths to the code being tested
-2. **Test Infrastructure Summary** — from Phase 2
-3. **Test cases to implement** — from Phase 3 plan
-4. **Existing test examples** — path to 1-2 representative test files for style reference
-5. **Test plan** — if one was found in Phase 1.5, include its path
-
-**Prompt template for kotlin-engineer:**
-```
-Write unit tests for the following code. Match the project's existing test conventions exactly.
-
-## Target code
-Read these files:
-{list of file paths}
-
-## Test Infrastructure
-{Test Infrastructure Summary from Phase 2}
-
-## Test cases to write
-{list of test cases from Phase 3}
-
-## Style reference
-Read this existing test for style and conventions: {path to example test}
-
-## Test plan (optional)
-{path to test plan from docs/testplans/, or "No test plan available"}
-
-## Requirements
-- Write complete, compilable test files — no TODOs, no placeholders
-- Follow the project's existing naming, assertion, and setup conventions exactly
-- Use the same mocking approach as existing tests (MockK/Mockito-Kotlin/fakes)
-- Cover happy path, edge cases, and error paths as specified in the test case list
-- Place test files in the correct test source set and package
-- Each test function tests exactly one behavior
-- Test names describe the behavior being verified, not the implementation
-
-Respond in the same language as the user's request.
-```
-
-**Prompt template for compose-developer:**
-```
-Write Compose UI tests for the following composables. Match the project's existing test conventions.
-
-## Target composables
-Read these files:
-{list of file paths}
-
-## Test Infrastructure
-{Test Infrastructure Summary from Phase 2}
-
-## Test cases to write
-{list of test cases from Phase 3}
-
-## Style reference
-Read this existing test for style and conventions: {path to example test}
-
-## Requirements
-- Use createComposeRule() or createAndroidComposeRule() as used in existing tests
-- Test UI state rendering, user interactions, and state changes
-- Use semantic matchers (onNodeWithText, onNodeWithTag) over implementation details
-- Write complete, compilable test files — no TODOs, no placeholders
-- Follow the project's existing conventions exactly
-
-Respond in the same language as the user's request.
-```
+See `references/agent-prompts.md` for the full prompt templates for `kotlin-engineer`,
+`compose-developer`, `swift-engineer`, and `swiftui-developer`. Fill in the `{…}`
+placeholders and keep the section headings intact.
 
 ---
 
@@ -248,19 +166,29 @@ Respond in the same language as the user's request.
 
 ### 5.1 Run tests
 
-Run the test suite for the target module:
+Run the test suite for the target module. Pick the command family that matches the project
+build system:
 
 ```bash
-# Unit tests
+# Kotlin / Android (Gradle)
 ./gradlew :module:test
 # or more specific: ./gradlew :module:testDebugUnitTest
 
-# Instrumentation / Compose UI tests (if generated into src/androidTest/)
+# Android instrumentation / Compose UI tests (if generated into src/androidTest/)
 ./gradlew :module:connectedAndroidTest
+
+# Swift — SwiftPM package
+swift test
+# or narrow to one target: swift test --filter <TargetName>Tests
+
+# Swift — Xcode project / workspace (iOS, macOS, etc.)
+xcodebuild test -scheme <Scheme> -destination 'platform=iOS Simulator,name=iPhone 15'
+# For a macOS scheme: -destination 'platform=macOS'
+# Narrow with: -only-testing:<TestTarget>/<TestClass>/<testMethod>
 ```
 
-Choose the appropriate command based on where tests were generated. If both unit and
-instrumentation tests were created, run both.
+Choose the appropriate command based on where tests were generated and what build system the
+project uses. If both unit and UI / instrumentation tests were created, run both.
 
 ### 5.2 Handle failures
 
@@ -268,7 +196,7 @@ If tests fail, classify each failure:
 
 | Failure type | Action |
 |-------------|--------|
-| **Test bug** — incorrect assertion, wrong setup, missing mock | Fix via `kotlin-engineer` (max 3 attempts) |
+| **Test bug** — incorrect assertion, wrong setup, missing mock | Fix via the same engineer agent that wrote the test (max 3 attempts) |
 | **Production bug** — test correctly exposes a real bug in the target code | Do NOT fix. Record as a finding. |
 
 **How to distinguish:**
@@ -282,7 +210,9 @@ If tests fail, classify each failure:
 ### 5.3 Fix cycle
 
 For test bugs:
-1. Delegate the fix to `kotlin-engineer` with the failure output and the test file path
+1. Delegate the fix to the engineer agent that wrote the test (`kotlin-engineer` /
+   `compose-developer` / `swift-engineer` / `swiftui-developer`) with the failure output and
+   the test file path
 2. Re-run the tests
 3. Repeat up to 3 times total
 
@@ -362,8 +292,9 @@ Target: {file/module path}
 
 ## Constraints
 
-- **Orchestrator only** — this skill plans and delegates; `kotlin-engineer` and
-  `compose-developer` write the actual test code
+- **Orchestrator only** — this skill plans and delegates; the platform engineer agents
+  (`kotlin-engineer`, `compose-developer`, `swift-engineer`, `swiftui-developer`) write the
+  actual test code
 - **No production code changes** — if tests reveal bugs, report them as findings.
   Do not fix the production code. The user decides what to do with findings.
 - **Match existing conventions** — generated tests must be indistinguishable from

--- a/plugins/developer-workflow/skills/write-tests/references/agent-prompts.md
+++ b/plugins/developer-workflow/skills/write-tests/references/agent-prompts.md
@@ -1,0 +1,140 @@
+# Agent Prompt Templates
+
+Reference for `write-tests` Phase 4.2 — see `../SKILL.md` for the skill entry point.
+
+Pick the template that matches the agent you selected in Phase 4.1 and fill in the `{…}`
+placeholders from Phases 1-3. Keep the section headings exactly as written — the agents
+parse these prompts by section.
+
+Every delegation prompt must include:
+
+1. **Target code paths** — full file paths to the code being tested
+2. **Test Infrastructure Summary** — from Phase 2
+3. **Test cases to implement** — from Phase 3 plan
+4. **Existing test examples** — path to 1-2 representative test files for style reference
+5. **Test plan** — if one was found in Phase 1.5, include its path
+
+## Prompt template for kotlin-engineer
+
+```
+Write unit tests for the following code. Match the project's existing test conventions exactly.
+
+## Target code
+Read these files:
+{list of file paths}
+
+## Test Infrastructure
+{Test Infrastructure Summary from Phase 2}
+
+## Test cases to write
+{list of test cases from Phase 3}
+
+## Style reference
+Read this existing test for style and conventions: {path to example test}
+
+## Test plan (optional)
+{path to test plan from docs/testplans/, or "No test plan available"}
+
+## Requirements
+- Write complete, compilable test files — no TODOs, no placeholders
+- Follow the project's existing naming, assertion, and setup conventions exactly
+- Use the same mocking approach as existing tests (MockK/Mockito-Kotlin/fakes)
+- Cover happy path, edge cases, and error paths as specified in the test case list
+- Place test files in the correct test source set and package
+- Each test function tests exactly one behavior
+- Test names describe the behavior being verified, not the implementation
+
+Respond in the same language as the user's request.
+```
+
+## Prompt template for compose-developer
+
+```
+Write Compose UI tests for the following composables. Match the project's existing test conventions.
+
+## Target composables
+Read these files:
+{list of file paths}
+
+## Test Infrastructure
+{Test Infrastructure Summary from Phase 2}
+
+## Test cases to write
+{list of test cases from Phase 3}
+
+## Style reference
+Read this existing test for style and conventions: {path to example test}
+
+## Requirements
+- Use createComposeRule() or createAndroidComposeRule() as used in existing tests
+- Test UI state rendering, user interactions, and state changes
+- Use semantic matchers (onNodeWithText, onNodeWithTag) over implementation details
+- Write complete, compilable test files — no TODOs, no placeholders
+- Follow the project's existing conventions exactly
+
+Respond in the same language as the user's request.
+```
+
+## Prompt template for swift-engineer
+
+```
+Write unit tests for the following Swift code. Match the project's existing test conventions exactly.
+
+## Target code
+Read these files:
+{list of file paths}
+
+## Test Infrastructure
+{Test Infrastructure Summary from Phase 2}
+
+## Test cases to write
+{list of test cases from Phase 3}
+
+## Style reference
+Read this existing test for style and conventions: {path to example test}
+
+## Test plan (optional)
+{path to test plan from docs/testplans/, or "No test plan available"}
+
+## Requirements
+- Write complete, compilable test files — no TODOs, no placeholders
+- Follow the project's existing naming and structure conventions (Swift Testing `@Test` / `@Suite`
+  vs XCTest `XCTestCase`) — do not mix the two in the same file
+- Use the project's existing test-double approach (protocol-backed fakes, stubs, spies); do not
+  introduce a new mocking library
+- Cover happy path, edge cases, and error paths as specified in the test case list
+- Place test files in the correct test target / Tests directory and module namespace
+- For async code use `async` tests and structured concurrency; avoid `DispatchSemaphore` hacks
+- Each test function tests exactly one behavior; names describe behavior, not implementation
+
+Respond in the same language as the user's request.
+```
+
+## Prompt template for swiftui-developer
+
+```
+Write SwiftUI UI tests for the following views. Match the project's existing test conventions.
+
+## Target views
+Read these files:
+{list of file paths}
+
+## Test Infrastructure
+{Test Infrastructure Summary from Phase 2}
+
+## Test cases to write
+{list of test cases from Phase 3}
+
+## Style reference
+Read this existing test for style and conventions: {path to example test}
+
+## Requirements
+- Match the project's existing approach — ViewInspector-style unit tests, XCUITest UI tests,
+  or snapshot tests — do not introduce a new UI-testing library
+- Test view state rendering, user interactions, and state changes
+- Prefer accessibility identifiers / labels over view-tree internals for queries
+- Write complete, compilable test files — no TODOs, no placeholders
+- Follow the project's existing conventions exactly
+
+Respond in the same language as the user's request.
+```

--- a/plugins/developer-workflow/skills/write-tests/references/agent-prompts.md
+++ b/plugins/developer-workflow/skills/write-tests/references/agent-prompts.md
@@ -3,8 +3,8 @@
 Reference for `write-tests` Phase 4.2 — see `../SKILL.md` for the skill entry point.
 
 Pick the template that matches the agent you selected in Phase 4.1 and fill in the `{…}`
-placeholders from Phases 1-3. Keep the section headings exactly as written — the agents
-parse these prompts by section.
+placeholders from Phases 1-3. Keep the section headings exactly as written so downstream
+agents can locate the slots reliably.
 
 Every delegation prompt must include:
 
@@ -127,6 +127,9 @@ Read these files:
 
 ## Style reference
 Read this existing test for style and conventions: {path to example test}
+
+## Test plan (optional)
+{path to test plan from docs/testplans/, or "No test plan available"}
 
 ## Requirements
 - Match the project's existing approach — ViewInspector-style unit tests, XCUITest UI tests,

--- a/plugins/developer-workflow/skills/write-tests/references/test-infrastructure-discovery.md
+++ b/plugins/developer-workflow/skills/write-tests/references/test-infrastructure-discovery.md
@@ -1,0 +1,55 @@
+# Test Infrastructure Discovery
+
+Reference for `write-tests` Phase 2 — see `../SKILL.md` for the skill entry point.
+
+Use these tables while inspecting existing tests (3-5 samples if available) and build
+configuration to produce the Test Infrastructure Summary that drives downstream code
+generation. Generated tests must be indistinguishable from hand-written tests in the
+project — do not introduce a new framework, assertion library, or mocking tool.
+
+## Detect frameworks and libraries
+
+| Category | What to detect | Where to look |
+|----------|---------------|---------------|
+| Test framework (Kotlin) | JUnit 4, JUnit 5, Kotest | `build.gradle(.kts)` dependencies, existing test imports |
+| Test framework (Swift) | Swift Testing (`@Test` / `@Suite`), XCTest (`XCTestCase`), Quick/Nimble | `Package.swift` dependencies, Xcode test targets, existing test imports |
+| Assertion library | Truth, AssertJ, Kotest matchers, kotlin.test, `#expect`, `XCTAssert*`, Nimble matchers | Existing test imports and assertions |
+| Mocking / test doubles | MockK, Mockito-Kotlin, manual fakes; protocol-backed fakes/stubs/spies in Swift | Existing test imports, `@MockK`, `mock()`, `Fake*`/`Stub*`/`Spy*` classes |
+| Async testing | `kotlinx-coroutines-test` (`runTest`), Turbine; Swift `async` tests, `withCheckedContinuation`, `XCTestExpectation` | Existing test imports, build config |
+| UI testing | Compose `createComposeRule`, `compose-ui-test`; ViewInspector, XCUITest, snapshot tests | Existing test imports, build config |
+| DI in tests | Hilt test, Koin test, manual construction (both stacks) | Existing test setup patterns |
+
+## Detect conventions
+
+| Convention | What to detect | How |
+|-----------|---------------|-----|
+| Naming | `should verb`, `test verb`, backtick names, `given_when_then`, Swift Testing descriptive strings (`@Test("Empty cart shows zero total")`) | Read existing test function / `@Test` names |
+| File placement | Kotlin: same package as source, or separate test package; Swift: `Tests/<Target>Tests/` (SwiftPM) or Xcode test target matching the module | Compare test file locations to source |
+| Test class naming | `ClassNameTest`, `ClassNameSpec`, `ClassNameTests`; Swift `@Suite` structs or `XCTestCase` subclasses named `<Type>Tests` | Read existing test class / suite names |
+| Setup pattern | `@Before`/`@BeforeEach`, `init {}`, builder/factory; Swift Testing `init` / `deinit`, XCTest `setUp` / `tearDown` | Read existing test setup blocks |
+| Assertion style | Fluent (`assertThat(x).isEqualTo(y)`) vs plain (`assertEquals`); `#expect(...)` vs `XCTAssertEqual(...)` | Read existing assertions |
+
+## Test Infrastructure Summary template
+
+Compile findings into a structured summary that the code-generation agent consumes verbatim:
+
+```
+## Test Infrastructure Summary
+
+**Platform:** {Kotlin/Android / Swift/iOS / Swift/macOS / KMP}
+**Framework:** {JUnit 4 / JUnit 5 / Kotest / Swift Testing / XCTest / Quick+Nimble}
+**Assertions:** {Truth / AssertJ / Kotest matchers / kotlin.test / #expect / XCTAssert / Nimble}
+**Test doubles:** {MockK / Mockito-Kotlin / manual fakes / protocol-backed fakes / stubs / spies / none}
+**Async testing:** {runTest + Turbine / runTest / runBlocking / async tests / XCTestExpectation / none}
+**UI testing:** {compose-ui-test / ViewInspector / XCUITest / snapshot / none}
+
+**Naming convention:** {description — e.g., "backtick names with 'should' prefix", or "Swift Testing descriptive strings"}
+**Class / suite naming:** {e.g., "ClassNameTest", "@Suite struct FooTests"}
+**File placement:** {e.g., "same package in src/test/kotlin/", or "Tests/AuthTests/"}
+**Setup pattern:** {e.g., "@Before with MockK annotations", or "Swift Testing init/deinit"}
+**Assertion style:** {e.g., "Truth fluent assertions", or "#expect with descriptive tests"}
+
+**Example test file:** {path to a representative existing test for reference}
+```
+
+Keep the section headings and field names stable — downstream prompts assume this structure.

--- a/plugins/developer-workflow/skills/write-tests/references/test-infrastructure-discovery.md
+++ b/plugins/developer-workflow/skills/write-tests/references/test-infrastructure-discovery.md
@@ -12,7 +12,7 @@ project — do not introduce a new framework, assertion library, or mocking tool
 | Category | What to detect | Where to look |
 |----------|---------------|---------------|
 | Test framework (Kotlin) | JUnit 4, JUnit 5, Kotest | `build.gradle(.kts)` dependencies, existing test imports |
-| Test framework (Swift) | Swift Testing (`@Test` / `@Suite`), XCTest (`XCTestCase`), Quick/Nimble | `Package.swift` dependencies, Xcode test targets, existing test imports |
+| Test framework (Swift) | Swift Testing (`@Test` / `@Suite`), XCTest (`XCTestCase`), Quick | `Package.swift` dependencies, Xcode test targets, existing test imports |
 | Assertion library | Truth, AssertJ, Kotest matchers, kotlin.test, `#expect`, `XCTAssert*`, Nimble matchers | Existing test imports and assertions |
 | Mocking / test doubles | MockK, Mockito-Kotlin, manual fakes; protocol-backed fakes/stubs/spies in Swift | Existing test imports, `@MockK`, `mock()`, `Fake*`/`Stub*`/`Spy*` classes |
 | Async testing | `kotlinx-coroutines-test` (`runTest`), Turbine; Swift `async` tests, `withCheckedContinuation`, `XCTestExpectation` | Existing test imports, build config |

--- a/plugins/developer-workflow/skills/write-tests/references/test-infrastructure-discovery.md
+++ b/plugins/developer-workflow/skills/write-tests/references/test-infrastructure-discovery.md
@@ -37,7 +37,7 @@ Compile findings into a structured summary that the code-generation agent consum
 ## Test Infrastructure Summary
 
 **Platform:** {Kotlin/Android / Swift/iOS / Swift/macOS / KMP}
-**Framework:** {JUnit 4 / JUnit 5 / Kotest / Swift Testing / XCTest / Quick+Nimble}
+**Framework:** {JUnit 4 / JUnit 5 / Kotest / Swift Testing / XCTest / Quick}
 **Assertions:** {Truth / AssertJ / Kotest matchers / kotlin.test / #expect / XCTAssert / Nimble}
 **Test doubles:** {MockK / Mockito-Kotlin / manual fakes / protocol-backed fakes / stubs / spies / none}
 **Async testing:** {runTest + Turbine / runTest / runBlocking / async tests / XCTestExpectation / none}


### PR DESCRIPTION
## Summary

Applies the progressive-disclosure pattern that already exists in `multiexpert-review/profiles/` and `drive-to-merge/references/` to five more skills, and folds in the only non-policy Major finding that touched the same files (Swift support in `write-tests`).

### Per-skill extractions

| Skill | Before | After | References created |
|---|---|---|---|
| `write-spec` | 664 lines / ~4,050 words | 411 lines / ~2,750 words | `research-prompts.md`, `spec-template.md`, `profile-hint-rationale.md` |
| `acceptance` | 736 lines / ~5,340 words | 438 lines / ~3,140 words | `subcheck-prompts.md`, `aggregation.md`, `re-verification.md` |
| `generate-test-plan` | 433 lines / ~2,750 words | 210 lines / ~1,540 words | `format-templates.md`, `receipt-format.md` |
| `write-tests` | 373 lines / ~2,090 words | ≈1,770 words **including new Swift content** | `test-infrastructure-discovery.md`, `agent-prompts.md` |
| `create-pr` | 359 lines / ~2,280 words | 320 lines / ~2,150 words | `body-sections.md`, `visual-change-patterns.md` |

No SKILL.md logic is rewritten. Every extracted block moved **verbatim** (only heading-level shifts where needed to fit under the new reference's single H1). Each SKILL.md block now reads as a 2-4 sentence imperative summary plus a single `See references/...md` pointer.

### Swift support in `write-tests`

The plugin family ships `developer-workflow-swift` with `swift-engineer` and `swiftui-developer`, but `write-tests` was silently Kotlin-only. This PR extends the skill in parallel with the extraction so the Swift additions land inside the new layout rather than bloating SKILL.md:

- Frontmatter `description` generalises the delegate list (944 chars, ≤1024 cap)
- Phase 1 target-intake handles Swift paths, `XCTestCase`/`@Test` detection, SwiftUI UI-vs-non-UI split
- Phase 2 detection matrix includes XCTest / Swift Testing / Quick / Nimble / ViewInspector / XCUITest / snapshot testing
- Phase 4.1 agent table adds routing rules for `swift-engineer` (non-UI Swift) and `swiftui-developer` (SwiftUI views) mirroring the Kotlin pair
- Phase 4.2 adds a Swift-specific prompt template
- Phase 5.1 adds `swift test` (SwiftPM) and `xcodebuild test` (Xcode) alongside Gradle

No Kotlin behaviour changes.

## Sibling PRs

This is **PR A** of three logical PRs from the skill-reviewer sweep. See also:

- **PR C** (#128) — Critical debug STOP + policy compliance.
- **PR B** — orchestrator state-machine holes and retry-cap reconciliation.

## Test plan

- [x] `bash scripts/validate.sh` — green across all five skills (description char limits, frontmatter)
- [ ] Manual: open each SKILL.md + walk every `See references/…` pointer, confirm the reference exists and covers the content that was extracted
- [ ] Manual: confirm no content was lost — spot-check three random sections against `git show main:<path>`
- [ ] Manual: dry-run `write-tests` on a Swift target (SwiftPM package) and confirm the skill follows the new Swift/SwiftPM paths end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)