### PR TITLE
Add advanced CodeQL workflow to unblock non-code PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,58 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly scan to match the previous default-setup schedule.
+    - cron: "37 5 * * 1"
+
+# Advanced setup (replaces default setup).
+#
+# Advanced setup runs for every PR regardless of changed paths, which is the
+# reason for switching. Default setup auto-skips PRs that touch no tracked
+# language files (JSON/YAML/MD-only changes), but the repo ruleset requires a
+# CodeQL analysis on every PR — resulting in permanently-blocked merges for
+# release-bump PRs. Advanced setup always uploads an analysis, so the
+# code_scanning ruleset is always satisfied.
+#
+# Languages mirror what default setup had detected: actions, javascript-
+# typescript (covers both JS and TS), python.
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: actions
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Problem

The repo ruleset on `main` requires CodeQL (`code_scanning` rule, tool=CodeQL) to produce an analysis on every PR. The current CodeQL **default setup** auto-skips PRs that touch no tracked language files — JSON/YAML/MD-only PRs never get an analysis, so the required check never appears and merge stays permanently BLOCKED.

This manifested twice today on `Release 0.11.0` (#131) and `Harden release workflow` (#132): both PRs had green CI and zero reviewer objections, but the missing CodeQL check forced admin bypass workarounds.

## Fix

Switch CodeQL from default setup to **advanced setup** via an explicit workflow that runs on every `push` to `main` and every `pull_request` to `main`, with no path filters. Advanced setup always uploads an analysis — even for "empty" PRs where the language analyzer finds nothing — so the ruleset is always satisfied.

Matrix mirrors what default setup had detected:
- `actions` — workflow YAML analysis
- `javascript-typescript` — plugins/maven-mcp
- `python` — scripts/check_frontmatter.py

All three languages use `build-mode: none`.

## Companion repo-setting change (manual, not in git)

The advanced workflow stays dormant as long as default setup is active. When merging:

1. Merge this PR.
2. Open Settings → Code security → CodeQL → click **Switch to advanced** on the default-setup row.
3. The `CodeQL` workflow from this PR takes over on the next push.

Do **not** switch before merging — the default setup disappears immediately, leaving a gap.

## Test plan

- [ ] CI green.
- [ ] After merge + UI switch, next PR (any kind, including JSON-only) produces a CodeQL run visible in `Actions → CodeQL`.
- [ ] Weekly schedule preserved via `cron: "37 5 * * 1"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)