### PR TITLE
fix: soft-ref pr-review-toolkit + release 0.11.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.11.0",
+      "version": "0.11.1",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/maven-mcp/plugin"
@@ -23,7 +23,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.11.0",
+      "version": "0.11.1",
       "category": "security",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/sensitive-guard"
@@ -34,7 +34,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.11.0",
+      "version": "0.11.1",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow"
@@ -45,7 +45,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.11.0",
+      "version": "0.11.1",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-experts"
@@ -56,7 +56,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.11.0",
+      "version": "0.11.1",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-kotlin"
@@ -67,7 +67,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.11.0",
+      "version": "0.11.1",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-swift"

--- a/docs/PLUGINS-GUIDE.md
+++ b/docs/PLUGINS-GUIDE.md
@@ -344,7 +344,7 @@ flowchart LR
 | Skill | Команда | Назначение |
 |-------|---------|------------|
 | check | `/check` | Mechanical-check runner (build + lint + typecheck + tests, fail-fast) с автодетектом стека. Используется `implement`, `finalize` и любым code-modifying скиллом |
-| finalize | `/finalize` | Multi-phase review-and-fix loop между `implement` и `acceptance`: code-reviewer → `/simplify` → pr-review-toolkit trio → условные expert reviews, `/check` между фиксами |
+| finalize | `/finalize` | Multi-phase review-and-fix loop между `implement` и `acceptance`: code-reviewer → `/simplify` → опциональная pr-review-toolkit trio (skip, если плагин не установлен) → условные expert reviews, `/check` между фиксами |
 
 #### Skills: Testing / QA
 
@@ -537,7 +537,7 @@ flowchart LR
 |-------|------------|
 | A | `code-reviewer` — независимое ревью diff, фикс BLOCK-findings |
 | B | `/simplify` — авто-рефакторинг на упрощение |
-| C | pr-review-toolkit trio (параллельно) — фикс BLOCK |
+| C | pr-review-toolkit trio (параллельно, опционально — skip, если плагин не установлен) — фикс BLOCK |
 | D | Experts (условно, параллельно) — architecture / security / performance / ux; фикс BLOCK |
 
 Лимит: 3 раунда; после 3 — escalate to user (`ESCALATE (3 rounds)` в оркестраторе).

--- a/plugins/developer-workflow-experts/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-experts/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-experts",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Reusable expert agents for code review, architecture, security, performance, UX, build, DevOps, business analysis, and debugging. Safe to install standalone \u2014 no skills, no hooks, no MCP servers.",
   "author": {
     "name": "kirich1409"

--- a/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-kotlin",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Kotlin, Android, and KMP specialist agents and migration skills \u2014 kotlin-engineer, compose-developer, code-migration, kmp-migration, migrate-to-compose. Extends developer-workflow for Kotlin/Android projects.",
   "author": {
     "name": "kirich1409"
@@ -18,11 +18,11 @@
   "dependencies": [
     {
       "name": "developer-workflow",
-      "version": "^0.11.0"
+      "version": "^0.11.1"
     },
     {
       "name": "developer-workflow-experts",
-      "version": "^0.11.0"
+      "version": "^0.11.1"
     }
   ]
 }

--- a/plugins/developer-workflow-swift/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-swift/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-swift",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Swift, iOS, and macOS specialist agents \u2014 swift-engineer and swiftui-developer, with references covering Swift concurrency, testing, and SwiftUI patterns/state/performance. Extends developer-workflow for Apple platforms.",
   "author": {
     "name": "kirich1409"
@@ -17,11 +17,11 @@
   "dependencies": [
     {
       "name": "developer-workflow",
-      "version": "^0.11.0"
+      "version": "^0.11.1"
     },
     {
       "name": "developer-workflow-experts",
-      "version": "^0.11.0"
+      "version": "^0.11.1"
     }
   ]
 }

--- a/plugins/developer-workflow/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Developer workflow pipeline \u2014 research, decomposition, specification, multiexpert review, implementation, debugging, QA (test plans, acceptance, bug hunt, retroactive tests), PR creation and autonomous drive-to-merge (CI monitor, review handler, re-request, poll), feature-flow and bugfix-flow orchestrators. Platform-neutral; platform-specific engineers live in developer-workflow-kotlin and developer-workflow-swift.",
   "author": {
     "name": "kirich1409"
@@ -18,12 +18,7 @@
   "dependencies": [
     {
       "name": "developer-workflow-experts",
-      "version": "^0.11.0"
-    },
-    {
-      "name": "pr-review-toolkit",
-      "marketplace": "claude-plugins-official",
-      "version": "*"
+      "version": "^0.11.1"
     }
   ]
 }

--- a/plugins/developer-workflow/CLAUDE.md
+++ b/plugins/developer-workflow/CLAUDE.md
@@ -43,7 +43,7 @@ Skills in this plugin delegate to engineer agents (kotlin-engineer / compose-dev
 - Planning/research: `research`, `decompose-feature`, `write-spec`, `multiexpert-review`, `design-options` (optional pre-multiexpert-review stage — generates 2-3 architectural alternatives for high-arch-risk tasks)
 - Implementation: `implement`, `write-tests`, `debug`
 - Verification utility: `check` — reusable mechanical-check runner (build + lint + typecheck + tests), invoked by `implement`, `finalize`, and any code-modifying skill
-- Code-quality pass: `finalize` — multi-round review-and-fix loop (code-reviewer → /simplify → pr-review-toolkit trio → expert reviews) that runs between `implement` and `acceptance`
+- Code-quality pass: `finalize` — multi-round review-and-fix loop (code-reviewer → /simplify → optional pr-review-toolkit trio → expert reviews) that runs between `implement` and `acceptance`. The `pr-review-toolkit` trio is a soft-reference: installed → Phase C runs; absent → Phase C is skipped with a log entry.
 - QA: `generate-test-plan`, `acceptance`, `bug-hunt`
 - PR: `create-pr`, `drive-to-merge`
 - Orchestrators: `feature-flow`, `bugfix-flow`

--- a/plugins/developer-workflow/README.md
+++ b/plugins/developer-workflow/README.md
@@ -114,7 +114,7 @@ The `finalize` skill's Phase C invokes the `pr-review-toolkit` trio (test qualit
 /plugin install pr-review-toolkit@claude-plugins-official
 ```
 
-The plugin is **not** declared as a hard dependency because `claude-plugins-official` publishes marketplace entries without `version` fields, making semver resolution impossible for Claude Code. When `pr-review-toolkit` is absent, `finalize` logs `Phase C skipped — pr-review-toolkit not installed` and continues normally.
+The plugin is **not** declared as a hard dependency because `claude-plugins-official` publishes marketplace entries without `version` fields, making semver resolution impossible for Claude Code. When `pr-review-toolkit` is absent, `finalize` logs `phase: C, status: skipped, reason: pr-review-toolkit not installed` and continues normally.
 
 ## Pipeline documentation
 

--- a/plugins/developer-workflow/README.md
+++ b/plugins/developer-workflow/README.md
@@ -38,7 +38,7 @@ Installing this plugin automatically pulls `developer-workflow-experts`. Install
 |---|---|
 | `/implement` | Writes code to meet the plan; mechanical checks via `/check` + intent check only. Semantic review, simplify, and expert review live in `/finalize`. |
 | `/check` | Mechanical verification utility — auto-detects project tooling (Gradle/Node/Cargo/Swift/Python/Go), runs build + lint + typecheck + tests. Called by `implement`, `finalize`, migration skills, or user. |
-| `/finalize` | Code-quality pass between `implement` and `acceptance`. Multi-round loop: `code-reviewer` → `/simplify` → `pr-review-toolkit` trio → conditional expert reviews, with `/check` between fixes. Max 3 rounds. |
+| `/finalize` | Code-quality pass between `implement` and `acceptance`. Multi-round loop: `code-reviewer` → `/simplify` → optional `pr-review-toolkit` trio (skipped if plugin absent) → conditional expert reviews, with `/check` between fixes. Max 3 rounds. |
 | `/debug` | Read-only root cause analysis (via `debugging-expert` from `-experts`) |
 | `/write-tests` | Retroactive tests for existing code — delegates test generation to engineers |
 
@@ -89,32 +89,32 @@ For **most skills**, these integrations are optional enhancements: when present,
 | `ast-index` | CLI + plugin | `research`, `write-spec`, `write-tests`, `decompose-feature` | Optional. Structured code index for symbol / usages / deps / API lookups — non-QA skills use it when available and fall back to `Grep` + `Read` otherwise. |
 | `/code-review` | Slash command (from `claude-plugins-official`) | optional post-PR review | Optional. Standalone GitHub PR review with confidence-based scoring — separate from in-pipeline `code-reviewer` gate. |
 | `ralph-loop` | Plugin (from `claude-plugins-official`) | ad-hoc use outside pipeline | Optional. While-true iteration on a single prompt until completion marker — alternative to our structured orchestrators for exploratory work. |
+| `pr-review-toolkit` | Plugin (from `claude-plugins-official`) | `finalize` Phase C | Optional. Enables the `pr-test-analyzer` / `silent-failure-hunter` / `type-design-analyzer` trio. When absent, `finalize` skips Phase C and continues. |
 
 ## Installation
-
-**Prerequisite — cross-marketplace dependency.** `developer-workflow` declares a hard dependency on `pr-review-toolkit` from Anthropic's official plugin marketplace. That marketplace's name is `claude-plugins-official` (see [`.claude-plugin/marketplace.json`](https://github.com/anthropics/claude-plugins-official/blob/main/.claude-plugin/marketplace.json)) and it is added by giving Claude Code the GitHub repo path `anthropics/claude-plugins-official`:
-
-```
-/plugin marketplace add anthropics/claude-plugins-official
-```
-
-After that, the marketplace is registered under its declared name `claude-plugins-official`, which matches the `marketplace` field in our `plugin.json` dependency entry.
-
-Then add our marketplace and install the plugin:
 
 ```
 /plugin marketplace add kirich1409/krozov-ai-tools
 /plugin install developer-workflow@krozov-ai-tools
 ```
 
-`developer-workflow-experts` and `pr-review-toolkit` install automatically as declared dependencies. Add platform plugins as needed:
+`developer-workflow-experts` installs automatically as a declared dependency. Add platform plugins as needed:
 
 ```
 /plugin install developer-workflow-kotlin@krozov-ai-tools
 /plugin install developer-workflow-swift@krozov-ai-tools
 ```
 
-If the cross-marketplace dep fails to resolve (e.g., `claude-plugins-official` marketplace not registered in the user's environment), `developer-workflow` installation will abort with a clear message. Add the marketplace and retry.
+### Recommended — richer `finalize` Phase C
+
+The `finalize` skill's Phase C invokes the `pr-review-toolkit` trio (test quality, silent failures, type design) when available. To enable it, install `pr-review-toolkit` from Anthropic's official marketplace:
+
+```
+/plugin marketplace add anthropics/claude-plugins-official
+/plugin install pr-review-toolkit@claude-plugins-official
+```
+
+The plugin is **not** declared as a hard dependency because `claude-plugins-official` publishes marketplace entries without `version` fields, making semver resolution impossible for Claude Code. When `pr-review-toolkit` is absent, `finalize` logs `Phase C skipped — pr-review-toolkit not installed` and continues normally.
 
 ## Pipeline documentation
 

--- a/plugins/developer-workflow/docs/ORCHESTRATION.md
+++ b/plugins/developer-workflow/docs/ORCHESTRATION.md
@@ -215,7 +215,7 @@ Between `implement` and `acceptance`, the orchestrator runs the `finalize` skill
 |---|---|---|
 | A | `code-reviewer` (from `developer-workflow-experts`) | Semantic review: plan conformance, CLAUDE.md, bug detection. Confidence-scored 0/25/50/75/100. |
 | B | `/simplify` (built-in) | Reuse / quality / efficiency pass with auto-fix (3 parallel review agents + direct fix) |
-| C | `pr-review-toolkit:pr-test-analyzer`, `pr-review-toolkit:silent-failure-hunter`, `pr-review-toolkit:type-design-analyzer` — parallel | Test quality, silent failures, type design invariants |
+| C | `pr-review-toolkit:pr-test-analyzer`, `pr-review-toolkit:silent-failure-hunter`, `pr-review-toolkit:type-design-analyzer` — parallel, optional (soft-ref; skipped if plugin not installed) | Test quality, silent failures, type design invariants |
 | D | `security-expert`, `performance-expert`, `architecture-expert` — conditional, parallel | Domain-specific deep review |
 
 Between phases and after any auto-fix, the orchestrator invokes `/check` to confirm mechanical pass.
@@ -293,7 +293,7 @@ Route implementation to the right specialist:
 | Full autonomous bug-fix cycle | `bugfix-flow` skill |
 | Architectural variability | `design-options` skill (optional pre-multiexpert-review stage) |
 | Mechanical verification (build/lint/typecheck/tests) | `check` skill |
-| Code-quality pass (review + /simplify + pr-review-toolkit + experts) | `finalize` skill |
+| Code-quality pass (review + /simplify + optional pr-review-toolkit + experts) | `finalize` skill |
 | PR creation and lifecycle management | `create-pr` skill (`--draft` / `--refresh` / `--promote`) |
 | Drive an open PR/MR to merge — monitor CI, handle review comments (categorize → propose concrete fixes → delegate → reply → resolve), re-request review, poll for activity, confirm merge with user | `drive-to-merge` skill |
 | Plan review (PoLL) | `multiexpert-review` skill |

--- a/plugins/developer-workflow/docs/WORKFLOW.md
+++ b/plugins/developer-workflow/docs/WORKFLOW.md
@@ -64,7 +64,7 @@ IDEA / FEATURE REQUEST
   | [finalize] ---- Code-quality pass (3-round loop)│
   |   |  |-- Phase A: code-reviewer               │
   |   |  |-- Phase B: /simplify                    │
-  |   |  |-- Phase C: pr-review-toolkit trio       │
+  |   |  |-- Phase C: pr-review-toolkit trio (opt) │
   |   |  '-- Phase D: experts (conditional)        │
   |   |        Artifact: <slug>-finalize.md        │
   |   v                                            │

--- a/plugins/developer-workflow/docs/WORKFLOW.md
+++ b/plugins/developer-workflow/docs/WORKFLOW.md
@@ -19,7 +19,7 @@ Quality is split into three stages, each answering a different question:
 well?) → **acceptance** (does the feature solve the user's problem?). `implement` runs a
 2-gate Quality Loop: mechanical checks via `/check` (build/lint/typecheck/tests) and intent
 check. `finalize` runs a multi-round review-and-fix loop (code-reviewer → /simplify →
-pr-review-toolkit trio → conditional expert reviews) with `/check` between each fix. Key
+optional pr-review-toolkit trio → conditional expert reviews) with `/check` between each fix. Key
 principle: the author of the code never reviews their own code — `finalize` Phase A
 launches a separate `code-reviewer` agent that receives only the task description, plan,
 and git diff, without any implementation context. Receipt-based gating ensures no stage
@@ -164,7 +164,7 @@ After implement PASSes both gates, orchestrator invokes `/finalize`:
 Round N  (max 3 rounds):
   Phase A  code-reviewer       -> fix BLOCK -> /check
   Phase B  /simplify (auto-fix)                -> /check
-  Phase C  pr-review-toolkit trio (parallel)  -> fix BLOCK -> /check
+  Phase C  pr-review-toolkit trio (parallel, optional) -> fix BLOCK -> /check
   Phase D  experts (conditional, parallel)    -> fix BLOCK -> /check
   end round: any BLOCK? yes -> next round. no -> PASS, exit.
 ```
@@ -173,7 +173,7 @@ Round N  (max 3 rounds):
 |---|---|---|
 | A | `code-reviewer` (from `developer-workflow-experts`) | Plan conformance, CLAUDE.md, bugs — confidence 0/25/50/75/100 rubric |
 | B | `/simplify` (built-in) | Reuse / quality / efficiency with auto-fix |
-| C | `pr-review-toolkit:pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer` (parallel) | Test quality, silent failures, type design invariants |
+| C | `pr-review-toolkit:pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer` (parallel, optional soft-ref — skipped if plugin not installed) | Test quality, silent failures, type design invariants |
 | D | `security-expert`, `performance-expert`, `architecture-expert` (conditional, parallel) | Domain-specific deep review |
 
 ### Phase D trigger table
@@ -410,7 +410,7 @@ research/debug ──→ implement ──→ acceptance ──→ create-pr ─�
 
 **Finalize loop:**
 - Runs after `implement` passes both gates, before `acceptance`
-- Four phases per round: code-reviewer → /simplify → pr-review-toolkit trio → conditional expert reviews
+- Four phases per round: code-reviewer → /simplify → optional pr-review-toolkit trio → conditional expert reviews
 - `/check` invoked between fixes
 - Max 3 rounds; PASS when no BLOCK remains; ESCALATE otherwise
 

--- a/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
@@ -162,7 +162,7 @@ After `implement` passes its two gates (mechanical checks + intent check), invok
   anchor because the plan carries the chosen approach, while debug.md stays authoritative
   for root cause and reproduction steps (see Phase 1.5).
 
-`finalize` runs a multi-round loop (max 3): code-reviewer → /simplify → pr-review-toolkit trio → conditional expert reviews, with `/check` between fixes.
+`finalize` runs a multi-round loop (max 3): code-reviewer → /simplify → optional pr-review-toolkit trio (skipped if plugin absent) → conditional expert reviews, with `/check` between fixes.
 
 Wait for `swarm-report/<slug>-finalize.md`.
 

--- a/plugins/developer-workflow/skills/feature-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/feature-flow/SKILL.md
@@ -342,7 +342,7 @@ After `implement` passes its two gates (mechanical checks + intent check), invok
 - Slug
 - Path to `swarm-report/<slug>-plan.md` (for Phase A code-reviewer anchor)
 
-`finalize` runs a multi-round loop (max 3 rounds): code-reviewer → /simplify → pr-review-toolkit trio → conditional expert reviews, with `/check` between fixes.
+`finalize` runs a multi-round loop (max 3 rounds): code-reviewer → /simplify → optional pr-review-toolkit trio (skipped if plugin absent) → conditional expert reviews, with `/check` between fixes.
 
 Wait for `swarm-report/<slug>-finalize.md`.
 

--- a/plugins/developer-workflow/skills/finalize/SKILL.md
+++ b/plugins/developer-workflow/skills/finalize/SKILL.md
@@ -3,8 +3,8 @@ name: finalize
 description: >
   This skill should be used when the user wants a code-quality pass over the current branch —
   multi-round review-and-fix loop that polishes how the code is written, not what it does.
-  Runs code-reviewer, /simplify, pr-review-toolkit, and conditional expert reviews with /check
-  between rounds; exits PASS when no BLOCK findings remain or ESCALATE after max rounds.
+  Runs code-reviewer, /simplify, optional pr-review-toolkit trio, and conditional expert reviews
+  with /check between rounds; exits PASS when no BLOCK findings remain or ESCALATE after max rounds.
   Triggers: "finalize", "run code quality pass", "clean up the code", "prepare for review",
   "полируй код", "финализация", "доведи код", "почисти".
 ---
@@ -49,7 +49,7 @@ Each round runs four phases A → B → C → D sequentially. Between phases and
 Round N:
   Phase A  → code-reviewer          → fix BLOCK → /check → continue
   Phase B  → /simplify (auto-fixes) → /check               → continue
-  Phase C  → pr-review-toolkit trio (parallel) → fix BLOCK → /check → continue
+  Phase C  → pr-review-toolkit trio (parallel, if installed) → fix BLOCK → /check → continue
   Phase D  → expert reviews (conditional, parallel) → fix BLOCK → /check → continue
   Round end: did any BLOCK remain unfixed?
     yes → go to round N+1 (up to max_rounds total — default 3, see §Max round budget)
@@ -113,9 +113,15 @@ Revert the simplify commits (or the last commit if unambiguously from `/simplify
 
 ---
 
-## Phase C — PR review toolkit (parallel)
+## Phase C — PR review toolkit (parallel, optional)
 
-Invoke three agents from the `pr-review-toolkit` plugin in **parallel**:
+Phase C is a **soft-reference** to the `pr-review-toolkit` plugin (marketplace: `claude-plugins-official`). It is **not** declared as a hard dependency in `plugin.json` because that marketplace publishes its plugin entries without `version` fields, which makes semver resolution impossible for Claude Code.
+
+### Detect-and-use
+
+Before invoking Phase C, check whether the three agents are available (for example via the Task tool's agent registry). If any of the three is missing, **skip Phase C** for this round — log `phase: C, status: skipped, reason: pr-review-toolkit not installed` and continue to Phase D. Do not fail the round.
+
+If all three are available, invoke them in **parallel**:
 
 | Agent | Focus |
 |---|---|
@@ -123,7 +129,7 @@ Invoke three agents from the `pr-review-toolkit` plugin in **parallel**:
 | `pr-review-toolkit:silent-failure-hunter` | Empty catch blocks, swallowed errors, catches too broad, errors logged but not surfaced |
 | `pr-review-toolkit:type-design-analyzer` | Can invalid states be represented? Are invariants encoded in types? Missing nullability markers, unsafe unions |
 
-Each agent returns findings graded by the same 0–100 confidence rubric used by our `code-reviewer` (the plugin is hard-dep'd via `plugin.json`; agents inherit the convention through prompt sharing).
+Each agent returns findings graded by the same 0–100 confidence rubric used by our `code-reviewer`; agents inherit the convention through prompt sharing.
 
 ### Handling Phase C findings
 
@@ -184,7 +190,7 @@ Save `swarm-report/<slug>-finalize.md` on exit (PASS or ESCALATE):
 ### Round 1
 - Phase A (code-reviewer): verdict, N findings (K BLOCK, M WARN, L NIT). Fixes applied: X.
 - Phase B (/simplify): Y files changed, auto-fixed.
-- Phase C (pr-review-toolkit): breakdown per agent.
+- Phase C (pr-review-toolkit): breakdown per agent, or `skipped` if plugin not installed.
 - Phase D (experts): triggered: [security-expert, ...]; findings, fixes.
 - `/check` after round: PASS | FAIL (reason)
 
@@ -251,7 +257,7 @@ When escalating: state which phase escalated, what the unresolved findings are, 
 
 - **`feature-flow`** and **`bugfix-flow`** invoke this skill between `implement` and `acceptance`.
 - **Manual invocation** is useful for: pre-PR cleanup on a branch that didn't come through an orchestrator, periodic quality audit on an old branch that wasn't finalized, review of a branch before marking draft PR ready (even though orchestrators already do this automatically).
-- The skill assumes `code-reviewer` and `pr-review-toolkit` agents are installed. `code-reviewer` comes from `developer-workflow-experts` (sibling dependency). `pr-review-toolkit` comes from `claude-plugins-official` (hard dep in `plugin.json`).
+- The skill requires `code-reviewer` from `developer-workflow-experts` (sibling hard dependency). The `pr-review-toolkit` trio is optional: if the plugin is installed (from `claude-plugins-official`), Phase C runs; otherwise Phase C is skipped with a log entry and the round continues through Phases D and beyond.
 
 ---
 
@@ -259,6 +265,7 @@ When escalating: state which phase escalated, what the unresolved findings are, 
 
 - Hard deps (declared in `plugins/developer-workflow/.claude-plugin/plugin.json`):
   - `developer-workflow-experts` — for `code-reviewer`, `security-expert`, `performance-expert`, `architecture-expert`
+- Optional soft-ref (install separately, Phase C auto-skips when absent):
   - `pr-review-toolkit` (marketplace: `claude-plugins-official`) — for `pr-test-analyzer`, `silent-failure-hunter`, `type-design-analyzer`
 - Built-in skills:
   - `/simplify` — Claude Code's built-in reuse/quality/efficiency pass

--- a/plugins/maven-mcp/package-lock.json
+++ b/plugins/maven-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@krozov/maven-central-mcp",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/plugins/maven-mcp/package.json
+++ b/plugins/maven-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "MCP server for Maven Central dependency intelligence",
   "main": "./dist/index.js",
   "type": "module",

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maven-mcp",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps, /latest-version, and /dependency-changes skills",
   "author": {
     "name": "kirich1409"

--- a/plugins/sensitive-guard/.claude-plugin/plugin.json
+++ b/plugins/sensitive-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sensitive-guard",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Prevents sensitive data (secrets, PII) from reaching AI servers by scanning files before they are read into conversation",
   "author": {
     "name": "kirich1409"


### PR DESCRIPTION
## Summary

- `developer-workflow@0.11.0` declared `pr-review-toolkit` as a hard dependency from `claude-plugins-official`, but that marketplace publishes plugin entries without `version` fields, so Claude Code cannot resolve `"version": "*"` — every install failed with `installed version unknown`, even after the user installed the plugin.
- Convert `pr-review-toolkit` to a soft-reference per the repo's Tier 3 dependency policy: drop the cross-marketplace entry from `plugin.json`, make `finalize` Phase C detect-and-use (skip with a log entry when the plugin is absent), and reword all family docs to match.
- Unified bump across all six plugins + `marketplace.json` → `0.11.1`.

## Changes

- `plugins/developer-workflow/.claude-plugin/plugin.json` — remove `pr-review-toolkit` dep; bump sibling range to `^0.11.1`.
- `skills/finalize/SKILL.md` — Phase C is now optional with a documented detect-and-use behaviour and skip-logging semantics.
- `README.md` — move cross-marketplace install block from Prerequisite to Recommended; explain why it can't be declared.
- `CLAUDE.md`, `WORKFLOW.md`, `ORCHESTRATION.md`, `PLUGINS-GUIDE.md`, `feature-flow/SKILL.md`, `bugfix-flow/SKILL.md` — wording updated (hard dep → optional soft-ref).

## Test plan

- [x] `bash scripts/validate.sh` green
- [ ] `plugin-dev:plugin-validator` on all six plugins (PASS or Minor-only)
- [ ] Install `developer-workflow@krozov-ai-tools` in a clean environment — succeeds without the marketplace registered
- [ ] Install `pr-review-toolkit` after — Phase C trio runs; without — Phase C logs skip and `finalize` continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)