### PR TITLE
ci: gate maven-mcp build by paths filter (closes #16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,12 @@ jobs:
       - name: Validate marketplace and plugin configs
         run: bash scripts/validate.sh
 
+  # The build job is registered as a required status check (build (20),
+  # build (22)) by the repo ruleset. It must therefore always run and report
+  # success - but heavy work (npm ci, lint, test, build) is gated by a
+  # paths filter so PRs that don't touch maven-mcp finish in seconds.
   build:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: plugins/maven-mcp
     strategy:
       matrix:
         node-version: [20, 22]
@@ -27,7 +28,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Detect maven-mcp changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            maven_mcp:
+              - 'plugins/maven-mcp/**'
+              - '.github/workflows/ci.yml'
+
+      - name: Skip - no maven-mcp changes
+        if: github.event_name == 'pull_request' && steps.changes.outputs.maven_mcp != 'true'
+        run: echo "No changes under plugins/maven-mcp/ - skipping build."
+
       - name: Setup Node.js ${{ matrix.node-version }}
+        if: github.event_name != 'pull_request' || steps.changes.outputs.maven_mcp == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
@@ -35,6 +50,8 @@ jobs:
           cache-dependency-path: plugins/maven-mcp/package-lock.json
 
       - name: Verify package.json version matches plugin.json version
+        if: github.event_name != 'pull_request' || steps.changes.outputs.maven_mcp == 'true'
+        working-directory: plugins/maven-mcp
         run: |
           set -euo pipefail
           PKG_VERSION=$(node -p 'require("./package.json").version')
@@ -45,7 +62,15 @@ jobs:
           fi
           echo "OK: version $PKG_VERSION"
 
-      - run: npm ci
-      - run: npm run lint
-      - run: npm test
-      - run: npm run build
+      - if: github.event_name != 'pull_request' || steps.changes.outputs.maven_mcp == 'true'
+        working-directory: plugins/maven-mcp
+        run: npm ci
+      - if: github.event_name != 'pull_request' || steps.changes.outputs.maven_mcp == 'true'
+        working-directory: plugins/maven-mcp
+        run: npm run lint
+      - if: github.event_name != 'pull_request' || steps.changes.outputs.maven_mcp == 'true'
+        working-directory: plugins/maven-mcp
+        run: npm test
+      - if: github.event_name != 'pull_request' || steps.changes.outputs.maven_mcp == 'true'
+        working-directory: plugins/maven-mcp
+        run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,9 @@ jobs:
 
   # The build job is registered as a required status check (build (20),
   # build (22)) by the repo ruleset. It must therefore always run and report
-  # success - but heavy work (npm ci, lint, test, build) is gated by a
-  # paths filter so PRs that don't touch maven-mcp finish in seconds.
+  # success - but heavy work (npm ci, lint, test, build) is gated by a path
+  # diff so PRs that don't touch maven-mcp finish in seconds. On push to
+  # main everything runs unconditionally - the gate only fires on PRs.
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -27,22 +28,36 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Detect maven-mcp changes
         id: changes
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            maven_mcp:
-              - 'plugins/maven-mcp/**'
-              - '.github/workflows/ci.yml'
-
-      - name: Skip - no maven-mcp changes
-        if: github.event_name == 'pull_request' && steps.changes.outputs.maven_mcp != 'true'
-        run: echo "No changes under plugins/maven-mcp/ - skipping build."
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "Push event - run all steps."
+            echo "maven_mcp=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Pull request: diff PR base vs PR head.
+          CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- \
+            'plugins/maven-mcp/**' '.github/workflows/ci.yml')
+          if [ -n "$CHANGED" ]; then
+            echo "maven-mcp changed:"
+            echo "$CHANGED"
+            echo "maven_mcp=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No maven-mcp changes - skipping build steps."
+            echo "maven_mcp=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup Node.js ${{ matrix.node-version }}
-        if: github.event_name != 'pull_request' || steps.changes.outputs.maven_mcp == 'true'
+        if: steps.changes.outputs.maven_mcp == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
@@ -50,7 +65,7 @@ jobs:
           cache-dependency-path: plugins/maven-mcp/package-lock.json
 
       - name: Verify package.json version matches plugin.json version
-        if: github.event_name != 'pull_request' || steps.changes.outputs.maven_mcp == 'true'
+        if: steps.changes.outputs.maven_mcp == 'true'
         working-directory: plugins/maven-mcp
         run: |
           set -euo pipefail
@@ -62,15 +77,15 @@ jobs:
           fi
           echo "OK: version $PKG_VERSION"
 
-      - if: github.event_name != 'pull_request' || steps.changes.outputs.maven_mcp == 'true'
+      - if: steps.changes.outputs.maven_mcp == 'true'
         working-directory: plugins/maven-mcp
         run: npm ci
-      - if: github.event_name != 'pull_request' || steps.changes.outputs.maven_mcp == 'true'
+      - if: steps.changes.outputs.maven_mcp == 'true'
         working-directory: plugins/maven-mcp
         run: npm run lint
-      - if: github.event_name != 'pull_request' || steps.changes.outputs.maven_mcp == 'true'
+      - if: steps.changes.outputs.maven_mcp == 'true'
         working-directory: plugins/maven-mcp
         run: npm test
-      - if: github.event_name != 'pull_request' || steps.changes.outputs.maven_mcp == 'true'
+      - if: steps.changes.outputs.maven_mcp == 'true'
         working-directory: plugins/maven-mcp
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,10 @@ jobs:
             echo "maven_mcp=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Pull request: diff PR base vs PR head.
-          CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- \
+          # Pull request: three-dot diff (merge-base..head) so we see only
+          # commits introduced by the PR, not unrelated changes that landed
+          # on main between fork-point and head.
+          CHANGED=$(git diff --name-only "$BASE_SHA...$HEAD_SHA" -- \
             'plugins/maven-mcp/**' '.github/workflows/ci.yml')
           if [ -n "$CHANGED" ]; then
             echo "maven-mcp changed:"


### PR DESCRIPTION
## Summary

PRs that don't touch `plugins/maven-mcp/**` no longer run `npm ci`, `npm run lint`,
`npm test`, `npm run build` for the maven-mcp package. The build job still runs (it's
required by the repo ruleset — `build (20)` / `build (22)` are listed as required
status checks) and reports success quickly.

## How

Inline `git diff` inside the `build` job detects whether the PR touches:
- `plugins/maven-mcp/**`
- `.github/workflows/ci.yml`

Detection uses the three-dot diff `BASE_SHA...HEAD_SHA` (merge-base..head) so the
comparison reflects exactly the files GitHub treats as "changed by this PR" — not
unrelated upstream commits that landed on main after fork-point.

Heavy steps (setup-node, version check, npm ci/lint/test/build) are gated by
`if: steps.changes.outputs.maven_mcp == 'true'`. On push to `main`, the detect step
sets `maven_mcp=true` unconditionally so post-merge sanity always runs.

## Tradeoff considered

Splitting into a separate workflow with `paths:` at the workflow level was the simpler
GitHub-native approach but would deregister `build (20)` / `build (22)` for unrelated
PRs — and the ruleset requires those checks before merge. Per-step gating keeps the
checks reporting and skips the work.

An earlier draft used `dorny/paths-filter@v3` but was replaced with inline `git diff`
after the action download failed transiently in the first CI run; inline is
self-contained and removes the external dependency.

## Test plan

- [x] `bash scripts/validate.sh` — green
- [x] `actionlint .github/workflows/ci.yml` — green
- [x] CI on this PR runs the full build (workflow file itself is in the path filter)
- [ ] Follow-up: confirm a docs-only PR (e.g. README typo) finishes the build job in
      under ~30s

Closes #16