### PR TITLE
Split write-spec SKILL.md (411 → 310) — extract Phase 2 and Phase 5

### DIFF
--- a/plugins/developer-workflow/skills/write-spec/SKILL.md
+++ b/plugins/developer-workflow/skills/write-spec/SKILL.md
@@ -179,112 +179,38 @@ Update as each agent completes.
 
 ## Phase 2: Interview
 
-### 2.1 Synthesize and run feature checklist
+**Entry contract.** Research has completed; state file holds findings. No user
+questions have been asked yet beyond the optional scope-depth question in
+Phase 0.
 
-After research completes, before formulating questions, run through this checklist.
-Any item that applies and is unanswered becomes a question or a spec entry.
+**Round loop.** Run the interview as a sequence of rounds. Each round:
 
-**Feature Checklist:**
-- [ ] **OS permissions** — does this feature need to request permissions (notifications,
-      camera, location, contacts, storage)? What happens if denied?
-- [ ] **Platform-specific behavior** — does this work differently on different OS/devices?
-- [ ] **Prerequisites** — are there external setup steps (console config, service accounts,
-      API keys, entitlements) that can't be automated in code?
-- [ ] **Error states** — what can fail? What does the user see when it fails?
-- [ ] **Security** — does this expose sensitive data, require auth, or touch user credentials?
-- [ ] **Performance** — any risk of blocking the main thread, excessive memory, or battery drain?
-- [ ] **Backward compatibility** — does this change existing behavior anyone depends on?
-- [ ] **Pattern quality** — did Critical Evaluation flag any existing pattern as problematic?
+1. Synthesize research findings against the feature checklist (OS permissions,
+   platform behavior, prerequisites, error states, security, performance,
+   backward compatibility, pattern quality).
+2. Sort remaining items into **already known** (skip), **proposed defaults**
+   (propose for confirmation), and **genuine gaps** (ask).
+3. If Critical Evaluation produced 3 approach options and the approach is not
+   yet chosen, present those options **first** and wait for the user's pick
+   before asking anything else — the chosen approach shapes all subsequent
+   questions.
+4. Present all current open questions in the Question Format (each with a
+   recommended answer and alternatives). Wait for responses.
+5. Record answers in the state file. Check whether new gaps opened.
+6. Loop on remaining gaps.
 
-### 2.2 Present approach options
+**Exit criteria.** Exit the round loop when either: no open gaps remain and
+the approach is chosen (proceed to Phase 3), OR round 100 has completed (cap).
+On cap exit, record remaining items as non-blocking open questions in the
+spec and flag any blockers for the Phase 4 review.
 
-If Critical Evaluation ran, present the 3 approach options **before** asking other questions.
-This is the most important decision — it shapes everything else.
+**Large-feature phasing.** If the feature spans multiple independent
+development phases, offer a phased approach and, if accepted, spec Phase 1
+only — remaining phases go into the "Future Phases" section.
 
-```
-Based on research, here are the implementation approaches:
-
-**Option A — Radical:** {name}
-{2-3 sentences describing the approach}
-Trade-offs: {pros} / {cons}
-Best when: {context where this wins}
-
-**Option B — Classic:** {name}
-{2-3 sentences describing the approach}
-Trade-offs: {pros} / {cons}
-Best when: {context where this wins}
-
-**Option C — Conservative:** {name}
-{2-3 sentences describing the approach}
-Trade-offs: {pros} / {cons}
-Best when: {context where this wins}
-
-Recommended: Option {X} — {one sentence rationale}
-Or describe a custom approach: ___
-```
-
-Wait for the user to choose before proceeding. The chosen approach becomes the baseline
-for all subsequent questions.
-
-### 2.3 Synthesize gaps
-
-After the approach is chosen, synthesize remaining findings into three categories:
-- **Already known** — research gave a clear answer, no need to ask
-- **Proposed defaults** — research suggests a direction, propose it for confirmation
-- **Genuine gaps** — requires user input to resolve
-
-Only ask about genuine gaps. Present proposed defaults as recommendations the user
-confirms or overrides.
-
-### 2.4 Question format
-
-Each question in a round:
-
-```
-**Q: {question}**
-→ Recommended: {answer} — {brief rationale}
-→ Alternative: {different option}
-→ Alternative: {another option, if relevant}
-→ Or describe your preference: ___
-```
-
-Skip questions where the recommendation is overwhelmingly obvious and the answer
-doesn't meaningfully change the architecture. Save those decisions for the "Decisions
-Made" section in the spec.
-
-### 2.5 Round structure
-
-Each round:
-1. Present what's already understood (brief — gives user context)
-2. Ask all current open questions with recommended answers
-3. Wait for responses
-4. Record answers in state file
-5. Check if any new gaps opened from the answers
-6. If gaps remain → another round. If complete → proceed to drafting.
-
-**Cap: maximum 100 interview rounds.** If the 100th round completes and gaps remain,
-record them as open questions in the spec (non-blocking where possible) and proceed
-to drafting. Surface any remaining blockers to the user in the review phase.
-
-### 2.6 Large feature handling
-
-If the feature spans multiple independent development phases, offer phased approach:
-
-```
-This feature is substantial. Suggested phases:
-
-**Phase 1 — {name}:** {what it delivers and why first}
-**Phase 2 — {name}:** {what it adds, depends on Phase 1}
-**Phase 3 — {name}:** {what it adds}
-
-Recommendation: spec and fully implement Phase 1 before speccing Phase 2.
-Real feedback from Phase 1 will inform Phase 2 design.
-
-Proceed phased, or spec the full feature at once?
-```
-
-If phased: spec covers Phase 1 only. Include a "Future Phases" section for what's
-planned but not yet specced.
+See [`references/interview-rounds.md`](references/interview-rounds.md) for the
+full feature checklist, approach-options presentation, question format,
+round-structure script, and large-feature phasing template.
 
 ---
 
@@ -362,27 +288,13 @@ Once the user is satisfied and no issues remain, update spec status from `draft`
 
 ## Phase 5: Save
 
-### 5.1 Create docs/specs/ if needed
+Save the approved spec to `docs/specs/YYYY-MM-DD-<slug>.md`, flip its
+frontmatter `status` from `draft` to `approved`, retire the state file, and
+confirm to the user. Do not auto-invoke any downstream skill — the user
+decides when to proceed.
 
-Check if `docs/specs/` exists in the project root. Create it if not.
-
-### 5.2 Save
-
-Save spec to `docs/specs/YYYY-MM-DD-<slug>.md`.
-
-Update state file status to `done`.
-
-### 5.3 Confirm
-
-```
-Spec saved: docs/specs/{filename}
-
-This document is self-sufficient for implementation. When you're ready,
-decompose-feature will break it into tasks for autonomous execution.
-```
-
-Do not auto-invoke decompose-feature or any other skill. The spec is the deliverable.
-The user decides when and how to proceed.
+See [`references/output-layout.md`](references/output-layout.md) for the full
+save procedure, path conventions, confirmation message, and hand-off rules.
 
 ---
 
@@ -396,16 +308,3 @@ The user decides when and how to proceed.
   Propose phased approach and wait for user alignment.
 - **Decision requires product authority** — choice has business, legal, or brand implications
   the team cannot make unilaterally. Flag as blocking open question.
-
----
-
-## Output Artifacts
-
-| Artifact | Path | Lifetime |
-|----------|------|----------|
-| Spec | `docs/specs/YYYY-MM-DD-<slug>.md` | Permanent — version controlled |
-| State file | `./swarm-report/spec-<slug>-state.md` | Temporary — delete after save |
-
-The spec is the sole deliverable. It is designed to be handed to `decompose-feature` +
-`implement` at any future point, producing a complete autonomous implementation with
-user involvement only at genuine critical blockers.

--- a/plugins/developer-workflow/skills/write-spec/references/interview-rounds.md
+++ b/plugins/developer-workflow/skills/write-spec/references/interview-rounds.md
@@ -1,0 +1,143 @@
+Referenced from: `plugins/developer-workflow/skills/write-spec/SKILL.md` (§Phase 2 Interview).
+
+# Interview Rounds — Question Bank, Round Structure, and Per-Round Prompts
+
+Full Phase 2 playbook. SKILL.md holds only the round-loop contract and exit
+criteria. Everything a round actually *says* to the user lives here.
+
+---
+
+## Feature Checklist (run before formulating questions)
+
+After research completes, sweep the checklist. Any item that applies and is
+unanswered becomes a question or a spec entry.
+
+- [ ] **OS permissions** — does this feature need to request permissions
+      (notifications, camera, location, contacts, storage)? What happens if denied?
+- [ ] **Platform-specific behavior** — does this work differently on different OS/devices?
+- [ ] **Prerequisites** — are there external setup steps (console config, service
+      accounts, API keys, entitlements) that can't be automated in code?
+- [ ] **Error states** — what can fail? What does the user see when it fails?
+- [ ] **Security** — does this expose sensitive data, require auth, or touch user
+      credentials?
+- [ ] **Performance** — any risk of blocking the main thread, excessive memory, or
+      battery drain?
+- [ ] **Backward compatibility** — does this change existing behavior anyone depends on?
+- [ ] **Pattern quality** — did Critical Evaluation flag any existing pattern as
+      problematic?
+
+---
+
+## Round 1: Present Approach Options (when Critical Evaluation ran)
+
+If Critical Evaluation produced 3 approach options, present them **before** asking
+other questions. This is the most important decision — it shapes everything else.
+
+```
+Based on research, here are the implementation approaches:
+
+**Option A — Radical:** {name}
+{2-3 sentences describing the approach}
+Trade-offs: {pros} / {cons}
+Best when: {context where this wins}
+
+**Option B — Classic:** {name}
+{2-3 sentences describing the approach}
+Trade-offs: {pros} / {cons}
+Best when: {context where this wins}
+
+**Option C — Conservative:** {name}
+{2-3 sentences describing the approach}
+Trade-offs: {pros} / {cons}
+Best when: {context where this wins}
+
+Recommended: Option {X} — {one sentence rationale}
+Or describe a custom approach: ___
+```
+
+Wait for the user to choose before proceeding. The chosen approach becomes the
+baseline for all subsequent questions.
+
+---
+
+## Synthesize Gaps
+
+After the approach is chosen, sort remaining findings into three buckets:
+
+- **Already known** — research gave a clear answer, no need to ask.
+- **Proposed defaults** — research suggests a direction; propose it for confirmation.
+- **Genuine gaps** — requires user input to resolve.
+
+Only ask about genuine gaps. Present proposed defaults as recommendations the
+user confirms or overrides.
+
+---
+
+## Question Format
+
+Each question in a round:
+
+```
+**Q: {question}**
+→ Recommended: {answer} — {brief rationale}
+→ Alternative: {different option}
+→ Alternative: {another option, if relevant}
+→ Or describe your preference: ___
+```
+
+Skip questions where the recommendation is overwhelmingly obvious and the answer
+doesn't meaningfully change the architecture. Save those decisions for the
+"Decisions Made" section in the spec.
+
+---
+
+## Round Structure
+
+Each round:
+
+1. Present what's already understood (brief — gives user context).
+2. Ask all current open questions with recommended answers.
+3. Wait for responses.
+4. Record answers in the state file.
+5. Check whether any new gaps opened from the answers.
+6. If gaps remain → another round. If complete → proceed to drafting.
+
+**Cap: maximum 100 interview rounds.** If the 100th round completes and gaps
+remain, record them as open questions in the spec (non-blocking where possible)
+and proceed to drafting. Surface any remaining blockers to the user in the
+review phase.
+
+---
+
+## Large-Feature Phasing
+
+If the feature spans multiple independent development phases, offer a phased
+approach:
+
+```
+This feature is substantial. Suggested phases:
+
+**Phase 1 — {name}:** {what it delivers and why first}
+**Phase 2 — {name}:** {what it adds, depends on Phase 1}
+**Phase 3 — {name}:** {what it adds}
+
+Recommendation: spec and fully implement Phase 1 before speccing Phase 2.
+Real feedback from Phase 1 will inform Phase 2 design.
+
+Proceed phased, or spec the full feature at once?
+```
+
+If phased: spec covers Phase 1 only. Include a "Future Phases" section for
+what's planned but not yet specced.
+
+---
+
+## Post-Review Discussion Round
+
+After self-review and `multiexpert-review` complete (Phase 4), if either
+surfaced issues or open questions, open one more user-facing round using the
+same question format above. This may loop back into the normal round loop to
+close remaining gaps.
+
+Once the user is satisfied and no issues remain, update spec status from
+`draft` to `approved` and proceed to save.

--- a/plugins/developer-workflow/skills/write-spec/references/output-layout.md
+++ b/plugins/developer-workflow/skills/write-spec/references/output-layout.md
@@ -1,0 +1,70 @@
+Referenced from: `plugins/developer-workflow/skills/write-spec/SKILL.md` (§Phase 5 Save).
+
+# Output Location and Artifact Layout
+
+Where the spec and the operational state file live, how they are named, and
+when they are retired.
+
+---
+
+## Target Layout
+
+| Artifact | Path | Lifetime |
+|----------|------|----------|
+| Spec | `docs/specs/YYYY-MM-DD-<slug>.md` | Permanent — version controlled |
+| State file | `./swarm-report/spec-<slug>-state.md` | Temporary — delete after save |
+
+---
+
+## Path Conventions
+
+- **Spec filename**: `YYYY-MM-DD-<slug>.md` at the project root under
+  `docs/specs/`. The date prefix is the day the spec was created (not merged,
+  not approved). The `<slug>` is the same kebab-case slug generated in Phase 0.
+- **State filename**: `spec-<slug>-state.md` under `./swarm-report/`. The
+  state file is operational — it tracks round numbers, research progress, and
+  open gaps. It is not committed; `swarm-report/` must be in the project's
+  `.gitignore`.
+
+Example: feature goal *"push notifications"* on 2026-04-20 →
+- `docs/specs/2026-04-20-push-notifications.md`
+- `./swarm-report/spec-push-notifications-state.md`
+
+---
+
+## Save Procedure
+
+### 1. Ensure `docs/specs/` exists
+
+Check if `docs/specs/` exists at the project root. Create it if not.
+
+### 2. Save the spec
+
+Write the approved draft to `docs/specs/YYYY-MM-DD-<slug>.md`. Update its
+frontmatter `status:` from `draft` to `approved` before writing.
+
+### 3. Retire the state file
+
+Update state file status to `done`. The file may be deleted at the discretion
+of the caller — it is no longer needed once the spec is saved.
+
+### 4. Confirm to the user
+
+```
+Spec saved: docs/specs/{filename}
+
+This document is self-sufficient for implementation. When you're ready,
+decompose-feature will break it into tasks for autonomous execution.
+```
+
+Do not auto-invoke `decompose-feature` or any other skill. The spec is the
+deliverable. The user decides when and how to proceed.
+
+---
+
+## Hand-off
+
+The saved spec is the sole deliverable of `write-spec`. It is designed to be
+handed to `decompose-feature` and then `implement` at any future point,
+producing a complete autonomous implementation with user involvement only at
+genuine critical blockers.


### PR DESCRIPTION
## Summary

- Closes #106.
- Follow-up to #130 progressive-disclosure sweep: that PR extracted research prompts, spec template, and profile-hint rationale but left the Phase 2 interview rubric and Phase 5 save procedure inline.
- Extracts Phase 2 body into `references/interview-rounds.md` (new, 142 lines) and Phase 5 body into `references/output-layout.md` (new, 71 lines).
- SKILL.md now keeps the entry contract + round-loop + exit criteria + hand-off in-line, and delegates mechanics to references — matching the `acceptance` split pattern (#137) and the already-extracted sections of this skill.

Line budget:
- `SKILL.md`: 411 → 310 (under the 500-line PLUGIN-STANDARDS guideline with headroom).
- No duplicated content between SKILL and references.

Kept in SKILL.md:
- Role + core principles.
- Phase 0 — parse input, hidden-complexity check, scope-depth clarification, research-track selection table.
- Phase 1 — consortium inclusion rules + state-file schema.
- Phase 2 — entry contract, round loop, exit criteria (100-round cap), large-feature phasing note.
- Phase 3 — template pointer.
- Phase 4 — full review loop (self-review, multiexpert-review `spec` profile hint, verdict table, discussion round).
- Phase 5 — save summary + pointer.
- Red Flags / STOP Conditions.

## Test plan

- [x] `bash scripts/validate.sh` — green.
- [x] `plugin-dev:plugin-validator` on `developer-workflow` — PASS (Minor finding fixed: `Referenced from:` header added to `interview-rounds.md`).
- [x] All `references/*.md` links in SKILL.md resolve.
- [ ] CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)