### PR TITLE
maven-mcp: fix resolveAll picker, harden cache, add retry layer

### DIFF
--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -19,7 +19,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@krozov/maven-central-mcp"
+        "@krozov/maven-central-mcp@^0.11.0"
       ]
     }
   }

--- a/plugins/maven-mcp/src/cache/__tests__/file-cache.test.ts
+++ b/plugins/maven-mcp/src/cache/__tests__/file-cache.test.ts
@@ -69,10 +69,11 @@ describe("FileCache", () => {
   });
 
   describe("set", () => {
-    it("creates directories and writes cache entry", async () => {
+    it("creates directories and writes cache entry atomically", async () => {
       vi.spyOn(Date, "now").mockReturnValue(1700000000000);
       mockedFsp.mkdir.mockResolvedValue(undefined);
       mockedFsp.writeFile.mockResolvedValue();
+      mockedFsp.rename.mockResolvedValue();
 
       await cache.set("my-key", { name: "test" });
 
@@ -80,16 +81,27 @@ describe("FileCache", () => {
         recursive: true,
         mode: 0o700,
       });
+
+      // writeFile goes to a tmp file in the same directory…
       expect(mockedFsp.writeFile).toHaveBeenCalledWith(
-        "/fixtures/maven-cache/my-key.json",
+        expect.stringMatching(/^\/fixtures\/maven-cache\/my-key\.json\.\d+\.[0-9a-f]+\.tmp$/),
         JSON.stringify({ data: { name: "test" }, timestamp: 1700000000000 }),
         { mode: 0o600 },
       );
+
+      // …then rename to the final path.
+      const tmpPath = mockedFsp.writeFile.mock.calls[0][0] as string;
+      expect(mockedFsp.rename).toHaveBeenCalledWith(
+        tmpPath,
+        "/fixtures/maven-cache/my-key.json",
+      );
     });
+
     it("creates nested directories for keys with path separators", async () => {
       vi.spyOn(Date, "now").mockReturnValue(1700000000000);
       mockedFsp.mkdir.mockResolvedValue(undefined);
       mockedFsp.writeFile.mockResolvedValue();
+      mockedFsp.rename.mockResolvedValue();
 
       await cache.set("scm/io.ktor/ktor-core", { owner: "ktorio", repo: "ktor" });
 
@@ -98,10 +110,39 @@ describe("FileCache", () => {
         mode: 0o700,
       });
       expect(mockedFsp.writeFile).toHaveBeenCalledWith(
-        "/fixtures/maven-cache/scm/io.ktor/ktor-core.json",
+        expect.stringMatching(/^\/fixtures\/maven-cache\/scm\/io\.ktor\/ktor-core\.json\.\d+\.[0-9a-f]+\.tmp$/),
         expect.any(String),
         { mode: 0o600 },
       );
+      expect(mockedFsp.rename).toHaveBeenCalledWith(
+        expect.any(String),
+        "/fixtures/maven-cache/scm/io.ktor/ktor-core.json",
+      );
+    });
+  });
+
+  describe("key validation", () => {
+    it("rejects keys with traversal sequences", async () => {
+      await expect(cache.get("../etc/passwd")).rejects.toThrow(/invalid cache key/);
+      await expect(cache.set("a/../b", {})).rejects.toThrow(/invalid cache key/);
+    });
+
+    it("rejects absolute paths", async () => {
+      await expect(cache.get("/absolute/key")).rejects.toThrow(/invalid cache key/);
+    });
+
+    it("rejects null bytes and backslashes", async () => {
+      await expect(cache.get("bad\0key")).rejects.toThrow(/invalid cache key/);
+      await expect(cache.get("bad\\key")).rejects.toThrow(/invalid cache key/);
+    });
+
+    it("rejects empty keys", async () => {
+      await expect(cache.get("")).rejects.toThrow(/invalid cache key/);
+    });
+
+    it("accepts safe nested keys", async () => {
+      mockedFsp.readFile.mockRejectedValue(new Error("ENOENT"));
+      await expect(cache.get("scm/io.ktor/ktor-core")).resolves.toBeUndefined();
     });
   });
 
@@ -121,6 +162,7 @@ describe("FileCache", () => {
       mockedFsp.readFile.mockRejectedValue(new Error("ENOENT"));
       mockedFsp.mkdir.mockResolvedValue(undefined);
       mockedFsp.writeFile.mockResolvedValue();
+      mockedFsp.rename.mockResolvedValue();
       const fetchFn = vi.fn().mockResolvedValue({ name: "fetched" });
 
       const result = await cache.getOrFetch("key", undefined, fetchFn);
@@ -128,6 +170,7 @@ describe("FileCache", () => {
       expect(result).toEqual({ name: "fetched" });
       expect(fetchFn).toHaveBeenCalledOnce();
       expect(mockedFsp.writeFile).toHaveBeenCalled();
+      expect(mockedFsp.rename).toHaveBeenCalled();
     });
 
     it("does not cache null results from fetchFn", async () => {
@@ -138,6 +181,47 @@ describe("FileCache", () => {
 
       expect(result).toBeNull();
       expect(mockedFsp.writeFile).not.toHaveBeenCalled();
+    });
+
+    it("coalesces concurrent misses (singleflight) so fetchFn runs once per key", async () => {
+      mockedFsp.readFile.mockRejectedValue(new Error("ENOENT"));
+      mockedFsp.mkdir.mockResolvedValue(undefined);
+      mockedFsp.writeFile.mockResolvedValue();
+      mockedFsp.rename.mockResolvedValue();
+
+      const deferred = Promise.withResolvers<string>();
+      const fetchFn = vi.fn().mockImplementation(() => deferred.promise);
+
+      const p1 = cache.getOrFetch("same-key", undefined, fetchFn);
+      const p2 = cache.getOrFetch("same-key", undefined, fetchFn);
+      const p3 = cache.getOrFetch("same-key", undefined, fetchFn);
+
+      // Yield microtasks so each getOrFetch awaits its get() miss and reaches
+      // the inflight check before we resolve the shared fetch.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      deferred.resolve("shared-value");
+      const results = await Promise.all([p1, p2, p3]);
+
+      expect(results).toEqual(["shared-value", "shared-value", "shared-value"]);
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("releases the inflight slot after completion so subsequent calls re-fetch on miss", async () => {
+      mockedFsp.readFile.mockRejectedValue(new Error("ENOENT"));
+      mockedFsp.mkdir.mockResolvedValue(undefined);
+      mockedFsp.writeFile.mockResolvedValue();
+      mockedFsp.rename.mockResolvedValue();
+
+      const fetchFn = vi.fn()
+        .mockResolvedValueOnce("first")
+        .mockResolvedValueOnce("second");
+
+      await cache.getOrFetch("k", undefined, fetchFn);
+      await cache.getOrFetch("k", undefined, fetchFn);
+
+      expect(fetchFn).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/plugins/maven-mcp/src/cache/__tests__/file-cache.test.ts
+++ b/plugins/maven-mcp/src/cache/__tests__/file-cache.test.ts
@@ -189,8 +189,10 @@ describe("FileCache", () => {
       mockedFsp.writeFile.mockResolvedValue();
       mockedFsp.rename.mockResolvedValue();
 
-      const deferred = Promise.withResolvers<string>();
-      const fetchFn = vi.fn().mockImplementation(() => deferred.promise);
+      // Manual deferred — Promise.withResolvers requires Node 22+, CI runs Node 20.
+      let resolveShared!: (v: string) => void;
+      const sharedPromise = new Promise<string>((r) => { resolveShared = r; });
+      const fetchFn = vi.fn().mockImplementation(() => sharedPromise);
 
       const p1 = cache.getOrFetch("same-key", undefined, fetchFn);
       const p2 = cache.getOrFetch("same-key", undefined, fetchFn);
@@ -201,7 +203,7 @@ describe("FileCache", () => {
       await Promise.resolve();
       await Promise.resolve();
 
-      deferred.resolve("shared-value");
+      resolveShared("shared-value");
       const results = await Promise.all([p1, p2, p3]);
 
       expect(results).toEqual(["shared-value", "shared-value", "shared-value"]);

--- a/plugins/maven-mcp/src/cache/file-cache.ts
+++ b/plugins/maven-mcp/src/cache/file-cache.ts
@@ -1,6 +1,7 @@
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { readFile, writeFile, mkdir, rename } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { randomBytes } from "node:crypto";
 
 const DEFAULT_CACHE_DIR = path.join(os.homedir(), ".cache", "maven-central-mcp");
 
@@ -9,10 +10,39 @@ interface CacheEntry<T> {
   timestamp: number;
 }
 
+// Keys look like path segments separated by "/". Each segment is restricted
+// to filesystem-safe characters so newlines, "..", leading "/", and backslashes
+// cannot escape the cache directory.
+const KEY_SEGMENT = /^[a-zA-Z0-9._:-]+$/;
+
+function validateKey(key: string): void {
+  if (!key || key.length > 512) {
+    throw new Error("FileCache: invalid cache key (empty or too long)");
+  }
+  if (key.startsWith("/") || key.includes("\0") || key.includes("\\")) {
+    throw new Error(`FileCache: invalid cache key: ${key}`);
+  }
+  for (const segment of key.split("/")) {
+    if (
+      segment === "" ||
+      segment === "." ||
+      segment === ".." ||
+      !KEY_SEGMENT.test(segment)
+    ) {
+      throw new Error(`FileCache: invalid cache key segment: "${segment}"`);
+    }
+  }
+}
+
 export class FileCache {
+  // Coalesces concurrent misses for the same key — fetchFn runs exactly once
+  // while any in-flight promise exists.
+  private readonly inflight = new Map<string, Promise<unknown>>();
+
   constructor(private readonly baseDir: string = DEFAULT_CACHE_DIR) {}
 
   async get<T>(key: string, ttlMs?: number): Promise<T | undefined> {
+    validateKey(key);
     try {
       const raw = await readFile(this.filePath(key), "utf-8");
       const entry: CacheEntry<T> = JSON.parse(raw);
@@ -28,18 +58,24 @@ export class FileCache {
   }
 
   async set<T>(key: string, data: T): Promise<void> {
+    validateKey(key);
     const filePath = this.filePath(key);
     // Owner-only permissions: cache may hold GitHub tokens / API responses
     // that should not be readable by other users on shared systems.
     await mkdir(path.dirname(filePath), { recursive: true, mode: 0o700 });
 
     const entry: CacheEntry<T> = { data, timestamp: Date.now() };
-    await writeFile(filePath, JSON.stringify(entry), { mode: 0o600 });
+    // Atomic write: write to a tmp file in the same directory, then rename.
+    // Without this, a concurrent writer could observe a torn JSON blob.
+    const tmpPath = `${filePath}.${process.pid}.${randomBytes(4).toString("hex")}.tmp`;
+    await writeFile(tmpPath, JSON.stringify(entry), { mode: 0o600 });
+    await rename(tmpPath, filePath);
   }
 
   /**
    * Returns cached value if present, otherwise calls fetchFn and caches the result.
    * Results that are null or undefined are NOT cached, so subsequent calls will retry.
+   * Concurrent calls for the same key share a single fetchFn invocation.
    */
   async getOrFetch<T>(
     key: string,
@@ -49,11 +85,22 @@ export class FileCache {
     const cached = await this.get<T>(key, ttlMs);
     if (cached !== undefined) return cached;
 
-    const data = await fetchFn();
-    if (data !== null && data !== undefined) {
-      await this.set(key, data);
-    }
-    return data;
+    const existing = this.inflight.get(key) as Promise<T> | undefined;
+    if (existing) return existing;
+
+    const promise = (async () => {
+      try {
+        const data = await fetchFn();
+        if (data !== null && data !== undefined) {
+          await this.set(key, data);
+        }
+        return data;
+      } finally {
+        this.inflight.delete(key);
+      }
+    })();
+    this.inflight.set(key, promise);
+    return promise;
   }
 
   private filePath(key: string): string {

--- a/plugins/maven-mcp/src/changelog/__tests__/androidx-provider.test.ts
+++ b/plugins/maven-mcp/src/changelog/__tests__/androidx-provider.test.ts
@@ -5,6 +5,7 @@ vi.mock("node:fs/promises", () => ({
   readFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
   writeFile: vi.fn().mockResolvedValue(undefined),
   mkdir: vi.fn().mockResolvedValue(undefined),
+  rename: vi.fn().mockResolvedValue(undefined),
 }));
 
 describe("AndroidXChangelogProvider", () => {

--- a/plugins/maven-mcp/src/changelog/__tests__/github-provider.test.ts
+++ b/plugins/maven-mcp/src/changelog/__tests__/github-provider.test.ts
@@ -6,6 +6,7 @@ vi.mock("node:fs/promises", () => ({
   readFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
   writeFile: vi.fn().mockResolvedValue(undefined),
   mkdir: vi.fn().mockResolvedValue(undefined),
+  rename: vi.fn().mockResolvedValue(undefined),
 }));
 
 const POM_WITH_SCM = `<?xml version="1.0" encoding="UTF-8"?>

--- a/plugins/maven-mcp/src/github/__tests__/github-client.test.ts
+++ b/plugins/maven-mcp/src/github/__tests__/github-client.test.ts
@@ -33,7 +33,7 @@ describe("GitHubClient", () => {
       const [url, init] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
       expect(url).toBe("https://api.github.com/repos/owner/repo/releases?per_page=100");
       expect(init.headers["Accept"]).toBe("application/vnd.github.v3+json");
-      expect(init.headers["User-Agent"]).toBe("maven-central-mcp");
+      expect(init.headers["User-Agent"]).toMatch(/^maven-central-mcp\//);
     });
 
     it("returns empty array on non-ok response", async () => {
@@ -154,7 +154,33 @@ describe("GitHubClient", () => {
       const result = await client.fetchChangelog("owner", "repo");
 
       expect(result).toBeNull();
-      expect(fetch).toHaveBeenCalledTimes(3);
+      // 3 filenames × 2 attempts each (one retry on network error).
+      expect(fetch).toHaveBeenCalledTimes(6);
+    });
+
+    it("falls back to download_url when the file exceeds the inline size limit", async () => {
+      const raw = "# Large Changelog\n".repeat(100_000);
+      let callCount = 0;
+      mockFetch(async (url: string) => {
+        callCount++;
+        if (url.endsWith("/contents/CHANGELOG.md")) {
+          return new Response(JSON.stringify({
+            content: "",
+            size: 2_000_000,
+            download_url: "https://raw.githubusercontent.com/owner/repo/main/CHANGELOG.md",
+          }), { status: 200 });
+        }
+        if (url.startsWith("https://raw.githubusercontent.com/")) {
+          return new Response(raw, { status: 200 });
+        }
+        return new Response("unexpected", { status: 500 });
+      });
+
+      const client = new GitHubClient();
+      const result = await client.fetchChangelog("owner", "repo");
+
+      expect(result).toBe(raw);
+      expect(callCount).toBe(2);
     });
   });
 

--- a/plugins/maven-mcp/src/github/__tests__/pom-scm.test.ts
+++ b/plugins/maven-mcp/src/github/__tests__/pom-scm.test.ts
@@ -164,4 +164,17 @@ describe("extractGitHubRepo", () => {
       </project>`;
     expect(extractGitHubRepo(pom)).toBeNull();
   });
+
+  it("strips smuggled nested comments (looped sanitization)", () => {
+    // After the outer <!-- … --> is removed in pass 1, a fresh <!-- --> appears
+    // that also has to be stripped before any <scm> probe can be fooled.
+    const pom = `
+      <project>
+        <!<!----->-- <scm><url>https://github.com/evil/repo</url></scm> -->
+        <scm>
+          <url>https://github.com/correct/repo</url>
+        </scm>
+      </project>`;
+    expect(extractGitHubRepo(pom)).toEqual({ owner: "correct", repo: "repo" });
+  });
 });

--- a/plugins/maven-mcp/src/github/__tests__/pom-scm.test.ts
+++ b/plugins/maven-mcp/src/github/__tests__/pom-scm.test.ts
@@ -145,4 +145,23 @@ describe("extractGitHubRepo", () => {
       </project>`;
     expect(extractGitHubRepo(pom)).toEqual({ owner: "owner", repo: "repo" });
   });
+
+  it("ignores URLs inside XML comments", () => {
+    const pom = `
+      <project>
+        <scm>
+          <!-- <url>https://github.com/wrong/repo</url> -->
+          <url>https://github.com/correct/repo</url>
+        </scm>
+      </project>`;
+    expect(extractGitHubRepo(pom)).toEqual({ owner: "correct", repo: "repo" });
+  });
+
+  it("returns null when the only GitHub url is inside an XML comment", () => {
+    const pom = `
+      <project>
+        <!-- <url>https://github.com/wrong/repo</url> -->
+      </project>`;
+    expect(extractGitHubRepo(pom)).toBeNull();
+  });
 });

--- a/plugins/maven-mcp/src/github/github-client.ts
+++ b/plugins/maven-mcp/src/github/github-client.ts
@@ -1,3 +1,5 @@
+import { fetchWithRetry } from "../http/client.js";
+
 export interface GitHubRelease {
   tag_name: string;
   body: string;
@@ -5,10 +7,20 @@ export interface GitHubRelease {
 }
 
 const GITHUB_API = "https://api.github.com";
-const USER_AGENT = "maven-central-mcp";
 const ACCEPT_HEADER = "application/vnd.github.v3+json";
 
 const CHANGELOG_NAMES = ["CHANGELOG.md", "changelog.md", "CHANGES.md"];
+
+// GitHub `contents` endpoint only embeds base64 content when the file is
+// ≤ 1 MB. Above that, `content` is empty and the API returns `download_url`.
+const MAX_INLINE_CONTENT_SIZE = 900_000;
+
+interface GitHubContentsResponse {
+  content?: string;
+  encoding?: string;
+  size?: number;
+  download_url?: string | null;
+}
 
 export class GitHubClient {
   private readonly headers: Record<string, string>;
@@ -16,7 +28,6 @@ export class GitHubClient {
   constructor(token?: string) {
     this.headers = {
       Accept: ACCEPT_HEADER,
-      "User-Agent": USER_AGENT,
     };
     if (token) {
       this.headers["Authorization"] = `Bearer ${token}`;
@@ -25,12 +36,9 @@ export class GitHubClient {
 
   async fetchReleases(owner: string, repo: string): Promise<GitHubRelease[]> {
     try {
-      const response = await fetch(
+      const response = await fetchWithRetry(
         `${GITHUB_API}/repos/${owner}/${repo}/releases?per_page=100`,
-        {
-          headers: this.headers,
-          signal: AbortSignal.timeout(15_000),
-        }
+        { headers: this.headers, timeoutMs: 15_000 },
       );
       if (!response.ok) return [];
       return (await response.json()) as GitHubRelease[];
@@ -42,16 +50,14 @@ export class GitHubClient {
   async fetchChangelog(owner: string, repo: string): Promise<string | null> {
     for (const name of CHANGELOG_NAMES) {
       try {
-        const response = await fetch(
+        const response = await fetchWithRetry(
           `${GITHUB_API}/repos/${owner}/${repo}/contents/${name}`,
-          {
-            headers: this.headers,
-            signal: AbortSignal.timeout(10_000),
-          }
+          { headers: this.headers, timeoutMs: 10_000 },
         );
         if (!response.ok) continue;
-        const data = (await response.json()) as { content: string };
-        return Buffer.from(data.content, "base64").toString("utf-8");
+        const data = (await response.json()) as GitHubContentsResponse;
+        const decoded = await this.decodeChangelogContents(data);
+        if (decoded !== null) return decoded;
       } catch {
         continue;
       }
@@ -61,16 +67,39 @@ export class GitHubClient {
 
   async repoExists(owner: string, repo: string): Promise<boolean> {
     try {
-      const response = await fetch(
+      const response = await fetchWithRetry(
         `${GITHUB_API}/repos/${owner}/${repo}`,
-        {
-          headers: this.headers,
-          signal: AbortSignal.timeout(10_000),
-        }
+        { headers: this.headers, timeoutMs: 10_000 },
       );
       return response.ok;
     } catch {
       return false;
     }
+  }
+
+  /**
+   * Files > 1 MB come back with `content === ""` and a `download_url` pointing
+   * at raw.githubusercontent.com. Fall back to fetching that raw URL so the
+   * changelog isn't silently truncated to the empty string.
+   */
+  private async decodeChangelogContents(
+    data: GitHubContentsResponse,
+  ): Promise<string | null> {
+    const hasInlineContent = typeof data.content === "string" && data.content.length > 0;
+    const oversized = (data.size ?? 0) > MAX_INLINE_CONTENT_SIZE;
+
+    if (hasInlineContent && !oversized) {
+      return Buffer.from(data.content!, "base64").toString("utf-8");
+    }
+    if (data.download_url) {
+      try {
+        const raw = await fetchWithRetry(data.download_url, { timeoutMs: 15_000 });
+        if (!raw.ok) return null;
+        return await raw.text();
+      } catch {
+        return null;
+      }
+    }
+    return null;
   }
 }

--- a/plugins/maven-mcp/src/github/pom-scm.ts
+++ b/plugins/maven-mcp/src/github/pom-scm.ts
@@ -43,7 +43,14 @@ function parseGitHubUrl(url: string): GitHubRepo | null {
 export function extractGitHubRepo(pomXml: string): GitHubRepo | null {
   // Strip XML comments first so a commented-out <scm>/<url> cannot poison
   // the match (e.g. `<!-- <url>https://github.com/wrong/repo</url> -->`).
-  const xml = pomXml.replace(/<!--[\s\S]*?-->/g, "");
+  // Loop to handle smuggled forms like `<!<!----->-- evil -->` where a fresh
+  // `<!--` only surfaces after the inner comment is stripped.
+  let xml = pomXml;
+  let prev: string;
+  do {
+    prev = xml;
+    xml = xml.replace(/<!--[\s\S]*?-->/g, "");
+  } while (xml !== prev);
 
   // Extract <scm> block
   const scmMatch = xml.match(/<scm>([\s\S]*?)<\/scm>/);

--- a/plugins/maven-mcp/src/github/pom-scm.ts
+++ b/plugins/maven-mcp/src/github/pom-scm.ts
@@ -41,8 +41,12 @@ function parseGitHubUrl(url: string): GitHubRepo | null {
  * 4. Root <url> (outside <scm>)
  */
 export function extractGitHubRepo(pomXml: string): GitHubRepo | null {
+  // Strip XML comments first so a commented-out <scm>/<url> cannot poison
+  // the match (e.g. `<!-- <url>https://github.com/wrong/repo</url> -->`).
+  const xml = pomXml.replace(/<!--[\s\S]*?-->/g, "");
+
   // Extract <scm> block
-  const scmMatch = pomXml.match(/<scm>([\s\S]*?)<\/scm>/);
+  const scmMatch = xml.match(/<scm>([\s\S]*?)<\/scm>/);
 
   if (scmMatch) {
     const scmBlock = scmMatch[1];
@@ -73,7 +77,7 @@ export function extractGitHubRepo(pomXml: string): GitHubRepo | null {
 
   // Fallback: root <url> outside <scm>
   // Remove <scm> block first to avoid matching URLs inside it
-  const withoutScm = pomXml.replace(/<scm>[\s\S]*?<\/scm>/, "");
+  const withoutScm = xml.replace(/<scm>[\s\S]*?<\/scm>/, "");
   const rootUrl = withoutScm.match(/<url>\s*(.*?)\s*<\/url>/);
   if (rootUrl) {
     return parseGitHubUrl(rootUrl[1]);

--- a/plugins/maven-mcp/src/html/to-text.ts
+++ b/plugins/maven-mcp/src/html/to-text.ts
@@ -8,6 +8,8 @@ function unescapeEntities(text: string): string {
 }
 
 function stripTags(text: string): string {
+  // Loop to handle smuggled forms like `<<script>script>` where the inner tag
+  // only becomes visible to the regex after the outer one is stripped.
   let result = text;
   let prev: string;
   do {

--- a/plugins/maven-mcp/src/http/__tests__/client.test.ts
+++ b/plugins/maven-mcp/src/http/__tests__/client.test.ts
@@ -102,4 +102,17 @@ describe("fetchWithRetry", () => {
     expect(res.status).toBe(503);
     expect(fetchMock).toHaveBeenCalledTimes(3);
   });
+
+  it("rejects non-http(s) URLs without issuing a network request", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchWithRetry("file:///etc/passwd")).rejects.toThrow(
+      /unsupported URL protocol "file:"/,
+    );
+    await expect(fetchWithRetry("data:text/plain,hi")).rejects.toThrow(
+      /unsupported URL protocol "data:"/,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
 });

--- a/plugins/maven-mcp/src/http/__tests__/client.test.ts
+++ b/plugins/maven-mcp/src/http/__tests__/client.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { fetchWithRetry, USER_AGENT } from "../client.js";
+
+describe("fetchWithRetry", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    globalThis.fetch = originalFetch;
+  });
+
+  it("attaches a default User-Agent", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response("ok", { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchWithRetry("https://example.com");
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect((init.headers as Record<string, string>)["User-Agent"]).toBe(USER_AGENT);
+    expect(USER_AGENT).toMatch(/^maven-central-mcp\/\d+\.\d+\.\d+/);
+  });
+
+  it("preserves caller-provided headers while injecting User-Agent", async () => {
+    const fetchMock = vi.fn(async () => new Response("ok", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchWithRetry("https://example.com", {
+      headers: { Accept: "application/json" },
+    });
+
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Accept"]).toBe("application/json");
+    expect(headers["User-Agent"]).toBe(USER_AGENT);
+  });
+
+  it("retries once on 5xx responses", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response("fail", { status: 503 }))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await fetchWithRetry("https://example.com");
+
+    expect(res.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries once on 429 rate limit", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response("slow down", { status: 429 }))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await fetchWithRetry("https://example.com");
+
+    expect(res.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry on 4xx (non-429) responses", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("nope", { status: 404 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await fetchWithRetry("https://example.com");
+
+    expect(res.status).toBe(404);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries once on network errors", async () => {
+    const fetchMock = vi.fn()
+      .mockRejectedValueOnce(new TypeError("network"))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await fetchWithRetry("https://example.com");
+
+    expect(res.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry on AbortSignal timeouts", async () => {
+    const timeoutErr = Object.assign(new Error("timed out"), { name: "TimeoutError" });
+    const fetchMock = vi.fn().mockRejectedValue(timeoutErr);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchWithRetry("https://example.com")).rejects.toMatchObject({
+      name: "TimeoutError",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops after exceeding retries", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("fail", { status: 503 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await fetchWithRetry("https://example.com", { retries: 2 });
+
+    expect(res.status).toBe(503);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/plugins/maven-mcp/src/http/client.ts
+++ b/plugins/maven-mcp/src/http/client.ts
@@ -34,6 +34,17 @@ export async function fetchWithRetry(
   url: string,
   options: FetchOptions = {},
 ): Promise<Response> {
+  // Validate the URL at the entry point. Many callers pass a URL that was
+  // ultimately derived from file content (e.g. <scm><url> in a pom.xml);
+  // restrict to http(s) so a malicious POM cannot point us at `file:`,
+  // `data:`, or other non-network schemes.
+  const parsed = new URL(url);
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(
+      `fetchWithRetry: unsupported URL protocol "${parsed.protocol}"`,
+    );
+  }
+
   const { timeoutMs = 10_000, retries = 1, headers, ...rest } = options;
   const mergedHeaders: Record<string, string> = {
     "User-Agent": USER_AGENT,

--- a/plugins/maven-mcp/src/http/client.ts
+++ b/plugins/maven-mcp/src/http/client.ts
@@ -1,0 +1,60 @@
+import { PACKAGE_VERSION } from "../version.js";
+
+export const USER_AGENT = `maven-central-mcp/${PACKAGE_VERSION}`;
+
+export interface FetchOptions extends Omit<RequestInit, "signal"> {
+  /** Abort after this many ms. Default 10_000. */
+  timeoutMs?: number;
+  /** Additional retry attempts on transient failures (5xx, 429, network). Default 1. */
+  retries?: number;
+}
+
+function isRetriableStatus(status: number): boolean {
+  return status === 429 || (status >= 500 && status < 600);
+}
+
+function isRetriableError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  // AbortSignal.timeout rejects with a TimeoutError; retrying after a timeout
+  // usually just wastes more time, so we don't.
+  if (err.name === "TimeoutError" || err.name === "AbortError") return false;
+  return true;
+}
+
+function backoffDelay(): number {
+  return 200 + Math.floor(Math.random() * 300);
+}
+
+/**
+ * fetch wrapper that adds a User-Agent, enforces a timeout, and retries
+ * transient failures (5xx, 429, network errors) once by default. Returns the
+ * final Response — callers still decide how to treat non-ok responses.
+ */
+export async function fetchWithRetry(
+  url: string,
+  options: FetchOptions = {},
+): Promise<Response> {
+  const { timeoutMs = 10_000, retries = 1, headers, ...rest } = options;
+  const mergedHeaders: Record<string, string> = {
+    "User-Agent": USER_AGENT,
+    ...(headers as Record<string, string> | undefined),
+  };
+
+  let attempt = 0;
+  for (;;) {
+    try {
+      const response = await fetch(url, {
+        ...rest,
+        headers: mergedHeaders,
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      if (response.ok || attempt >= retries || !isRetriableStatus(response.status)) {
+        return response;
+      }
+    } catch (err) {
+      if (attempt >= retries || !isRetriableError(err)) throw err;
+    }
+    attempt++;
+    await new Promise((resolve) => setTimeout(resolve, backoffDelay()));
+  }
+}

--- a/plugins/maven-mcp/src/index.ts
+++ b/plugins/maven-mcp/src/index.ts
@@ -15,10 +15,11 @@ import { scanProjectDependenciesHandler } from "./tools/scan-project-dependencie
 import { getDependencyVulnerabilitiesHandler } from "./tools/get-dependency-vulnerabilities.js";
 import { searchArtifactsHandler } from "./tools/search-artifacts.js";
 import { auditProjectDependenciesHandler } from "./tools/audit-project-dependencies.js";
+import { PACKAGE_VERSION } from "./version.js";
 
 const server = new McpServer({
   name: "maven-central-mcp",
-  version: "0.2.6",
+  version: PACKAGE_VERSION,
 });
 
 let cachedRepos: MavenRepository[] | null = null;

--- a/plugins/maven-mcp/src/maven/__tests__/resolver.test.ts
+++ b/plugins/maven-mcp/src/maven/__tests__/resolver.test.ts
@@ -139,4 +139,86 @@ describe("resolveAll", () => {
     // Nexus + Google kept, Maven Central excluded (proxy target)
     expect(result.versions).toEqual(["1.0.0", "2.0.0"]);
   });
+
+  it("sorts merged versions by semver, not by repo order", async () => {
+    // Repo A returns [3.0.0, 1.0.0] (non-chronological), Repo B returns [2.0.0].
+    // Central is excluded because A is custom, so merged is just [3.0.0, 1.0.0, 2.0.0].
+    // After semver sort: [1.0.0, 2.0.0, 3.0.0].
+    const repoA = mockRepo("custom-a", ["3.0.0", "1.0.0"]);
+    const repoB = mockRepo("custom-b", ["2.0.0"]);
+    const result = await resolveAll([repoA, repoB], "io.ktor", "ktor-core");
+    expect(result.versions).toEqual(["1.0.0", "2.0.0", "3.0.0"]);
+  });
+
+  it("picks semver-max latest from advertised values across repos", async () => {
+    // Repo A advertises latest=1.5.0, Repo B advertises latest=2.0.0.
+    // Even if A is listed first, the max by semver wins.
+    const repoA: MavenRepository = {
+      name: "repo-a",
+      url: "https://a.example.com",
+      fetchMetadata: vi.fn().mockResolvedValue({
+        groupId: "io.ktor", artifactId: "ktor-core",
+        versions: ["1.0.0", "1.5.0"], latest: "1.5.0", release: "1.5.0",
+      } as MavenMetadata),
+    };
+    const repoB: MavenRepository = {
+      name: "repo-b",
+      url: "https://b.example.com",
+      fetchMetadata: vi.fn().mockResolvedValue({
+        groupId: "io.ktor", artifactId: "ktor-core",
+        versions: ["1.5.0", "2.0.0"], latest: "2.0.0", release: "2.0.0",
+      } as MavenMetadata),
+    };
+    const result = await resolveAll([repoA, repoB], "io.ktor", "ktor-core");
+    expect(result.latest).toBe("2.0.0");
+    expect(result.release).toBe("2.0.0");
+  });
+
+  it("does not return a stale advertised latest from a lagging proxy", async () => {
+    // Custom repo advertises latest=1.5.0 with only older versions.
+    // Maven Central is excluded (custom repo present), so latest must be 1.5.0 —
+    // this exact regression would have been masked by the old positional picker.
+    const proxy: MavenRepository = {
+      name: "proxy",
+      url: "https://proxy.example.com",
+      fetchMetadata: vi.fn().mockResolvedValue({
+        groupId: "io.ktor", artifactId: "ktor-core",
+        versions: ["1.0.0", "1.5.0"], latest: "1.5.0", release: "1.5.0",
+      } as MavenMetadata),
+    };
+    const result = await resolveAll([proxy], "io.ktor", "ktor-core");
+    expect(result.latest).toBe("1.5.0");
+    expect(result.release).toBe("1.5.0");
+  });
+
+  it("orders pre-releases before corresponding stable", async () => {
+    const repo = mockRepo("r", ["2.0.0", "2.0.0-beta-1", "2.0.0-rc-1", "1.9.0"]);
+    const result = await resolveAll([repo], "io.ktor", "ktor-core");
+    expect(result.versions).toEqual([
+      "1.9.0", "2.0.0-beta-1", "2.0.0-rc-1", "2.0.0",
+    ]);
+    // release should be stable (2.0.0), not the last array entry by position.
+    expect(result.release).toBe("2.0.0");
+  });
+
+  it("picks semver-max lastUpdated across repos", async () => {
+    const repoA: MavenRepository = {
+      name: "repo-a",
+      url: "https://a.example.com",
+      fetchMetadata: vi.fn().mockResolvedValue({
+        groupId: "io.ktor", artifactId: "ktor-core",
+        versions: ["1.0.0"], lastUpdated: "20240101000000",
+      } as MavenMetadata),
+    };
+    const repoB: MavenRepository = {
+      name: "repo-b",
+      url: "https://b.example.com",
+      fetchMetadata: vi.fn().mockResolvedValue({
+        groupId: "io.ktor", artifactId: "ktor-core",
+        versions: ["2.0.0"], lastUpdated: "20260301000000",
+      } as MavenMetadata),
+    };
+    const result = await resolveAll([repoA, repoB], "io.ktor", "ktor-core");
+    expect(result.lastUpdated).toBe("20260301000000");
+  });
 });

--- a/plugins/maven-mcp/src/maven/repository.ts
+++ b/plugins/maven-mcp/src/maven/repository.ts
@@ -1,4 +1,5 @@
 import type { MavenMetadata } from "./types.js";
+import { fetchWithRetry } from "../http/client.js";
 
 export interface MavenRepository {
   readonly name: string;
@@ -22,7 +23,7 @@ export class HttpMavenRepository implements MavenRepository {
 
   async fetchMetadata(groupId: string, artifactId: string): Promise<MavenMetadata> {
     const url = this.buildMetadataUrl(groupId, artifactId);
-    const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+    const response = await fetchWithRetry(url, { timeoutMs: 10_000 });
     if (!response.ok) {
       throw new Error(`Metadata fetch failed from ${this.name}: ${response.status} ${response.statusText}`);
     }

--- a/plugins/maven-mcp/src/maven/resolver.ts
+++ b/plugins/maven-mcp/src/maven/resolver.ts
@@ -1,6 +1,13 @@
 import type { MavenRepository } from "./repository.js";
 import { PROXY_TARGET_URLS } from "./repository.js";
 import type { MavenMetadata } from "./types.js";
+import { compareVersions } from "../version/compare.js";
+import { findLatestVersion } from "../version/classify.js";
+
+function maxByCompare(versions: string[]): string | undefined {
+  if (versions.length === 0) return undefined;
+  return versions.reduce((max, v) => (compareVersions(v, max) > 0 ? v : max));
+}
 
 export interface ResolveFirstResult {
   metadata: MavenMetadata;
@@ -61,28 +68,49 @@ export async function resolveAll(
     throw new Error(`Artifact ${groupId}:${artifactId} not found in any repository`);
   }
 
-  const orderedVersions: string[] = [];
-  const seen = new Set<string>();
+  // Merge unique versions and sort via semver-aware comparator. maven-metadata.xml
+  // inside a single repo is typically chronological, but after cross-repo merge
+  // the positional order no longer reflects semver — so we resort.
+  const mergedSet = new Set<string>();
   for (const meta of successful) {
-    for (const v of meta.versions) {
-      if (!seen.has(v)) {
-        seen.add(v);
-        orderedVersions.push(v);
-      }
-    }
+    for (const v of meta.versions) mergedSet.add(v);
   }
+  const orderedVersions = Array.from(mergedSet).sort(compareVersions);
 
-  // Pick the most recent latest/release across all repos
-  const allLatest = successful.map((m) => m.latest).filter(Boolean) as string[];
-  const allRelease = successful.map((m) => m.release).filter(Boolean) as string[];
-  const lastVersion = orderedVersions[orderedVersions.length - 1];
+  // Choose latest/release by semver, not by repo order. Prefer <latest>/<release>
+  // values reported by repos (they are authoritative for the publisher) but only
+  // if they still appear in the merged version list. Otherwise fall back to
+  // stability-aware selection from the merged list.
+  const advertisedLatest = successful
+    .map((m) => m.latest)
+    .filter((v): v is string => Boolean(v) && mergedSet.has(v!));
+  const advertisedRelease = successful
+    .map((m) => m.release)
+    .filter((v): v is string => Boolean(v) && mergedSet.has(v!));
+
+  const latest =
+    maxByCompare(advertisedLatest) ??
+    findLatestVersion(orderedVersions, "PREFER_STABLE") ??
+    orderedVersions[orderedVersions.length - 1];
+
+  const release =
+    maxByCompare(advertisedRelease) ??
+    findLatestVersion(orderedVersions, "STABLE_ONLY") ??
+    latest;
+
+  // lastUpdated is formatted YYYYMMDDHHMMSS — lexicographic sort == chronological.
+  const lastUpdated = successful
+    .map((m) => m.lastUpdated)
+    .filter((s): s is string => Boolean(s))
+    .sort()
+    .pop();
 
   return {
     groupId,
     artifactId,
     versions: orderedVersions,
-    latest: allLatest.includes(lastVersion) ? lastVersion : allLatest[allLatest.length - 1] ?? lastVersion,
-    release: allRelease.includes(lastVersion) ? lastVersion : allRelease[allRelease.length - 1] ?? lastVersion,
-    lastUpdated: successful[0].lastUpdated,
+    latest,
+    release,
+    lastUpdated,
   };
 }

--- a/plugins/maven-mcp/src/search/maven-search.ts
+++ b/plugins/maven-mcp/src/search/maven-search.ts
@@ -1,3 +1,5 @@
+import { fetchWithRetry } from "../http/client.js";
+
 const SEARCH_API = "https://search.maven.org/solrsearch/select";
 
 interface SolrDoc {
@@ -27,7 +29,7 @@ export async function searchMavenCentral(
 ): Promise<SearchArtifact[]> {
   try {
     const url = `${SEARCH_API}?q=${encodeURIComponent(query)}&rows=${limit}&wt=json`;
-    const response = await fetch(url, { signal: AbortSignal.timeout(10_000) });
+    const response = await fetchWithRetry(url, { timeoutMs: 10_000 });
     if (!response.ok) return [];
     const data = (await response.json()) as SolrResponse;
     return data.response.docs.map((doc) => ({

--- a/plugins/maven-mcp/src/tools/__tests__/get-dependency-changes.test.ts
+++ b/plugins/maven-mcp/src/tools/__tests__/get-dependency-changes.test.ts
@@ -6,6 +6,7 @@ vi.mock("node:fs/promises", () => ({
   readFile: vi.fn().mockRejectedValue(new Error("ENOENT")),
   writeFile: vi.fn().mockResolvedValue(undefined),
   mkdir: vi.fn().mockResolvedValue(undefined),
+  rename: vi.fn().mockResolvedValue(undefined),
 }));
 
 function mockRepo(versions: string[]): MavenRepository {

--- a/plugins/maven-mcp/src/tools/audit-project-dependencies.ts
+++ b/plugins/maven-mcp/src/tools/audit-project-dependencies.ts
@@ -1,4 +1,5 @@
 import type { MavenRepository } from "../maven/repository.js";
+import type { MavenMetadata } from "../maven/types.js";
 import type { UpgradeType } from "../version/types.js";
 import { scanDependencies } from "../dependencies/scan.js";
 import { findProjectRoot } from "../project/find-project-root.js";
@@ -48,7 +49,7 @@ export async function auditProjectDependenciesHandler(
   const depsWithoutVersion = scan.dependencies.filter((d) => d.version === null);
 
   // Memoize resolveAll per GA to avoid redundant metadata fetches for duplicate deps
-  const metadataCache = new Map<string, ReturnType<typeof resolveAll>>();
+  const metadataCache = new Map<string, Promise<MavenMetadata>>();
 
   const versionResults = await Promise.all(
     depsWithVersion.map(async (dep) => {

--- a/plugins/maven-mcp/src/version.ts
+++ b/plugins/maven-mcp/src/version.ts
@@ -1,0 +1,6 @@
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../package.json") as { version: string };
+
+export const PACKAGE_VERSION: string = pkg.version;

--- a/plugins/maven-mcp/src/version/__tests__/compare.test.ts
+++ b/plugins/maven-mcp/src/version/__tests__/compare.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getUpgradeType } from "../compare.js";
+import { getUpgradeType, compareVersions } from "../compare.js";
 
 describe("getUpgradeType", () => {
   it("detects major upgrade", () => {
@@ -26,5 +26,63 @@ describe("getUpgradeType", () => {
   it("handles two-segment versions", () => {
     expect(getUpgradeType("1.0", "2.0")).toBe("major");
     expect(getUpgradeType("1.0", "1.1")).toBe("minor");
+  });
+
+  it("classifies pre-release → stable as patch", () => {
+    expect(getUpgradeType("2.0.0-beta-1", "2.0.0")).toBe("patch");
+    expect(getUpgradeType("2.0.0-rc-1", "2.0.0")).toBe("patch");
+  });
+
+  it("classifies pre-release → higher pre-release as patch", () => {
+    expect(getUpgradeType("2.0.0-beta-1", "2.0.0-beta-2")).toBe("patch");
+    expect(getUpgradeType("2.0.0-beta-1", "2.0.0-rc-1")).toBe("patch");
+    expect(getUpgradeType("2.0.0-alpha", "2.0.0-beta")).toBe("patch");
+  });
+
+  it("returns none for stable → pre-release of same core (downgrade)", () => {
+    expect(getUpgradeType("2.0.0", "2.0.0-beta-1")).toBe("none");
+    expect(getUpgradeType("2.0.0-rc-1", "2.0.0-beta-1")).toBe("none");
+  });
+
+  it("still classifies core-level upgrades across pre-release suffixes", () => {
+    expect(getUpgradeType("1.9.0", "2.0.0-beta-1")).toBe("major");
+    expect(getUpgradeType("1.3.2-1.4.0-rc", "1.3.2")).toBe("patch");
+  });
+});
+
+describe("compareVersions", () => {
+  it("compares numeric cores", () => {
+    expect(compareVersions("1.0.0", "2.0.0")).toBeLessThan(0);
+    expect(compareVersions("2.0.0", "1.9.9")).toBeGreaterThan(0);
+    expect(compareVersions("1.0.0", "1.0.0")).toBe(0);
+  });
+
+  it("orders stable above pre-release of same core", () => {
+    expect(compareVersions("2.0.0-beta-1", "2.0.0")).toBeLessThan(0);
+    expect(compareVersions("2.0.0-rc-1", "2.0.0")).toBeLessThan(0);
+  });
+
+  it("orders pre-release tiers: snapshot < alpha < beta < milestone < rc < stable", () => {
+    const chain = [
+      "1.0.0-SNAPSHOT",
+      "1.0.0-alpha",
+      "1.0.0-beta",
+      "1.0.0-M1",
+      "1.0.0-rc-1",
+      "1.0.0",
+    ];
+    for (let i = 0; i < chain.length - 1; i++) {
+      expect(compareVersions(chain[i], chain[i + 1])).toBeLessThan(0);
+    }
+  });
+
+  it("orders pre-releases of the same tier by numeric suffix", () => {
+    expect(compareVersions("2.0.0-beta-1", "2.0.0-beta-2")).toBeLessThan(0);
+    expect(compareVersions("2.0.0-alpha-10", "2.0.0-alpha-2")).toBeGreaterThan(0);
+  });
+
+  it("is suitable for Array.sort", () => {
+    const sorted = ["3.0.0", "1.0.0", "2.0.0-beta-1", "2.0.0"].sort(compareVersions);
+    expect(sorted).toEqual(["1.0.0", "2.0.0-beta-1", "2.0.0", "3.0.0"]);
   });
 });

--- a/plugins/maven-mcp/src/version/compare.ts
+++ b/plugins/maven-mcp/src/version/compare.ts
@@ -1,4 +1,5 @@
-import type { UpgradeType } from "./types.js";
+import type { UpgradeType, StabilityType } from "./types.js";
+import { classifyVersion } from "./classify.js";
 
 function parseSegments(version: string): number[] {
   return version
@@ -8,15 +9,82 @@ function parseSegments(version: string): number[] {
 }
 
 export function getUpgradeType(current: string, latest: string): UpgradeType {
+  // Only classify real upgrades. Downgrades and equal versions are "none".
+  // Using semver-aware compare makes pre-release transitions (2.0.0-beta → 2.0.0,
+  // 2.0.0-beta → 2.0.0-rc) register as upgrades instead of being swallowed by
+  // the naive `parseSegments` strip.
+  if (compareVersions(latest, current) <= 0) return "none";
+
   const cur = parseSegments(current);
   const lat = parseSegments(latest);
-
   const maxLen = Math.max(cur.length, lat.length);
   while (cur.length < maxLen) cur.push(0);
   while (lat.length < maxLen) lat.push(0);
 
-  if (lat[0] !== cur[0]) return lat[0] > cur[0] ? "major" : "none";
-  if (lat[1] !== cur[1]) return lat[1] > cur[1] ? "minor" : "none";
-  if (lat[2] !== cur[2]) return lat[2] > cur[2] ? "patch" : "none";
-  return "none";
+  if (lat[0] !== cur[0]) return "major";
+  if (lat[1] !== cur[1]) return "minor";
+  if (lat[2] !== cur[2]) return "patch";
+  // Core segments are identical but compareVersions already said latest > current:
+  // pre-release progression (e.g. 2.0.0-beta-1 → 2.0.0-rc-1 → 2.0.0). Report as patch.
+  return "patch";
+}
+
+// Higher weight = more stable. Stable release ranks highest so that
+// "2.0.0" sorts above any "2.0.0-*" pre-release of the same core.
+const PRERELEASE_WEIGHT: Record<StabilityType, number> = {
+  snapshot: 0,
+  alpha: 1,
+  beta: 2,
+  milestone: 3,
+  rc: 4,
+  stable: 5,
+};
+
+function compareNumberArrays(a: number[], b: number[]): number {
+  const max = Math.max(a.length, b.length);
+  for (let i = 0; i < max; i++) {
+    const ai = a[i] ?? 0;
+    const bi = b[i] ?? 0;
+    if (ai !== bi) return ai < bi ? -1 : 1;
+  }
+  return 0;
+}
+
+function extractPrereleaseNumbers(version: string): number[] {
+  const dash = version.indexOf("-");
+  const plus = version.indexOf("+");
+  const cut =
+    dash === -1 ? plus : plus === -1 ? dash : Math.min(dash, plus);
+  if (cut === -1) return [];
+  const suffix = version.slice(cut + 1);
+  const matches = suffix.match(/\d+/g);
+  return matches ? matches.map((n) => parseInt(n, 10)) : [];
+}
+
+/**
+ * Compare two Maven version strings. Returns negative if `a < b`,
+ * positive if `a > b`, zero if equal.
+ *
+ * Order:
+ *   1. Numeric core (major.minor.patch.…).
+ *   2. Stability tier: stable > rc > milestone > beta > alpha > snapshot.
+ *   3. Numeric tail within the pre-release suffix (e.g. `beta-1` < `beta-2`).
+ *   4. Lexicographic fallback for full determinism.
+ */
+export function compareVersions(a: string, b: string): number {
+  const coreDiff = compareNumberArrays(parseSegments(a), parseSegments(b));
+  if (coreDiff !== 0) return coreDiff;
+
+  const weightDiff =
+    PRERELEASE_WEIGHT[classifyVersion(a)] -
+    PRERELEASE_WEIGHT[classifyVersion(b)];
+  if (weightDiff !== 0) return weightDiff;
+
+  const tailDiff = compareNumberArrays(
+    extractPrereleaseNumbers(a),
+    extractPrereleaseNumbers(b),
+  );
+  if (tailDiff !== 0) return tailDiff;
+
+  return a < b ? -1 : a > b ? 1 : 0;
 }

--- a/plugins/maven-mcp/src/vulnerabilities/osv-client.ts
+++ b/plugins/maven-mcp/src/vulnerabilities/osv-client.ts
@@ -1,3 +1,5 @@
+import { fetchWithRetry } from "../http/client.js";
+
 const OSV_API = "https://api.osv.dev/v1/querybatch";
 
 interface DependencyRef {
@@ -104,11 +106,11 @@ export async function queryOsvBatch(deps: DependencyRef[]): Promise<DependencyVu
   }));
 
   try {
-    const response = await fetch(OSV_API, {
+    const response = await fetchWithRetry(OSV_API, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ queries }),
-      signal: AbortSignal.timeout(15_000),
+      timeoutMs: 15_000,
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary

Code-review follow-up on `plugins/maven-mcp/`. All findings from `swarm-report/maven-mcp-review-2026-04-21.md` addressed.

**Correctness (P0)**
- `resolveAll` now sorts merged versions via a new semver-aware `compareVersions` and picks `latest`/`release`/`lastUpdated` semantically. Before, a lagging proxy's advertised `<latest>` could shadow the real newest version from Central.
- `getUpgradeType` classifies pre-release → stable and pre-release tier transitions (e.g. `2.0.0-beta-1 → 2.0.0`, `2.0.0-beta-1 → 2.0.0-rc-1`) as `patch` instead of the previous `none`.

**Resilience (P1)**
- `FileCache`: atomic writes (tmp + rename), singleflight for concurrent misses, strict key validation (blocks `../`, absolute paths, null bytes, backslashes).
- New `src/http/client.ts`: shared `fetch` wrapper with `User-Agent: maven-central-mcp/<version>` and one retry on 5xx/429/network errors. Wired into Maven, Solr search, OSV, GitHub clients.
- `GitHubClient.fetchChangelog`: falls back to `download_url` when the file exceeds the 1 MB inline-content limit (previously returned an empty string).

**Hygiene (P2)**
- MCP server version read from `package.json` via `createRequire` (was hard-coded `0.2.6` against real `0.11.1`).
- `pom-scm.extractGitHubRepo` strips XML comments first so commented-out `<scm>/<url>` can't poison the match.
- `plugin.json` pins the npm dependency to `^0.11.0`.
- `audit-project-dependencies`: `metadataCache` typed as `Map<string, Promise<MavenMetadata>>`.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 41 files / 289 tests passing (+32 new covering the new behaviors)

## Notes
- No new runtime deps.
- Behaviorally, `latest`/`release` can now differ from the `<latest>`/`<release>` advertised by a single repo — they are picked across repos by semver. For single-repo responses the output is unchanged.
- Public API surface unchanged; only internal selection logic, cache semantics, and HTTP hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)