### PR TITLE
Add Non-negotiables convention to CLAUDE.md files and skill prompts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Non-negotiables
+
+Rules that are not open for discussion. Violating these is an error, not a judgment call.
+
+- **Never run `npm publish` locally.** Publishing is exclusively via GitHub Actions — prevents partial releases and version skew.
+- **All 8 version locations must stay in sync.** A version bump touches all `plugin.json` files, `package.json`, and `marketplace.json` simultaneously — see Publishing for the list.
+- **Critical or Major violations of PLUGIN-STANDARDS.md block the release.** Fix first, release later.
+
 ## Project
 
 Monorepo for Claude Code plugins by krozov. Contains six plugins:

--- a/docs/PLUGIN-STANDARDS.md
+++ b/docs/PLUGIN-STANDARDS.md
@@ -4,6 +4,14 @@
 
 Проверка — ручная по чек-листу ниже, автоматическая через `validate.sh` (см. корень репо), и отдельная проверка через `plugin-dev:plugin-validator` agent перед каждым релизом.
 
+## Non-negotiables convention
+
+Each plugin that has a `CLAUDE.md` should include a `## Non-negotiables` section as its first section. This section lists hard rules specific to that plugin — rules whose violation is always an error, not a judgment call. Format: one bullet per rule, rule + why-one-liner. No trade-off discussion.
+
+Review and validation skills (`code-reviewer`, `finalize`, `multiexpert-review`) treat any violation of a `## Non-negotiables` rule as a blocker (critical severity, confidence 100).
+
+Plugins with no plugin-specific invariants beyond the project root `CLAUDE.md` and global `~/.claude/CLAUDE.md` do not need a `CLAUDE.md` at all.
+
 ## References
 
 - [Plugins reference](https://code.claude.com/docs/en/plugins-reference) — schema `plugin.json`, namespacing, caching

--- a/plugins/developer-workflow-experts/agents/code-reviewer.md
+++ b/plugins/developer-workflow-experts/agents/code-reviewer.md
@@ -93,6 +93,8 @@ Read the task description and the plan (if a path is provided). Extract:
 - Acceptance criteria (from plan)
 - Scope boundaries (what should and should NOT be in this change)
 
+Read any `## Non-negotiables` sections from the applicable `CLAUDE.md` files (project root, global, plugin-specific). Any diff change that violates a non-negotiable is automatically **critical, confidence 100** — do not apply the reporting filter to these, and do not downgrade them.
+
 ### Step 2: Read the diff
 Read the git diff carefully. For each changed file:
 - Understand what changed and why (infer from the code, not from author's intent)

--- a/plugins/developer-workflow/CLAUDE.md
+++ b/plugins/developer-workflow/CLAUDE.md
@@ -1,5 +1,12 @@
 # developer-workflow (core)
 
+## Non-negotiables
+
+Rules that are not open for discussion. Violating these is an error, not a judgment call.
+
+- **Non-QA skills must not hardcode MCP tool names.** They must run (with reduced capability) when an MCP server is absent. Exception: QA-execution skills (`manual-tester`, live parts of `acceptance`, `bug-hunt`) that require real device/browser automation may fail fast with an install/enable message — graceful degradation is impossible there.
+- **Tier-3 hard-dep escalation requires explicit user approval per change.** Proposing is allowed; editing `plugin.json` `dependencies` or `.mcp.json` without explicit go-ahead is not.
+
 ## Structure
 
 ```

--- a/plugins/developer-workflow/skills/finalize/SKILL.md
+++ b/plugins/developer-workflow/skills/finalize/SKILL.md
@@ -80,6 +80,8 @@ The agent returns a structured verdict: PASS / WARN / FAIL with findings scored 
 
 ### Handling findings
 
+Non-negotiables violations (flagged by `code-reviewer` from the `## Non-negotiables` sections in applicable `CLAUDE.md` files) are always BLOCK regardless of any confidence threshold — they cannot be moved to "acknowledged risks".
+
 | Severity × confidence | Action |
 |---|---|
 | critical ≥ 75 | Fix immediately. After fix, re-run `/check`. If `/check` PASSes and the finding is resolved → BLOCK cleared. If the fix does not converge, the finding stays BLOCK — the round ends without exiting PASS; counted against the 3-round budget. Do not silently downgrade a critical finding to "acknowledged risk". |

--- a/plugins/developer-workflow/skills/implement/SKILL.md
+++ b/plugins/developer-workflow/skills/implement/SKILL.md
@@ -107,7 +107,7 @@ After code is written, run the Quality Loop defined in [`docs/ORCHESTRATION.md`]
 
 Summary for this skill's callers:
 - Gate 1 invokes `/check` (mechanical: build + lint + typecheck + tests)
-- Gate 2 is the intent check — re-read task + plan, verify the diff addresses them; scope creep or drift → fix or flag
+- Gate 2 is the intent check — re-read task + plan, verify the diff addresses them; scope creep or drift → fix or flag; also verify no `## Non-negotiables` rule from applicable `CLAUDE.md` files is violated — a violation is treated as DRIFT and triggers a fix cycle
 - A gate failure triggers a fix cycle; total loop is capped per ORCHESTRATION.md
 
 Do not duplicate gate details here — read ORCHESTRATION.md before executing. If ORCHESTRATION.md is missing, escalate rather than guessing the current rules.

--- a/plugins/developer-workflow/skills/multiexpert-review/SKILL.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/SKILL.md
@@ -29,6 +29,8 @@ The review follows the Panel of LLM Evaluators protocol:
 3. **Confidence-weighted synthesis** — the orchestrator aggregates results, weighting by domain relevance
 4. **Explicit uncertainty** — disagreements between agents surface as "requires decision", not silently resolved
 
+Each reviewing agent must check the artifact against the `## Non-negotiables` sections in applicable `CLAUDE.md` files (project root, global, plugin-specific) before forming their opinion. Any proposed approach that violates a non-negotiable is automatically a blocker — critical severity, confidence 100, not subject to the reporting filter or trade-off discussion.
+
 ## Engine invariants (not overridable by profiles)
 
 Profiles MUST NOT declare these — they are engine constants:

--- a/plugins/maven-mcp/CLAUDE.md
+++ b/plugins/maven-mcp/CLAUDE.md
@@ -2,6 +2,12 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in `plugins/maven-mcp/`.
 
+## Non-negotiables
+
+Rules that are not open for discussion. Violating these is an error, not a judgment call.
+
+- **No XML parser dependency.** All XML parsing is regex-based — avoids a heavyweight dependency for the small subset of XML used in Maven metadata and POM files.
+
 ## Project
 
 MCP server for Maven dependency intelligence. Provides tools to query artifact versions from Maven repositories (Maven Central, Google Maven, custom repos). Distributed as npm package, runs via `npx @krozov/maven-central-mcp`.


### PR DESCRIPTION
## Summary

- Adds `## Non-negotiables` as the first section to root `CLAUDE.md`, `plugins/developer-workflow/CLAUDE.md`, and `plugins/maven-mcp/CLAUDE.md` — extracting hard rules that already existed in those files
- Documents the convention in `docs/PLUGIN-STANDARDS.md` (section before References)
- Updates review/validation skills to treat Non-negotiables violations as blockers:
  - `code-reviewer`: reads Non-negotiables in Step 1, auto-promotes violations to critical/100
  - `finalize`: Non-negotiables violations are always BLOCK, cannot be moved to "acknowledged risks"
  - `multiexpert-review`: agents check Non-negotiables before forming their opinion
  - `implement`: Gate 2 intent check now includes Non-negotiables verification

Plugins without a CLAUDE.md are not touched — the convention does not force new files on them.

## Test plan

- [ ] Root `CLAUDE.md` opens with `## Non-negotiables` listing 3 project-specific rules
- [ ] `plugins/developer-workflow/CLAUDE.md` lists 2 non-negotiables from its Conventions section
- [ ] `plugins/maven-mcp/CLAUDE.md` lists 1 non-negotiable (no XML parser dep)
- [ ] `docs/PLUGIN-STANDARDS.md` contains the convention description before References
- [ ] `code-reviewer.md` Step 1 mentions reading Non-negotiables
- [ ] `finalize/SKILL.md` Phase A mentions Non-negotiables as always BLOCK
- [ ] `multiexpert-review/SKILL.md` instructs agents to check Non-negotiables first
- [ ] `implement/SKILL.md` Gate 2 includes Non-negotiables check
- [ ] `bash scripts/validate.sh` passes

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)