### PR TITLE
Add split-output contract to lifecycle skills

### DIFF
--- a/plugins/developer-workflow/skills/acceptance/SKILL.md
+++ b/plugins/developer-workflow/skills/acceptance/SKILL.md
@@ -369,6 +369,25 @@ template in [`references/aggregation.md`](references/aggregation.md) §Receipt f
 Routing for downstream orchestrators (VERIFIED / FAILED / PARTIAL branches) lives in the
 same reference §Routing.
 
+After saving the receipt, post a chat summary (≤20 lines):
+
+**VERIFIED:**
+- One sentence: "Acceptance: VERIFIED. N checks passed."
+- Bullets (max 3): which checks ran (code, build, manual-test, etc.), any that were skipped and why.
+- One line: "Next step: `/create-pr`" (or `/drive-to-merge` if PR already exists).
+
+**FAILED:**
+- One sentence: "Acceptance: FAILED. N check(s) failed."
+- Bullets (max 5): failed checks — one bullet per failure with check name + one-line description of what failed.
+- ONE question: ask if user wants to fix and re-run, or ship as-is accepting the risk.
+
+**PARTIAL:**
+- One sentence: "Acceptance: PARTIAL. N passed, M inconclusive."
+- Bullets: list inconclusive checks and why.
+- ONE question: proceed to PR or re-run inconclusive checks?
+
+Do NOT paste acceptance receipt tables into chat. The file is for audit trail only.
+
 ---
 
 ## Re-verification Loop

--- a/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
@@ -233,6 +233,21 @@ gate always requires explicit confirmation.
 
 ---
 
+## Stage result relay
+
+When a lifecycle skill completes, **do not add a wrapper summary** on top of the skill's own
+chat output. The skill's ≤30-line chat summary IS the user-facing result for that stage.
+
+The orchestrator's job at each transition:
+1. Read the skill's receipt from `swarm-report/` (for gating and state tracking)
+2. Decide the next step based on verdict/status in the receipt
+3. If the next step requires user input — ask ONE question (if the skill didn't already ask one)
+4. Otherwise — proceed to the next stage and announce it in one line: "Starting `<skill-name>`..."
+
+Do NOT re-summarize what the skill already told the user.
+
+---
+
 ## Backward Transitions (STRICT limits)
 
 | From | To | Trigger | Max |

--- a/plugins/developer-workflow/skills/debug/SKILL.md
+++ b/plugins/developer-workflow/skills/debug/SKILL.md
@@ -158,3 +158,18 @@ What needs to change and where — NOT the implementation, just the direction
 ## Status
 Diagnosed / Escalated / Not Reproducible
 ```
+
+### Chat output
+
+After saving, post a chat summary (≤15 lines):
+
+1. One sentence: what the bug is and what causes it (Root Cause in one line).
+2. Bullets (max 4):
+   - Symptom (one line — what the user observed)
+   - Root cause location: file:line or component
+   - Fix direction (one line — what needs to change, not how)
+   - Any side effects or adjacent code at risk (one line, only if relevant)
+3. If reproduction requires specific steps or environment: ONE question to confirm.
+4. One line: "Recommended next step: implement the fix via `/implement`" (or `/bugfix-flow` if in standalone context).
+
+Do NOT post the full investigation log or hypothesis list in chat — those are in the file.

--- a/plugins/developer-workflow/skills/decompose-feature/SKILL.md
+++ b/plugins/developer-workflow/skills/decompose-feature/SKILL.md
@@ -286,11 +286,14 @@ format below.
 
 Update the state file status to `done`.
 
-Present the decomposition to the user with a brief summary of:
-- Total number of tasks and wave count
-- Complexity breakdown (how many S/M/L)
-- Tasks flagged for research
-- Number of open questions that need user decision
+After saving, post a chat summary — enough to approve the decomposition without opening the file:
+
+1. One sentence: feature name, N tasks across W waves.
+2. 3–5 bullets: key tasks per wave (name + complexity only), research-flagged tasks, any cross-cutting constraints. If N > 10 tasks: name the first wave in full, summarise remaining waves as "Wave K: N tasks (complexity range)".
+3. If any open questions block next steps: ask exactly ONE now. State which question it is out of N total. Save the rest — present one-by-one as each is answered.
+4. One line: proposed next step with command (e.g. `/write-spec` or `/implement`).
+
+Hard limit: ≤30 lines. No full task tables, no dependency graphs, no source citations.
 
 ---
 

--- a/plugins/developer-workflow/skills/feature-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/feature-flow/SKILL.md
@@ -450,6 +450,21 @@ always remains).
 
 ---
 
+## Stage result relay
+
+When a lifecycle skill completes, **do not add a wrapper summary** on top of the skill's own
+chat output. The skill's ≤30-line chat summary IS the user-facing result for that stage.
+
+The orchestrator's job at each transition:
+1. Read the skill's receipt from `swarm-report/` (for gating and state tracking)
+2. Decide the next step based on verdict/status in the receipt
+3. If the next step requires user input — ask ONE question (if the skill didn't already ask one)
+4. Otherwise — proceed to the next stage and announce it in one line: "Starting `<skill-name>`..."
+
+Do NOT re-summarize what the skill already told the user.
+
+---
+
 ## Backward Transitions (STRICT limits)
 
 | From | To | Trigger | Max |

--- a/plugins/developer-workflow/skills/finalize/SKILL.md
+++ b/plugins/developer-workflow/skills/finalize/SKILL.md
@@ -226,6 +226,23 @@ Findings that the user explicitly decided to accept (e.g., during escalation). N
 - <hash> <message>
 ```
 
+### Chat summary on exit
+
+After saving the report, post a chat summary (≤20 lines):
+
+**PASS exit:**
+- One sentence: "Finalize: PASS after N round(s). Code is ready for acceptance."
+- Bullets: N findings fixed (by category: security X, quality Y, style Z). If 0 findings: state that.
+- One line: "Next step: `/acceptance`"
+
+**ESCALATE exit:**
+- One sentence: "Finalize: ESCALATE after N round(s). X unresolved BLOCK(s) require decision."  
+- Bullets (max 5): unresolved BLOCKs — one bullet per BLOCK with category + one-line description. If >5 BLOCKs: list top 5 by severity.
+- ONE question: which BLOCK to resolve first, or ask user to choose: accept risk / loop to implement / re-scope.
+- One line: options — "Accept risks and proceed to `/acceptance`" OR "Return to `/implement` with new task".
+
+Do NOT paste the report table into chat. The file is for reference only.
+
 ---
 
 ## Scope rules

--- a/plugins/developer-workflow/skills/multiexpert-review/SKILL.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/SKILL.md
@@ -293,7 +293,7 @@ Per `profile.source_routing`:
 |--------|------------------|
 | **Plan Mode** | `EnterPlanMode` with issues list |
 | **File** | Edit the file directly (add `## Issues to Resolve` or restructure inline) |
-| **Conversation** | Present issues and work through inline with user |
+| **Conversation** | Present issues and work through inline with user — surface the highest-severity item first, ask ONE question per round. Do not dump the full findings list — work through it item by item. |
 
 Profiles may override or mark actions as `N/A` for sources they don't support.
 
@@ -309,7 +309,9 @@ If `profile.receipt` is absent — skip receipt writing.
 ### Verdict handling
 
 - **PASS** — confirm artifact is ready; done.
-- **CONDITIONAL** — present improvements; ask user; fix per `source_routing` if confirmed.
+- **CONDITIONAL** — present improvements in chat as bullets (max 5). If there are more than
+  5 improvement items, group them by category. Ask exactly ONE question if user decision is
+  needed. Fix per `source_routing` if confirmed.
 - **WARN** — pipeline continues; engine records warnings in receipt; no revise-loop.
 - **FAIL** — fix per `source_routing` without asking; auto re-run review on same agents + same profile; update state file with cycle N and new verdict. After cycle 3 still FAIL → escalate to user.
 

--- a/plugins/developer-workflow/skills/research/SKILL.md
+++ b/plugins/developer-workflow/skills/research/SKILL.md
@@ -349,10 +349,19 @@ Save the final research report to `./swarm-report/<slug>-research.md`.
 
 Update the state file status to `done`.
 
-Present the report to the user with a brief summary of:
-- How many expert tracks ran
-- Key recommendation (one sentence)
-- Number of open questions that need user decision
+After saving, post a chat summary. The summary must be self-contained — the user
+should be able to make a decision without opening the file. Format:
+
+1. One sentence: topic, how many tracks ran, overall recommendation.
+2. 3–5 bullets: key findings, blockers, constraints discovered — pick the most decision-relevant ones. No sub-lists, no source citations.
+3. If any open questions block next steps: ask exactly ONE question now. State
+   which question it is out of N total (e.g. "Question 1 of 3:"). Save the rest
+   to the report — present subsequent questions one-by-one only after the user
+   answers the current one.
+4. One line: suggested next step with command (e.g. `/decompose-feature` or `/implement`).
+
+Hard limit: ≤30 lines in chat. No tables, no source lists, no inline markdown citations.
+The swarm-report file is for downstream pipeline stages and compaction recovery — not for the user.
 
 ### Suggest next action
 
@@ -428,6 +437,7 @@ In all cases, the artifact location and format are the same — downstream stage
 |----------|------|---------|
 | Research report | `./swarm-report/<slug>-research.md` | Final synthesized findings — the receipt for the next pipeline stage |
 | State file | `./swarm-report/research-<slug>-state.md` | Compaction-resilient progress tracking during investigation |
+| Chat summary | — | ≤30-line user-facing output posted after the file is saved |
 
 The research report is the primary deliverable. The state file is operational and can be
 deleted after the research is complete.

--- a/plugins/developer-workflow/skills/write-spec/SKILL.md
+++ b/plugins/developer-workflow/skills/write-spec/SKILL.md
@@ -230,8 +230,14 @@ See [`references/spec-template.md`](references/spec-template.md) for the full te
 
 ### 4.1 Present draft to user
 
-Share the draft spec with the user. Invite them to review it — read through it,
-check if anything is missing, wrong, or needs adjustment.
+Do NOT paste the full spec into chat — the spec file is the artifact; chat is for
+navigation. Instead, present a compact summary:
+- Spec title and one-sentence goal
+- 3–5 key acceptance criteria (by AC-N id and a short label)
+- Any open questions that remain unresolved
+
+If there are open questions, ask exactly ONE of them now. After the user responds,
+loop back for the next open question if any remain.
 
 ### 4.2 Self-review while user reads
 
@@ -292,6 +298,11 @@ Save the approved spec to `docs/specs/YYYY-MM-DD-<slug>.md`, flip its
 frontmatter `status` from `draft` to `approved`, retire the state file, and
 confirm to the user. Do not auto-invoke any downstream skill — the user
 decides when to proceed.
+
+After saving, confirm to the user in one sentence: spec saved to
+`docs/specs/YYYY-MM-DD-<slug>.md`, status: approved. Suggest the next step
+(e.g. `/generate-test-plan` or `/implement`).
+No inline content — the file is the artifact; chat is just a status ping.
 
 See [`references/output-layout.md`](references/output-layout.md) for the full
 save procedure, path conventions, confirmation message, and hand-off rules.


### PR DESCRIPTION
## Summary

- Each lifecycle skill now posts a ≤30-line chat summary after saving its swarm-report artifact: 1 sentence outcome, 3–5 key bullets, 1 blocking question (if any), 1 next-step proposal
- `swarm-report` files remain untouched — they continue serving as inter-stage receipts and compaction anchors
- `feature-flow` and `bugfix-flow` get a "Stage result relay" rule: do not re-wrap skill output, relay it directly

## Skills updated (9 files)

- `research` — Phase 5 chat format
- `decompose-feature` — Phase 6 chat format
- `write-spec` — §4.1 draft presentation + Phase 5 save confirmation
- `multiexpert-review` — CONDITIONAL verdict presentation + Conversation routing
- `finalize` — PASS/ESCALATE chat summary
- `acceptance` — VERIFIED/FAILED/PARTIAL chat summary
- `debug` — chat output after debug.md save
- `feature-flow` / `bugfix-flow` — Stage result relay section

## Test plan

- [ ] Invoke `/research` on a topic — confirm chat returns ≤30-line summary without opening swarm-report
- [ ] Invoke `/decompose-feature` — confirm task list appears in chat (not file pointer)
- [ ] Run `feature-flow` end-to-end — confirm no double-wrapping at stage transitions

Closes #140

🤖 Generated with [Claude Code](https://claude.ai/claude-code)