### PR TITLE
Add Clarify pit-stop stage to feature-flow

### DIFF
--- a/plugins/developer-workflow/CLAUDE.md
+++ b/plugins/developer-workflow/CLAUDE.md
@@ -45,9 +45,9 @@ Skills in this plugin delegate to engineer agents (kotlin-engineer / compose-dev
 - Pipeline orchestration rules (task profiling, Research Consortium, Quality Loop gates, State Machine, receipt-based gating) ship with this plugin at [`docs/ORCHESTRATION.md`](docs/ORCHESTRATION.md) — skills and the core feature-flow/bugfix-flow orchestrators read from there.
 - Quality Loop gates are defined in `docs/ORCHESTRATION.md`, not in any individual skill.
 
-## Skills roster (17)
+## Skills roster (18)
 
-- Planning/research: `research`, `decompose-feature`, `write-spec`, `multiexpert-review`, `design-options` (optional pre-multiexpert-review stage — generates 2-3 architectural alternatives for high-arch-risk tasks)
+- Planning/research: `research`, `clarify` (lightweight Q&A pit-stop — locks requirements between Research and Decompose), `decompose-feature`, `write-spec`, `multiexpert-review`, `design-options` (optional pre-multiexpert-review stage — generates 2-3 architectural alternatives for high-arch-risk tasks)
 - Implementation: `implement`, `write-tests`, `debug`
 - Verification utility: `check` — reusable mechanical-check runner (build + lint + typecheck + tests), invoked by `implement`, `finalize`, and any code-modifying skill
 - Code-quality pass: `finalize` — multi-round review-and-fix loop (code-reviewer → /simplify → optional pr-review-toolkit trio → expert reviews) that runs between `implement` and `acceptance`. The `pr-review-toolkit` trio is a soft-reference: installed → Phase C runs; absent → Phase C is skipped with a log entry.

--- a/plugins/developer-workflow/CLAUDE.md
+++ b/plugins/developer-workflow/CLAUDE.md
@@ -22,7 +22,7 @@ This plugin is part of a split family. Depending on the task, Claude Code will h
 
 | Plugin | Contributes |
 |---|---|
-| `developer-workflow` (this) | 17 lifecycle skills + `manual-tester` |
+| `developer-workflow` (this) | 18 lifecycle skills + `manual-tester` |
 | `developer-workflow-experts` | `code-reviewer`, `architecture-expert`, `security-expert`, `performance-expert`, `ux-expert`, `build-engineer`, `devops-expert`, `business-analyst`, `debugging-expert` — required, auto-installed as a dependency |
 | `developer-workflow-kotlin` | `kotlin-engineer`, `compose-developer`; skills `code-migration`, `kmp-migration`, `migrate-to-compose` — install for Kotlin/Android/KMP work |
 | `developer-workflow-swift` | `swift-engineer`, `swiftui-developer` — install for Swift/iOS/macOS work |

--- a/plugins/developer-workflow/CLAUDE.md
+++ b/plugins/developer-workflow/CLAUDE.md
@@ -10,7 +10,7 @@ Rules that are not open for discussion. Violating these is an error, not a judgm
 ## Structure
 
 ```
-skills/<name>/SKILL.md    # 17 lifecycle skills, each a directory with YAML frontmatter
+skills/<name>/SKILL.md    # 18 lifecycle skills, each a directory with YAML frontmatter
 agents/manual-tester.md   # only agent in core (QA executor)
 docs/WORKFLOW.md          # Full pipeline documentation with diagrams
 docs/ORCHESTRATORS.md     # feature-flow and bugfix-flow diagrams

--- a/plugins/developer-workflow/docs/ORCHESTRATION.md
+++ b/plugins/developer-workflow/docs/ORCHESTRATION.md
@@ -63,7 +63,7 @@ Allowed transitions between stages. Forward is default; backward transitions are
 
 ```
 Research ──→ Clarify        (lock requirements before decomposition — default-on after Research)
-Research ──→ Plan           (skip-clarify path — trivial task or --no-clarify)
+Research ──→ Plan           (skip-clarify path — --no-clarify, requirements already locked, or user opted out)
 Clarify  ──→ Plan           (locked requirements ready — proceed to decompose/plan)
 Clarify  ──→ Research       (gap exposed during Q&A — cap 1)
 Plan ──→ TestPlan           (test-plan stage not skipped)

--- a/plugins/developer-workflow/docs/ORCHESTRATION.md
+++ b/plugins/developer-workflow/docs/ORCHESTRATION.md
@@ -62,7 +62,10 @@ Include these paths in the agent's context handoff prompt. This prevents drift f
 Allowed transitions between stages. Forward is default; backward transitions are explicit recovery paths.
 
 ```
-Research ──→ Plan
+Research ──→ Clarify        (lock requirements before decomposition — default-on after Research)
+Research ──→ Plan           (skip-clarify path — trivial task or --no-clarify)
+Clarify  ──→ Plan           (locked requirements ready — proceed to decompose/plan)
+Clarify  ──→ Research       (gap exposed during Q&A — cap 1)
 Plan ──→ TestPlan           (test-plan stage not skipped)
 Plan ──→ Implement          (test-plan stage skipped: skip-detector conditions or --skip-test-plan)
 Plan ──→ Research           (multiexpert review reveals gaps or missing context)
@@ -91,6 +94,7 @@ Each stage produces an artifact in `swarm-report/`. The next stage reads it befo
 | Stage | Artifact |
 |-------|----------|
 | Research | `<slug>-research.md` |
+| Clarify | `<slug>-clarify.md` |
 | Plan | `<slug>-plan.md` |
 | TestPlan | `docs/testplans/<slug>-test-plan.md` (permanent, source of truth) + `<slug>-test-plan.md` (receipt: `status`, `permanent_path`, `source_spec`, `review_verdict`, `phase_coverage`). Created by `generate-test-plan` when invoked from the orchestrator with a slug; read by `multiexpert-review` (test-plan profile) and `acceptance`. |
 | TestPlanReview | `<slug>-test-plan.md` receipt updated in place: `review_verdict` set to PASS / WARN / FAIL, `status` advances Draft → Ready on PASS/WARN. |

--- a/plugins/developer-workflow/docs/ORCHESTRATION.md
+++ b/plugins/developer-workflow/docs/ORCHESTRATION.md
@@ -105,10 +105,10 @@ Each stage produces an artifact in `swarm-report/`. The next stage reads it befo
 
 If a stage artifact is missing — the previous stage did not complete. Do not skip ahead.
 
-**Exception — optional stages (Clarify, DesignOptions):** these stages may be skipped by
-the orchestrator without producing an artifact. A missing `<slug>-clarify.md` or
-`<slug>-design-options.md` means the stage was skipped, not incomplete. The orchestrator
-must announce the skip explicitly; downstream stages proceed normally.
+**Exception — optional stage (Clarify):** this stage may be skipped by the orchestrator
+without producing an artifact. A missing `<slug>-clarify.md` means the stage was skipped,
+not incomplete. The orchestrator must announce the skip explicitly; downstream stages
+proceed normally.
 
 ## Quality Pipeline
 

--- a/plugins/developer-workflow/docs/ORCHESTRATION.md
+++ b/plugins/developer-workflow/docs/ORCHESTRATION.md
@@ -105,6 +105,11 @@ Each stage produces an artifact in `swarm-report/`. The next stage reads it befo
 
 If a stage artifact is missing — the previous stage did not complete. Do not skip ahead.
 
+**Exception — optional stages (Clarify, DesignOptions):** these stages may be skipped by
+the orchestrator without producing an artifact. A missing `<slug>-clarify.md` or
+`<slug>-design-options.md` means the stage was skipped, not incomplete. The orchestrator
+must announce the skip explicitly; downstream stages proceed normally.
+
 ## Quality Pipeline
 
 Three stages cover the full quality picture. Each stage answers a different question.

--- a/plugins/developer-workflow/docs/ORCHESTRATORS.md
+++ b/plugins/developer-workflow/docs/ORCHESTRATORS.md
@@ -24,7 +24,7 @@ flowchart TD
 
     needs_research -->|No| impl
     needs_research -->|Yes| research[/research/]
-    research --> needs_clarify{Skip clarify?<br/>trivial/--no-clarify}
+    research --> needs_clarify{Skip clarify?<br/>see Clarify skip conditions}
     needs_clarify -->|Skip| needs_decompose{Multi-task?}
     needs_clarify -->|Run| clarify[/clarify/]
     clarify --> clarify_result{Gap found?}

--- a/plugins/developer-workflow/docs/ORCHESTRATORS.md
+++ b/plugins/developer-workflow/docs/ORCHESTRATORS.md
@@ -24,7 +24,12 @@ flowchart TD
 
     needs_research -->|No| impl
     needs_research -->|Yes| research[/research/]
-    research --> needs_decompose{Multi-task?}
+    research --> needs_clarify{Skip clarify?<br/>trivial/--no-clarify}
+    needs_clarify -->|Skip| needs_decompose{Multi-task?}
+    needs_clarify -->|Run| clarify[/clarify/]
+    clarify --> clarify_result{Gap found?}
+    clarify_result -->|Research gap| research
+    clarify_result -->|OK| needs_decompose{Multi-task?}
 
     needs_decompose -->|No, simple| needs_plan{Complex single task?}
     needs_decompose -->|Yes| decompose[/decompose-feature/]
@@ -81,6 +86,7 @@ flowchart TD
     merge_gate -->|Stop| blocked([Blocker surfaced])
 
     style research fill:#e1f5fe
+    style clarify fill:#e1f5fe
     style decompose fill:#e1f5fe
     style design_opts fill:#e1f5fe
     style plan_review fill:#e1f5fe
@@ -114,6 +120,7 @@ flowchart TD
 
 | From → To | Max | After limit |
 |-----------|-----|-------------|
+| Clarify → Research | 1 | Escalate |
 | PlanReview → Research | 2 | Escalate |
 | TestPlanReview → TestPlan | 3 | Escalate |
 | Finalize → Implement | 1 | Escalate |

--- a/plugins/developer-workflow/skills/clarify/SKILL.md
+++ b/plugins/developer-workflow/skills/clarify/SKILL.md
@@ -83,9 +83,14 @@ For every extracted item, assign one of three dispositions:
 
 Sort items by impact × uncertainty: high-impact, high-uncertainty items first.
 
-Keep the question list to **5-7 items maximum** for round 1. If more items exist:
-- Lower-priority items go to round 2 only if the user keeps engaging after round 1
-- Items that cannot fit in 2 rounds become non-blocking open questions in the artifact
+Keep the list as short as possible — aim for the minimum set that unblocks decomposition.
+If many questions surface, that is usually a sign Research was too shallow, not that all
+questions must be asked. Ruthlessly cut low-impact items; record them as non-blocking open
+questions in the artifact without asking.
+
+Separate remaining items into two buckets:
+- **Round 1** — high-impact items that must be resolved before decomposition
+- **Round 2 candidates** — lower-priority items and any new gaps opened by round 1 answers
 
 ### 1.5 Save state
 
@@ -118,17 +123,21 @@ Present all questions in a single message. Wait for the user's response before p
 ### 2.2 Accepting defaults
 
 If the user says "accept all defaults", "принимаю всё", or any equivalent phrasing:
-- Record every proposed default as a confirmed assumption in the artifact
-- Do not re-ask any of the defaulted items
+- Record every proposed default from round 1 as a confirmed assumption in the artifact
+- For round 2 candidates: auto-confirm those that have an obvious default; record the rest
+  as non-blocking open questions
+- Do not ask any further questions
 - Proceed directly to Phase 3
 
 ### 2.3 Round structure
 
-**Round 1:** present all prepared items (max 7). Record answers and any follow-up gaps they open.
+**Round 1:** present high-impact items from the round 1 bucket. Record answers and note any
+new gaps they open (add those to the round 2 candidates bucket).
 
-**Round 2 (optional):** only if round 1 answers opened new genuine gaps — for example, the user
-chose an alternative that implies a constraint not previously known. Announce explicitly:
-"Round 2 of 2:" before presenting questions. Max 3 new questions.
+**Round 2 (optional):** run only if the round 2 candidates bucket is non-empty after round 1.
+Candidates come from two sources: lower-priority items carried over from Phase 1.4, and new
+gaps opened by round 1 answers. Announce explicitly: "Round 2 of 2:" before presenting.
+Keep it short — fewer questions, not more.
 
 **Hard cap:** after 2 rounds, record any remaining items as non-blocking open questions.
 Do NOT ask a third round under any circumstances.
@@ -209,8 +218,8 @@ high-impact items remain as open questions due to the round cap or a failed back
 
 ### 3.2 Clean up state file
 
-Update `swarm-report/clarify-<slug>-state.md` status to `done`, then delete the file.
-It is operational only and must not persist after the artifact is saved.
+Delete `swarm-report/clarify-<slug>-state.md`. It is operational only and must not persist
+after the artifact is saved.
 
 ### 3.3 Post chat summary
 
@@ -245,7 +254,10 @@ phases run identically to the inline invocation. The output path is always
 
 **Decompose, PlanReview, TestPlan:** feature-flow passes `swarm-report/<slug>-clarify.md`
 as an additional input to all three stages. They must treat locked requirements as binding
-constraints — a plan that contradicts an AC is a defect, not an open question.
+constraints — a plan that contradicts an AC is a defect, not an open question. When the
+artifact has `status: partial`, downstream stages should surface the open questions to the
+user before committing to a decomposition or plan — partial clarification is better than
+none, but the gaps are real.
 
 **multiexpert-review on PlanReview:** receives the clarify artifact alongside the plan.
 Ambiguity in the plan that is contradicted by a locked AC is a FAIL finding — "unclear

--- a/plugins/developer-workflow/skills/clarify/SKILL.md
+++ b/plugins/developer-workflow/skills/clarify/SKILL.md
@@ -40,8 +40,8 @@ identical — the output artifact lands at the same path for full downstream com
 
 Skip Clarify entirely when any of the following is true:
 
-- **Trivial task** — same threshold as Research skip: single-file change, obviously scoped change,
-  no external APIs involved, no unfamiliar libraries, no architectural decisions required
+- **Obviously scoped change** — single-file change, no architectural decisions, no external APIs
+  or unfamiliar libraries involved
 - **Explicit opt-out** — user passed `--no-clarify`, or their message contained "no questions",
   "don't ask", or equivalent
 - **Requirements already locked** — the research artifact contains a "Requirements" section
@@ -109,7 +109,7 @@ Present each question using this format:
 ```
 Q{N}: {Topic — one line}
 
-Recommendation: {One-sentence default answer or assumption}
+Recommendation: {One-sentence default answer or assumption} | none
 Alternatives:
   A. {Option A — label + consequence}
   B. {Option B — label + consequence}
@@ -117,6 +117,9 @@ Alternatives:
 
 Impact if deferred: {One sentence — what breaks or becomes ambiguous if left unresolved}
 ```
+
+For items classified as "genuine gap" in Phase 1.3 (no obvious default), use
+`Recommendation: none` and omit the Alternatives block if no clear options exist.
 
 Present all questions in a single message. Wait for the user's response before proceeding.
 
@@ -149,14 +152,16 @@ research (for example: "we don't know how the payment API handles retries"), ann
 
 > **Backward: Clarify → Research**
 > Reason: [what gap was exposed]
-> Re-invoking research on the specific gap.
+> Requested research scope: [the specific gap to investigate]
 
-Then invoke the research skill on the specific gap, read the new artifact, and continue
-Clarify from where it left off with the new information.
+Then stop Clarify and return control to the orchestrator (feature-flow). The orchestrator
+is responsible for performing the `Clarify → Research` transition, enforcing the
+backward-edge cap, and resuming Clarify with the updated research artifact.
 
-**Cap:** 1 backward transition per Clarify invocation. If the targeted re-research still
-leaves the gap unresolved — record it as an open question and continue. Do not loop back
-to Research a second time.
+**Cap:** 1 backward transition per Clarify invocation, enforced by the orchestrator. If
+the targeted re-research still leaves the gap unresolved, feature-flow resumes Clarify
+once with the best available artifact — Clarify must then record the item as an open
+question and continue. Do not request or perform a second transition to Research.
 
 ---
 
@@ -242,11 +247,16 @@ Do NOT paste the full artifact content into chat.
 
 When invoked outside feature-flow, the user must supply one of:
 - **Slug** — Clarify resolves `swarm-report/<slug>-research.md` automatically
-- **Direct artifact path** — path to a research artifact that may use a non-standard location
+- **Direct artifact path** — path to a research artifact that may use a non-standard
+  location; if the filename matches `<slug>-research.md`, derive `<slug>` from that
+  filename; otherwise the caller must also provide `slug: <slug>` explicitly
 
-If neither is provided, ask for one before proceeding. Once the artifact is located, all
-phases run identically to the inline invocation. The output path is always
-`swarm-report/<slug>-clarify.md` for downstream compatibility.
+If neither is provided, ask for one before proceeding. If a direct artifact path is
+provided and `<slug>` cannot be derived from a `<slug>-research.md` filename and no
+explicit `slug:` is supplied, stop and ask the user for the slug before proceeding.
+Once the artifact is located and `<slug>` is known, all phases run identically to the
+inline invocation. The output path is always `swarm-report/<slug>-clarify.md` for
+downstream compatibility.
 
 ---
 

--- a/plugins/developer-workflow/skills/clarify/SKILL.md
+++ b/plugins/developer-workflow/skills/clarify/SKILL.md
@@ -44,16 +44,17 @@ Skip Clarify entirely when any of the following is true:
   or unfamiliar libraries involved
 - **Explicit opt-out** — user passed `--no-clarify`, or their message contained "no questions",
   "don't ask", or equivalent
-- **Requirements already locked** — the research artifact contains a "Requirements" section
-  with acceptance criteria already answered in full
+- **Requirements already locked** — the research artifact already documents explicit,
+  complete requirements and acceptance criteria with no material ambiguities left to resolve
 
 When skipping: announce the skip reason in one line. Do NOT write an artifact. Return
 control to the caller; in feature-flow, the caller then proceeds immediately to the next
 stage.
 
 If the skip reason is **Requirements already locked**, downstream stages (Decompose,
-PlanReview, TestPlan) must treat the research artifact's `Requirements` section as the
-binding source of locked requirements — equivalent to a Clarify artifact for this run.
+PlanReview, TestPlan) must treat the requirements and acceptance criteria documented in the
+research artifact as the binding source of locked requirements for this run — equivalent to
+a Clarify artifact.
 
 ---
 

--- a/plugins/developer-workflow/skills/clarify/SKILL.md
+++ b/plugins/developer-workflow/skills/clarify/SKILL.md
@@ -47,8 +47,13 @@ Skip Clarify entirely when any of the following is true:
 - **Requirements already locked** — the research artifact contains a "Requirements" section
   with acceptance criteria already answered in full
 
-When skipping: announce the skip reason in one line. Do NOT write an artifact. Proceed
-immediately to the next stage.
+When skipping: announce the skip reason in one line. Do NOT write an artifact. Return
+control to the caller; in feature-flow, the caller then proceeds immediately to the next
+stage.
+
+If the skip reason is **Requirements already locked**, downstream stages (Decompose,
+PlanReview, TestPlan) must treat the research artifact's `Requirements` section as the
+binding source of locked requirements — equivalent to a Clarify artifact for this run.
 
 ---
 

--- a/plugins/developer-workflow/skills/clarify/SKILL.md
+++ b/plugins/developer-workflow/skills/clarify/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: clarify
+description: Lightweight Q&A pit-stop that locks requirements before decomposition — elicits acceptance criteria, non-functional constraints, and out-of-scope boundaries from research findings via 2-round interview with pre-filled defaults. Runs inside feature-flow between Research and Decompose; can also be invoked standalone when requirements need clarification before planning.
+---
+
+# Clarify
+
+Lightweight requirements lock between Research and Decompose. Clarify reads the research
+artifact, identifies gaps and ambiguities, and resolves them through a concise Q&A session
+(max 2 rounds, 5-7 questions each). The output is a structured artifact of locked requirements
+that Decompose, PlanReview, and TestPlan treat as binding constraints.
+
+**Key difference from write-spec:** write-spec is a standalone heavy-spec path that produces
+a formal specification document through multiple interview rounds. Clarify is an inline pit-stop
+— it never replaces write-spec and does not produce a full spec. Its sole purpose is to prevent
+ambiguous requirements from reaching decomposition.
+
+**When invoked inside feature-flow:** automatically triggered after Research completes and
+before Decompose begins. The orchestrator passes the research slug and task description.
+
+**When invoked standalone:** the user provides a slug or direct artifact path. Behavior is
+identical — the output artifact lands at the same path for full downstream compatibility.
+
+---
+
+## Inputs
+
+**Required:**
+- `swarm-report/<slug>-research.md` — the research artifact produced by the research skill
+
+**Optional:**
+- `swarm-report/<slug>-design-options.md` — architectural alternatives artifact, if produced by design-options
+
+**Context:**
+- Task description from the caller (feature goal, constraints, success criteria stated so far)
+
+---
+
+## Skip Conditions
+
+Skip Clarify entirely when any of the following is true:
+
+- **Trivial task** — same threshold as Research skip: single-file change, obviously scoped change,
+  no external APIs involved, no unfamiliar libraries, no architectural decisions required
+- **Explicit opt-out** — user passed `--no-clarify`, or their message contained "no questions",
+  "don't ask", or equivalent
+- **Requirements already locked** — the research artifact contains a "Requirements" section
+  with acceptance criteria already answered in full
+
+When skipping: announce the skip reason in one line. Do NOT write an artifact. Proceed
+immediately to the next stage.
+
+---
+
+## Phase 1: Extract Questions
+
+### 1.1 Read inputs
+
+Read `swarm-report/<slug>-research.md`. If `swarm-report/<slug>-design-options.md` exists,
+read it as well.
+
+### 1.2 Identify unclear items
+
+Extract items that are unclear or have multiple valid interpretations across these categories:
+
+| Category | Examples |
+|---|---|
+| Acceptance criteria boundaries | What counts as "done"? What is the measurable success condition? |
+| Non-functional constraints | Performance targets, security requirements, platform/OS compatibility |
+| Edge cases with product impact | Error handling behaviour, limits, empty states, concurrent access |
+| Out-of-scope decisions | What should NOT be built to keep scope bounded |
+| Priority conflicts | When two requirements conflict — which wins? |
+
+### 1.3 Classify each item
+
+For every extracted item, assign one of three dispositions:
+
+- **Already answered in research** → do not ask; record the answer directly as a locked requirement
+- **Has an obvious default** → propose the default; list as "accept-or-override" in the Q&A
+- **Genuine gap** → ask explicitly; no default proposed (or default is clearly arbitrary)
+
+### 1.4 Prioritize and trim
+
+Sort items by impact × uncertainty: high-impact, high-uncertainty items first.
+
+Keep the question list to **5-7 items maximum** for round 1. If more items exist:
+- Lower-priority items go to round 2 only if the user keeps engaging after round 1
+- Items that cannot fit in 2 rounds become non-blocking open questions in the artifact
+
+### 1.5 Save state
+
+Save the extracted and classified items to `swarm-report/clarify-<slug>-state.md` before
+presenting any questions. This protects against context compaction — if the session is
+interrupted, resume from this file rather than re-reading all inputs.
+
+---
+
+## Phase 2: Q&A Rounds
+
+### 2.1 Question format
+
+Present each question using this format:
+
+```
+Q{N}: {Topic — one line}
+
+Recommendation: {One-sentence default answer or assumption}
+Alternatives:
+  A. {Option A — label + consequence}
+  B. {Option B — label + consequence}
+  [C. Custom]
+
+Impact if deferred: {One sentence — what breaks or becomes ambiguous if left unresolved}
+```
+
+Present all questions in a single message. Wait for the user's response before proceeding.
+
+### 2.2 Accepting defaults
+
+If the user says "accept all defaults", "принимаю всё", or any equivalent phrasing:
+- Record every proposed default as a confirmed assumption in the artifact
+- Do not re-ask any of the defaulted items
+- Proceed directly to Phase 3
+
+### 2.3 Round structure
+
+**Round 1:** present all prepared items (max 7). Record answers and any follow-up gaps they open.
+
+**Round 2 (optional):** only if round 1 answers opened new genuine gaps — for example, the user
+chose an alternative that implies a constraint not previously known. Announce explicitly:
+"Round 2 of 2:" before presenting questions. Max 3 new questions.
+
+**Hard cap:** after 2 rounds, record any remaining items as non-blocking open questions.
+Do NOT ask a third round under any circumstances.
+
+### 2.4 Backward edge to Research
+
+If user answers reveal a significant knowledge gap that cannot be resolved from existing
+research (for example: "we don't know how the payment API handles retries"), announce:
+
+> **Backward: Clarify → Research**
+> Reason: [what gap was exposed]
+> Re-invoking research on the specific gap.
+
+Then invoke the research skill on the specific gap, read the new artifact, and continue
+Clarify from where it left off with the new information.
+
+**Cap:** 1 backward transition per Clarify invocation. If the targeted re-research still
+leaves the gap unresolved — record it as an open question and continue. Do not loop back
+to Research a second time.
+
+---
+
+## Phase 3: Save Artifact
+
+### 3.1 Write the artifact
+
+Save `swarm-report/<slug>-clarify.md` using the template below. Fill every section — do not
+leave placeholder text. If a section has no items, write "None." rather than omitting the
+section.
+
+```markdown
+---
+slug: <slug>
+date: YYYY-MM-DD
+status: done | partial
+research_path: swarm-report/<slug>-research.md
+backward_to_research: 0 | 1
+---
+
+## Locked Requirements
+
+Acceptance criteria confirmed during clarification. Each criterion must be verifiable.
+
+- AC-1: ...
+- AC-2: ...
+
+## Non-Functional Constraints
+
+- Performance: ...
+- Security: ...
+- Compatibility: ...
+- [category]: ...
+
+## Confirmed Assumptions
+
+Items where the user accepted the proposed default, or where an obvious default was applied
+without asking.
+
+- [auto-confirmed] <assumption text>
+- [user-confirmed] <assumption text>
+
+## Out of Scope
+
+Explicitly excluded to keep the feature bounded.
+
+- ...
+
+## Open Questions (non-blocking)
+
+Items deferred due to the round cap or insufficient information. These do not block
+implementation but should be revisited during or after the first implementation wave.
+
+- ...
+```
+
+**status field:** use `done` when all high-impact items were resolved. Use `partial` when
+high-impact items remain as open questions due to the round cap or a failed backward edge.
+
+### 3.2 Clean up state file
+
+Update `swarm-report/clarify-<slug>-state.md` status to `done`, then delete the file.
+It is operational only and must not persist after the artifact is saved.
+
+### 3.3 Post chat summary
+
+Post a summary in the chat (20 lines maximum):
+
+1. One sentence: "Clarify complete. N requirements locked, M assumptions recorded."
+2. Up to 5 bullets covering:
+   - Key ACs added (e.g. "AC-1: success = response <2 s under 100 concurrent users")
+   - Non-trivial non-functional constraints locked
+   - Surprising out-of-scope decisions (if any)
+   - Assumptions that could affect architecture choices
+3. If non-blocking open questions remain: list them in 3 bullets or fewer.
+4. One line: "Next step: Decompose." (or the appropriate downstream stage).
+
+Do NOT paste the full artifact content into chat.
+
+---
+
+## Standalone Invocation
+
+When invoked outside feature-flow, the user must supply one of:
+- **Slug** — Clarify resolves `swarm-report/<slug>-research.md` automatically
+- **Direct artifact path** — path to a research artifact that may use a non-standard location
+
+If neither is provided, ask for one before proceeding. Once the artifact is located, all
+phases run identically to the inline invocation. The output path is always
+`swarm-report/<slug>-clarify.md` for downstream compatibility.
+
+---
+
+## Integration Notes
+
+**Decompose, PlanReview, TestPlan:** feature-flow passes `swarm-report/<slug>-clarify.md`
+as an additional input to all three stages. They must treat locked requirements as binding
+constraints — a plan that contradicts an AC is a defect, not an open question.
+
+**multiexpert-review on PlanReview:** receives the clarify artifact alongside the plan.
+Ambiguity in the plan that is contradicted by a locked AC is a FAIL finding — "unclear
+requirements" is no longer an acceptable excuse when a clarify artifact exists.
+
+**write-spec:** unaffected. write-spec remains the standalone heavy-spec path for features
+that require a formal specification document. Clarify and write-spec serve different purposes
+and can coexist in the same flow if the user explicitly invokes both.

--- a/plugins/developer-workflow/skills/feature-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/feature-flow/SKILL.md
@@ -35,13 +35,20 @@ It only manages transitions, passes context between stages, and reports summarie
 ```
 Setup          -> Research         (unknown APIs, libraries, or architectural decisions)
 Setup          -> Implement        (trivial/simple task — skip research/planning)
-Research       -> Decompose        (large feature — split into tasks)
-Research       -> PlanReview       (complex single-task — needs multiexpert review)
-Research       -> DesignOptions    (high-arch-risk single-task — explore alternatives first)
+Research       -> Clarify         (after research — always, unless skip conditions fire)
+Research       -> Decompose        (skip-clarify path — trivial task or --no-clarify)
+Research       -> PlanReview       (skip-clarify path — trivial task or --no-clarify)
+Research       -> DesignOptions    (skip-clarify path — trivial task or --no-clarify)
+Research       -> TestPlan         (skip-clarify path — trivial task or --no-clarify)
+Research       -> Implement        (skip-clarify path — trivial task or --no-clarify)
+Clarify        -> Decompose        (large feature — split into tasks)
+Clarify        -> PlanReview       (complex single-task — needs multiexpert review)
+Clarify        -> DesignOptions    (high-arch-risk single-task — explore alternatives first)
+Clarify        -> TestPlan         (simple single-task, test-plan stage not skipped)
+Clarify        -> Implement        (simple single-task, test-plan stage skipped)
+Clarify        -> Research         (gap exposed during Q&A — cap 1)
 DesignOptions  -> PlanReview       (user picked an option)
 DesignOptions  -> Research         (options exposed missing requirements — re-research)
-Research       -> TestPlan         (simple single-task, test-plan stage not skipped)
-Research       -> Implement        (simple single-task, test-plan stage skipped)
 Decompose      -> PlanReview       (complex decomposition — needs review)
 Decompose      -> TestPlan         (straightforward tasks, test-plan stage not skipped)
 Decompose      -> Implement        (straightforward tasks, test-plan stage skipped)
@@ -75,6 +82,7 @@ reached, the orchestrator **escalates** instead of looping again.
 
 **Decision criteria for skipping stages:**
 - **Skip Research:** task is well-understood, no external APIs, no unfamiliar libraries
+- **Skip Clarify:** task is trivial, single-file change, user passed `--no-clarify`, research report already contains complete acceptance criteria
 - **Skip Decompose:** task is a single logical unit, no independent sub-parts
 - **Skip PlanReview:** change is straightforward, touches 1-3 files, no architectural impact
 - **Skip TestPlan (+ TestPlanReview):** see [TestPlan Stage Skip Detection](#testplan-stage-skip-detection) — default-on stage, skipped only when a detector condition fires.
@@ -118,6 +126,29 @@ Wait for `swarm-report/<slug>-research.md`.
 
 Skip if the task is well-understood and doesn't touch external APIs, unfamiliar libraries,
 or architectural decisions.
+
+### 1.1a Clarify (default-on)
+
+After research completes, invoke `developer-workflow:clarify` with:
+- Slug
+- Research artifact path: `swarm-report/<slug>-research.md`
+- Design options path (optional): `swarm-report/<slug>-design-options.md` if it already exists
+
+Wait for `swarm-report/<slug>-clarify.md`.
+
+**Skip conditions (any one fires → skip Clarify):**
+- Task is trivial (same criteria as Research skip)
+- Single-file change
+- `--no-clarify` flag passed by user
+- Research report already contains a complete "Requirements" section with acceptance criteria
+- User explicitly said "no questions" / "don't ask"
+
+When skipping: announce `Stage: Research → (Clarify skipped) → <next>` with the skip reason.
+
+When running: announce `Stage: Research → Clarify`.
+
+**Pass `swarm-report/<slug>-clarify.md`** as additional context to all downstream stages:
+Decompose, PlanReview, DesignOptions, TestPlan, and Implement. Downstream stages treat locked requirements as binding constraints.
 
 ### 1.2 Decompose (optional)
 
@@ -454,6 +485,7 @@ always remains).
 
 | From | To | Trigger | Max |
 |------|----|---------|-----|
+| Clarify | Research | gap exposed during Q&A | 1 |
 | PlanReview | Research | FAIL — knowledge gaps | 2 |
 | TestPlanReview | TestPlan | FAIL — test-plan revise loop | 3 |
 | Finalize | Implement | ESCALATE — user routes back to fix root issues | 1 |

--- a/plugins/developer-workflow/skills/feature-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/feature-flow/SKILL.md
@@ -139,7 +139,7 @@ If Clarify runs, wait for `swarm-report/<slug>-clarify.md`.
 **Skip conditions (any one fires → skip Clarify):**
 - Single-file change or obviously scoped change with no architectural decisions
 - `--no-clarify` flag passed by user
-- Research report already contains a complete "Requirements" section with acceptance criteria
+- Research artifact already documents explicit, complete requirements and ACs with no material ambiguities
 - User explicitly said "no questions" / "don't ask"
 
 When skipping: announce `Stage: Research → (Clarify skipped) → <next>` with the skip reason.
@@ -152,9 +152,9 @@ stages treat locked requirements as binding constraints.
 
 **If Clarify was skipped:** pass an explicit note — `(clarify: skipped — <reason>)` — so
 downstream stages do not attempt to read a non-existent artifact. If the skip reason is
-"requirements already locked", downstream stages must treat the research artifact's
-`Requirements` section as the binding constraints. For all other skip reasons, downstream
-stages should assume requirements are not locked.
+"requirements already locked", downstream stages must treat the requirements and acceptance
+criteria documented in the research artifact as the binding constraints. For all other skip
+reasons, downstream stages should assume requirements are not locked.
 
 ### 1.2 Decompose (optional)
 

--- a/plugins/developer-workflow/skills/feature-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/feature-flow/SKILL.md
@@ -82,7 +82,7 @@ reached, the orchestrator **escalates** instead of looping again.
 
 **Decision criteria for skipping stages:**
 - **Skip Research:** task is well-understood, no external APIs, no unfamiliar libraries
-- **Skip Clarify:** task is trivial, single-file change, user passed `--no-clarify`, research report already contains complete acceptance criteria
+- **Skip Clarify:** task is single-file or obviously scoped, user passed `--no-clarify`, requirements are already locked (research contains complete ACs), or user explicitly opted out
 - **Skip Decompose:** task is a single logical unit, no independent sub-parts
 - **Skip PlanReview:** change is straightforward, touches 1-3 files, no architectural impact
 - **Skip TestPlan (+ TestPlanReview):** see [TestPlan Stage Skip Detection](#testplan-stage-skip-detection) — default-on stage, skipped only when a detector condition fires.
@@ -134,7 +134,7 @@ After research completes, invoke `developer-workflow:clarify` with:
 - Research artifact path: `swarm-report/<slug>-research.md`
 - Design options path (optional): `swarm-report/<slug>-design-options.md` if it already exists
 
-Wait for `swarm-report/<slug>-clarify.md`.
+If Clarify runs, wait for `swarm-report/<slug>-clarify.md`.
 
 **Skip conditions (any one fires → skip Clarify):**
 - Single-file change or obviously scoped change with no architectural decisions
@@ -151,8 +151,10 @@ downstream stages: Decompose, PlanReview, DesignOptions, TestPlan, and Implement
 stages treat locked requirements as binding constraints.
 
 **If Clarify was skipped:** pass an explicit note — `(clarify: skipped — <reason>)` — so
-downstream stages know requirements are not locked and must not attempt to read a
-non-existent artifact.
+downstream stages do not attempt to read a non-existent artifact. If the skip reason is
+"requirements already locked", downstream stages must treat the research artifact's
+`Requirements` section as the binding constraints. For all other skip reasons, downstream
+stages should assume requirements are not locked.
 
 ### 1.2 Decompose (optional)
 

--- a/plugins/developer-workflow/skills/feature-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/feature-flow/SKILL.md
@@ -36,11 +36,11 @@ It only manages transitions, passes context between stages, and reports summarie
 Setup          -> Research         (unknown APIs, libraries, or architectural decisions)
 Setup          -> Implement        (trivial/simple task — skip research/planning)
 Research       -> Clarify         (after research — always, unless skip conditions fire)
-Research       -> Decompose        (skip-clarify path — trivial task or --no-clarify)
-Research       -> PlanReview       (skip-clarify path — trivial task or --no-clarify)
-Research       -> DesignOptions    (skip-clarify path — trivial task or --no-clarify)
-Research       -> TestPlan         (skip-clarify path — trivial task or --no-clarify)
-Research       -> Implement        (skip-clarify path — trivial task or --no-clarify)
+Research       -> Decompose        (skip-clarify path — --no-clarify / requirements already locked / user said no questions)
+Research       -> PlanReview       (skip-clarify path — --no-clarify / requirements already locked / user said no questions)
+Research       -> DesignOptions    (skip-clarify path — --no-clarify / requirements already locked / user said no questions)
+Research       -> TestPlan         (skip-clarify path — --no-clarify / requirements already locked / user said no questions)
+Research       -> Implement        (skip-clarify path — --no-clarify / requirements already locked / user said no questions)
 Clarify        -> Decompose        (large feature — split into tasks)
 Clarify        -> PlanReview       (complex single-task — needs multiexpert review)
 Clarify        -> DesignOptions    (high-arch-risk single-task — explore alternatives first)
@@ -137,8 +137,7 @@ After research completes, invoke `developer-workflow:clarify` with:
 Wait for `swarm-report/<slug>-clarify.md`.
 
 **Skip conditions (any one fires → skip Clarify):**
-- Task is trivial (same criteria as Research skip)
-- Single-file change
+- Single-file change or obviously scoped change with no architectural decisions
 - `--no-clarify` flag passed by user
 - Research report already contains a complete "Requirements" section with acceptance criteria
 - User explicitly said "no questions" / "don't ask"
@@ -147,8 +146,13 @@ When skipping: announce `Stage: Research → (Clarify skipped) → <next>` with 
 
 When running: announce `Stage: Research → Clarify`.
 
-**Pass `swarm-report/<slug>-clarify.md`** as additional context to all downstream stages:
-Decompose, PlanReview, DesignOptions, TestPlan, and Implement. Downstream stages treat locked requirements as binding constraints.
+**If Clarify ran:** pass `swarm-report/<slug>-clarify.md` as additional context to all
+downstream stages: Decompose, PlanReview, DesignOptions, TestPlan, and Implement. Downstream
+stages treat locked requirements as binding constraints.
+
+**If Clarify was skipped:** pass an explicit note — `(clarify: skipped — <reason>)` — so
+downstream stages know requirements are not locked and must not attempt to read a
+non-existent artifact.
 
 ### 1.2 Decompose (optional)
 


### PR DESCRIPTION
## Summary

- New skill `clarify` — lightweight Q&A pit-stop between Research and Decompose
- 2-round interview (max 7 questions/round) with pre-filled defaults; user can "accept all defaults"
- Produces `swarm-report/<slug>-clarify.md`: locked AC, NFR, confirmed assumptions, out-of-scope list
- Skipped for trivial tasks, single-file changes, `--no-clarify`, or when research already has complete requirements
- Backward edge `Clarify → Research` capped at 1 (gap exposed during Q&A)
- Downstream stages (Decompose, PlanReview, TestPlan) receive clarify artifact as binding constraints

## Files changed

| File | Change |
|------|--------|
| `skills/clarify/SKILL.md` | New skill (257 lines) |
| `skills/feature-flow/SKILL.md` | State machine + Phase 1.1a + backward transitions |
| `docs/ORCHESTRATORS.md` | Mermaid diagram + backward limit table |
| `docs/ORCHESTRATION.md` | State machine + receipt gating |
| `CLAUDE.md` | Skills roster 17 → 18 |

## State machine delta

```
Before: Research → Decompose / PlanReview / DesignOptions / TestPlan / Implement
After:  Research → Clarify → Decompose / PlanReview / DesignOptions / TestPlan / Implement
        Clarify → Research  (gap exposed, cap 1)
        Research → * still valid as skip-clarify path
```

## Test plan

- [ ] Invoke `feature-flow` on a non-trivial task — confirm Clarify runs after Research
- [ ] Invoke with `--no-clarify` — confirm skip is announced and Clarify is skipped
- [ ] Invoke `clarify` standalone — confirm Q&A runs and artifact saved
- [ ] Trigger `Clarify → Research` backward — confirm cap of 1 is enforced

Closes #141

🤖 Generated with [Claude Code](https://claude.ai/claude-code)