### PR TITLE
Add reverse-spec skill — code to tech-agnostic feature spec

### DIFF
--- a/plugins/developer-workflow/skills/reverse-spec/SKILL.md
+++ b/plugins/developer-workflow/skills/reverse-spec/SKILL.md
@@ -111,10 +111,9 @@ Then **propose** a boundary to the user in one line:
 
 - **In scope** — the files and symbols that clearly implement the feature itself.
 - **Direct dependencies** — modules the feature calls into (repositories, shared UI
-  kit, auth, analytics) that will be referenced, not redescribed. Every module that
-  lands on this list is later detailed in §10.7 Collaborators and consumers as a
-  contract point (with role, operations used, and any pre/postconditions it must
-  satisfy). Keep the list here high-level; the contract detail belongs to §10.7.
+  kit, auth, analytics) that will be referenced, not redescribed. Every module on
+  this list is later detailed in §10.7 Collaborators and consumers as a capability
+  contract. Keep the list here high-level; contract detail belongs to §10.7.
 - **Out of scope** — unrelated modules surfaced by the scout but not part of this
   feature.
 
@@ -433,13 +432,13 @@ draft is presented.
 ### Definition of Done
 
 The three passes above are mechanical checks. The spec is only ready to hand off when
-the full **Definition of Done** checklist passes — nine binary gates covering section
+the full **Definition of Done** checklist passes — eleven binary gates covering section
 presence, the three Pass results, Open Questions and Known Defects completeness, Code
 map coverage, header fill, and user review. See `references/definition-of-done.md`
 for the detailed gates, rationale, and the handoff-format rules.
 
 A half-satisfied checklist is not a ready spec — it is a progress report. Never
-declare the draft ready unless all nine gates pass.
+declare the draft ready unless all eleven gates pass.
 
 ---
 

--- a/plugins/developer-workflow/skills/reverse-spec/SKILL.md
+++ b/plugins/developer-workflow/skills/reverse-spec/SKILL.md
@@ -84,8 +84,9 @@ The user may specify the feature in several ways:
   autocomplete".
 
 For path/symbol inputs, verify the target exists and resolve it to a concrete location.
-Use ast-index where available (see global code-search rules) to expand a class name into
-all related files. Grep / Glob are fallbacks only.
+Use ast-index where available (see [`docs/ORCHESTRATION.md`](../../docs/ORCHESTRATION.md)
+for the canonical code-navigation tooling order) to expand a class name into all related
+files. Grep / Glob are fallbacks only.
 
 For prose inputs, run a short discovery pass:
 
@@ -431,11 +432,12 @@ draft is presented.
 
 ### Definition of Done
 
-The three passes above are mechanical checks. The spec is only ready to hand off when
-the full **Definition of Done** checklist passes — eleven binary gates covering section
-presence, the three Pass results, Open Questions and Known Defects completeness, Code
-map coverage, header fill, and user review. See `references/definition-of-done.md`
-for the detailed gates, rationale, and the handoff-format rules.
+The five passes plus the typo sweep above are mechanical checks. The spec is only ready
+to hand off when the full **Definition of Done** checklist passes — eleven binary gates
+covering section presence, the five Pass results plus typo sweep, Open Questions and
+Known Defects completeness, Code map coverage, header fill, and user review. See
+`references/definition-of-done.md` for the detailed gates, rationale, and the
+handoff-format rules.
 
 A half-satisfied checklist is not a ready spec — it is a progress report. Never
 declare the draft ready unless all eleven gates pass.

--- a/plugins/developer-workflow/skills/reverse-spec/SKILL.md
+++ b/plugins/developer-workflow/skills/reverse-spec/SKILL.md
@@ -1,0 +1,471 @@
+---
+name: reverse-spec
+description: "Reverse-engineers an existing feature into a tech-agnostic specification — reads the code, maps behavior, interviews the user for missing intent, and produces a PM/BA-grade spec that a developer on any stack could use to reimplement the feature identically. Use when: \"reverse spec\", \"extract spec from code\", \"document this feature from code\", \"reverse engineer this screen\", \"turn this code into a spec\", \"build a spec for existing feature\", \"what does this feature actually do\", \"write docs for this module\", \"recreate this feature on <other stack>\", \"migrate this feature — first document it\". Input can be a file/class/directory path or a prose description of the feature. Output: single versioned markdown in docs/spec/. Do NOT use for: new features (use write-spec), high-level architecture overview of a whole project (too broad), library API docs (use the library's own docs), bug investigation (use debug)."
+---
+
+# Reverse Spec
+
+Take an existing feature that already lives in code and produce a specification that is
+good enough to rebuild the feature from scratch — on a different stack, with a different
+implementation, but with the same observable behavior, the same UX, and the same
+integrations.
+
+**Role:** this skill acts as a senior engineer translating implementation back into a
+PM/BA-grade document. Like a tech lead handing a feature brief to a new team, it extracts
+*what the feature does and why it matters*, not *how the current code happens to be
+organized*. The output is what you would give a stranger on another platform so they can
+ship the same feature.
+
+**Core principles:**
+
+1. **Zero code identifiers in the body.** The body of the spec (Sections 1–8 and
+   10–11) must not contain any name that only exists in the current codebase. That
+   includes class names, method names, type names, field names, sealed-class cases,
+   enum values, package paths, file paths, and framework idioms. The spec describes
+   *what the feature does*, in language a PM/BA can read. Implementation names live
+   in Section 13 (Code map) — as location pointers, not as the subject of
+   description. See `references/behavior-translation.md` for the full rule and
+   before/after examples.
+
+   Sanity check a sentence by asking: *"If I renamed every class in the codebase, would
+   this sentence still describe the same feature?"* If the sentence breaks, it is
+   talking about code, not behavior — rewrite it.
+
+   Quick examples of what this forbids in the body:
+   - ❌ "`OAuthClient.authorize()` returns an `OAuthResult.Success(tokens)` or
+     `OAuthResult.Error(exception)`"
+     ✅ "Authorization returns either a valid token set or a structured failure."
+   - ❌ "An observable `StateFlow<AuthState>` with cases `Unauthenticated`,
+     `Authenticating`, `Authenticated(tokens)`, `Error(exception)` drives the UI."
+     ✅ "The UI reflects the current authentication state: not authenticated, authorizing,
+     authenticated, or failed."
+   - ❌ "`TokenStorage.save(tokens)` persists the `OAuthTokens` to KV storage."
+     ✅ "The token set is persisted in platform key-value storage after a successful
+     exchange."
+
+2. **Tech stays in only when it is load-bearing.** Keeping "Uses Jetpack Compose" in the
+   spec is noise — any UI toolkit can render the same result. Keeping "Uses Google ML
+   Kit face detection" matters — swapping changes capability, accuracy, latency, or
+   licensing. Rule of thumb: a technology stays in the spec only if removing it would
+   change the feature's behavior, constraints, or cost. Even when kept, it belongs in
+   Section 12 (Tech-specific constraints), phrased as a *capability* with acceptable
+   substitutes — not as a direct SDK reference. See `references/tech-abstraction.md`.
+
+3. **Inferred intent is flagged, not guessed silently.** When the code reveals *what*
+   happens but not *why* (a retry count of 3, a 250 ms debounce, a specific error copy),
+   write it into the spec as an observed fact and raise a clarification question. Do not
+   invent rationale.
+
+4. **Project conventions fill the gaps the feature does not own.** Things like
+   accessibility, error copy style, analytics naming, localization coverage, logging
+   levels are usually project-wide rather than feature-specific. Before asking the user,
+   check the project: if a convention exists, reference it ("error states follow project
+   convention X, see `<path>`"); if not, explicitly mark the absence ("no accessibility
+   handling — consistent with project-wide absence"). See
+   `references/analysis-checklist.md` for the full list of cross-cutting concerns.
+
+5. **One question per round.** After each interview question, new answers change which
+   question is most valuable next. Batching locks in assumptions prematurely. The user
+   can always override ("just ask me everything at once") — respect that, but the default
+   is one-by-one. After the main interview is complete, offer the user a freeform round
+   to add anything that was not covered.
+
+---
+
+## Phase 0: Parse Input
+
+### 0.1 Identify the target
+
+The user may specify the feature in several ways:
+
+- **Explicit path** — `app/src/main/.../PaymentScreen.kt`, a directory, or a set of files.
+- **Class / symbol name** — `PaymentCheckoutViewModel`.
+- **Prose description** — "the onboarding welcome screen", "the search bar with
+  autocomplete".
+
+For path/symbol inputs, verify the target exists and resolve it to a concrete location.
+Use ast-index where available (see global code-search rules) to expand a class name into
+all related files. Grep / Glob are fallbacks only.
+
+For prose inputs, run a short discovery pass:
+
+1. Extract likely keywords from the description (screen names, UI strings, domain nouns).
+2. Search the codebase for candidates via ast-index / grep for user-visible strings, route
+   names, feature folders.
+3. Present 1-3 candidates to the user and confirm before proceeding. If ambiguous, ask
+   one question: *"Which of these matches what you mean? [A] X, [B] Y, [C] none — let me
+   search with different terms."*
+
+### 0.2 Scout before scope lock
+
+Do not lock the boundary yet — the scope of a feature is rarely visible from the target
+alone. Run a *scout pass*:
+
+1. Open the confirmed target (file / class / directory).
+2. Trace one hop outward — every type the target directly depends on, every symbol
+   that calls into it, every resource it reads (strings, layouts, navigation graph
+   entries).
+3. Note modules / directories that appear in the scout set.
+
+Then **propose** a boundary to the user in one line:
+
+- **In scope** — the files and symbols that clearly implement the feature itself.
+- **Direct dependencies** — modules the feature calls into (repositories, shared UI
+  kit, auth, analytics) that will be referenced, not redescribed. Every module that
+  lands on this list is later detailed in §10.7 Collaborators and consumers as a
+  contract point (with role, operations used, and any pre/postconditions it must
+  satisfy). Keep the list here high-level; the contract detail belongs to §10.7.
+- **Out of scope** — unrelated modules surfaced by the scout but not part of this
+  feature.
+
+Ask the user for confirmation with a single question: *"Вот что я отношу к фиче: [in
+scope]. Зависимости: [deps]. Вне скоупа: [out]. Подтверждаешь границы?"*. Adjust based
+on the answer before proceeding. A wrong boundary at this step cascades: too narrow
+misses behaviors, too wide drowns the spec in unrelated detail.
+
+**Scope sanity check** (soft gate). After the boundary is confirmed, evaluate against
+these heuristics:
+
+- Scope covers **more than one user-facing flow** (e.g., both sign-in AND sign-up AND
+  password reset) — probably an aggregate, not a feature.
+- Scope spans **more than one top-level feature directory** in the project's module
+  tree — probably more than one feature.
+- Scope includes **more than one screen** with distinct purposes (onboarding carousel
+  across 4 screens is one flow; sign-in + profile-edit + settings is three).
+
+If any of these trip, surface to the user: *"Scope на [N flows / N features / N
+screens] — это, скорее, набор фич, чем одна. Хочешь одну большую спеку или
+per-flow спеки? Рекомендация — разбить: каждая отдельная спека полезнее
+реимплементатору, чем аггрегат."*. A large aggregate spec produces a Phase 1 state
+file and §10.1 Network operations table that are unusable in practice. Split first,
+then spec each piece.
+
+Generate a kebab-case slug from the feature name: `payment-checkout`, `search-bar`,
+`onboarding-welcome`.
+
+### 0.3 Create or resume state file
+
+State lives in `./swarm-report/reverse-spec-<slug>-state.md`. It persists across
+context compaction and holds:
+
+- target location(s) and confirmed boundary
+- spec language (see 0.4)
+- open questions queue
+- per-phase checklist (pending / in progress / done)
+- draft fragments as they accumulate
+
+**If the state file already exists** when the skill starts — that means this feature
+has been started before. Read the file and present a one-line summary to the user:
+*"Нашёл незавершённый state на фичу `<slug>` (Phase N, queue: K open questions).
+Продолжить с того же места или начать заново?"*. Default is **continue**; restart wipes
+answers already given and is rarely what the user wants.
+
+If the user confirms restart, delete the old state file and start fresh. Otherwise
+resume from the first unchecked phase.
+
+Re-read this file at the start of each phase so that work survives compaction.
+
+### 0.4 Determine spec language
+
+Check the project for signals of working language:
+
+- existing `docs/`, `docs/spec/`, `docs/specs/` contents — what language do they use?
+- README, commit history, code comments — dominant language?
+- CLAUDE.md — any language directive?
+
+Pick the dominant project language as the default. Announce it to the user in one line
+and offer to override: *"По умолчанию пишу спеку на русском (как остальные доки проекта).
+Другой язык?"* A single yes/no check is enough; do not escalate if the user says nothing.
+
+### 0.5 Output path
+
+Default: `docs/spec/<slug>.md`.
+
+If the project already uses a different convention (`docs/specs/`, `specs/`, `doc/spec/`,
+etc.), match it — consistency with the repo beats the skill's default. Announce the
+chosen path before writing.
+
+---
+
+## Phase 1: Static Analysis
+
+No interview yet. Extract everything the code itself answers.
+
+Go through `references/analysis-checklist.md` section by section and capture findings
+into the state file. The checklist covers:
+
+- entry points and triggers (how the user reaches this feature)
+- user-visible states (happy path, loading, empty, error, offline, permission-denied,
+  degraded)
+- data in / data out (API calls, persistence, events emitted)
+- external dependencies (SDKs, native APIs, third-party services)
+- side effects (analytics, logging, notifications, inter-feature messages)
+- constraints enforced by the code (rate limits, retries, timeouts, debounces, maxima)
+- platform capabilities used (camera, location, biometrics, file system, background
+  work)
+- navigation in and out
+- localization and accessibility treatment
+
+For each item, note: *what happens*, *under which condition*, *with which concrete
+parameters*. Do not yet decide what is feature-specific vs project-wide — that happens in
+Phase 2.
+
+When the code shows a concrete number or string (retry = 3, debounce = 250 ms, error
+copy = "Something went wrong"), write it down verbatim. The spec will carry these exact
+values so a reimplementation matches.
+
+---
+
+## Phase 2: Convention Mapping
+
+For every cross-cutting concern not owned by the feature (error handling, a11y,
+analytics naming, localization, logging, pagination, caching), check how the rest of the
+project handles it.
+
+Decision table:
+
+- **Feature follows project convention** — reference the convention in the spec
+  ("Error states follow the project's standard ErrorBanner pattern; see
+  `docs/<path>`"). Do not redescribe the convention itself.
+- **Feature deviates** — call it out explicitly ("This screen overrides the project
+  error banner with an inline snackbar; rationale unknown — see Open Questions").
+- **Project has no convention and feature does not address it either** — mark absent
+  ("No accessibility labels; consistent with project-wide absence."). This is the most
+  commonly forgotten case; mark it honestly rather than inventing requirements.
+- **Project has no convention but feature does something** — describe the feature
+  behavior; flag that the project lacks a shared pattern.
+
+These judgments live in the state file. They become cross-references in the spec.
+
+---
+
+## Phase 3: Clarification Loop
+
+Now the user gets involved. Goal: close gaps the code cannot answer on its own.
+
+**Default pacing: one question per round.** Each question is chosen based on the highest
+remaining uncertainty after the previous answer. This is deliberately slower than batch
+interviews — it produces better questions because each follow-up is informed by the
+previous answer.
+
+**Before the first question, set expectation.** Announce the queue size in one line so
+the user can make an informed choice about pacing: *"Нашёл ~N пробелов после анализа.
+Пойду по одному вопросу за раунд (так лучше формируются следующие вопросы). Скажи
+«батчем» если хочешь получить всё сразу."*. This prevents the common failure mode where
+the user patiently answers 10 questions in a row, then at the end says "could have done
+that in one message".
+
+For each open question in the state queue:
+
+1. Re-read the state file.
+2. Pick the single most valuable open question — typically one that unblocks the most
+   downstream spec sections or one whose assumed answer would be most expensive to get
+   wrong.
+3. Ask it, with a **pre-filled default** derived from the code or from project
+   convention. Example: *"Retry count is 3 in code. Is that an intentional product
+   requirement, or an implementation default? (default: intentional — keep in spec as
+   requirement)"*. The user accepts, overrides, or says "не знаю" (which itself is a
+   valid answer and goes into Open Questions).
+4. Update the state file with the answer.
+5. Repeat until the queue is empty.
+
+If the queue is large (>8 questions) and the user signals impatience or explicitly asks
+to batch ("задавай всё сразу"), switch to batched mode for the remainder. Always respect
+an explicit override.
+
+Question categories that typically need user input:
+
+- **Intent behind observed behavior** — is that 3-second timeout a product decision or
+  copy-paste default?
+- **Out of scope confirmation** — "these related screens are not in scope; confirm?"
+- **Missing business context** — success metric, target user segment, historical
+  context ("this was built for X partner integration").
+- **Design source** — is there a Figma / design doc? Analytics plan? PRD?
+- **Deviation rationale** — why does this feature bypass the project's standard error
+  handler?
+
+### 3.1 Freeform round
+
+When the curated queue is empty, ask one final open question: *"Any additional context
+that I have not asked about? (design links, analytics plan, PRD, constraints,
+history…)"*.
+
+Offer a menu of common inputs the user can supply:
+
+- Figma or design links
+- Screenshots / screen recordings
+- API contract documents (OpenAPI, Protobuf, sample payloads)
+- Analytics event taxonomy
+- Localization glossary
+- Product requirements document (PRD) or brief
+- Historical context (who owns it, which partner requested it, prior incidents)
+
+Anything the user supplies is treated as authoritative over inferred-from-code
+information and is referenced in the spec.
+
+---
+
+## Phase 4: Draft Spec
+
+### Phase 4.0: Translate findings to behavior (mandatory)
+
+Before writing a single sentence into the spec, translate every Phase 1 finding into
+behavior. This is the step where code identifiers die.
+
+The state file holds findings in the code's own vocabulary — class names, sealed-class
+cases, exception types, reactive primitives, method signatures. Leaving any of that in
+the spec produces a document that describes the current implementation, not the feature.
+The whole point of the skill is the opposite.
+
+Open `references/behavior-translation.md` and apply the 13 translation recipes to the
+findings. The recipes cover sealed-class cases, method signatures, exception
+hierarchies, reactive / async primitives, DTO shapes, DI plumbing, UI-toolkit
+components, defect observations, navigation graphs, and more.
+
+Rewrite each finding into a sentence that would remain correct if every class in the
+codebase were renamed tomorrow. If the sentence breaks under that test, it is code, not
+behavior — rewrite again.
+
+Preserve literally, from the state file into the spec:
+
+- user-visible copy (quoted verbatim)
+- exact numeric values (retries, timeouts, lengths, thresholds)
+- external-contract names (URLs, endpoints, event names, provider field names,
+  protocol/RFC references)
+
+### Phase 4.1: Write the spec
+
+Produce a draft at `docs/spec/<slug>.md` following `references/spec-template.md`.
+
+Writing rules:
+
+- **Zero code identifiers in the body** (see Principle 1 and
+  `references/behavior-translation.md`). Sections 1–8 and 10–11 must read as if no
+  particular codebase exists. Code identifiers belong only in §13 (Code map) as
+  location pointers; §9 (Known defects) allows identifiers as evidence.
+- **Tech only when load-bearing.** Technology names appear only in §12, and only when
+  they pass the four-question test in `references/tech-abstraction.md`. Even then,
+  phrase as a capability with acceptable substitutes, not as a direct SDK reference.
+- **Concrete observable facts.** "On tap, the list refreshes" beats "the refresh flow
+  is invoked". Include exact copy, exact numbers, exact states.
+- **Cross-references instead of duplication.** When a section relies on a project
+  convention, link to the existing doc or code rather than inlining.
+- **Every claim is verifiable.** A reviewer with access to the code should be able to
+  confirm or refute each bullet. Speculation goes under Open Questions, not in the
+  body.
+- **Appendix: code map.** At the end of the spec, include a table mapping each spec
+  section to the file(s) that implement it. This is the only place where code paths
+  appear. It enables round-trip verification and future maintenance.
+
+Template structure — product first, tech at the end, defined in full at
+`references/spec-template.md`:
+
+- **Part A (§§1-7) Product behavior** — Overview, User-facing behavior, UI, States,
+  Navigation, L10n & a11y, Analytics.
+- **Part B (§§8-9) Product decisions & risks** — Open Questions (body uses `[OQ-N]`
+  cross-refs), Known Defects.
+- **Part C (§§10-12) Technical integration** — Data & integrations (8 subsections:
+  network ops / persistence / platform events / flags / services / contracts /
+  collaborators / domain model), Platform capabilities, Tech-specific constraints.
+- **Part D (§13) Appendix** — Code map (the only place code identifiers are
+  allowed).
+
+Sections that are genuinely not applicable are written as "N/A — reason", not
+omitted. Missing sections look like oversight; explicit N/A shows intent.
+
+---
+
+## Phase 5: Coverage Verification
+
+Before presenting the draft to the user, run a five-pass self-review plus a typo
+sweep. The governing rule is the **proof standard** (full definition in
+`references/coverage-verification.md`): every factual claim in the spec body traces
+to one of four sources — code location, recorded user answer, project convention, or
+an explicit Open Questions entry. Speculation — "it probably does X because that
+would make sense" — is not a proof and must be removed or escalated.
+
+Procedure (detailed steps in `references/coverage-verification.md`):
+
+1. **Pass 1 — code → spec** (coverage). Every significant code branch maps to a spec
+   section, or is explicitly recorded in §13 as intentionally omitted. Fix gaps.
+2. **Pass 2 — spec → code** (grounding). Every spec claim traces to code, a user
+   answer, a project convention, or §8 Open Questions. Remove or escalate
+   untraceable claims. §9 Known Defects entries have an extra bar: code pointer +
+   defect class + consequence all required.
+3. **Pass 3 — identifier-leak scan** (vocabulary). Scan §§1-8 and 10-11 for tokens
+   that exist only because this codebase exists. **Zero tolerance** — every hit is
+   translated, moved to §13, or kept only if it is an external contract. §9, §12,
+   §13 are excluded — they exist specifically for implementation detail.
+4. **Pass 4 — reference integrity.** Every `[OQ-N]` marker in the body has a
+   matching §8 entry; every §8 entry with body impact has at least one `[OQ-N]`
+   in the body. Scriptable via grep.
+5. **Pass 5 — code-map validity.** Every `path:line` in §13 points to an existing
+   file, and the line (or end-of-range) is within the file's total lines. Scriptable
+   via `test -f` + `wc -l`. Does not verify content match — that is covered
+   indirectly by Pass 1 + Pass 2.
+
+Plus a **typo / formatting sweep** at the end: orphan spaces inside words,
+doubled-word typos, mixed Latin/Cyrillic characters, inconsistent punctuation around
+quotes. Light but mandatory — a spec with typos erodes reader trust in substantive
+claims.
+
+The verification output — passed items, gaps fixed, identifier leaks cleaned,
+reference-integrity resolutions, code-map validity count, typo sweep result,
+unresolved gaps — goes into the state file and is summarized in one line when the
+draft is presented.
+
+### Definition of Done
+
+The three passes above are mechanical checks. The spec is only ready to hand off when
+the full **Definition of Done** checklist passes — nine binary gates covering section
+presence, the three Pass results, Open Questions and Known Defects completeness, Code
+map coverage, header fill, and user review. See `references/definition-of-done.md`
+for the detailed gates, rationale, and the handoff-format rules.
+
+A half-satisfied checklist is not a ready spec — it is a progress report. Never
+declare the draft ready unless all nine gates pass.
+
+---
+
+## Phase 6: User Review & Iteration
+
+Present the draft path plus a one-paragraph summary. Ask:
+
+- anything missing or wrong?
+- additional inputs to incorporate (Figma, screenshots, etc.)?
+
+Iterate based on feedback. Each iteration re-runs the relevant phase (typically Phase 3
+with specific new questions, then Phase 4 partial regeneration, then Phase 5).
+
+When the user approves, the spec is final.
+
+---
+
+## Phase 7: Save & Handoff
+
+The spec already lives at `docs/spec/<slug>.md`. Final steps:
+
+- Confirm the file exists and is readable.
+- Delete the state file (`./swarm-report/reverse-spec-<slug>-state.md`) — operational,
+  no longer needed.
+- Offer to commit: *"Спека сохранена в `docs/spec/<slug>.md`. Закоммитить?"*. Do not
+  commit without explicit confirmation.
+- If the user intends to use this spec for reimplementation on another stack, mention
+  that `write-spec` and `decompose-feature` can take this spec as input for the new
+  implementation.
+
+---
+
+## Anti-patterns
+
+Common failure modes and their fixes are catalogued in `references/anti-patterns.md`.
+Run through that list as a pre-publish checklist before declaring a draft ready — most
+anti-patterns are invisible from inside the skill itself.
+
+Recurring themes:
+- Code identifiers leaking into body (use `behavior-translation.md` recipes).
+- Copying code structure (ViewModel/UseCase/Repository naming) into the spec.
+- Inventing rationale that was never confirmed.
+- Skipping Phase 4.0 translate-step or Phase 5 verification.
+- Hiding absent conventions (silent omission of things like missing a11y).
+- Treating defect findings as spec content (defects go in §9, not body).

--- a/plugins/developer-workflow/skills/reverse-spec/SKILL.md
+++ b/plugins/developer-workflow/skills/reverse-spec/SKILL.md
@@ -185,6 +185,20 @@ If the project already uses a different convention (`docs/specs/`, `specs/`, `do
 etc.), match it — consistency with the repo beats the skill's default. Announce the
 chosen path before writing.
 
+### 0.6 Project-overview check
+
+Check for a project-overview document at `docs/project-overview.md` (alternates:
+`docs/PROJECT.md`, `docs/overview.md`, `PROJECT.md`). If found, read it and reference
+it from the feature spec instead of duplicating project-wide context. If not found,
+offer to draft one and wait for user review before proceeding (or proceed without it
+if the user declines, noting the gap as `[OQ-N]`).
+
+Full protocol — when to check, what the overview contains, how the feature spec
+short-circuits when an overview exists, update discipline — in
+`references/project-overview-protocol.md`.
+
+Override: *"пропусти project-overview"* skips this phase entirely.
+
 ---
 
 ## Phase 1: Static Analysis
@@ -364,9 +378,11 @@ Template structure — product first, tech at the end, defined in full at
   Navigation, L10n & a11y, Analytics.
 - **Part B (§§8-9) Product decisions & risks** — Open Questions (body uses `[OQ-N]`
   cross-refs), Known Defects.
-- **Part C (§§10-12) Technical integration** — Data & integrations (8 subsections:
-  network ops / persistence / platform events / flags / services / contracts /
-  collaborators / domain model), Platform capabilities, Tech-specific constraints.
+- **Part C (§§10-12.5) Technical integration** — Data & integrations (8
+  subsections: network ops / persistence / platform events at capability level /
+  flags / services / contracts / collaborators at business level / domain model),
+  Platform capabilities, Tech-specific constraints, External references (links to
+  provider docs / RFCs).
 - **Part D (§13) Appendix** — Code map (the only place code identifiers are
   allowed).
 
@@ -450,6 +466,19 @@ The spec already lives at `docs/spec/<slug>.md`. Final steps:
   no longer needed.
 - Offer to commit: *"Спека сохранена в `docs/spec/<slug>.md`. Закоммитить?"*. Do not
   commit without explicit confirmation.
+- **Hygiene artefact (optional).** If the analysis surfaced implementation-level
+  concerns that did not qualify for §9 Known Defects (hardcoded strings, weak PRNG
+  for security values, plaintext token storage, log leakage, code-style issues),
+  save them to `docs/spec/<slug>-hygiene.md` per `references/analysis-checklist.md`
+  §14. Mention the artefact in the handoff: *"Также сохранил implementation-hygiene
+  findings в `docs/spec/<slug>-hygiene.md` (N items) — это backlog для команды,
+  поведения фичи не касается."* If no hygiene findings exist, mention briefly
+  (*"Hygiene artefact: не понадобился."*) and do not create the file.
+- **Project overview update flag.** If Phase 0.6 surfaced discrepancies between the
+  observed code and the existing project-overview document, mention them once:
+  *"В `docs/project-overview.md` поле <X> может быть устаревшим — наблюдаемое <Y>.
+  Обновлять не стал — вне scope текущей фичи."*. The skill never silently edits
+  the project overview.
 - If the user intends to use this spec for reimplementation on another stack, mention
   that `write-spec` and `decompose-feature` can take this spec as input for the new
   implementation.

--- a/plugins/developer-workflow/skills/reverse-spec/evals/README.md
+++ b/plugins/developer-workflow/skills/reverse-spec/evals/README.md
@@ -1,0 +1,36 @@
+# reverse-spec evals
+
+Eval prompts use placeholders of the form `<TARGET_*>` that must be filled in from a
+concrete target repository before the eval set runs. Leaving placeholders unresolved
+produces meaningless runs.
+
+## Placeholders
+
+| Placeholder | Meaning |
+| --- | --- |
+| `<TARGET_REPO>` | Absolute path or clone URL of the repo with the feature |
+| `<TARGET_SCREEN_NAME>` | Human-readable name of the feature ("Onboarding welcome") |
+| `<TARGET_PATH>` | Explicit code path (file / directory / class) |
+| `<TARGET_FEATURE_DESCRIPTION>` | Prose description for discovery-input tests |
+| `<TARGET_BEHAVIORAL_HINT>` | Behavioral hint that narrows the feature ("the one that shows a map") |
+| `<TARGET_TECH_HEAVY_FEATURE>` | Feature that genuinely relies on a load-bearing SDK |
+| `<TARGET_LOAD_BEARING_TECH>` | The specific SDK name (e.g., "Google ML Kit", "Stripe SDK") |
+
+## Resolving placeholders
+
+Before iteration 1:
+
+1. Pick the target repo provided by the user.
+2. Copy `evals.json` to a per-run scratch file (e.g., `evals.filled.json`) and substitute
+   each `<TARGET_*>` with a concrete value.
+3. Run the skill-creator's workflow against the filled file. Do not commit the filled
+   version — prompts with a specific repo path are ephemeral; the templated version is
+   the durable artifact.
+
+## Assertions
+
+Assertions are drafted after iteration 1 outputs are reviewed, not up-front. The reason:
+for a skill whose output is a long narrative document, it is hard to write meaningful
+assertions until we see where the skill over- or under-delivers on a real target.
+
+After iteration 1, each eval gets 3-6 assertions grounded in observed failure modes.

--- a/plugins/developer-workflow/skills/reverse-spec/evals/evals.json
+++ b/plugins/developer-workflow/skills/reverse-spec/evals/evals.json
@@ -1,0 +1,203 @@
+{
+  "skill_name": "reverse-spec",
+  "evals": [
+    {
+      "id": 1,
+      "name": "eval-path-input-complex-screen",
+      "prompt": "Сделай reverse-spec на фичу авторизации в FrameIO. Код UI лежит в features/auth/ (AuthScreen, AuthComponent, AuthState, DefaultAuthComponent, AuthUseCase, AuthKoin). OAuth-движок — в модуле oauth/. Это самодостаточная фича с несколькими состояниями, интеграциями и навигацией — нужна полная спека для возможной перереализации на другом стеке.",
+      "expected_output": "Полная спека в auth-spec.md. Содержит все 12 секций шаблона (включая явные N/A). Тело стек-нейтрально (Compose/Decompose/Koin/Ktor не упоминаются вне Code Map/§10). Code Map с path:line granularity. §11 Open Questions не пустая. Покрывает PKCE, token storage, token refresh, process-death recovery.",
+      "principle": "path input — полный путь, сложная фича, проверка покрытия и tech-abstraction",
+      "files": [],
+      "assertions": [
+        {
+          "text": "spec_has_all_12_sections — auth-spec.md содержит все 12 секций шаблона (Overview, User-facing behavior, UI description, Data & integrations, States, Analytics & logging, Localization & accessibility, Navigation, Platform capabilities, Tech-specific constraints, Open questions, Code map)",
+          "type": "structural"
+        },
+        {
+          "text": "body_is_tech_agnostic — тело спеки (секции 1-9, 11) не упоминает Jetpack Compose, Decompose, Koin, Ktor Client, kotlinx.serialization; эти упоминания допустимы только в §10 (load-bearing) или §12 (code map)",
+          "type": "quality"
+        },
+        {
+          "text": "code_map_uses_line_ranges — Code Map (§13) содержит записи формата path:line или path:start-end, а не только путей к файлам",
+          "type": "quality"
+        },
+        {
+          "text": "open_questions_has_entries — §11 Open Questions содержит ≥3 записи (в non-interactive прогоне без интервью реально незакрытых вопросов всегда остаётся несколько; пустой §11 = спекуляция)",
+          "type": "quality"
+        },
+        {
+          "text": "covers_oauth_flow_end_to_end — спека описывает PKCE challenge/verifier, authorization URL, redirect + code exchange, access/refresh token storage, token refresh path",
+          "type": "coverage"
+        },
+        {
+          "text": "covers_process_death_recovery — спека упоминает сохранение/восстановление OAuth state при смерти процесса (недавний commit в проекте про это)",
+          "type": "coverage"
+        },
+        {
+          "text": "coverage_report_has_both_passes — coverage-report.md содержит Pass 1 (code → spec) и Pass 2 (spec → code) с конкретными числами покрытия",
+          "type": "process"
+        },
+        {
+          "text": "state_file_has_phase_checklist — state-file.md содержит чеклист фаз (Phase 0-5) с отметками выполнения и зафиксированными findings из Phase 1/2",
+          "type": "process"
+        },
+        {
+          "text": "no_code_identifiers_in_body — в секциях 1-9 и 11 отсутствуют имена из кодовой базы: OAuthClient, OAuthTokens, OAuthResult, OAuthException, AuthState, AuthComponent, AuthUseCase, TokenStorage, OAuthBrowser, FrameClient, StateFlow, а также любые другие CamelCase-идентификаторы классов/типов/методов из features/auth и oauth модулей",
+          "type": "quality"
+        },
+        {
+          "text": "section_12_known_defects_present — спека содержит §12 Known defects с заголовком-соответствием и либо ≥1 записью, либо явным N/A",
+          "type": "structural"
+        },
+        {
+          "text": "section_12_entries_structured — каждая запись в §12 содержит все 4 поля: what / class / evidence (path:line) / consequence",
+          "type": "quality"
+        },
+        {
+          "text": "defect_koin_not_wired — §12 содержит запись про authFeatureKoinModule / AuthUseCase DI wiring (crash на login tap)",
+          "type": "correctness"
+        },
+        {
+          "text": "defect_sign_up_dead_link — §12 содержит запись про dead link на accounts.frame.io/welcome (no registered deep-link handler)",
+          "type": "correctness"
+        },
+        {
+          "text": "defect_hardcoded_cancel — §12 содержит запись про hardcoded 'Cancel' (localization gap)",
+          "type": "correctness"
+        },
+        {
+          "text": "section_13_is_code_map — в переименованной §13 лежит Code Map с path:line записями",
+          "type": "structural"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "eval-prose-input-discovery",
+      "prompt": "В проекте FrameIO есть экран авторизации — не помню точно как называется класс, но это фича где юзер логинится через OAuth. Собери по коду спеку чтобы я потом мог эту фичу переписать на другом стеке.",
+      "expected_output": "Skill сначала находит фичу через discovery-pass, документирует кандидаты в state-file, затем делает полную спеку на правильный target (features/auth). Все структурные/качественные требования как в eval 1.",
+      "principle": "prose input — проверка discovery-pass и подтверждения перед анализом",
+      "files": [],
+      "assertions": [
+        {
+          "text": "state_file_documents_discovery — state-file.md содержит явную секцию с 1+ кандидатами из Phase 0.1, с evidence (имена файлов/классов, ключевые слова-совпадения) для каждого",
+          "type": "process"
+        },
+        {
+          "text": "discovery_landed_on_features_auth — итоговый target — features/auth/ (либо явный пакет dev.androidbroadcast.frameio.features.auth)",
+          "type": "correctness"
+        },
+        {
+          "text": "spec_has_all_12_sections — auth-spec.md содержит все 12 секций шаблона",
+          "type": "structural"
+        },
+        {
+          "text": "body_is_tech_agnostic — тело не упоминает Compose/Decompose/Koin/Ktor кроме §10 и §12",
+          "type": "quality"
+        },
+        {
+          "text": "code_map_uses_line_ranges — Code Map с path:line granularity",
+          "type": "quality"
+        },
+        {
+          "text": "open_questions_has_entries — §11 ≥3 записи",
+          "type": "quality"
+        },
+        {
+          "text": "no_code_identifiers_in_body — в секциях 1-9 и 11 отсутствуют имена из кодовой базы (CamelCase-классы/типы/методы из features/auth и oauth модулей; имена sealed-class кейсов вроде Authenticated/Unauthenticated/Error)",
+          "type": "quality"
+        },
+        {
+          "text": "section_12_known_defects_present — спека содержит §12 Known defects (или явный N/A)",
+          "type": "structural"
+        },
+        {
+          "text": "section_12_entries_structured — каждая запись §12 содержит what / class / evidence (path:line) / consequence",
+          "type": "quality"
+        },
+        {
+          "text": "defect_sign_up_dead_link — §12 упоминает dead link на accounts.frame.io/welcome",
+          "type": "correctness"
+        },
+        {
+          "text": "section_13_is_code_map — §13 = Code Map с path:line",
+          "type": "structural"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "name": "eval-load-bearing-tech",
+      "prompt": "Сделай reverse-spec на OAuth-часть авторизации в FrameIO (oauth/ модуль). Там PKCE и специфика под платформы (Android Chrome Custom Tabs, iOS ASWebAuthenticationSession, Desktop — локальный redirect server). Это важно сохранить на любой другой реализации, потому что иначе безопасность/UX OAuth потеряется.",
+      "expected_output": "Спека корректно идентифицирует PKCE и platform browser integration как load-bearing, помещает их в §10 с capability-first phrasing. В теле не упоминаются Ktor/Koin/kotlinx.serialization — только capability-level требования. coverage-report.md явно перечисляет 4-question test для каждой рассмотренной технологии.",
+      "principle": "load-bearing technology — проверка tech-abstraction.md heuristic на практике",
+      "files": [],
+      "assertions": [
+        {
+          "text": "pkce_classified_load_bearing — PKCE явно описан как load-bearing и помещён в §10 Tech-specific constraints",
+          "type": "correctness"
+        },
+        {
+          "text": "platform_browser_classified_load_bearing — Chrome Custom Tabs / ASWebAuthenticationSession / desktop local redirect server в §10 с указанием, что конкретные механизмы важны для security+UX OAuth",
+          "type": "correctness"
+        },
+        {
+          "text": "ktor_not_in_body — Ktor не упоминается в теле спеки (секции 1-9, 11) — только в code map или вообще отсутствует",
+          "type": "quality"
+        },
+        {
+          "text": "koin_not_in_body — Koin не упоминается в теле спеки (только code map или отсутствует)",
+          "type": "quality"
+        },
+        {
+          "text": "kotlinx_serialization_not_in_body — kotlinx.serialization не упоминается в теле (только code map или отсутствует)",
+          "type": "quality"
+        },
+        {
+          "text": "secure_storage_abstracted — Settings-библиотека абстрагирована до capability 'platform secure storage' / 'защищённое хранилище', а не прямая ссылка на `Settings`/`multiplatform-settings` в теле",
+          "type": "quality"
+        },
+        {
+          "text": "four_question_test_documented — coverage-report.md содержит явные ответы на 4-question test (behavior dependency, integration rework, unique capability, cost/licensing) для каждой рассмотренной технологии",
+          "type": "process"
+        },
+        {
+          "text": "capability_first_phrasing — §10 записи используют паттерн '[capability] — currently provided by [tech], any equivalent is acceptable that preserves [property]' или эквивалентный",
+          "type": "quality"
+        },
+        {
+          "text": "spec_has_all_12_sections — oauth-spec.md содержит все 12 секций шаблона",
+          "type": "structural"
+        },
+        {
+          "text": "no_code_identifiers_in_body — в секциях 1-9 и 11 отсутствуют имена из кодовой базы: OAuthClient, OAuthTokens, OAuthResult, OAuthException, OAuthBrowser, PKCEGenerator, TokenStorage, OAuthStateStorage, AuthorizationUrlBuilder и другие CamelCase-типы из oauth модуля; состояния описаны в бизнес-терминах, а не именами sealed-class кейсов",
+          "type": "quality"
+        },
+        {
+          "text": "section_12_known_defects_present — спека содержит §12 Known defects (или явный N/A)",
+          "type": "structural"
+        },
+        {
+          "text": "section_12_entries_structured — каждая запись §12 содержит what / class / evidence (path:line) / consequence",
+          "type": "quality"
+        },
+        {
+          "text": "defect_weak_prng — §12 содержит запись про слабый PRNG (kotlin.random.Random вместо SecureRandom) для PKCE state или code_verifier",
+          "type": "correctness"
+        },
+        {
+          "text": "defect_nonsecure_token_storage — §12 содержит запись про токены в non-encrypted storage (multiplatform-settings) как security weakness",
+          "type": "correctness"
+        },
+        {
+          "text": "defect_process_death_asymmetry — §12 отмечает что process-death recovery только на Android (iOS/Desktop теряют in-flight auth)",
+          "type": "correctness"
+        },
+        {
+          "text": "section_13_is_code_map — §13 = Code Map с path:line",
+          "type": "structural"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/developer-workflow/skills/reverse-spec/evals/evals.json
+++ b/plugins/developer-workflow/skills/reverse-spec/evals/evals.json
@@ -62,7 +62,7 @@
           "type": "correctness"
         },
         {
-          "text": "defect_hardcoded_cancel — §9 содержит запись про hardcoded 'Cancel' (localization gap)",
+          "text": "hygiene_hardcoded_cancel — `<slug>-hygiene.md` содержит запись про hardcoded 'Cancel' (localization-readiness hygiene per references/analysis-checklist.md §14 — feature behaves correctly today, gap manifests only when project ships another locale)",
           "type": "correctness"
         },
         {
@@ -182,11 +182,11 @@
           "type": "quality"
         },
         {
-          "text": "defect_weak_prng — §9 содержит запись про слабый PRNG (kotlin.random.Random вместо SecureRandom) для PKCE state или code_verifier",
+          "text": "hygiene_weak_prng — `<slug>-hygiene.md` содержит запись про слабый PRNG (kotlin.random.Random вместо SecureRandom) для PKCE state или code_verifier (security-posture hygiene per references/analysis-checklist.md §14 — feature flow completes successfully; problem is the strength of the secret, not feature behavior)",
           "type": "correctness"
         },
         {
-          "text": "defect_nonsecure_token_storage — §9 содержит запись про токены в non-encrypted storage (multiplatform-settings) как security weakness",
+          "text": "hygiene_nonsecure_token_storage — `<slug>-hygiene.md` содержит запись про токены в non-encrypted storage (multiplatform-settings) как security-posture hygiene (per references/analysis-checklist.md §14 — feature works; risk is about device-compromise threat models, not feature behavior)",
           "type": "correctness"
         },
         {

--- a/plugins/developer-workflow/skills/reverse-spec/evals/evals.json
+++ b/plugins/developer-workflow/skills/reverse-spec/evals/evals.json
@@ -5,16 +5,16 @@
       "id": 1,
       "name": "eval-path-input-complex-screen",
       "prompt": "Сделай reverse-spec на фичу авторизации в FrameIO. Код UI лежит в features/auth/ (AuthScreen, AuthComponent, AuthState, DefaultAuthComponent, AuthUseCase, AuthKoin). OAuth-движок — в модуле oauth/. Это самодостаточная фича с несколькими состояниями, интеграциями и навигацией — нужна полная спека для возможной перереализации на другом стеке.",
-      "expected_output": "Полная спека в auth-spec.md. Содержит все 12 секций шаблона (включая явные N/A). Тело стек-нейтрально (Compose/Decompose/Koin/Ktor не упоминаются вне Code Map/§10). Code Map с path:line granularity. §11 Open Questions не пустая. Покрывает PKCE, token storage, token refresh, process-death recovery.",
+      "expected_output": "Полная спека в auth-spec.md. Содержит все 13 секций шаблона (включая явные N/A). Тело стек-нейтрально (Compose/Decompose/Koin/Ktor не упоминаются вне Code Map/§10). Code Map с path:line granularity. §8 Open questions не пустая. Покрывает PKCE, token storage, token refresh, process-death recovery.",
       "principle": "path input — полный путь, сложная фича, проверка покрытия и tech-abstraction",
       "files": [],
       "assertions": [
         {
-          "text": "spec_has_all_12_sections — auth-spec.md содержит все 12 секций шаблона (Overview, User-facing behavior, UI description, Data & integrations, States, Analytics & logging, Localization & accessibility, Navigation, Platform capabilities, Tech-specific constraints, Open questions, Code map)",
+          "text": "spec_has_all_13_sections — auth-spec.md содержит все 13 секций шаблона (Overview, User-facing behavior, UI description, Data & integrations, States, Analytics & logging, Localization & accessibility, Navigation, Platform capabilities, Tech-specific constraints, Open questions, Code map)",
           "type": "structural"
         },
         {
-          "text": "body_is_tech_agnostic — тело спеки (секции 1-9, 11) не упоминает Jetpack Compose, Decompose, Koin, Ktor Client, kotlinx.serialization; эти упоминания допустимы только в §10 (load-bearing) или §12 (code map)",
+          "text": "body_is_tech_agnostic — тело спеки (секции 1-8) не упоминает Jetpack Compose, Decompose, Koin, Ktor Client, kotlinx.serialization; эти упоминания допустимы только в §10 (Data & integrations, load-bearing tech), §11 (Platform capabilities), §12 (Tech-specific constraints), §12.5 (External references) или §13 (Code map)",
           "type": "quality"
         },
         {
@@ -22,7 +22,7 @@
           "type": "quality"
         },
         {
-          "text": "open_questions_has_entries — §11 Open Questions содержит ≥3 записи (в non-interactive прогоне без интервью реально незакрытых вопросов всегда остаётся несколько; пустой §11 = спекуляция)",
+          "text": "open_questions_has_entries — §8 Open questions содержит ≥3 записи (в non-interactive прогоне без интервью реально незакрытых вопросов всегда остаётся несколько; пустой §8 = спекуляция)",
           "type": "quality"
         },
         {
@@ -34,35 +34,35 @@
           "type": "coverage"
         },
         {
-          "text": "coverage_report_has_both_passes — coverage-report.md содержит Pass 1 (code → spec) и Pass 2 (spec → code) с конкретными числами покрытия",
+          "text": "coverage_report_has_both_passes — state-файл `swarm-report/reverse-spec-<slug>-state.md` содержит итоги Pass 1 (code → spec) и Pass 2 (spec → code) с конкретными числами покрытия",
           "type": "process"
         },
         {
-          "text": "state_file_has_phase_checklist — state-file.md содержит чеклист фаз (Phase 0-5) с отметками выполнения и зафиксированными findings из Phase 1/2",
+          "text": "state_file_has_phase_checklist — state-файл `swarm-report/reverse-spec-<slug>-state.md` содержит чеклист фаз (Phase 0-5) с отметками выполнения и зафиксированными findings из Phase 1/2",
           "type": "process"
         },
         {
-          "text": "no_code_identifiers_in_body — в секциях 1-9 и 11 отсутствуют имена из кодовой базы: OAuthClient, OAuthTokens, OAuthResult, OAuthException, AuthState, AuthComponent, AuthUseCase, TokenStorage, OAuthBrowser, FrameClient, StateFlow, а также любые другие CamelCase-идентификаторы классов/типов/методов из features/auth и oauth модулей",
+          "text": "no_code_identifiers_in_body — в секциях 1-8 отсутствуют имена из кодовой базы: OAuthClient, OAuthTokens, OAuthResult, OAuthException, AuthState, AuthComponent, AuthUseCase, TokenStorage, OAuthBrowser, FrameClient, StateFlow, а также любые другие CamelCase-идентификаторы классов/типов/методов из features/auth и oauth модулей",
           "type": "quality"
         },
         {
-          "text": "section_12_known_defects_present — спека содержит §12 Known defects с заголовком-соответствием и либо ≥1 записью, либо явным N/A",
+          "text": "section_9_known_defects_present — спека содержит §9 Known defects с заголовком-соответствием и либо ≥1 записью, либо явным N/A",
           "type": "structural"
         },
         {
-          "text": "section_12_entries_structured — каждая запись в §12 содержит все 4 поля: what / class / evidence (path:line) / consequence",
+          "text": "section_9_entries_structured — каждая запись в §9 содержит все 4 поля: what / class / evidence (path:line) / consequence",
           "type": "quality"
         },
         {
-          "text": "defect_koin_not_wired — §12 содержит запись про authFeatureKoinModule / AuthUseCase DI wiring (crash на login tap)",
+          "text": "defect_koin_not_wired — §9 содержит запись про authFeatureKoinModule / AuthUseCase DI wiring (crash на login tap)",
           "type": "correctness"
         },
         {
-          "text": "defect_sign_up_dead_link — §12 содержит запись про dead link на accounts.frame.io/welcome (no registered deep-link handler)",
+          "text": "defect_sign_up_dead_link — §9 содержит запись про dead link на accounts.frame.io/welcome (no registered deep-link handler)",
           "type": "correctness"
         },
         {
-          "text": "defect_hardcoded_cancel — §12 содержит запись про hardcoded 'Cancel' (localization gap)",
+          "text": "defect_hardcoded_cancel — §9 содержит запись про hardcoded 'Cancel' (localization gap)",
           "type": "correctness"
         },
         {
@@ -80,7 +80,7 @@
       "files": [],
       "assertions": [
         {
-          "text": "state_file_documents_discovery — state-file.md содержит явную секцию с 1+ кандидатами из Phase 0.1, с evidence (имена файлов/классов, ключевые слова-совпадения) для каждого",
+          "text": "state_file_documents_discovery — state-файл `swarm-report/reverse-spec-<slug>-state.md` содержит явную секцию с 1+ кандидатами из Phase 0.1, с evidence (имена файлов/классов, ключевые слова-совпадения) для каждого",
           "type": "process"
         },
         {
@@ -88,11 +88,11 @@
           "type": "correctness"
         },
         {
-          "text": "spec_has_all_12_sections — auth-spec.md содержит все 12 секций шаблона",
+          "text": "spec_has_all_13_sections — auth-spec.md содержит все 13 секций шаблона",
           "type": "structural"
         },
         {
-          "text": "body_is_tech_agnostic — тело не упоминает Compose/Decompose/Koin/Ktor кроме §10 и §12",
+          "text": "body_is_tech_agnostic — тело не упоминает Compose/Decompose/Koin/Ktor кроме §10 / §11 / §12 / §13",
           "type": "quality"
         },
         {
@@ -100,23 +100,23 @@
           "type": "quality"
         },
         {
-          "text": "open_questions_has_entries — §11 ≥3 записи",
+          "text": "open_questions_has_entries — §8 ≥3 записи",
           "type": "quality"
         },
         {
-          "text": "no_code_identifiers_in_body — в секциях 1-9 и 11 отсутствуют имена из кодовой базы (CamelCase-классы/типы/методы из features/auth и oauth модулей; имена sealed-class кейсов вроде Authenticated/Unauthenticated/Error)",
+          "text": "no_code_identifiers_in_body — в секциях 1-8 отсутствуют имена из кодовой базы (CamelCase-классы/типы/методы из features/auth и oauth модулей; имена sealed-class кейсов вроде Authenticated/Unauthenticated/Error)",
           "type": "quality"
         },
         {
-          "text": "section_12_known_defects_present — спека содержит §12 Known defects (или явный N/A)",
+          "text": "section_9_known_defects_present — спека содержит §9 Known defects (или явный N/A)",
           "type": "structural"
         },
         {
-          "text": "section_12_entries_structured — каждая запись §12 содержит what / class / evidence (path:line) / consequence",
+          "text": "section_9_entries_structured — каждая запись §9 содержит what / class / evidence (path:line) / consequence",
           "type": "quality"
         },
         {
-          "text": "defect_sign_up_dead_link — §12 упоминает dead link на accounts.frame.io/welcome",
+          "text": "defect_sign_up_dead_link — §9 упоминает dead link на accounts.frame.io/welcome",
           "type": "correctness"
         },
         {
@@ -129,7 +129,7 @@
       "id": 3,
       "name": "eval-load-bearing-tech",
       "prompt": "Сделай reverse-spec на OAuth-часть авторизации в FrameIO (oauth/ модуль). Там PKCE и специфика под платформы (Android Chrome Custom Tabs, iOS ASWebAuthenticationSession, Desktop — локальный redirect server). Это важно сохранить на любой другой реализации, потому что иначе безопасность/UX OAuth потеряется.",
-      "expected_output": "Спека корректно идентифицирует PKCE и platform browser integration как load-bearing, помещает их в §10 с capability-first phrasing. В теле не упоминаются Ktor/Koin/kotlinx.serialization — только capability-level требования. coverage-report.md явно перечисляет 4-question test для каждой рассмотренной технологии.",
+      "expected_output": "Спека корректно идентифицирует PKCE и platform browser integration как load-bearing, помещает их в §10 с capability-first phrasing. В теле не упоминаются Ktor/Koin/kotlinx.serialization — только capability-level требования. State-файл `swarm-report/reverse-spec-<slug>-state.md` явно перечисляет 4-question test для каждой рассмотренной технологии.",
       "principle": "load-bearing technology — проверка tech-abstraction.md heuristic на практике",
       "files": [],
       "assertions": [
@@ -142,7 +142,7 @@
           "type": "correctness"
         },
         {
-          "text": "ktor_not_in_body — Ktor не упоминается в теле спеки (секции 1-9, 11) — только в code map или вообще отсутствует",
+          "text": "ktor_not_in_body — Ktor не упоминается в теле спеки (секции 1-8) — только в §10/§11/§12/§13 (где разрешены tech-named упоминания) или вообще отсутствует",
           "type": "quality"
         },
         {
@@ -158,7 +158,7 @@
           "type": "quality"
         },
         {
-          "text": "four_question_test_documented — coverage-report.md содержит явные ответы на 4-question test (behavior dependency, integration rework, unique capability, cost/licensing) для каждой рассмотренной технологии",
+          "text": "four_question_test_documented — state-файл `swarm-report/reverse-spec-<slug>-state.md` содержит явные ответы на 4-question test (behavior dependency, integration rework, unique capability, cost/licensing) для каждой рассмотренной технологии",
           "type": "process"
         },
         {
@@ -166,31 +166,31 @@
           "type": "quality"
         },
         {
-          "text": "spec_has_all_12_sections — oauth-spec.md содержит все 12 секций шаблона",
+          "text": "spec_has_all_13_sections — oauth-spec.md содержит все 13 секций шаблона",
           "type": "structural"
         },
         {
-          "text": "no_code_identifiers_in_body — в секциях 1-9 и 11 отсутствуют имена из кодовой базы: OAuthClient, OAuthTokens, OAuthResult, OAuthException, OAuthBrowser, PKCEGenerator, TokenStorage, OAuthStateStorage, AuthorizationUrlBuilder и другие CamelCase-типы из oauth модуля; состояния описаны в бизнес-терминах, а не именами sealed-class кейсов",
+          "text": "no_code_identifiers_in_body — в секциях 1-8 отсутствуют имена из кодовой базы: OAuthClient, OAuthTokens, OAuthResult, OAuthException, OAuthBrowser, PKCEGenerator, TokenStorage, OAuthStateStorage, AuthorizationUrlBuilder и другие CamelCase-типы из oauth модуля; состояния описаны в бизнес-терминах, а не именами sealed-class кейсов",
           "type": "quality"
         },
         {
-          "text": "section_12_known_defects_present — спека содержит §12 Known defects (или явный N/A)",
+          "text": "section_9_known_defects_present — спека содержит §9 Known defects (или явный N/A)",
           "type": "structural"
         },
         {
-          "text": "section_12_entries_structured — каждая запись §12 содержит what / class / evidence (path:line) / consequence",
+          "text": "section_9_entries_structured — каждая запись §9 содержит what / class / evidence (path:line) / consequence",
           "type": "quality"
         },
         {
-          "text": "defect_weak_prng — §12 содержит запись про слабый PRNG (kotlin.random.Random вместо SecureRandom) для PKCE state или code_verifier",
+          "text": "defect_weak_prng — §9 содержит запись про слабый PRNG (kotlin.random.Random вместо SecureRandom) для PKCE state или code_verifier",
           "type": "correctness"
         },
         {
-          "text": "defect_nonsecure_token_storage — §12 содержит запись про токены в non-encrypted storage (multiplatform-settings) как security weakness",
+          "text": "defect_nonsecure_token_storage — §9 содержит запись про токены в non-encrypted storage (multiplatform-settings) как security weakness",
           "type": "correctness"
         },
         {
-          "text": "defect_process_death_asymmetry — §12 отмечает что process-death recovery только на Android (iOS/Desktop теряют in-flight auth)",
+          "text": "defect_process_death_asymmetry — §9 отмечает что process-death recovery только на Android (iOS/Desktop теряют in-flight auth)",
           "type": "correctness"
         },
         {

--- a/plugins/developer-workflow/skills/reverse-spec/references/analysis-checklist.md
+++ b/plugins/developer-workflow/skills/reverse-spec/references/analysis-checklist.md
@@ -1,0 +1,339 @@
+# Static Analysis Checklist
+
+What to extract from code before talking to the user. Work through this list in order;
+each section maps to a spec section. Capture findings verbatim in the state file — exact
+numbers, exact strings, exact conditions.
+
+For every item, answer three questions:
+1. **What** — the observable fact or value in code.
+2. **Under what condition** — the trigger or branch that makes it apply.
+3. **Is it feature-specific or project-wide** — flag obvious project-convention cases
+   (e.g. a shared `ErrorBanner` component); defer hard judgments to Phase 2 (Convention
+   Mapping).
+
+When in doubt, record the raw observation and move on. Interpretation happens later.
+
+**Code identifiers in the state file: allowed and encouraged.** The state file names
+classes, methods, types, file paths, line numbers — that is what makes it a useful
+operational artifact. It is the bridge between the code and the spec.
+
+**Code identifiers in the spec body: forbidden.** The translation from code-vocabulary
+to behavior-vocabulary happens in Phase 4.0 (see SKILL.md), using the recipes in
+`behavior-translation.md`. Do not pre-translate in this phase — capture literally,
+translate later. Pre-translation loses precision; post-translation is where judgment
+applies.
+
+---
+
+## 1. Boundary & entry points
+
+- Every route, deep link, intent, URL, navigation action, notification tap, widget tap,
+  or programmatic call that can land the user on this feature.
+- Dependencies the feature calls into — note them as cross-references, not as part of
+  the feature.
+- What calls the feature from outside (if any) — other features, background jobs,
+  schedulers.
+
+Record entry points as a list; each entry contains the trigger and any required
+arguments (deep-link path params, navigation args, etc.).
+
+### 1.1 Cross-feature surface (collaborators and consumers)
+
+While enumerating entry points, also map the feature's broader integration surface
+with the rest of the app. For every symbol the feature imports from outside its own
+module, decide:
+
+- Is it a **platform / third-party library** (stdlib, Kotlin stdlib, OS SDK)? — not a
+  collaborator in the spec sense; skip.
+- Is it a **value provided by the host app** (config, flags, keys, endpoints)? →
+  collaborator (configuration type).
+- Is it an **in-app service** (shared networking client, deep-link processor,
+  navigation stack, analytics dispatcher, theme)? → collaborator (service type).
+- Is it an **observable stream / store maintained elsewhere** that the feature
+  subscribes to? → collaborator (shared state source).
+
+In the other direction — who reads or subscribes to what this feature exposes? Grep
+for imports of the feature's public symbols:
+- **Downstream screens** that receive navigation arguments on completion → consumer.
+- **Other modules** that subscribe to streams the feature emits → consumer.
+- **Shared storage slots** the feature writes that others read (tokens, cache keys) →
+  consumer (via shared state).
+
+Also capture:
+- **Preconditions** observable in code: assertions, early returns, required flags.
+- **Postconditions** the feature commits to before it hands off: persistent writes,
+  navigation-stack manipulations, stream values it must emit.
+
+These findings feed §10.7 Collaborators and consumers, and the boundary they describe
+is as important to preserve in a reimplementation as the feature's internal flow.
+
+## 2. User-visible states
+
+For each state variable or branch in the UI layer, identify the resulting state:
+
+- **happy path** — primary success rendering
+- **loading** — is there a spinner, skeleton, placeholder? where?
+- **empty** — when does the feature render "no data"? what copy?
+- **error** — every error path; group by error class if the code groups them
+- **offline / no-network** — explicit handling or inherited from a shared error path?
+- **permission-denied** — every platform permission requested; what if the user refuses?
+- **degraded** — feature flag off, remote config disabled, third-party down, account in
+  a special state (unverified, restricted, etc.)
+
+For each, capture: trigger condition, visible copy (verbatim), available actions.
+
+**State-diagram heuristic:** if the feature has 5+ distinct user-visible states or a
+non-trivial state machine (loading → success → partial → retry → offline-cached), a
+one-page state diagram is worth the effort. Sketch it in the state file — nodes for
+states, edges labeled with the trigger that moves between them. Include it in the spec
+as a fenced mermaid block in Section 4. For simpler features (≤4 states with linear
+transitions), prose is enough.
+
+## 3. Network operations (every endpoint the feature talks to)
+
+If the feature makes any network call, capture **every single one** as a row for the
+§10.1 Network operations table. Split by *trigger context*, not by transport: the same
+URL called for "initial auth" vs "refresh" is two operations because the trigger and
+the request shape differ.
+
+For each call, record:
+
+- **Operation name** in business terms ("authorize via browser", "exchange code for
+  tokens", "fetch current user").
+- **Method** (GET / POST / PATCH / WS / SSE / GQL query-name).
+- **Endpoint** — URL pattern with path params in `{braces}`, hostname abstracted via
+  §10.5 placeholder if applicable.
+- **Auth** — none / Bearer / Basic / custom header.
+- **Triggered when** — the user action, state transition, or lifecycle event that
+  fires the call. Include conditions ("only when access token within 60 s of expiry").
+- **Request fields actually sent** — wire names only.
+- **Response fields actually read** — wire names only. Ignore fields the code doesn't
+  consume.
+- **Retry / timeout / idempotency** behavior if the code sets any.
+- **Source** — `file:line` of the call site (for the §13 Code map).
+
+Do not collapse similar calls into "uses REST endpoints"; a reimplementer needs the
+full list.
+
+## 4. Local persistence, platform events, and side effects
+
+What the feature reads / writes locally, and what platform-level side effects it
+triggers.
+
+- **Local storage reads:** key / database table / file path, trigger (startup,
+  on-demand, lifecycle event), what the data represents.
+- **Local storage writes:** key, trigger, contents, invalidation rule (on logout, on
+  expiry, on user action).
+- **Platform events consumed:** deep-link intents, app lifecycle callbacks, OS push
+  payloads — topic / URL pattern / event name as delivered by the platform.
+- **Platform-level side effects:** system toasts, haptics, audio, clipboard writes,
+  notifications, vibration — user-visible ones.
+- **Feature-to-feature events:** in-app bus / signals — name, payload role, meaning.
+  (Analytics events go in Section 7, not here.)
+- **Flags / remote config:** name verbatim, default, consequence per legal value,
+  source of truth.
+- **Platform data requests:** location, contacts, calendar, clipboard, camera
+  capture, file picker — trigger and what is requested.
+
+Record each with `file:line` so the §13 Code map writes itself.
+
+## 5. External dependencies
+
+SDKs and services this feature pulls in. For each, note:
+
+- purpose (why the SDK is used)
+- scope (feature-only or project-wide)
+- behavior contract exposed to the feature
+
+Flag any that are load-bearing for the spec's Tech-specific constraints section
+(ML/AI libraries, payment SDKs, biometrics, DRM, maps, AR, realtime, etc.).
+
+## 6. Constraints & magic numbers
+
+Any concrete value the code enforces that would affect behavior if changed:
+
+- timeouts (network, UI, animation)
+- retry counts and backoff schedules
+- debounce / throttle intervals
+- rate limits
+- pagination page sizes
+- maximum input lengths, file sizes, character counts
+- minimum interaction intervals
+- cache TTLs
+- validation rules (regex, whitelists, blacklists)
+
+Each value goes into the spec with its literal number. If the code allows overriding via
+remote config, note the default AND the override mechanism.
+
+### 6.1 Async / concurrency / timing behavior
+
+Static analysis has a blind spot for *when things happen relative to each other*. If the
+feature has any of the following, record the concrete behavior AND raise a question for
+Phase 3 — these are areas where code alone often does not tell the full story:
+
+- async callbacks that can fire after the screen is dismissed (what wins: the callback
+  or the dismiss?)
+- background work that continues after the user leaves (is it cancelled? does it write
+  state the user will see next time?)
+- concurrent updates to shared state from multiple coroutines / tasks / subscribers
+- rapid repeated user actions (double-tap, fast scroll) that could race a debounce
+- ordering guarantees between events (does event A always arrive before event B?)
+
+Capture the observed code path. Phase 3 should ask the user whether the observed
+behavior is intentional ("this is the contract") or incidental ("it just happened to
+work this way"). The answer decides whether the spec pins the behavior or leaves it
+flexible.
+
+## 7. Platform capabilities & permissions
+
+- runtime permissions requested, and the flow when they are denied or revoked
+- hardware capabilities used (camera, microphone, location, biometrics, NFC, Bluetooth,
+  sensors)
+- background behavior (wake locks, background fetch, push wake-up, long-running tasks)
+- minimum OS version requirements (API-level gates, version checks in code)
+- platform-specific behavior branching (`if (Build.VERSION.SDK_INT >= …)` etc.)
+
+## 8. Navigation (in and out)
+
+- every way to arrive (from section 1, restated from the navigation-graph perspective)
+- every way to leave: primary success exit, cancel exit, back behavior, deep-link exits
+- what state is preserved on back navigation or process death
+- modality (modal vs pushed vs replaced) — relevant if it affects interaction semantics
+  (e.g. swipe-to-dismiss, gesture handling)
+
+## 9. Analytics & logging
+
+- every call to an analytics SDK or tracking utility — event name, properties
+- every log statement that describes a user-visible event or a business-state transition
+- any feature-flag evaluation logged (these are often product-relevant)
+
+Distinguish product-meaningful events (user performed X) from engineering telemetry
+(method entered, latency = Y ms). The former is spec-level; the latter is not.
+
+## 10. Localization & accessibility
+
+- strings sourced from resource files vs hard-coded
+- pluralization, formatting (dates, numbers, currency)
+- RTL handling (explicit code, layout mirroring)
+- content descriptions / accessibility labels on interactive elements
+- dynamic type / font-scaling support
+- color/contrast considerations in code (high-contrast theme, reduced-motion handling)
+- screen-reader announcements (live regions, focus management)
+
+Absence is a finding, not a non-finding. "No accessibility labels in this feature" goes
+into the state file.
+
+## 11. Feature flags / remote config gates
+
+Any runtime switch that changes the feature's behavior:
+
+- flag name (verbatim)
+- default value
+- consequence when off / on / variant-A / variant-B
+- source (Firebase Remote Config, launchdarkly, internal config service, etc.)
+
+These affect the spec directly: a feature behind a flag has a "degraded (flag off)"
+state, and the spec should describe both sides.
+
+## 12. Tests as source of truth
+
+Existing tests often encode invariants the code does not make obvious. Skim the test
+files for:
+
+- assertions about exact values (copy, counts, thresholds)
+- behavior-describing test names ("shows error when network fails" → spec bullet)
+- edge cases the developer bothered to test (they had a reason)
+
+Tests are secondary to code, but they help confirm which behaviors are intentional.
+
+## 13. Comments and TODOs
+
+Read code comments and TODOs for intent the code alone does not express:
+
+- "retry 3 times because payment API is flaky" — rationale to record
+- "TODO: localize this when we ship in EU" — known gap, goes to Open Questions
+- "HACK — remove when BE fixes X" — unstable area worth flagging
+
+Do not treat comments as authoritative product statements, but do capture them as
+evidence for Phase 3 questions.
+
+## 14. Defect classification
+
+During analysis you will find observations that look wrong. Classify each one into
+exactly one of three buckets before Phase 4.0. Mixing them produces a spec that either
+hides bugs or turns every rough edge into a defect report.
+
+**Intended behavior** (→ spec body in §§2-7, 10-11)
+The code does something that makes sense given the product intent, even if it is
+unusual. The observation describes feature behavior. Record literally; translate in
+Phase 4.0.
+
+Examples:
+- Retry count is 3 and rationale is plausible (product wants eventual consistency).
+- The screen shows a different empty-state for new users vs returning users.
+- A specific error type gets a specific copy.
+
+**Unknown intent / ambiguous** (→ §8 Open Questions)
+The code does something that could be intentional or accidental. You cannot tell from
+the code alone. Every such finding goes to §8 with a stated assumption and the
+consequence of being wrong. A later clarification round (or user review) resolves it.
+
+Examples:
+- Retry count is 3 but the surrounding code suggests copy-paste from another feature.
+- A 250 ms debounce — product decision, UX safeguard, or left-over default?
+- An error case is routed to a generic "Unknown error" screen — is that intentional
+  grouping, or incomplete error handling?
+
+**Confirmed defect** (→ §9 Known defects in current implementation)
+The code demonstrably does something wrong. A rebuild must not reproduce it. Each
+entry requires three pieces of evidence:
+1. Code pointer showing the defective state (path:line).
+2. Defect class (crash, unreachable code, security weakness, dead link, localization
+   gap, data loss, race condition, other).
+3. User-observable consequence or risk.
+
+Examples:
+- A use-case is wired into a dependency graph module that is never loaded → login tap
+  throws at runtime → **crash**.
+- A link points to a URL with no registered handler → tap silently no-ops →
+  **dead link**.
+- Tokens are stored in plain KV storage → risk of credential theft if device is
+  compromised → **security weakness**.
+- A single label is hard-coded where the rest of the screen uses localized resources
+  → the label never translates → **localization gap**.
+- Non-cryptographic `Random` is used where security requires `SecureRandom` →
+  predictable values → **security weakness**.
+
+**Hard line:** if you cannot produce all three pieces of evidence, the finding is not a
+defect — demote to §8 Open Questions. "Looks wrong" is not a defect report.
+
+The distinction matters because §9 is actionable: a reimplementer explicitly avoids
+these patterns; the original team can use §9 as a backlog. A §9 entry carries more
+authority than a §8 entry, which is why it has a higher evidence bar.
+
+---
+
+## Recording findings
+
+Capture everything into the state file in a consistent shape. A simple list works —
+each finding carries a `file:line` or `file:start-end` pointer so the code map in the
+final spec writes itself.
+
+```
+## Phase 1 findings
+
+### Entry points
+- deep link `app://payment/confirm?orderId=…` → opens PaymentConfirmScreen
+- notification tap on type=`payment.required` → same screen with orderId param
+- navigation from CartScreen "Checkout" button → same screen
+
+### States
+- loading: spinner centered, no copy; triggered while order fetch is in flight
+- error (network): ErrorBanner with "Не удалось загрузить заказ. Проверьте интернет.";
+  retry action present
+- error (order not found): full-screen empty state with "Заказ не найден" and "Назад"
+…
+```
+
+Tight, literal, with source references (files/lines captured in a separate column or as
+trailing annotations) — interpretation waits for Phase 2 and the interview.

--- a/plugins/developer-workflow/skills/reverse-spec/references/analysis-checklist.md
+++ b/plugins/developer-workflow/skills/reverse-spec/references/analysis-checklist.md
@@ -284,32 +284,88 @@ Examples:
 - An error case is routed to a generic "Unknown error" screen — is that intentional
   grouping, or incomplete error handling?
 
-**Confirmed defect** (→ §9 Known defects in current implementation)
-The code demonstrably does something wrong. A rebuild must not reproduce it. Each
-entry requires three pieces of evidence:
+**Behavior defect** (→ §9 Known defects in current implementation)
+The code makes the **feature do something wrong as a feature** — the user observes
+incorrect behavior, the feature crashes, a control silently does nothing it should
+do, the wrong data is shown, an unreachable state is hit. A rebuild must not
+reproduce it. Each entry requires three pieces of evidence:
 1. Code pointer showing the defective state (path:line).
-2. Defect class (crash, unreachable code, security weakness, dead link, localization
-   gap, data loss, race condition, other).
-3. User-observable consequence or risk.
+2. Defect class (`crash`, `unreachable state`, `dead UI control`, `wrong-data shown`,
+   `silent failure`, `lost user action`, `incorrect state transition`, `other`).
+3. **Observable user consequence** — what the user sees or what intended outcome
+   is missed.
 
 Examples:
-- A use-case is wired into a dependency graph module that is never loaded → login tap
-  throws at runtime → **crash**.
+- A use-case is wired into a dependency graph module that is never loaded → login
+  tap throws at runtime → **crash**, user cannot sign in.
 - A link points to a URL with no registered handler → tap silently no-ops →
-  **dead link**.
-- Tokens are stored in plain KV storage → risk of credential theft if device is
-  compromised → **security weakness**.
-- A single label is hard-coded where the rest of the screen uses localized resources
-  → the label never translates → **localization gap**.
-- Non-cryptographic `Random` is used where security requires `SecureRandom` →
-  predictable values → **security weakness**.
+  **dead UI control**, user has no way to start sign-up from the app.
+- All non-network OAuth errors collapse into one "Unknown error" copy, including
+  the case where the provider explicitly returned `error=access_denied` → user who
+  *chose* to deny consent sees an error implying brokenness → **wrong-data shown**.
 
-**Hard line:** if you cannot produce all three pieces of evidence, the finding is not a
-defect — demote to §8 Open Questions. "Looks wrong" is not a defect report.
+**Implementation hygiene finding** (→ separate `<slug>-hygiene.md` artefact, NOT
+in §9)
+The code does something concerning at the *implementation* level, but the feature
+itself behaves as intended (or its behavior is unaffected). These are valuable
+findings for the engineering team, but they are not what §9 is for. They go into
+a separate hygiene artefact alongside the spec.
 
-The distinction matters because §9 is actionable: a reimplementer explicitly avoids
-these patterns; the original team can use §9 as a backlog. A §9 entry carries more
-authority than a §8 entry, which is why it has a higher evidence bar.
+Examples:
+- A single label is hard-coded where the rest of the screen uses localized
+  resources. Feature still behaves correctly today; problem manifests only when
+  the project ships another locale. → **hygiene** (localization-readiness).
+- Tokens are stored in plaintext key-value storage. Feature works; the risk is
+  about device-compromise threat models, not about feature behavior. →
+  **hygiene** (security posture).
+- Non-cryptographic `Random` for security-sensitive values like CSRF state or PKCE
+  verifier. Feature flow completes successfully; the problem is the strength of
+  the secret, not the feature behavior. → **hygiene** (security posture).
+- Logging of full redirect URL containing the OAuth `code`. Feature works; risk is
+  log exposure of a transient secret. → **hygiene** (security posture).
+- Mixed code conventions, dead code, copy-pasted blocks. → **hygiene**
+  (maintainability).
+
+**Hard line for §9 vs hygiene:** if removing the finding does not change *what the
+user observes when they use the feature*, it is hygiene, not §9. §9 is about
+behavior; hygiene is about how the code is written.
+
+**Hard line for §9 vs §8:** if you cannot produce all three pieces of evidence
+(code pointer, defect class, observable user consequence), the finding is not a
+behavior defect — demote to §8 Open Questions or to hygiene. "Looks wrong" is not
+a defect report.
+
+The distinction matters because each artefact has a different audience and
+different action: §9 binds the reimplementer to *not reproduce* a behavior; hygiene
+informs the original team's backlog without affecting the spec; §8 surfaces
+unknowns for clarification.
+
+## Hygiene artefact format
+
+When hygiene findings exist, save them to `<slug>-hygiene.md` next to the spec
+(`docs/spec/<slug>.md` → `docs/spec/<slug>-hygiene.md`). Format:
+
+```markdown
+# Implementation hygiene findings — <feature name>
+
+> Related spec: `<slug>.md`
+> Source: extracted during reverse-engineering at <commit-sha>
+
+These findings are about **how the current code is written**, not about what the
+feature does. The feature spec describes intent; this document tracks
+implementation-level concerns the engineering team may want to act on as a
+backlog.
+
+## Findings
+
+| What | Class | Evidence | Why it matters |
+| --- | --- | --- | --- |
+| Hardcoded "Cancel" label | localization-readiness | `AuthScreen.kt:171` — literal string instead of resource lookup | When the project adds a non-English locale, this single label will remain English |
+| Non-cryptographic `Random` for OAuth `state` and PKCE `code_verifier` | security posture | `OAuthClient.kt:180-185`, `PKCEGenerator.kt:14-19` | Predictable secrets reduce CSRF protection strength and weaken PKCE benefit |
+```
+
+If no hygiene findings exist, do not create the file. Mention in handoff:
+*"Hygiene artefact: not produced — no implementation-level concerns identified."*
 
 ---
 

--- a/plugins/developer-workflow/skills/reverse-spec/references/analysis-checklist.md
+++ b/plugins/developer-workflow/skills/reverse-spec/references/analysis-checklist.md
@@ -4,14 +4,14 @@ What to extract from code before talking to the user. Work through this list in 
 each section maps to a spec section. Capture findings verbatim in the state file — exact
 numbers, exact strings, exact conditions.
 
-For every item, answer three questions:
+For every item, answer two questions:
 1. **What** — the observable fact or value in code.
 2. **Under what condition** — the trigger or branch that makes it apply.
-3. **Is it feature-specific or project-wide** — flag obvious project-convention cases
-   (e.g. a shared `ErrorBanner` component); defer hard judgments to Phase 2 (Convention
-   Mapping).
 
-When in doubt, record the raw observation and move on. Interpretation happens later.
+When in doubt, record the raw observation and move on. Classification (intended
+behavior / unknown intent / behavior defect / hygiene finding, and feature-specific
+vs project-wide) happens in Phase 2 (Convention Mapping) and Phase 4.0 (Translate),
+not here. Capture literally first.
 
 **Code identifiers in the state file: allowed and encouraged.** The state file names
 classes, methods, types, file paths, line numbers — that is what makes it a useful

--- a/plugins/developer-workflow/skills/reverse-spec/references/anti-patterns.md
+++ b/plugins/developer-workflow/skills/reverse-spec/references/anti-patterns.md
@@ -1,0 +1,86 @@
+# Anti-patterns
+
+Ways reverse-spec runs go wrong. Each entry describes the pattern, what makes it
+tempting, and what to do instead. These are not rare — they are the most common
+failure modes observed in practice, and most of them are invisible from inside the
+skill itself (they feel right while being wrong).
+
+Treat this list as a pre-publish review checklist: run through it before declaring
+a draft ready.
+
+## Leaking code identifiers into the body
+
+Writing "`OAuthClient.authorize()` returns `OAuthResult.Success(tokens)` or
+`OAuthResult.Error(exception)`" describes the current Kotlin API, not the feature. A
+reimplementer on SwiftUI / Flutter / web gets nothing transferable from this.
+
+The spec should say "authorization returns either a valid token set or a structured
+failure" and let §13 (Code map) point at the file where that contract currently
+lives. See `behavior-translation.md` for the full translation recipes.
+
+## Copying code structure into the spec
+
+"The feature has a ViewModel, a UseCase, and a Repository" describes the current
+implementation, not the feature. A reimplementer on a different architecture gets
+nothing from this — their architecture may have no equivalent concept. Describe
+behavior; §13 records the current code layout.
+
+## Inventing rationale
+
+If the code has `retryCount = 3` and the user does not know why, the spec says
+"retries 3 times" and adds "rationale unknown" to §8 Open Questions. Do NOT write
+"retries 3 times to balance reliability and user wait time" unless the user confirmed
+that. Invented rationale looks authoritative, but it corrupts decision-making
+downstream when someone treats it as truth.
+
+## Batching questions on the first pass
+
+The user's preference by default is one question per round, because later questions
+depend on earlier answers. Batch only when the user explicitly asks ("задавай всё
+сразу"). Batching feels efficient but commonly produces shallower clarifications and
+a queue of questions that needed the previous answers to formulate.
+
+## Hiding absent conventions
+
+If the feature has no accessibility support and the project has none either, the
+spec must say so explicitly. Silent omission reads as "handled elsewhere" — the gap
+is reintroduced during reimplementation because the new team assumes the spec
+simply forgot to mention it. Explicit N/A with reason is the correct form.
+
+## Over-specifying trivia
+
+Exact font sizes, hex colors, and pixel margins are not spec-level unless they carry
+product meaning (brand red, accessibility-critical contrast). Refer to the design
+source (Figma, screenshots) for pixel-perfect values. Pinning trivia in the spec
+creates spurious breaking-change reports every time a designer tweaks visuals.
+
+## Declaring done without round-trip verification
+
+A spec that misses a code branch will produce a reimplementation that misses a
+behavior. Phase 5 is not optional — all five passes plus the typo sweep must run
+before the draft is presented. Skipping to user review because the draft "looks
+complete" is the most common way shipping specs acquire silent holes.
+
+## Treating defect findings as spec content
+
+When reverse-engineering surfaces a bug (crash path, dead link, security weakness),
+the temptation is to describe the feature *as the code behaves*. That bakes the bug
+into the spec and any reimplementation copies it. The feature's intent and the
+current code's actual behavior are two different things. Defects belong in §9 with
+four fields (what / class / evidence / consequence), marked "do not reproduce" —
+never in the body.
+
+## Skipping Phase 4.0 translate-step
+
+The single biggest driver of identifier leakage is drafting directly from the state
+file without the translate-step. Phase 4.0 is mandatory. A shortcut here shows up
+several passes later as dozens of Pass 3 failures, and the translate work then has
+to be done anyway — but now mid-document, which is harder.
+
+## Confusing Phase 3 questions with §8 Open Questions
+
+Phase 3 is the live interview with the user — questions get answers and close
+immediately. §8 Open Questions is the section for questions that could *not* be
+resolved in interview (user said "не знаю", no authoritative source available). Do
+not dump every Phase 3 question into §8 — only the ones that remain open after the
+interview.

--- a/plugins/developer-workflow/skills/reverse-spec/references/behavior-translation.md
+++ b/plugins/developer-workflow/skills/reverse-spec/references/behavior-translation.md
@@ -1,0 +1,321 @@
+# Behavior Translation
+
+The single hardest thing about reverse-spec is resisting the pull of the codebase's own
+vocabulary. Phase 1 captures findings in the code's native words — class names,
+sealed-class cases, method signatures, reactive primitives — because that is what the
+state file is *for*. The state file is an operational artifact. The spec is not.
+
+In Phase 4, before a single sentence is written into the spec, every finding must be
+translated into behavior. This file is the translation table.
+
+---
+
+## The rule
+
+**The body of the spec (Sections 1–9 and 11) must not contain any name that only exists
+in the current codebase.** That includes:
+
+- Class, interface, struct, object, record, module names
+- Method / function / property names
+- Type parameters, generics
+- Sealed-class cases, enum values
+- Field / column / DTO names
+- Package paths, file paths
+- DI graph module names
+- Reactive-primitive names (`StateFlow`, `Observable`, `Publisher`, `BehaviorSubject`, …)
+- Async-primitive names (`suspend`, `async`, `Task`, `Future`, `Deferred`, `Promise`, …)
+- Language keywords that leak idioms (`expect`/`actual`, `sealed`, `data class`, …)
+- Framework-specific idioms (Compose `remember`, React hooks, SwiftUI `@State`, …)
+
+The only place these names may appear is **Section 13 (Code map)** — and there they
+appear as location pointers (`path/to/File.kt:42-58`), not as the subject of the
+description.
+
+**Sanity check a sentence by asking:** *if I renamed every symbol in the codebase
+tomorrow, would this sentence still describe the same feature?* If the sentence would
+break, it is talking about code, not behavior — rewrite it before it enters the spec.
+
+---
+
+## Translation recipes
+
+### 1. Sealed-class / enum cases → business states
+
+The code says:
+
+> `AuthState` is a sealed class with cases `Unauthenticated`, `Authenticating`,
+> `Authenticated(tokens)`, `Error(exception)`.
+
+The spec says:
+
+> The feature has four observable states: **not authenticated** (user has not signed in
+> yet or has signed out), **authorizing** (sign-in in progress), **authenticated**
+> (valid tokens are held), and **failed** (the last sign-in attempt ended with an
+> error). Transitions are described in §4.
+
+The case names are an implementation artifact. The *business states* they represent are
+what the reimplementer needs.
+
+### 2. Method signatures → user-observable operations
+
+Code:
+
+> `OAuthClient.authorize(): OAuthResult<OAuthTokens>` and
+> `OAuthClient.refresh(): OAuthResult<OAuthTokens>` are the public API of the module.
+
+Spec:
+
+> The feature exposes two operations to its host: **sign in** (interactive; opens a
+> browser, exchanges the resulting code for tokens, stores them) and **refresh tokens**
+> (non-interactive; uses the stored refresh token to obtain a new access token). Both
+> return either a valid token set or a structured failure.
+
+Describe *what the operation accomplishes*, not the function signature.
+
+### 3. Exception hierarchies → failure classes
+
+Code:
+
+> `OAuthException` is sealed into `NetworkError`, `AuthorizationError`, `TokenError`,
+> `StorageError`, `InvalidConfiguration`, `RefreshTokenExpired`.
+
+Spec:
+
+> Authorization can fail in six distinguishable ways:
+> 1. **No network** — request to the identity provider could not be made.
+> 2. **Provider refused authorization** — the provider returned an error during the
+>    browser redirect (e.g., user denied, invalid scope).
+> 3. **Token exchange failed** — the provider accepted the code but returned an error
+>    when the app requested tokens.
+> 4. **Storage failed** — tokens could not be persisted locally.
+> 5. **Misconfiguration** — the app was launched with an invalid OAuth configuration
+>    and cannot start a sign-in.
+> 6. **Refresh token expired** — a background refresh failed because the provider
+>    revoked or expired the refresh token; the user must sign in again.
+
+The reimplementer needs the *failure taxonomy and user consequences*, not the Kotlin
+exception tree.
+
+### 4. Reactive primitives → "subscribes to / reflects"
+
+Code:
+
+> `DefaultAuthComponent.authState: StateFlow<AuthState>` is collected by
+> `AuthScreen` via `collectAsState()`.
+
+Spec:
+
+> The sign-in screen reflects the current authentication state: whenever the state
+> changes, the UI re-renders to match.
+
+The reactive plumbing is implementation detail. The behavior is: "UI is always in sync
+with state".
+
+### 5. Async primitives → "when ready / concurrently"
+
+Code:
+
+> `AuthUseCase.login()` is a `suspend fun` that awaits `oauthClient.authorize()` and
+> then `frameClient.currentUser()` via `async`/`await`.
+
+Spec:
+
+> Sign-in completes in two steps: first the OAuth flow obtains tokens, then the app's
+> user profile is fetched. The second step starts only after the first succeeds.
+
+The suspension model is incidental. What matters is the ordering and dependency.
+
+### 6. Internal DTO shapes → external contract
+
+Code:
+
+> `OAuthTokens(accessToken: String, refreshToken: String?, tokenType: String = "Bearer",
+> expiresIn: Long, scope: String?, issuedAt: Long)`
+
+Spec, Section 10.6 Data contracts:
+
+> The token response from the identity provider includes, at minimum: an access token
+> (string, required), a refresh token (string, optional — may be absent), a token type
+> (string, currently always `"Bearer"`), an expiry in seconds (number, required), and
+> an optional scope list (space-separated string).
+>
+> The app records the issuance timestamp (milliseconds since epoch) at receipt time so
+> that expiry can be computed locally.
+>
+> The full OAuth 2.0 contract is defined by RFC 6749; this spec covers only the subset
+> the feature relies on.
+
+The Kotlin `data class` is not the contract. The *wire shape* is, and it is specified
+by an RFC plus the fields the app actually reads.
+
+### 7. DI / factory plumbing → "is configured with"
+
+Code:
+
+> `authFeatureKoinModule { factory { AuthUseCase(get(), get()) } }` — `AuthUseCase`
+> depends on `OAuthClient` and `FrameClient`.
+
+Spec:
+
+> The authorization flow is configured with two collaborators: an OAuth client and the
+> application's Frame API client. Both are expected to be provided by the host
+> application.
+
+DI is how *this* implementation wires the feature. The spec documents that the feature
+has two required collaborators with stated responsibilities.
+
+### 8. Platform `expect`/`actual` → "per platform"
+
+Code:
+
+> `expect class PKCEGenerator` with `actual` implementations in `androidMain`,
+> `iosMain`, `desktopMain`.
+
+Spec:
+
+> PKCE code verifier and challenge are generated per platform, using each platform's
+> native secure randomness source. Output shape and semantics are identical across
+> platforms.
+
+`expect`/`actual` is KMP-specific. The behavior — per-platform implementation of a
+common contract — can be stated in plain language.
+
+### 9. Coroutine / scope plumbing → "runs until / is cancelled when"
+
+Code:
+
+> `componentContext.coroutineScope` is used; on decompose destroy, all inflight jobs are
+> cancelled.
+
+Spec:
+
+> When the sign-in screen is dismissed, any in-flight authorization is cancelled and
+> does not complete in the background.
+
+Component lifecycles are implementation. The behavior is: "closing the screen cancels
+the work".
+
+### 10. UI toolkit components → component role
+
+Code:
+
+> `AuthScreen` uses a `Box` with `Scaffold` containing a `Column` of `Text`, `Button`,
+> and a `CircularProgressIndicator` shown on `AuthState.Authenticating`.
+
+Spec:
+
+> The screen is a single full-height surface with, top to bottom: the app identity, a
+> short product pitch, a primary "Sign in" action, and a secondary link for sign-up.
+> While authorization is in progress, a spinner replaces the primary action.
+
+Describe the *roles* of the components, not their Compose names.
+
+### 11. Storage library → "persists / retrieves"
+
+Code:
+
+> `SettingsTokenStorage` wraps a `Settings` instance and serialises `OAuthTokens` via
+> `Json.encodeToString`.
+
+Spec:
+
+> Tokens are persisted in platform key-value storage as a JSON payload. On app start,
+> the stored payload is read and used to restore the authenticated state.
+
+Library name drops. What stays: storage medium (key-value, here non-encrypted — flagged
+in §12), serialisation format, startup behavior.
+
+### 12. Defect observation → §9 Known defects entry
+
+Code:
+
+> `authFeatureKoinModule()` is defined in `AuthKoin.kt:12-18` but grep across
+> `InitKoin.*.kt`, `AppModule.kt`, and every `platformKoinModule.*.kt` returns no
+> callers — the module is never loaded. `AuthUseCase` therefore cannot resolve its
+> dependencies at runtime.
+
+State file entry:
+
+> Phase 1 finding: DI module `authFeatureKoinModule` defined but never loaded.
+> Classification (Phase 4.0): confirmed defect — reproducible crash path.
+
+§9 entry in the spec:
+
+> | Sign-in tap crashes on first use | crash | `AuthKoin.kt:12-18` defines the DI
+> module for the authorization use case but no call site loads it (verified by
+> grepping `InitKoin`, `AppModule`, and all platform DI modules) | Tapping the primary
+> action on the sign-in screen throws a dependency-resolution error and the app
+> crashes |
+
+Note how the translation shifts framing from **code structure** ("`authFeatureKoinModule()`
+is not loaded") to **user consequence** ("sign-in tap crashes"). The code pointer stays
+as evidence; it does not become the subject of the sentence. That way a reimplementer
+on SwiftUI or web reads the entry and immediately knows "make sure the equivalent of
+'authorization use case' is wired into whatever dependency system we end up using" —
+rather than "match Koin's module-loading contract", which is a meaningless instruction
+on another stack.
+
+### 13. Internal navigation graph → named transitions
+
+Code:
+
+> `DefaultRootComponent` uses `StackNavigation<RootConfig>`; on successful sign-in,
+> `navigation.replaceAll(InitialUserSetup(userId))` is called.
+
+Spec:
+
+> On successful sign-in, the app replaces the sign-in screen with the initial user
+> setup screen, passing the authenticated user's ID. The sign-in screen is not retained
+> in the navigation back-stack.
+
+Navigation library is implementation. What matters: destination, argument, back-stack
+effect.
+
+---
+
+## What to preserve literally
+
+The translation rule drops *code identifiers*. It does not drop:
+
+- **Exact user-visible copy** — quote verbatim: `"Cancel"`, `"Не удалось загрузить заказ"`.
+- **Exact numbers** — retry count 3, timeout 5 minutes, buffer 60 seconds.
+- **Exact external contracts** — URL patterns, query parameter names (they are the
+  *contract* with an external system, not internal code).
+- **Exact event names and property keys** — these are the analytics contract;
+  `"payment_confirmed"` with `order_id` stays as `"payment_confirmed"` with `order_id`.
+- **Standard specification references** — "OAuth 2.0 Authorization Code + PKCE per
+  RFC 7636" is a *protocol*, not a codebase name.
+
+The test: *if the codebase burned down tonight and was rewritten on a different stack
+by a different team, would this string/number/URL still appear identically?* If yes,
+keep it literal.
+
+---
+
+## Where code identifiers are OK
+
+**Section 13 (Code map) only.** That section is explicitly about the current
+implementation — it points at files and line ranges so future readers (including a
+re-run of this skill) can verify the spec still matches the code. The format is
+`spec section → path:start-end`, not "`AuthViewModel` does X".
+
+**State file (`./swarm-report/...`), not the spec.** Phase 1 findings are recorded with
+code identifiers for operational reasons — the state file is how Phase 4 knows what to
+translate. It is deleted in Phase 7 and never ships.
+
+---
+
+## Drafting discipline
+
+Before writing each paragraph of the spec, scan the related Phase 1 findings in the
+state file and ask two questions for every proper-noun-looking token:
+
+1. *Is this name something that exists only in this repo?* If yes, translate.
+2. *Is this name an external contract (URL, event, field in a provider response,
+   protocol)?* If yes, keep literal.
+
+The habit is uncomfortable at first — reverse-engineering rewards pattern-matching to
+code, and dropping the code's vocabulary feels like losing information. But a spec that
+leaks identifiers produces a reimplementation that copies structure instead of
+behavior. The whole point of the skill is the opposite: extract behavior that survives
+reimplementation on any stack.

--- a/plugins/developer-workflow/skills/reverse-spec/references/behavior-translation.md
+++ b/plugins/developer-workflow/skills/reverse-spec/references/behavior-translation.md
@@ -225,7 +225,15 @@ Spec:
 Library name drops. What stays: storage medium (key-value, here non-encrypted — flagged
 in §12), serialisation format, startup behavior.
 
-### 12. Defect observation → §9 Known defects entry
+### 12. Defect observation → §9 Known defects (behavior bug) OR hygiene artefact
+
+This recipe has two forks because Phase 4.0 must distinguish **behavior defects**
+(go to §9) from **implementation hygiene findings** (go to a separate
+`<slug>-hygiene.md` file). The classification rule lives in
+`analysis-checklist.md` §14; the hard line is: *if removing the finding does not
+change what the user observes when they use the feature, it is hygiene, not §9*.
+
+#### Fork A — Behavior defect (§9)
 
 Code:
 
@@ -237,23 +245,54 @@ Code:
 State file entry:
 
 > Phase 1 finding: DI module `authFeatureKoinModule` defined but never loaded.
-> Classification (Phase 4.0): confirmed defect — reproducible crash path.
+> Classification (Phase 4.0): behavior defect — sign-in tap crashes (observable
+> user consequence).
 
 §9 entry in the spec:
 
 > | Sign-in tap crashes on first use | crash | `AuthKoin.kt:12-18` defines the DI
 > module for the authorization use case but no call site loads it (verified by
-> grepping `InitKoin`, `AppModule`, and all platform DI modules) | Tapping the primary
-> action on the sign-in screen throws a dependency-resolution error and the app
-> crashes |
+> grepping `InitKoin`, `AppModule`, and all platform DI modules) | Tapping the
+> primary action on the sign-in screen throws a dependency-resolution error and
+> the app crashes |
 
-Note how the translation shifts framing from **code structure** ("`authFeatureKoinModule()`
-is not loaded") to **user consequence** ("sign-in tap crashes"). The code pointer stays
-as evidence; it does not become the subject of the sentence. That way a reimplementer
-on SwiftUI or web reads the entry and immediately knows "make sure the equivalent of
-'authorization use case' is wired into whatever dependency system we end up using" —
-rather than "match Koin's module-loading contract", which is a meaningless instruction
-on another stack.
+The translation shifts framing from **code structure** ("`authFeatureKoinModule()`
+is not loaded") to **observable user consequence** ("sign-in tap crashes"). The
+code pointer stays as evidence; it does not become the subject of the sentence. A
+reimplementer on SwiftUI or web reads the entry and knows "make sure the
+authorization use case is wired into whatever dependency system we end up using" —
+not "match Koin's module-loading contract", which is meaningless on another stack.
+
+#### Fork B — Implementation hygiene (separate artefact, NOT §9)
+
+Code:
+
+> `AuthScreen.kt:171` — `Text(text = "Cancel")`, a literal string instead of a
+> resource lookup. All other strings on the screen go through the resource
+> mechanism with keys in `strings.xml`.
+
+State file entry:
+
+> Phase 1 finding: "Cancel" hardcoded; rest of screen uses resources.
+> Classification (Phase 4.0): hygiene — feature behaves correctly today; the
+> problem only manifests when the project adds a non-English locale.
+
+`<slug>-hygiene.md` entry:
+
+> | Hardcoded "Cancel" label | localization-readiness | `AuthScreen.kt:171` —
+> literal string, not a resource lookup; rest of screen uses resources |
+> When the project ships a non-English locale, this single label will remain
+> English |
+
+The same code-finding could *not* go into §9 because the feature presently
+behaves correctly — the user sees "Cancel" in English alongside other English
+strings. Removing the finding (replacing the literal with a resource lookup)
+does not change what the user sees today. It is hygiene.
+
+Same fork applies to: weak PRNG for security values (feature flow completes;
+risk is secret strength), plaintext token storage (feature works; risk is
+device-compromise threat model), log leakage of sensitive data (feature works;
+risk is log exposure). All hygiene, not §9.
 
 ### 13. Internal navigation graph → named transitions
 

--- a/plugins/developer-workflow/skills/reverse-spec/references/behavior-translation.md
+++ b/plugins/developer-workflow/skills/reverse-spec/references/behavior-translation.md
@@ -12,8 +12,8 @@ translated into behavior. This file is the translation table.
 
 ## The rule
 
-**The body of the spec (Sections 1–9 and 11) must not contain any name that only exists
-in the current codebase.** That includes:
+**The body of the spec (Sections 1–8 and 10–11) must not contain any name that only
+exists in the current codebase.** That includes:
 
 - Class, interface, struct, object, record, module names
 - Method / function / property names

--- a/plugins/developer-workflow/skills/reverse-spec/references/coverage-verification.md
+++ b/plugins/developer-workflow/skills/reverse-spec/references/coverage-verification.md
@@ -104,20 +104,23 @@ Valid evidence sources:
   the project, recorded in Phase 2 findings.
 - **Explicit Open Question** — the claim is marked "assumed" in section 8 of the spec.
 
-**Extra bar for §9 Known defects entries.** A claim that the current code has a bug is
-stronger than a regular spec claim and requires more than "I saw this in the code" as
-evidence. Every §9 entry must have:
+**Extra bar for §9 Known defects entries.** §9 carries behavior bugs only — the
+feature does not do what it should as a feature. The classification rule (behavior
+defect vs implementation hygiene vs open question) lives in
+`analysis-checklist.md` §14. Every §9 entry must have:
 
-- A concrete code pointer showing the defective behavior (path:line with a short quote
-  or condition).
-- A stated defect class (crash, unreachable code, security weakness, dead link,
-  localization gap, data loss, race condition, other).
-- A stated consequence (what user sees, what risk is created).
+- A concrete code pointer showing the defective behavior (path:line with a short
+  quote or condition).
+- A defect class from the §14 enumeration (`crash`, `unreachable state`, `dead UI
+  control`, `wrong-data shown`, `silent failure`, `lost user action`, `incorrect
+  state transition`, `other`).
+- An observable user consequence — what the user sees or what intended outcome is
+  missed.
 
-If any of those three are missing, the entry is not a confirmed defect — downgrade it
-to §8 Open Questions and let a later clarification round (or user review) decide.
-Speculation disguised as a defect report is worse than a plain open question, because
-it signals false confidence.
+If any of those three are missing, the entry is not a behavior defect — demote to
+§8 Open Questions or to the `<slug>-hygiene.md` artefact per §14. Speculation
+disguised as a defect report is worse than a plain open question, because it
+signals false confidence.
 
 If a claim has no evidence, it is speculation and must be removed or rewritten:
 
@@ -135,7 +138,7 @@ The biggest failure mode of a reverse-engineered spec is describing the current 
 instead of the feature. The first two passes catch coverage and grounding. Pass 3
 catches vocabulary.
 
-**Scan every sentence in the body (Sections 1–9 and 11)** for any token that exists
+**Scan every sentence in the body (Sections 1–8 and 10–11)** for any token that exists
 only because this codebase exists. The pattern list:
 
 - `CamelCase` or `PascalCase` words that are class / interface / type names
@@ -173,7 +176,7 @@ The scan output goes into the state file as a short report:
 > 0 leaks."*
 
 If the grep / search tool is available, this pass can be partially automated:
-`rg -n "\b[A-Z][a-zA-Z]+(Client|Service|Repository|ViewModel|Component|Use[Cc]ase|State|Storage|Config|Result|Exception)\b"` through sections 1–9 and 11 flags the majority of candidate leaks. Human judgment still required on each hit.
+`rg -n "\b[A-Z][a-zA-Z]+(Client|Service|Repository|ViewModel|Component|Use[Cc]ase|State|Storage|Config|Result|Exception)\b"` through sections 1–8 and 10–11 flags the majority of candidate leaks. Human judgment still required on each hit.
 
 ---
 

--- a/plugins/developer-workflow/skills/reverse-spec/references/coverage-verification.md
+++ b/plugins/developer-workflow/skills/reverse-spec/references/coverage-verification.md
@@ -1,0 +1,298 @@
+# Coverage Verification
+
+Round-trip self-review run in Phase 5, before the draft is shown to the user. Purpose:
+make sure the spec covers the code, and that everything in the spec is grounded in code
+or user input.
+
+A spec that looks thorough but misses a branch produces a reimplementation that misses
+a behavior. A spec with claims that do not trace back to evidence is fiction. Both are
+caught here.
+
+---
+
+## Proof standard (the rule that drives both passes)
+
+Every factual claim in the spec body must trace to exactly one of these:
+
+- **Code location** — `path/to/File.kt:42` or `path/to/File.kt:42-58`. Direct
+  observation with a pointer a reviewer can open and verify.
+- **User answer** — a Phase 3 clarification response recorded in the state file (quote
+  the answer, not a paraphrase).
+- **Project convention** — a cross-reference to an existing doc, shared component, or a
+  code location that establishes the pattern project-wide. Recorded in Phase 2 findings.
+- **Open Question** — the claim is marked as assumed in Section 8 of the spec and the
+  consequence of being wrong is spelled out.
+
+**No speculation.** If a claim cannot attach to one of the four sources, it does not
+belong in the spec body — either find the evidence, escalate to Open Questions, or
+delete the claim. "It probably does X because it would make sense" is not a proof; it
+is speculation with nice phrasing.
+
+This rule is what separates a reverse-engineered spec from an imagined one. A
+reimplementer trusts the spec only if every statement can be traced back. The two passes
+below operationalise the rule in both directions.
+
+---
+
+## Five passes, all required
+
+Each pass catches a different class of failure and cannot substitute for the others:
+
+- **Pass 1 — coverage:** *what code did the spec miss?*
+- **Pass 2 — grounding:** *what spec claims have no evidence?*
+- **Pass 3 — vocabulary:** *what implementation details leaked into the body?*
+- **Pass 4 — reference integrity:** *do the spec's internal cross-references resolve?*
+- **Pass 5 — code-map validity:** *do the Code Map pointers point at real code?*
+
+Plus a final typo / formatting sweep before the draft leaves the skill. The five
+passes are fast when run in order; skipping one breaks a specific guarantee the spec
+claims to make.
+
+---
+
+## Pass 1 & 2: coverage and grounding
+
+### Pass 1: code → spec (no code branch left behind)
+
+Enumerate every significant branch, conditional, and public entry point in the feature's
+files. For each one, locate the spec section that describes its **observable effect**.
+
+**Branches that count as significant:**
+
+- every `if / when / switch` that produces a different user-visible outcome
+- every early return that changes what the user sees
+- every `try / catch` branch that results in a distinct error state
+- every `launch / runBlocking / Task { … }` that triggers side effects
+- every navigation call
+- every external call (API, DB, event emission, analytics, logging of product events)
+- every string shown to the user (localized or hard-coded)
+- every feature-flag / remote-config read that alters behavior
+
+**Branches that do not count:**
+
+- pure utility functions with no user-visible effect
+- routine logging at debug / trace level
+- architectural plumbing (DI wiring, coroutine scope management) without behavior
+  change
+
+Record findings in a simple table:
+
+| Code location | What it does | Spec section | Status |
+| --- | --- | --- | --- |
+| `FooVM.kt:42` if branch | empty-state when list.isEmpty() | §4 States / empty | covered |
+| `FooVM.kt:58` catch branch | offline error copy | — | **gap — add** |
+| `FooUseCase.kt:77` retry loop | retry up to 3× | §2.2 / §7 | covered |
+
+Every "gap" must be resolved before presenting the draft:
+
+- **Add to spec** — the behavior is spec-worthy; extend the relevant section.
+- **Justify omission** — the branch has no observable effect (e.g., a fallback logger);
+  note in the code map that it is intentionally not in the spec.
+- **Escalate** — the branch is ambiguous; put the question into Phase 6's open-questions
+  queue instead of inventing coverage.
+
+### Pass 2: spec → code (every claim is grounded)
+
+Walk through the draft spec top to bottom. For each concrete claim — a number, an exact
+copy string, a state description, an event name — answer: *what is the evidence?*
+
+Valid evidence sources:
+
+- **Code location** — direct observation, recorded in the code map.
+- **User input** — a clarification answer from Phase 3, recorded in the state file.
+- **Project convention** — a cross-reference to a documented or widely-used pattern in
+  the project, recorded in Phase 2 findings.
+- **Explicit Open Question** — the claim is marked "assumed" in section 8 of the spec.
+
+**Extra bar for §9 Known defects entries.** A claim that the current code has a bug is
+stronger than a regular spec claim and requires more than "I saw this in the code" as
+evidence. Every §9 entry must have:
+
+- A concrete code pointer showing the defective behavior (path:line with a short quote
+  or condition).
+- A stated defect class (crash, unreachable code, security weakness, dead link,
+  localization gap, data loss, race condition, other).
+- A stated consequence (what user sees, what risk is created).
+
+If any of those three are missing, the entry is not a confirmed defect — downgrade it
+to §8 Open Questions and let a later clarification round (or user review) decide.
+Speculation disguised as a defect report is worse than a plain open question, because
+it signals false confidence.
+
+If a claim has no evidence, it is speculation and must be removed or rewritten:
+
+- if the user can answer it → move it to Phase 6 questions
+- if the user also does not know → leave the observed fact in the spec body, add an
+  Open Questions entry for the missing rationale
+- if it was filler ("this feature is important for customer retention") with no grounding
+  → delete
+
+---
+
+### Pass 3: identifier-leak scan (the zero-tolerance pass)
+
+The biggest failure mode of a reverse-engineered spec is describing the current code
+instead of the feature. The first two passes catch coverage and grounding. Pass 3
+catches vocabulary.
+
+**Scan every sentence in the body (Sections 1–9 and 11)** for any token that exists
+only because this codebase exists. The pattern list:
+
+- `CamelCase` or `PascalCase` words that are class / interface / type names
+- `lowerCamelCase` identifiers that are method or property names
+- `snake_case_package` paths, `com.example.x.y.z` dotted paths
+- file paths (`AuthScreen.kt`, `path/to/File.swift`)
+- sealed-class case names (`OAuthResult.Success`, `AuthState.Error`)
+- reactive-primitive names (`StateFlow`, `Observable`, `Publisher`, `BehaviorSubject`)
+- async-primitive names (`suspend`, `Task`, `Future`, `Deferred`, `Promise`, `async`)
+- language keywords that leak idioms (`expect`, `actual`, `sealed`, `data class`)
+- framework-specific terms (`@Composable`, `@State`, React hook names)
+
+For every hit, decide:
+
+- **Translate** — rephrase using `references/behavior-translation.md`. Rewrite the
+  sentence; re-run Pass 1 and Pass 2 on the rewritten claim to confirm coverage and
+  grounding are preserved.
+- **Move to §13** — if the identifier was a location pointer dressed as prose (`see
+  AuthViewModel`), move it into the Code Map table and delete the mention from the
+  body.
+- **Keep** — only when the identifier is an *external contract* (e.g., `Bearer` token
+  type from RFC 6749, `application/x-www-form-urlencoded` content type,
+  `payment_confirmed` analytics event). The test: *does this name exist in an
+  external specification or wire protocol, independent of this codebase?* If yes,
+  keep literal. Otherwise, translate or move.
+
+**Zero tolerance.** A single leaked identifier in the body means the spec describes the
+implementation, not the feature. If the pass finds any, the draft is not ready — fix
+and re-scan before presenting.
+
+The scan output goes into the state file as a short report:
+
+> *"Pass 3 scan: 14 identifier hits initially — 9 translated (see change log below), 4
+> moved to Code Map, 1 kept as external contract (`Bearer` per RFC 6749). Final scan:
+> 0 leaks."*
+
+If the grep / search tool is available, this pass can be partially automated:
+`rg -n "\b[A-Z][a-zA-Z]+(Client|Service|Repository|ViewModel|Component|Use[Cc]ase|State|Storage|Config|Result|Exception)\b"` through sections 1–9 and 11 flags the majority of candidate leaks. Human judgment still required on each hit.
+
+---
+
+### Pass 4: reference integrity
+
+A spec with broken internal cross-references tells the reader to go somewhere that
+isn't there. The most common break: body mentions `[OQ-3]` but §8 has no entry 3.
+
+Run two scans:
+
+**Body → §8** — grep the body (§§1-8 excluding §8 itself, §§10-11) for markers
+matching `\[OQ-\d+\]`. For each hit:
+
+- Does §8 contain an entry with exactly that marker? If not → fail.
+
+**§8 → body** — list every entry in §8. For each entry:
+
+- Does its `Why it matters` or `Current assumption` imply body impact (i.e., the
+  claim is something the body relies on)? If yes, is there at least one matching
+  `[OQ-N]` in the body? If no match → fail.
+- Entries that are purely follow-ups without body dependency (e.g., "should we add
+  analytics later?") are exempt from the reverse scan.
+
+**Implementation note.** This pass can be automated with a small script: extract all
+`[OQ-N]` from body text and all entry numbers from §8, then diff. Run it manually
+during Phase 5 or bake into a pre-commit hook.
+
+Any failure blocks the DoD gate for §8 — the spec is not ready until both directions
+resolve.
+
+### Pass 5: code-map validity
+
+Every entry in §13 Code map is a promise: "open this file at this line and you'll
+see the referenced behavior". When the file is renamed, deleted, or the lines shift,
+the promise breaks silently. Pass 5 tests the promise mechanically.
+
+For each row of the §13 table:
+
+1. **Parse the pointer.** Format is `path/to/File.ext:N` or `path/to/File.ext:N-M`.
+   Paths are relative to the repository root. Multiple pointers in one cell are
+   comma-separated.
+2. **File existence.** `test -f <path>` — file must exist. If not → fail with "file
+   missing".
+3. **Line range validity.** `wc -l <path>` — line number N (or end-of-range M) must
+   be ≤ total lines in the file. If not → fail with "line out of range".
+4. **Range sanity.** For ranges `N-M`, require `N ≤ M`. Reversed ranges → fail.
+
+Pass 5 does not verify *content match* (whether the linked lines actually show the
+described behavior) — that would require semantic analysis. It verifies only that
+the pointer resolves. Content match is covered indirectly by Pass 1 (each body
+section mapped to a location) + Pass 2 (each claim grounded in code).
+
+A short shell snippet does all three checks:
+
+```sh
+while read path line_spec; do
+  [ -f "$path" ] || { echo "FAIL: $path missing"; continue; }
+  total=$(wc -l < "$path")
+  end=${line_spec##*-}
+  [ "$end" -le "$total" ] || echo "FAIL: $path:$line_spec exceeds $total lines"
+done < code-map-pointers.txt
+```
+
+Any failure blocks the DoD gate for §13.
+
+### Final sweep: typos and formatting
+
+A trailing pass, light but mandatory. Run through the body and catch:
+
+- stray orphan spaces inside words (`«не заверш ается»`)
+- common misspellings in the document's working language
+- inconsistent punctuation around code spans / quotes
+- accidentally doubled words ("the the", "для для")
+- mixed Latin / Cyrillic characters that look identical (e.g., Latin `a` inside a
+  Cyrillic word)
+
+This is not a rigorous spell-check pass — it is the equivalent of a quick proofread.
+A spec with typos in the body reads as sloppy and erodes reader trust in the more
+substantive claims nearby. The pass takes a minute; skipping it costs more.
+
+---
+
+## Summarizing the result
+
+Before presenting the draft, write a one-line summary of the verification into the state
+file and include it in the hand-off message:
+
+> *"Coverage: 42/42 branches mapped, 3 intentionally omitted (see Code Map). All spec
+> claims traced to code or answers. Identifier scan: 0 leaks in body. Reference
+> integrity: 14 OQ-markers ↔ 14 entries, all resolve. Code-map validity: 18/18
+> pointers valid. Typo sweep: clean. 2 entries in Open Questions remain unresolved."*
+
+This summary is the signal to the user that the draft was checked, not just written.
+
+---
+
+## When gaps cannot be closed
+
+Sometimes analysis reveals a branch whose behavior depends on context only the user can
+supply (e.g., a server-driven config value that changes copy). In that case:
+
+1. Capture the observed code behavior in the spec body ("renders copy from remote
+   config key `payment.tooltip.copy`").
+2. Add to Open Questions: *"What are the valid values for `payment.tooltip.copy`? The
+   spec currently lists the fallback string only."*.
+3. Do not fabricate values to close the gap.
+
+The spec remains honest about what is known and what is outstanding. A reimplementer can
+act on both — on the known behavior immediately, on the open questions once the user
+answers.
+
+---
+
+## Interaction with Phase 6
+
+The coverage report drives Phase 6's question batch. When the draft is presented:
+
+- *"2 branches had ambiguous intent — do you want me to ask about them?"* is a natural
+  opener if the user has capacity.
+- If the user approves the draft as-is, the Open Questions entries stay and travel with
+  the spec. That is the correct outcome: a spec that surfaces unknowns beats a spec that
+  hides them.

--- a/plugins/developer-workflow/skills/reverse-spec/references/definition-of-done.md
+++ b/plugins/developer-workflow/skills/reverse-spec/references/definition-of-done.md
@@ -1,0 +1,116 @@
+# Definition of Done
+
+The five coverage-verification passes plus the typo sweep (Pass 1 / Pass 2 / Pass 3 /
+Pass 4 / Pass 5 / typo) are mechanical checks. They catch specific failure modes —
+missing coverage, ungrounded claims, leaked code identifiers, broken cross-refs,
+dangling code-map pointers, sloppy text. But they do not by themselves answer the
+question *"is this spec ready to hand off?"*.
+
+This file is that answer: a binary gate of eleven items. The spec is ready only when
+every item is checked. A half-satisfied checklist is not a ready spec — it is a
+progress report. Always report the checklist in the Phase 6 handoff alongside the
+Phase 5 verification summary.
+
+Treat the gate as sequential only when convenient; most items can be checked in any
+order, but all must be checked before the skill declares the draft ready.
+
+## The eleven gates
+
+### 1. All 13 sections present
+
+Every section from `spec-template.md` appears in the draft, either with content or
+with an explicit `N/A — <one-line reason>` stub. Never silently skip a section —
+missing sections read as oversight; explicit N/A reads as considered absence.
+
+### 2. Pass 1 (coverage) clean
+
+Every significant code branch in the scoped files maps to a spec section, or is
+explicitly recorded in §13 Code map as intentionally omitted (architectural plumbing,
+routine logging, DI wiring). No unmapped branch is acceptable.
+
+### 3. Pass 2 (grounding) clean
+
+Every factual claim in the body traces to exactly one of: code location, recorded
+user answer, project convention cross-reference, or an explicit Open Question entry.
+Zero speculation. If a sentence cannot be traced, it is removed or demoted to an
+Open Question.
+
+### 4. Pass 3 (identifier leak) clean
+
+Zero code identifiers in §§1-8 and 10-11. Allowed in body: external contract names — URL
+patterns, RFC field names, analytics event names, wire-protocol terms. Forbidden in
+body: codebase-specific class names, method names, sealed-class cases, reactive /
+async primitive names, framework idioms, file paths.
+
+### 5. §8 Open Questions populated or explicitly empty
+
+Either ≥1 entry with assumption + consequence of being wrong, or the literal line
+`No open questions — all clarifications resolved.` in the section body. An empty
+section reads as oversight; either form of content reads as considered.
+
+### 6. §9 Known defects complete
+
+Every defect entry has all four required fields: **what**, **class**, **evidence**
+(path:line pointer + quote/scenario), **consequence**. If the feature has no
+confirmed defects, the section contains `N/A — no confirmed defects identified.`
+Partial entries (missing one of the four fields) are not acceptable — demote to §8
+Open Questions instead.
+
+### 7. §13 Code map covers body
+
+Every body section that has content (§§2-7 Product, §§10-11 Technical, as applicable;
+sections marked N/A are exempt) has at least one location pointer in the Code map
+table. A body section without any Code map entry means the claim cannot be verified
+by a reader.
+
+### 8. Header fully filled
+
+The spec's header block contains, at minimum:
+
+- **Status** — `Draft` or `Approved`
+- **Source** — commit SHA or calendar date when the code was analysed
+- **Language** — the working language of the document
+- **Owner** — team / person, if known; `unknown` if not
+
+Missing fields = spec not ready. The header is how a future reader knows which
+version of the code this spec describes.
+
+### 9. Pass 4 (reference integrity) clean
+
+Every `[OQ-N]` marker in the body has a matching entry in §8, and every §8 entry
+with body impact has at least one `[OQ-N]` in the body. Unidirectional references
+in either direction fail this gate.
+
+### 10. Pass 5 (code-map validity) clean
+
+Every `path:line` pointer in §13 points to a file that exists and a line (or range)
+that falls within the file's total lines. No missing files, no out-of-range pointers,
+no reversed ranges.
+
+### 11. Typo sweep and user review
+
+Two items bundled as the final gate:
+
+- **Typo sweep completed.** Body read through for orphan spaces inside words,
+  doubled words, mixed Latin/Cyrillic characters, inconsistent punctuation. No
+  typos remain.
+- **User reviewed in Phase 6.** The user has seen the draft and either approved it
+  or requested changes. The skill does not self-approve. This is the gate that
+  distinguishes *"the machinery said yes"* from *"a human stakeholder confirmed
+  this matches intent"*.
+
+## Handoff format
+
+When all nine items are checked, the skill produces a one-line ready signal in the
+Phase 6 / Phase 7 handoff:
+
+> *"Spec ready — all DoD gates passed. Saved at `docs/spec/<slug>.md`."*
+
+When any item is unchecked, the skill produces a progress report instead, listing:
+
+- Which items are checked (say "N/11 passed" with the list)
+- Which items remain open and what would need to happen to close each one
+- Estimated next action (another review round? user clarification? coverage gap fix?)
+
+Never hide an unchecked gate by treating it as optional. The DoD is the skill's
+contract with the user — if gates are optional, the contract is empty.

--- a/plugins/developer-workflow/skills/reverse-spec/references/definition-of-done.md
+++ b/plugins/developer-workflow/skills/reverse-spec/references/definition-of-done.md
@@ -101,7 +101,7 @@ Two items bundled as the final gate:
 
 ## Handoff format
 
-When all nine items are checked, the skill produces a one-line ready signal in the
+When all eleven items are checked, the skill produces a one-line ready signal in the
 Phase 6 / Phase 7 handoff:
 
 > *"Spec ready — all DoD gates passed. Saved at `docs/spec/<slug>.md`."*

--- a/plugins/developer-workflow/skills/reverse-spec/references/project-overview-protocol.md
+++ b/plugins/developer-workflow/skills/reverse-spec/references/project-overview-protocol.md
@@ -1,0 +1,148 @@
+# Project Overview Protocol
+
+Many feature specs end up duplicating the same project-level information — what the
+app is, who it's for, what languages it supports, what core domain entities it
+operates on, what authentication / payment / API providers it uses, what the
+architectural style is. Without a single shared document, every feature spec must
+restate this context, and the redundancy bloats every spec while still failing to
+guarantee consistency.
+
+The reverse-spec skill resolves this by **consulting a project-overview document
+before drafting any feature spec**. If the overview exists, the feature spec
+references it instead of duplicating. If it does not exist, the skill offers to
+draft one and waits for user review before proceeding.
+
+This file describes when, where, and how that mechanism runs.
+
+## Where the document lives
+
+Default path: `docs/project-overview.md`.
+
+Alternative paths checked in order if the default does not exist:
+
+- `docs/PROJECT.md`
+- `docs/overview.md`
+- `PROJECT.md` (repo root)
+
+The first existing file wins. If a project uses a different convention, ask the user
+to point at it once; record the path in the spec's state file so subsequent runs find
+it without re-asking.
+
+## What the document contains
+
+The project overview is **business-level**, not architectural. It complements (not
+replaces) `CLAUDE.md` and similar engineering docs. Recommended sections:
+
+```markdown
+# <Project name>
+
+## What this app is
+1-2 paragraphs. Purpose. Primary user. Why it exists. What it lets users do that
+they could not do otherwise.
+
+## Primary user segments
+Who the users are, in business terms. Roles if multi-role.
+
+## Supported languages and regions
+Languages the UI is translated into. Regions where the app is distributed. Any
+region-specific behavior worth flagging at app level.
+
+## Core domain entities
+The 3-7 main entities the app reasons about (e.g., for Frame.io: Asset, Comment,
+Review, Workspace, User). One-line definitions. Detailed contracts live in
+feature specs that own each entity.
+
+## Identity & authentication provider
+The IdP the app uses (Adobe IMS, Auth0, custom). Link to provider docs.
+
+## External services and integrations
+The app's standing dependencies on external systems (payment, storage, analytics,
+push, etc.). One line per service + link to provider docs.
+
+## Architecture posture
+1-2 sentences. Native vs cross-platform. Single-codebase or per-platform.
+Online-first, offline-first, hybrid.
+
+## Cross-cutting conventions
+Project-wide patterns: error display style, analytics taxonomy doc location,
+logging level conventions, accessibility floor, theming approach. One line per
+convention.
+
+## Known project-wide constraints
+Compliance, regulatory, contractual constraints that bind every feature
+(GDPR, PCI, HIPAA, contracted SLA, etc.).
+
+## External documentation references
+Authoritative provider docs, standards, RFCs the app collectively depends on.
+```
+
+This is a starting structure — adapt to what the project actually has. Aim for
+~200-400 lines, not 50 and not 1000.
+
+## When the skill consults the document
+
+In Phase 0.5 (between scope-lock and static analysis), the skill:
+
+1. Looks for the overview at the default and alternative paths.
+2. If found:
+   a. Reads it.
+   b. Captures relevant excerpts in the state file.
+   c. Notes the path so the feature spec can cross-reference instead of duplicate.
+3. If not found:
+   a. Tells the user — *"Не нашёл project-overview в `docs/project-overview.md` или
+      аналогах. Хотел бы предложить набросок (минут на 5 чтения), чтобы фича-спека
+      могла на него ссылаться вместо дублирования. Создать?"*
+   b. If the user agrees, the skill drafts a project-overview from what it can
+      observe in the repo (README, package metadata, top-level config files, source
+      layout). The draft is **explicit about confidence** — every claim is sourced
+      or marked `[unknown — please fill in]`.
+   c. The user reviews and edits.
+   d. Once approved, save to `docs/project-overview.md` and proceed.
+   e. If the user declines, proceed without overview — the feature spec will
+      include some duplicated context. Note the missing overview as `[OQ-N]` in §8.
+
+## What changes in the feature spec when the overview exists
+
+The feature spec gets shorter and more focused. Specifically:
+
+- **§1 Overview** — refers to project-overview's "What this app is" instead of
+  restating it. "This feature is the sign-in screen for the Frame.io app (see
+  `docs/project-overview.md` §What this app is). Its purpose is..."
+- **§4 States, §5 Navigation** — language-agnostic where the project has a stated
+  language stance. "Strings follow the project's standard localization
+  pattern (see project-overview §Supported languages)."
+- **§6 Localization & accessibility** — refers to project conventions; lists only
+  feature-specific deviations.
+- **§7 Analytics & logging** — refers to project taxonomy doc.
+- **§10.5 External services** — links provider docs once at project level; feature
+  spec mentions only feature-specific behavior.
+- **§10.7 Collaborators** — names project-standard services ("the project's
+  standard authenticated HTTP client") and links to overview rather than
+  enumerating types.
+- **§12.5 External references** — only feature-specific links; project-wide ones
+  live in the overview.
+
+## Update discipline
+
+A project-overview is a living document. When this skill runs and sees outdated
+content (e.g., the overview says "supported languages: en, ru" but the app added
+de), the skill:
+
+1. Flags the discrepancy in the state file.
+2. Mentions it once in the handoff: *"Замечено в project-overview.md: <field> может
+   быть устаревшим — наблюдаемое в коде <X>, в документе <Y>. Обновлять не стал —
+   это вне scope текущей фичи."*
+
+The skill never silently edits the project overview. Updates are user-driven, like
+the document's initial creation.
+
+## When to skip Phase 0.5
+
+- The user explicitly says "пропусти project-overview" or "у меня одиночный спек".
+- The repo is a single-feature library (no cross-feature context to share).
+- The skill is being run for retrospective documentation of a feature in a repo
+  that has no plans for additional features.
+
+In all other cases, run Phase 0.5. The overhead is a 30-second file lookup; the
+upside is dramatic when 5+ feature specs eventually exist and would have repeated
+the same boilerplate five times.

--- a/plugins/developer-workflow/skills/reverse-spec/references/project-overview-protocol.md
+++ b/plugins/developer-workflow/skills/reverse-spec/references/project-overview-protocol.md
@@ -81,7 +81,7 @@ This is a starting structure — adapt to what the project actually has. Aim for
 
 ## When the skill consults the document
 
-In Phase 0.5 (between scope-lock and static analysis), the skill:
+In Phase 0.6 (between output-path resolution and static analysis), the skill:
 
 1. Looks for the overview at the default and alternative paths.
 2. If found:
@@ -136,13 +136,13 @@ de), the skill:
 The skill never silently edits the project overview. Updates are user-driven, like
 the document's initial creation.
 
-## When to skip Phase 0.5
+## When to skip Phase 0.6
 
 - The user explicitly says "пропусти project-overview" or "у меня одиночный спек".
 - The repo is a single-feature library (no cross-feature context to share).
 - The skill is being run for retrospective documentation of a feature in a repo
   that has no plans for additional features.
 
-In all other cases, run Phase 0.5. The overhead is a 30-second file lookup; the
+In all other cases, run Phase 0.6. The overhead is a 30-second file lookup; the
 upside is dramatic when 5+ feature specs eventually exist and would have repeated
 the same boilerplate five times.

--- a/plugins/developer-workflow/skills/reverse-spec/references/spec-template.md
+++ b/plugins/developer-workflow/skills/reverse-spec/references/spec-template.md
@@ -1,0 +1,538 @@
+# Spec Template
+
+Full template for `docs/spec/<slug>.md`. Section order is fixed — a reimplementer scans
+specs in the same order for comparable features, so consistency across specs matters.
+
+Sections that are genuinely not applicable for a given feature are kept as `N/A —
+<one-line reason>`. Never delete a section; an empty section reads as oversight.
+
+## Reading order
+
+The spec is organised in four parts so that different readers can stop where they have
+what they need:
+
+- **Part A (§§1-7) — Product behavior.** What the feature does for the user. A PM /
+  designer can read this and stop — they have the full product-facing picture.
+- **Part B (§§8-9) — Product decisions & risks.** Open questions (unresolved intent)
+  and known defects (bugs not to reproduce). Also product-facing — these are the
+  decisions the team still owes the feature.
+- **Part C (§§10-12) — Technical integration.** How the feature connects to the rest
+  of the system: endpoints, storage, platform, collaborators, load-bearing tech. A
+  dev-reimplementer reads this as the bridge between product intent and engineering
+  choices.
+- **Part D (§13) — Appendix.** Code map — `path:line` pointers for those who are
+  actually modifying the current code. Safe to skip for anyone reimplementing on a
+  different stack.
+
+**Language rules for the body (Sections 1–8, 10–11):**
+
+- Zero code identifiers. No class names, method names, type names, sealed-class cases,
+  enum values, field names, file paths, reactive-primitive names, async-primitive
+  names, or framework idioms. See `behavior-translation.md` for recipes.
+- Keep technology references only when load-bearing (§12 only) — see
+  `tech-abstraction.md`.
+- Preserve verbatim: user-visible copy (quoted), exact numbers, URL patterns, external
+  event/field names, RFC/protocol references.
+- Sanity test for each sentence: *if every symbol in the codebase were renamed
+  tomorrow, would this sentence still describe the same feature?* If not, rewrite.
+
+---
+
+## Template
+
+```markdown
+# <Feature name>
+
+> Status: <Draft | Approved>
+> Source: reverse-engineered from code at <commit-sha or date>
+> Owner: <if known, else "unknown">
+> Language: <ru | en | ...>
+
+<!-- ============================================================ -->
+<!-- Part A — Product behavior (§§1-7)                              -->
+<!-- ============================================================ -->
+
+## 1. Overview
+
+One or two paragraphs. What the feature is. Who uses it. What problem it solves. Why it
+exists. If business context is unknown, write "business context: unknown — see Open
+Questions" rather than inventing one.
+
+Also list in one line:
+- **Primary user:** <role / segment>
+- **Trigger:** <how a user reaches this feature — navigation, notification, deep link,
+  automatic>
+- **Primary outcome:** <what the user takes away when the flow succeeds>
+
+## 2. User-facing behavior
+
+Describe the feature as a sequence of observable interactions. Each step:
+- **Action:** what the user does (or what triggers the system)
+- **System response:** what the user observes
+- **Exact copy:** verbatim text shown, quoted
+- **Exact values:** timeouts, counts, thresholds — numeric
+
+Cover the happy path first, then every meaningful branch. Group by flow if the feature
+has several distinct flows (e.g. first-time vs returning user).
+
+Describe operations by *purpose*, not by function signature. "Sign in" and "refresh
+tokens" are operations; `OAuthClient.authorize()` and `OAuthClient.refresh()` are code.
+If the finding in the state file names a method, rewrite it as an operation with a
+stated outcome before it enters this section.
+
+### 2.1 Happy path
+<numbered steps>
+
+### 2.2 Alternative flows
+<by branch — name each>
+
+### 2.3 Interruptions & resumption
+What happens if the user backgrounds the app mid-flow, loses connectivity, receives an
+incoming call, rotates the device, or the OS kills the process. If the feature has no
+special handling, state that explicitly. This is the single home for interruption
+behavior — §5.3 covers back-stack preservation, not process death.
+
+## 3. UI description
+
+Tech-agnostic description of layout and components. Describe the *role* of each
+element, not its implementation. Allowed vocabulary: *primary action button*, *list*,
+*modal*, *input field*, *secondary link*, *toolbar*, *bottom sheet*, *spinner*,
+*avatar*. Forbidden vocabulary: `Button`, `LazyColumn`, `Box`, `Scaffold`, `UITableView`,
+`<Dialog>`, `Composable`, `Fragment`, `View`, `MaterialCard`, any component library name.
+
+For each screen / surface:
+- **Layout:** top-to-bottom or visual structure in prose; a labelled ASCII sketch is
+  welcome when it clarifies
+- **Components:** list with role and behavior ("primary action button labelled 'Confirm';
+  disabled until all required fields valid")
+- **Interactive states:** default, hover/focus, pressed, disabled, loading
+- **Transitions:** what animates, how, and why (if product-meaningful)
+
+If a design source (Figma, screenshots) is available, link it here and note that the
+design source is authoritative for pixel-level details. The spec carries behavior and
+copy; the design source carries visuals.
+
+## 4. States
+
+Table or list of states, each with:
+- **Name** — a business name for the state ("not authenticated", "authorizing",
+  "token-expired", "offline-cached"). Not the code name of the sealed-class case.
+- **Trigger:** when this state appears
+- **What the user sees:** copy, component roles, actions available
+- **Exit transitions:** how the user leaves this state
+
+At minimum cover these (mark N/A if truly not applicable):
+- loading
+- empty
+- error (with per-error-class breakdown if meaningful)
+- offline / no connectivity
+- permission-denied (per permission required)
+- degraded / partial (third-party unavailable, feature flag off, etc.)
+
+If the feature has a non-trivial state machine (5+ states or non-linear transitions),
+include a mermaid state diagram here:
+
+```mermaid
+stateDiagram-v2
+    [*] --> Loading
+    Loading --> Success : data received
+    Loading --> Error : network fail
+    Error --> Loading : user taps retry
+    Success --> [*]
+```
+
+Every edge in the diagram must correspond to a real transition. If an edge is
+unreachable or only theoretical, do not draw it — unreachable edges break trust in
+the diagram as a whole. For simpler flows, skip the diagram — prose transitions are
+enough.
+
+## 5. Navigation
+
+### 5.1 Entry points
+
+Table form is preferred — it scans faster and is easier to keep complete than prose.
+
+| Type | Trigger | Parameters | Resulting state |
+| --- | --- | --- | --- |
+| Deep link | `app://payment/confirm?orderId=…` | `orderId` (required) | Confirm screen, order preloaded |
+| Notification tap | topic `payment.required` | payload `orderId` | Same as above |
+| In-app navigation | "Checkout" button on CartScreen | current cart via nav arg | Confirm screen with cart data |
+| Deferred deep link | install-referrer `promo=X` | promo code | Confirm screen with promo applied |
+
+Columns:
+- **Type** — deep link, in-app navigation, notification, widget, deferred link, API
+  callback, etc.
+- **Trigger** — the exact URL, route name, event name, or UI action
+- **Parameters** — what is passed in; mark required vs optional
+- **Resulting state** — which screen / state the user lands on
+
+### 5.2 Exit routes
+
+Every way the user leaves the feature (completion, cancellation, error exit, deep
+linking out). Note whether the exit is terminal (cannot return) or back-navigable.
+
+### 5.3 State preservation
+
+What is preserved on back navigation. What is reset on logout, on deep-link re-entry,
+on switching accounts. Process-death behavior lives in §2.3 (Interruptions &
+resumption), not here — §5.3 is about back-stack and explicit navigation.
+
+## 6. Localization & accessibility
+
+### 6.1 Localization
+- languages supported by this feature
+- strings that are hard-coded vs localized
+- dynamic content (numbers, dates, currency) and how it is formatted
+- any RTL considerations
+
+If localization follows a project-wide convention, reference it and list only
+feature-specific deviations.
+
+### 6.2 Accessibility
+- content descriptions / accessibility labels for interactive elements
+- dynamic type / text scaling support
+- color contrast considerations
+- screen-reader flow if non-trivial
+
+If the feature has no accessibility handling and the project has none either, state
+that explicitly. Silent omission is not acceptable.
+
+## 7. Analytics & logging
+
+### 7.1 Events
+Each user-visible action that sends an analytics event:
+- event name (verbatim)
+- trigger
+- properties attached
+- analytics destination (if several)
+
+If the project has an analytics taxonomy doc, cross-reference it.
+
+### 7.2 Logging
+Log statements that carry product meaning (state transitions, failures, key decisions).
+Routine debug logs are not spec-level.
+
+<!-- ============================================================ -->
+<!-- Part B — Product decisions & risks (§§8-9)                     -->
+<!-- ============================================================ -->
+
+## 8. Open questions
+
+Questions raised during reverse-engineering that the code could not answer and the user
+could not (yet) resolve. Each entry is tagged `[OQ-N]` so body sections can cross-reference
+back.
+
+- **[OQ-N] Question:** one-liner
+- **Why it matters:** what decision depends on it
+- **Current assumption:** what the spec currently implies (so the consequence of being
+  wrong is explicit)
+
+Body sections that depend on an open answer must include the `[OQ-N]` marker inline at
+the relevant sentence, so a reader of §2, §4, or §10 immediately sees which claims are
+contested. Bidirectional cross-reference: every `[OQ-N]` in the body has an entry here;
+every entry here is referenced at least once in the body unless the question is
+purely a follow-up without body impact.
+
+Keep this section alive. When a question is resolved, move the answer into the
+relevant body section, delete the `[OQ-N]` markers from the body, and remove the
+entry here.
+
+## 9. Known defects in current implementation (do not reproduce)
+
+Dedicated section for **confirmed bugs** — places where the current code does something
+that is clearly wrong, not something whose intent is unclear. A reimplementation must
+**not** reproduce these. The spec body above describes the feature as it is *intended*
+to work; this section flags where the current code deviates from that intent.
+
+Each entry has four fields:
+
+- **What** — one-line description of the observable defect.
+- **Class** — one of: `crash`, `unreachable code`, `security weakness`, `dead link`,
+  `localization gap`, `data loss`, `race condition`, `other` (name it).
+- **Evidence** — `path:line` pointer plus short quote / scenario showing the defect.
+- **Consequence** — what the user would observe or what risk this creates.
+
+Do not put ambiguous findings here. If you are not certain it is a defect (e.g., a
+retry count of 3 with unclear rationale), it belongs in §8 Open Questions, not here.
+Pass 2 of coverage verification requires every §9 entry to have direct evidence plus
+a stated reason it counts as a defect; speculation and "this looks wrong" do not
+survive that gate.
+
+When §9 has no entries, write `N/A — no confirmed defects identified.` The absence
+of the section reads as oversight; explicit `N/A` is the correct signal.
+
+### Example entries
+
+| What | Class | Evidence | Consequence |
+| --- | --- | --- | --- |
+| Sign-in tap crashes on first use | crash | `AuthKoin.kt:12-18` defines the use-case module but no call site loads it — grepped `InitKoin`, `AppModule`, all `platformKoinModule.*.kt` | Tapping the primary action on the sign-in screen throws `NoBeanDefFoundException` and the app crashes |
+| Sign-up link does nothing | dead link | `DefaultAuthComponent.kt:32` opens `https://accounts.frame.io/welcome` via `deepLinkProcessor.open(...)`; no matcher is registered for that URL | The secondary link silently no-ops when tapped |
+| Non-cryptographic randomness used for PKCE state | security weakness | `PKCEGenerator.kt:14` uses `kotlin.random.Random`, not `SecureRandom` / `Security.randomBytes` | Predictable CSRF `state` weakens OAuth protection against cross-site request forgery |
+
+<!-- ============================================================ -->
+<!-- Part C — Technical integration (§§10-12)                       -->
+<!-- ============================================================ -->
+
+## 10. Data & integrations
+
+### 10.1 Network operations
+
+If the feature talks to the network — to any external service, to the backend, to an
+identity provider, to a third-party API — list every endpoint here **as a single
+consolidated table**, before anything else in §10. A reviewer asking "what endpoints
+does this feature hit and why" should find the complete answer in one place.
+
+One row per logical operation. A single endpoint called in multiple distinct contexts
+(e.g., initial token exchange vs refresh) gets one row per context — the *trigger* is
+part of the identity.
+
+| Operation | Method | Endpoint | Auth | Triggered when | Key request fields | Key response fields |
+| --- | --- | --- | --- | --- | --- | --- |
+| Authorize (browser) | GET | `https://{idp-host}/authorize` | none | User taps Sign in | `client_id`, `redirect_uri`, `response_type=code`, `scope`, `state`, `code_challenge`, `code_challenge_method=S256` | (user-agent redirect to `redirect_uri?code=…&state=…`) |
+| Exchange code for tokens | POST | `https://{idp-host}/token` | none (public client) | After redirect with `code` | `grant_type=authorization_code`, `code`, `redirect_uri`, `client_id`, `code_verifier` | `access_token`, `refresh_token?`, `token_type`, `expires_in`, `scope?` |
+| Refresh tokens | POST | `https://{idp-host}/token` | none | Access token within 60 s of expiry, or host requests refresh | `grant_type=refresh_token`, `refresh_token`, `client_id` | same shape as exchange |
+| Fetch current user | GET | `https://{api-host}/v4/users/me` | `Authorization: Bearer {access_token}` | Immediately after a successful token exchange | — | `id` (used); other fields ignored |
+
+Column rules:
+
+- **Operation** — short business name (not the code method that calls it).
+- **Method** — HTTP verb; `WS` / `SSE` / `GQL` acceptable for non-REST protocols.
+- **Endpoint** — URL pattern with path parameters in `{braces}`. Host placeholders
+  (`{idp-host}`, `{api-host}`) expand via §10.5 External services — which pins each
+  host to a concrete provider (or lists the fallbacks).
+- **Auth** — `none`, `Bearer`, `Basic`, custom header name, or reference to the spec
+  section that defines the scheme.
+- **Triggered when** — the user action or state transition that fires the call. If
+  triggered by a background timer / lifecycle event, say so.
+- **Key request / response fields** — only fields the feature actually reads or sends.
+  Full wire contracts live in §10.6 Data contracts. Use *wire* names, never code
+  names.
+
+If the feature does not talk to the network: `N/A — this feature runs entirely offline
+within the app.` Explicit N/A, not an omitted subsection.
+
+### 10.2 Local persistence
+
+What the feature reads and writes to local storage.
+
+- Reads: key or identifier, trigger (startup, on-demand, lifecycle event), what the
+  data represents.
+- Writes: key or identifier, trigger, contents (by role, not by code shape),
+  invalidation rule (on logout, on expiry, on user action).
+
+### 10.3 Platform events and push
+
+- Platform events consumed (deep-link intents, app-lifecycle callbacks, OS-delivered
+  push payloads) — topic / URL pattern / event name as delivered by the platform.
+- Platform-level side effects the feature triggers (system toasts, haptics, audio,
+  clipboard writes, notifications, system vibration) — user-visible ones.
+- Feature-to-feature events (in-app event bus, cross-module signals) — name + payload
+  role + meaning. Analytics events go in §7, not here.
+
+### 10.4 Flags and remote config
+
+Every runtime switch that changes this feature's behavior.
+
+- Flag name as delivered by the config service (verbatim).
+- Default value.
+- Consequence for each legal value / variant.
+- Source of truth (Firebase Remote Config, LaunchDarkly, internal service, etc.).
+
+### 10.5 External services
+
+Every external service the feature depends on.
+
+- **Service name** and role (identity provider, payment processor, maps, ML, etc.).
+- **Host** that §10.1 placeholders resolve to (e.g., `{idp-host}` → `ims-na1.adobelogin.com`).
+- **Required configuration** provided by the host app (client IDs, API keys — values
+  quoted literally when they appear in code as constants; otherwise a pointer to where
+  the host supplies them).
+- **Graceful-degradation behavior** — what happens to the feature when the service is
+  unavailable: hard fail, retry, fall back, stale cache, queued for later.
+
+### 10.6 Data contracts
+
+Exact wire shapes, not internal DTO classes.
+
+Name fields by the *wire* names the external contract uses. Full contracts live in
+OpenAPI / Protobuf / JSON Schema — link the source of truth and quote only the subset
+the feature relies on. If the contract is standard (OAuth 2.0, OIDC, WebPush, WebRTC,
+…), reference the RFC / spec and list only app-specific deviations.
+
+Do not inline Kotlin / Swift / TypeScript data classes — those are implementations of
+the wire contract, not the contract.
+
+### 10.7 Collaborators and consumers
+
+Where this feature touches the rest of the application and the surrounding system. A
+reimplementation must preserve these boundaries — they define what the host app owes
+this feature, what other features can rely on it for, and what state must hold before
+and after the feature runs.
+
+The section has three parts: the **boundary** (who talks to whom), **preconditions**
+(what must be true before the feature operates), and **postconditions** (what the
+feature guarantees when it completes). All three are aspects of the same integration
+contract.
+
+#### Boundary
+
+**Collaborators** — what this feature requires from the host app or other features.
+
+| Collaborator | Role | What the feature uses from it |
+| --- | --- | --- |
+| *<name, in business terms>* | configuration / service / state source | <concrete operations called, values read, streams subscribed to> |
+
+Types of collaborators to enumerate:
+
+- **Configuration sources** — values the host supplies at boot time (API hosts,
+  client IDs, feature flags, scopes). Constants hard-coded in the feature's own code
+  are not collaborators; values that come from outside it are.
+- **Services** — in-app modules the feature calls into (deep-link processor, shared
+  networking client, analytics dispatcher, navigation stack).
+- **Shared state sources** — observable streams / stores the feature reads from.
+
+**Consumers** — what the rest of the app observes or depends on from this feature.
+
+| Consumer | What it uses | Contract |
+| --- | --- | --- |
+| *<name>* | <output / stream / shared state / navigation arg> | <guarantee the feature provides> |
+
+Types of consumers to enumerate:
+
+- Downstream screens that receive arguments on successful completion.
+- Other features that subscribe to state the feature writes (e.g., auth-state stream
+  consumed by every authenticated screen).
+- Shared storage slots the feature writes that other features read (e.g., access token
+  in platform key-value storage — read by the networking layer for every outbound
+  request).
+- Events / signals emitted for other features to react to.
+
+#### Preconditions
+
+Must be true for the feature to behave as specified. If any precondition is violated,
+the feature's behavior is undefined — this is the contract the host app must satisfy.
+
+- Host app has performed the required OS-level registration (custom URL scheme
+  handlers, manifest entries, Info.plist entries).
+- External configuration passed in is valid and reachable.
+- Any prerequisite feature has completed (e.g., user consent screen ran before this
+  feature loads).
+
+#### Postconditions
+
+State the feature guarantees upon successful completion. Consumers (listed above)
+depend on these guarantees; changing them is a breaking contract change.
+
+- Persistent state written (tokens stored, user id cached, flags set).
+- Observable streams updated to specific values.
+- Navigation stack manipulated in a specific way (current screen removed / next
+  destination pushed / stack replaced).
+
+If the feature is a closed leaf with no cross-feature boundary (purely local utility,
+self-contained screen with no external effects), write `N/A — this feature has no
+collaborators or consumers beyond its own scope.` Explicit N/A only; do not omit.
+
+### 10.8 Domain model & invariants
+Data entities the feature owns or meaningfully reasons about, and the rules that must
+hold for them to be valid.
+
+**Describe entities by role and invariant, not by code shape.** Name each entity in
+business terms (order, payment, session, token set, device session) and list:
+
+- fields that matter to the feature (wire-name or business-concept names, not
+  `data class` field names)
+- invariants: "amount > 0", "status ∈ {pending, confirmed, cancelled}", uniqueness
+  constraints, lifetime (e.g., "access token expires `expires_in` seconds after the
+  issuance timestamp; refreshed before expiry minus a 60-second safety buffer")
+- computed values the feature derives (with the formula, not just a name)
+- legal / illegal state transitions — what can move to what and under which event
+
+Business rules that span multiple entities (multi-entity constraints, cross-flow
+invariants) also live here.
+
+For pure UI features that do not own domain logic — `N/A — this feature is a
+presentation layer over <referenced domain>`. Do not omit the section; explicit N/A is
+the correct signal that the absence was considered.
+
+## 11. Platform capabilities
+
+Device / OS features the feature requires:
+- camera, microphone, location, contacts, calendar, biometrics, files, Bluetooth, NFC,
+  background execution, notifications, etc.
+- permission flow (if the platform requires runtime permission)
+- minimum OS version if the feature uses a version-gated API
+
+For each, note the consequence of the capability being unavailable: hard-block the
+feature? graceful fallback? skip?
+
+## 12. Tech-specific constraints
+
+Technologies whose presence changes the feature's behavior, capability, cost, or
+licensing — and therefore must carry over to any reimplementation. Examples:
+
+- "Face detection uses Google ML Kit — a reimplementation needs an equivalent on-device
+  face detector for parity on accuracy and latency."
+- "Payment is processed via Stripe SDK — the reimplementation must remain PCI-compliant
+  by keeping card input in a Stripe-provided component."
+
+If nothing in the feature is load-bearing-tech, this section is `N/A — no load-bearing
+technology constraints`.
+
+<!-- ============================================================ -->
+<!-- Part D — Appendix (§13)                                        -->
+<!-- Skip if not modifying the current implementation.              -->
+<!-- ============================================================ -->
+
+## 13. Code map (appendix — skip if not reimplementing on the current stack)
+
+Table mapping spec sections to the files that currently implement them. **This is the
+only place in the spec where code paths and code identifiers are allowed.** Every
+class name, method name, package path, or file path must live here — nowhere else.
+
+Readers who are reimplementing the feature on a different stack can safely skip this
+section entirely — the spec body above is intentionally stack-neutral and contains
+everything needed to rebuild the feature elsewhere. This appendix exists for
+readers who are auditing, refactoring, or maintaining the current implementation.
+
+Use `path:line` or `path:start-end` granularity — point to the smallest region that
+proves the claim, not the whole file. A reviewer should be able to open the link and
+immediately see the branch or value being referenced.
+
+Entries describe *where* the spec section is implemented today, not *how*. The column
+is "Location", not "Design description".
+
+| Spec section | Location |
+| --- | --- |
+| 2. User-facing behavior | `ui/PaymentScreen.kt:40-120`, `ui/PaymentViewModel.kt:55-200` |
+| 3. UI description | `ui/PaymentScreen.kt:40-120` |
+| 4. States (error) | `ui/PaymentViewModel.kt:140-190` |
+| 5.1 Entry points | `navigation/PaymentGraph.kt:22-60` |
+| 7.1 Events | `analytics/PaymentEvents.kt` |
+| 9. Known defects | `ui/PaymentViewModel.kt:210` (race condition in retry), `AuthKoin.kt:12-18` (DI module never loaded) |
+| 10.1 Network operations | `domain/PaymentApi.kt:12-60`, `domain/OrderRepository.kt:30-90` |
+| 10.2 Local persistence | `data/OrderCache.kt:20-70` |
+| 10.5 External services | `config/PaymentProviderConfig.kt:8-24` |
+| 10.7 Collaborators and consumers | `app/AppModule.kt:55-80`, `navigation/PaymentGraph.kt:22-60` |
+| 10.8 Domain model | `domain/Order.kt`, `domain/Payment.kt:18-55` |
+| 11. Platform capabilities | `permissions/CameraPermission.kt:10-40` |
+
+The code map is a maintenance artifact — it helps a future reader (or a re-run of this
+skill) verify that the spec still matches the code.
+```
+
+---
+
+## Notes on the template
+
+- **Section order is fixed.** Reorder only for a very strong reason.
+- **N/A is a positive statement**, not a blank. It tells the reader "we considered this
+  and decided the feature has no handling" — which is different from "we forgot".
+- **Exact copy goes in double quotes.** A paraphrase is a translation; a quote is a
+  contract.
+- **Numeric values are literal.** "Several seconds" is not acceptable — write "3 seconds"
+  if the code says so.
+- **When in doubt, add to Open Questions.** Unresolved items in Section 8 are honest;
+  invented resolutions in the body are corrupting.
+- **Bidirectional cross-refs.** Every `[OQ-N]` marker in the body has a matching entry
+  in §8, and every §8 entry that has body impact carries at least one `[OQ-N]`
+  reference from the body.

--- a/plugins/developer-workflow/skills/reverse-spec/references/spec-template.md
+++ b/plugins/developer-workflow/skills/reverse-spec/references/spec-template.md
@@ -94,23 +94,54 @@ behavior — §5.3 covers back-stack preservation, not process death.
 
 ## 3. UI description
 
-Tech-agnostic description of layout and components. Describe the *role* of each
-element, not its implementation. Allowed vocabulary: *primary action button*, *list*,
-*modal*, *input field*, *secondary link*, *toolbar*, *bottom sheet*, *spinner*,
-*avatar*. Forbidden vocabulary: `Button`, `LazyColumn`, `Box`, `Scaffold`, `UITableView`,
-`<Dialog>`, `Composable`, `Fragment`, `View`, `MaterialCard`, any component library name.
+This section describes the UI **only as much as needed to understand the feature** —
+not as a re-implementation of the design. A spec is not a substitute for design
+artefacts; the design source (Figma, screenshots, mockups) is authoritative for any
+pixel- or layout-level detail.
 
-For each screen / surface:
-- **Layout:** top-to-bottom or visual structure in prose; a labelled ASCII sketch is
-  welcome when it clarifies
-- **Components:** list with role and behavior ("primary action button labelled 'Confirm';
-  disabled until all required fields valid")
-- **Interactive states:** default, hover/focus, pressed, disabled, loading
-- **Transitions:** what animates, how, and why (if product-meaningful)
+### 3.1 Design source
 
-If a design source (Figma, screenshots) is available, link it here and note that the
-design source is authoritative for pixel-level details. The spec carries behavior and
-copy; the design source carries visuals.
+State the source of authoritative visuals:
+
+- **Figma:** `<link>` (file id, page name, frames included)
+- **Screenshots:** `<paths>` if attached
+- **Mockups:** `<links / paths>`
+
+If no design source exists, mark `Design source: none — describe with text below`. This
+is the only case where the §3.2 textual description below should attempt a substitute
+for visuals. With a design source, §3.2 is intentionally minimal.
+
+### 3.2 What the spec adds beyond the design source
+
+The spec carries information the design source does not, or that the reimplementer
+needs to interpret the design correctly:
+
+- **Component roles** — what each interactive element *does*, named in role terms
+  (*primary action button*, *secondary link*, *list*, *modal*, *input field*, etc.).
+  Forbidden: framework / toolkit names (`Button`, `LazyColumn`, `Composable`,
+  `UITableView`, `<Dialog>`, `MaterialCard`, etc.).
+- **Functional layout differences across screen sizes** — only when the feature
+  *behaves* differently (different actions available, different content visible),
+  not for purely visual responsive reflows. If the only difference between
+  compact / medium / expanded is decorative arrangement, the design source covers it
+  — do not duplicate.
+- **Interactive states** — default, focus, pressed, disabled, loading, error — only
+  when the design source lacks a state and behavior would otherwise be ambiguous.
+- **Transitions** — what animates, only when the *product meaning* of the animation
+  matters (e.g., crossfade between modes signalling state change). Decorative
+  motion belongs in the design source.
+
+### 3.3 Visual fidelity rule
+
+Pixel-perfect fidelity (exact margins, font sizes, colors) is the design source's
+responsibility, not the spec's. Hex colors, dp values, exact icon SVGs do not belong
+in the body. The exception: a single value that carries product meaning (the brand
+red, an accessibility-critical contrast ratio) — call it out and explain why it
+matters.
+
+If you find yourself describing the screen in detail because no design source exists,
+flag it as `[OQ-N] Missing design source` in §8 — the question for the user is whether
+to commission designs before reimplementation, not whether the spec should fill in.
 
 ## 4. States
 
@@ -239,35 +270,71 @@ entry here.
 
 ## 9. Known defects in current implementation (do not reproduce)
 
-Dedicated section for **confirmed bugs** — places where the current code does something
-that is clearly wrong, not something whose intent is unclear. A reimplementation must
-**not** reproduce these. The spec body above describes the feature as it is *intended*
-to work; this section flags where the current code deviates from that intent.
+This section is for **behavior bugs** — places where the feature does not do what it
+*should* do as a feature: it crashes, it shows the wrong thing, it silently fails to
+take an action the user expects, it reaches an unreachable state. A reimplementation
+must not reproduce these.
+
+Implementation-level concerns (a hardcoded string that bypasses i18n, plaintext
+storage of credentials, a non-cryptographic PRNG) are **not** in scope for §9 —
+they describe how the current code is written, not how the feature behaves. Those
+findings live in a separate `<slug>-hygiene.md` artefact alongside the spec
+(see `references/anti-patterns.md` and `references/analysis-checklist.md` §14 for the
+classification rule).
+
+### What counts as a §9 entry
+
+A finding belongs here only if **all three** are true:
+
+1. **It changes what the user observes.** The feature does X when it should do Y, or
+   crashes, or silently fails. Pure code-quality issues that do not surface
+   externally are not §9 material.
+2. **It is reproducible from code analysis alone, without speculation.** You can
+   point to the exact path and line that produces the wrong behavior.
+3. **It contradicts the feature's intent** as described in §§1-7 of this spec. If
+   the intent is unknown, the finding belongs in §8 Open Questions, not here.
 
 Each entry has four fields:
 
-- **What** — one-line description of the observable defect.
-- **Class** — one of: `crash`, `unreachable code`, `security weakness`, `dead link`,
-  `localization gap`, `data loss`, `race condition`, `other` (name it).
-- **Evidence** — `path:line` pointer plus short quote / scenario showing the defect.
-- **Consequence** — what the user would observe or what risk this creates.
+- **What** — one-line description of the observable misbehavior.
+- **Class** — one of: `crash`, `unreachable state`, `dead UI control`, `wrong-data
+  shown`, `silent failure`, `lost user action`, `incorrect state transition`,
+  `other` (name it).
+- **Evidence** — `path:line` pointer plus short quote / scenario showing the bug.
+- **Consequence** — what the user observes or what intended outcome is missed.
 
-Do not put ambiguous findings here. If you are not certain it is a defect (e.g., a
-retry count of 3 with unclear rationale), it belongs in §8 Open Questions, not here.
-Pass 2 of coverage verification requires every §9 entry to have direct evidence plus
-a stated reason it counts as a defect; speculation and "this looks wrong" do not
-survive that gate.
+Do not include ambiguous findings. If you are not certain it is a defect (e.g., a
+retry count of 3 with unclear rationale), it belongs in §8 Open Questions. Pass 2 of
+coverage verification requires every §9 entry to have direct evidence plus a stated
+behavior consequence; speculation and "this looks wrong" do not survive that gate.
 
-When §9 has no entries, write `N/A — no confirmed defects identified.` The absence
-of the section reads as oversight; explicit `N/A` is the correct signal.
+When §9 has no entries, write `N/A — no confirmed behavior defects identified.` The
+absence of the section reads as oversight; explicit `N/A` is the correct signal.
 
 ### Example entries
 
 | What | Class | Evidence | Consequence |
 | --- | --- | --- | --- |
-| Sign-in tap crashes on first use | crash | `AuthKoin.kt:12-18` defines the use-case module but no call site loads it — grepped `InitKoin`, `AppModule`, all `platformKoinModule.*.kt` | Tapping the primary action on the sign-in screen throws `NoBeanDefFoundException` and the app crashes |
-| Sign-up link does nothing | dead link | `DefaultAuthComponent.kt:32` opens `https://accounts.frame.io/welcome` via `deepLinkProcessor.open(...)`; no matcher is registered for that URL | The secondary link silently no-ops when tapped |
-| Non-cryptographic randomness used for PKCE state | security weakness | `PKCEGenerator.kt:14` uses `kotlin.random.Random`, not `SecureRandom` / `Security.randomBytes` | Predictable CSRF `state` weakens OAuth protection against cross-site request forgery |
+| Sign-in tap crashes on first use | crash | `AuthKoin.kt:12-18` defines the use-case module but no call site loads it — grepped `InitKoin`, `AppModule`, all `platformKoinModule.*.kt` | Tapping the primary action on the sign-in screen throws an unresolved-dependency error and the app crashes |
+| Sign-up link does nothing | dead UI control | `DefaultAuthComponent.kt:32` opens `https://accounts.frame.io/welcome` via the deep-link processor; no matcher is registered for that URL anywhere in the repo | The secondary link silently no-ops when tapped — the user has no way to start sign-up from inside the app |
+| Generic error shown when the OAuth provider explicitly denied access | wrong-data shown | `AuthUseCase.kt:46-53` maps every non-network OAuth failure (including provider `error=access_denied`) to the same "Unknown error" copy | The user who chose to deny consent on the provider screen is shown an error message implying something is broken, when in fact the system worked correctly |
+
+### What goes in `<slug>-hygiene.md` instead
+
+If you find any of the following, capture them in the hygiene artefact, not in §9:
+
+- Hardcoded strings that bypass localization
+- Non-cryptographic randomness for security-sensitive values
+- Tokens or secrets stored without encryption
+- Logging of sensitive data
+- Code-style inconsistencies (mixed conventions, dead code, copy-pasted blocks)
+- Missing input validation that does not yet manifest as a behavior bug
+- Test gaps
+
+These are valuable findings for the engineering team, but they are about *how* the
+code is written. The feature spec describes *what the feature does*. Mixing the two
+makes the spec less useful for product readers and dilutes the defect signal for
+reimplementers.
 
 <!-- ============================================================ -->
 <!-- Part C — Technical integration (§§10-12)                       -->
@@ -322,12 +389,28 @@ What the feature reads and writes to local storage.
 
 ### 10.3 Platform events and push
 
-- Platform events consumed (deep-link intents, app-lifecycle callbacks, OS-delivered
-  push payloads) — topic / URL pattern / event name as delivered by the platform.
-- Platform-level side effects the feature triggers (system toasts, haptics, audio,
-  clipboard writes, notifications, system vibration) — user-visible ones.
-- Feature-to-feature events (in-app event bus, cross-module signals) — name + payload
-  role + meaning. Analytics events go in §7, not here.
+Describe the **capability** the feature requires from the platform, not the specific
+mechanism the current code uses to obtain it. Implementation specifics — port
+numbers, intent filters, callback registration patterns, event-bus libraries — are
+the reimplementer's choice, not part of the contract.
+
+- **Platform events the feature reacts to** — what kind of external event causes the
+  feature to act, and what it does with the payload. Examples:
+  - "Application receives an OAuth redirect from the system browser and continues
+    the sign-in flow with the returned authorization code." *(not "intent-filter on
+    `adobe+...://authorize` triggers `OAuthRedirectActivity` which posts to ...")*
+  - "Application receives a notification of type `payment.required` and opens the
+    confirm screen with the order ID from the payload."
+- **Side effects the feature produces on the platform** — the *user-visible* outcome,
+  named at capability level. Examples:
+  - "Open external URL in the system browser."
+  - "Vibrate the device on payment confirmation."
+  - "Trigger a system notification with copy '...'"
+- **Feature-to-feature signals** — name and meaning of in-app signals other features
+  observe, not the bus library used. Analytics events live in §7, not here.
+
+If the only thing to say about platform events is "user taps a deep link and the
+feature opens", that one line is enough. Resist enumerating mechanism.
 
 ### 10.4 Flags and remote config
 
@@ -364,73 +447,88 @@ the wire contract, not the contract.
 
 ### 10.7 Collaborators and consumers
 
-Where this feature touches the rest of the application and the surrounding system. A
-reimplementation must preserve these boundaries — they define what the host app owes
-this feature, what other features can rely on it for, and what state must hold before
-and after the feature runs.
+Where this feature touches the rest of the application — at the **business** and
+**capability** level, not at the implementation level. The reimplementer needs to
+know *what kind* of host service this feature requires, not *which concrete class*
+the current code happens to call.
 
-The section has three parts: the **boundary** (who talks to whom), **preconditions**
-(what must be true before the feature operates), and **postconditions** (what the
-feature guarantees when it completes). All three are aspects of the same integration
-contract.
+If the project has a top-level overview document (see Phase 0.5 in SKILL.md), prefer
+references to it over inline enumeration. "This feature relies on the project's
+standard authenticated HTTP client (see project-overview.md §X)" beats listing every
+service the code touches.
 
 #### Boundary
 
-**Collaborators** — what this feature requires from the host app or other features.
+**Collaborators** — what kind of host functionality this feature requires.
 
-| Collaborator | Role | What the feature uses from it |
-| --- | --- | --- |
-| *<name, in business terms>* | configuration / service / state source | <concrete operations called, values read, streams subscribed to> |
+| Collaborator (business name) | Capability used |
+| --- | --- |
+| *<role, in business terms>* | <what the feature relies on this collaborator for, named at the level of behavior — "validates payment input", "delivers OAuth result back to the app", "renders authenticated user session", not "calls `validate(input)` on `PaymentValidator`"> |
 
-Types of collaborators to enumerate:
+Types of collaborators worth naming:
 
-- **Configuration sources** — values the host supplies at boot time (API hosts,
-  client IDs, feature flags, scopes). Constants hard-coded in the feature's own code
-  are not collaborators; values that come from outside it are.
-- **Services** — in-app modules the feature calls into (deep-link processor, shared
-  networking client, analytics dispatcher, navigation stack).
-- **Shared state sources** — observable streams / stores the feature reads from.
+- **Configuration sources** — what values the host must supply (provider host names,
+  API keys, feature flags, supported scopes). Do not name DI containers or factory
+  functions — name the values needed.
+- **Services and capabilities** — what host capabilities the feature consumes
+  (in-app navigation, an HTTP client that adds auth headers, deep-link routing).
+  Name the *capability* (e.g., "an authenticated HTTP client that attaches the
+  current bearer token"); name the SDK or class only when load-bearing per
+  `tech-abstraction.md`.
+- **Shared state** — what app-wide state streams the feature reads from (current
+  authenticated session, current locale, current theme).
 
-**Consumers** — what the rest of the app observes or depends on from this feature.
+**Consumers** — what other features observe or depend on from this feature.
 
-| Consumer | What it uses | Contract |
-| --- | --- | --- |
-| *<name>* | <output / stream / shared state / navigation arg> | <guarantee the feature provides> |
+| Consumer | What they consume |
+| --- | --- |
+| *<feature or surface>* | <what this feature provides to them — named at observable level> |
 
-Types of consumers to enumerate:
+Types of consumers worth naming:
 
-- Downstream screens that receive arguments on successful completion.
-- Other features that subscribe to state the feature writes (e.g., auth-state stream
-  consumed by every authenticated screen).
-- Shared storage slots the feature writes that other features read (e.g., access token
-  in platform key-value storage — read by the networking layer for every outbound
-  request).
-- Events / signals emitted for other features to react to.
+- Downstream features that receive a navigation argument on successful completion.
+- Other features that observe shared state this feature owns (current session,
+  current user id).
+- Storage slots written by this feature that downstream consumers read (the
+  feature is the writer of "user is authenticated"; the rest of the app is the
+  reader).
 
 #### Preconditions
 
-Must be true for the feature to behave as specified. If any precondition is violated,
-the feature's behavior is undefined — this is the contract the host app must satisfy.
+Conditions on the **product / business state** that must hold for the feature to
+behave as specified. Implementation-level setup (manifest entries, intent filters,
+Info.plist registrations, DI graph wiring) is the responsibility of the reimplementer
+on their stack — those are *implementation* preconditions, not feature
+preconditions, and they belong in the platform's own setup docs, not in this spec.
 
-- Host app has performed the required OS-level registration (custom URL scheme
-  handlers, manifest entries, Info.plist entries).
-- External configuration passed in is valid and reachable.
-- Any prerequisite feature has completed (e.g., user consent screen ran before this
-  feature loads).
+Examples of *feature* preconditions:
+
+- "The user is on a build that has been provisioned with valid OAuth client
+  credentials for the target environment."
+- "A previous step (consent screen) has been completed before this feature loads."
+- "An identity provider is reachable; offline behavior is described in §4."
+
+If a "precondition" reads as a developer setup checklist, it is implementation —
+move it out of the spec, or note it as a one-line reference: "Platform-level setup
+(manifest, Info.plist, etc.) follows the host app's standard OAuth integration
+pattern; not specified here."
 
 #### Postconditions
 
-State the feature guarantees upon successful completion. Consumers (listed above)
-depend on these guarantees; changing them is a breaking contract change.
+What the feature guarantees about **product / business state** when it completes
+successfully — the contract downstream features depend on.
 
-- Persistent state written (tokens stored, user id cached, flags set).
-- Observable streams updated to specific values.
-- Navigation stack manipulated in a specific way (current screen removed / next
-  destination pushed / stack replaced).
+- "The user has an authenticated session readable by other features."
+- "The user's preferred language has been recorded."
+- "The current screen has been removed from the back-stack so 'back' does not
+  return to it."
 
-If the feature is a closed leaf with no cross-feature boundary (purely local utility,
-self-contained screen with no external effects), write `N/A — this feature has no
-collaborators or consumers beyond its own scope.` Explicit N/A only; do not omit.
+Avoid listing exact storage keys, observable stream names, or navigation graph
+IDs — those are implementation. Describe the *outcome*, not the bookkeeping.
+
+If the feature is a closed leaf with no cross-feature boundary, write `N/A — this
+feature has no collaborators or consumers beyond its own scope.` Explicit N/A only;
+do not omit.
 
 ### 10.8 Domain model & invariants
 Data entities the feature owns or meaningfully reasons about, and the rules that must
@@ -482,6 +580,34 @@ technology constraints`.
 <!-- Part D — Appendix (§13)                                        -->
 <!-- Skip if not modifying the current implementation.              -->
 <!-- ============================================================ -->
+
+## 12.5 External references
+
+Links to the authoritative documentation for every external system, protocol, or
+SDK the spec mentions. A reimplementer following the spec must be able to look up
+what every external thing actually does, not just see its name.
+
+For each item, provide:
+
+- **Subject** — the system / protocol / SDK / standard
+- **Link** — a URL to its primary documentation (provider docs page, RFC, spec)
+- **What we use from it** — the subset the feature relies on (one line)
+
+Examples:
+
+- **Adobe IMS OAuth** — [`developer.adobe.com/frameio/guides/Authentication`](https://developer.adobe.com/frameio/guides/Authentication/) — Authorization Code + PKCE flow with custom URL-scheme redirect.
+- **OAuth 2.0 Authorization Code Grant** — [RFC 6749 §4.1](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1) — the base protocol.
+- **PKCE** — [RFC 7636](https://datatracker.ietf.org/doc/html/rfc7636) — extension for public clients; this feature uses S256 challenge method.
+- **OAuth 2.0 native apps** — [RFC 8252](https://datatracker.ietf.org/doc/html/rfc8252) — guidance for OAuth in native applications, including loopback redirect on desktop.
+- **Google ML Kit Face Detection** — [`developers.google.com/ml-kit/vision/face-detection`](https://developers.google.com/ml-kit/vision/face-detection) — on-device face detector.
+
+A reimplementer who follows a link should land on the canonical source — the
+provider's own documentation, the IETF datatracker, the standard's authoring body.
+Do not link to blog posts, tutorials, or third-party explanations.
+
+If the feature has no external dependencies worth linking, write `N/A — feature is
+self-contained, no external systems involved.` Otherwise, every external system
+named anywhere in the spec must appear here.
 
 ## 13. Code map (appendix — skip if not reimplementing on the current stack)
 

--- a/plugins/developer-workflow/skills/reverse-spec/references/spec-template.md
+++ b/plugins/developer-workflow/skills/reverse-spec/references/spec-template.md
@@ -118,30 +118,24 @@ needs to interpret the design correctly:
 
 - **Component roles** — what each interactive element *does*, named in role terms
   (*primary action button*, *secondary link*, *list*, *modal*, *input field*, etc.).
-  Forbidden: framework / toolkit names (`Button`, `LazyColumn`, `Composable`,
-  `UITableView`, `<Dialog>`, `MaterialCard`, etc.).
+  Use role names, not framework / toolkit names — see SKILL.md Principle 1 and
+  `behavior-translation.md` recipes 1, 4, 10.
 - **Functional layout differences across screen sizes** — only when the feature
   *behaves* differently (different actions available, different content visible),
-  not for purely visual responsive reflows. If the only difference between
-  compact / medium / expanded is decorative arrangement, the design source covers it
-  — do not duplicate.
+  not for purely visual responsive reflows.
 - **Interactive states** — default, focus, pressed, disabled, loading, error — only
   when the design source lacks a state and behavior would otherwise be ambiguous.
 - **Transitions** — what animates, only when the *product meaning* of the animation
   matters (e.g., crossfade between modes signalling state change). Decorative
   motion belongs in the design source.
 
-### 3.3 Visual fidelity rule
+The single exception to "no pixels": a value that carries product meaning (brand
+red, accessibility-critical contrast ratio) — call it out and explain why.
 
-Pixel-perfect fidelity (exact margins, font sizes, colors) is the design source's
-responsibility, not the spec's. Hex colors, dp values, exact icon SVGs do not belong
-in the body. The exception: a single value that carries product meaning (the brand
-red, an accessibility-critical contrast ratio) — call it out and explain why it
-matters.
-
-If you find yourself describing the screen in detail because no design source exists,
-flag it as `[OQ-N] Missing design source` in §8 — the question for the user is whether
-to commission designs before reimplementation, not whether the spec should fill in.
+If you find yourself describing the screen in detail because no design source
+exists, flag it as `[OQ-N] Missing design source` in §8 — the question for the
+user is whether to commission designs before reimplementation, not whether the
+spec should fill in.
 
 ## 4. States
 
@@ -452,7 +446,7 @@ Where this feature touches the rest of the application — at the **business** a
 know *what kind* of host service this feature requires, not *which concrete class*
 the current code happens to call.
 
-If the project has a top-level overview document (see Phase 0.5 in SKILL.md), prefer
+If the project has a top-level overview document (see Phase 0.6 in SKILL.md), prefer
 references to it over inline enumeration. "This feature relies on the project's
 standard authenticated HTTP client (see project-overview.md §X)" beats listing every
 service the code touches.
@@ -576,11 +570,6 @@ licensing — and therefore must carry over to any reimplementation. Examples:
 If nothing in the feature is load-bearing-tech, this section is `N/A — no load-bearing
 technology constraints`.
 
-<!-- ============================================================ -->
-<!-- Part D — Appendix (§13)                                        -->
-<!-- Skip if not modifying the current implementation.              -->
-<!-- ============================================================ -->
-
 ## 12.5 External references
 
 Links to the authoritative documentation for every external system, protocol, or
@@ -608,6 +597,11 @@ Do not link to blog posts, tutorials, or third-party explanations.
 If the feature has no external dependencies worth linking, write `N/A — feature is
 self-contained, no external systems involved.` Otherwise, every external system
 named anywhere in the spec must appear here.
+
+<!-- ============================================================ -->
+<!-- Part D — Appendix (§13)                                        -->
+<!-- Skip if not modifying the current implementation.              -->
+<!-- ============================================================ -->
 
 ## 13. Code map (appendix — skip if not reimplementing on the current stack)
 

--- a/plugins/developer-workflow/skills/reverse-spec/references/tech-abstraction.md
+++ b/plugins/developer-workflow/skills/reverse-spec/references/tech-abstraction.md
@@ -1,0 +1,156 @@
+# Tech Abstraction Heuristic
+
+When to strip a technology from the spec, when to keep it, and how to phrase it either
+way.
+
+The spec describes *what the feature does*, not *how this codebase happens to build it*.
+A reimplementation on a different stack must remain faithful to the product — but not to
+the current architecture. This file is the rulebook for deciding which technology
+references survive that translation and which do not.
+
+---
+
+## The test
+
+A technology reference stays in the spec only if **removing it would change the
+feature's behavior, capability, cost, legal posture, or performance envelope**.
+
+Work through these four questions for every technology mention:
+
+1. **Does the feature's observable behavior depend on this specific technology?**
+   Face detection via ML Kit produces different bounding boxes than OpenCV Haar
+   cascades. The observable result differs. → keep.
+   Render via Jetpack Compose vs UIKit. The observable result is identical text on a
+   screen. → drop.
+
+2. **Does a swap require reworking integrations or compliance?**
+   Payment via Stripe SDK keeps card data out of the app — a PCI-compliance win.
+   Swapping to a custom form changes the regulatory scope. → keep.
+   Swap Kotlin coroutines for RxJava. Identical behavior. No compliance impact. → drop.
+
+3. **Is there a capability unique to the technology that the feature relies on?**
+   AR via ARKit uses LiDAR for precise depth on iPhone Pro models. The feature's
+   accuracy depends on it. → keep.
+   HTTP via Ktor vs OkHttp. Both send HTTP. → drop.
+
+4. **Does cost or licensing materially change?**
+   Maps via Google Maps — tile cost, quota, licensing. → keep.
+   Logging via Timber vs SLF4J. → drop.
+
+If the answer to **any** of the four is yes, keep the technology. Otherwise drop.
+
+---
+
+## Load-bearing categories (usually keep)
+
+- **ML / computer vision / speech** — ML Kit, Core ML, ONNX, AR frameworks, TTS/STT
+  engines. Model differences are user-visible.
+- **Payments** — Stripe, Adyen, Braintree, Apple Pay, Google Pay. Compliance and UX
+  rules are SDK-specific.
+- **Biometrics** — Android BiometricPrompt, iOS LocalAuthentication. Platform capability.
+- **Maps & location** — Google Maps, Apple Maps, Mapbox, HERE. Tile licensing and
+  rendering differ.
+- **Realtime communication** — WebRTC, Agora, Twilio. Protocol and provider differ.
+- **DRM / media** — Widevine, FairPlay, ExoPlayer streaming protocols. Compatibility is
+  content-dependent.
+- **Push / messaging backbone** — Firebase Cloud Messaging, APNs, Amazon SNS. Delivery
+  semantics differ.
+- **Identity providers** — Firebase Auth, AWS Cognito, Auth0. Flow and token shape
+  differ.
+- **Large vendor SDKs with product impact** — Segment (analytics pipeline), Branch
+  (deep-link attribution), AppsFlyer (attribution), Intercom (support chat UX).
+- **Platform-specific APIs** — Android WorkManager, iOS BackgroundTasks,
+  BluetoothGattCallback patterns. The reimplementation needs an equivalent.
+
+When keeping, phrase the constraint, not the SDK call:
+
+> *"Face detection requires an on-device CV model with accuracy comparable to Google ML
+> Kit v1.x (currently in use). Cloud-based detection is not acceptable for latency and
+> privacy reasons."*
+
+Not:
+
+> *"Use `FaceDetector.getClient(...).process(image)` from the ML Kit SDK."*
+
+The first lets a reimplementer substitute any equivalent; the second pins them to ML
+Kit.
+
+---
+
+## Not load-bearing (usually drop)
+
+- **UI toolkits** — Jetpack Compose, SwiftUI, React, UIKit, AppKit, Qt, Flutter.
+  Describe the UI as components and behaviors; let the reimplementer choose.
+- **HTTP clients** — Ktor, OkHttp, URLSession, Alamofire, axios, fetch. HTTP is HTTP.
+- **Serialization** — Moshi, kotlinx.serialization, Codable, JSON.NET, Jackson.
+- **DI frameworks** — Hilt, Koin, Dagger, Swinject, InversifyJS.
+- **Async primitives** — coroutines, RxJava, Combine, async/await, Promises.
+- **Persistence** — Room, SQLDelight, Core Data, SQLite directly, Realm (borderline —
+  Realm's sync is load-bearing if used; plain Realm storage is not).
+- **Image loading** — Coil, Glide, Picasso, SDWebImage, Kingfisher.
+- **Logging / crash** — Timber, SLF4J, CocoaLumberjack, Crashlytics (borderline if the
+  project uses a proprietary crash taxonomy; usually not).
+- **Testing frameworks** — irrelevant to spec; the spec is not a test plan.
+- **Build tools** — Gradle, Bazel, CocoaPods, SPM, npm. Never in a spec.
+
+When you find these in code during analysis, ignore them for the spec body. A one-line
+mention may appear under Code Map if it helps future maintenance.
+
+---
+
+## Borderline cases
+
+Some technologies are load-bearing only because of *how* the feature uses them:
+
+- **Caching libraries** — mostly not load-bearing, but if the feature relies on a
+  specific invalidation behavior (e.g., Realm's live-updating queries driving UI
+  reactivity), call it out.
+- **State management** — MVI, Redux, MVVM are not spec-level. But if the feature exposes
+  an observable stream to other features (inter-feature contract), describe the contract
+  tech-agnostically.
+- **Analytics backends** — the event *names and properties* are spec-level; the
+  *pipeline* (Segment vs Mixpanel direct) usually is not, unless the feature has
+  backend-coupled event validation.
+- **Localization libraries** — the *coverage* is spec-level; which library drives it is
+  not.
+
+When uncertain: apply the four-question test. If still unclear, describe the *capability
+or contract* rather than the technology, and add a note to Open Questions so the user
+can flag it for keep-or-drop.
+
+---
+
+## Phrasing pattern
+
+When a technology must be mentioned, prefer this shape:
+
+> *"[Capability / contract] — currently provided by [technology], any equivalent is
+> acceptable that preserves [specific property]."*
+
+Examples:
+
+- *"Face detection on-device — currently ML Kit v1.x. Any equivalent is acceptable that
+  provides landmark detection (left eye, right eye, nose base) at ≥15 FPS on
+  mid-range hardware."*
+
+- *"Card input form — currently Stripe PaymentSheet. Any equivalent is acceptable that
+  keeps PAN data out of application memory and storage (PCI SAQ-A eligibility)."*
+
+- *"Push delivery — currently FCM for Android, APNs for iOS. Equivalents are acceptable
+  if they preserve at-least-once delivery and the existing `payment.required` topic."*
+
+This pattern transfers the *requirement* without pinning the *implementation*.
+
+---
+
+## Review step
+
+Before declaring the spec draft complete, search it for technology names. For each hit:
+
+1. Does it pass the four-question test?
+2. If yes, is it phrased as a capability-with-acceptable-substitute rather than a
+   direct-SDK-reference?
+3. If no, delete the reference and describe the behavior instead.
+
+Technology mentions in the Code Map appendix are fine — that section is explicitly about
+the current implementation. The restriction applies to the spec body.


### PR DESCRIPTION
## Summary
- New `reverse-spec` skill that reverse-engineers existing feature code into a stack-neutral behavior specification suitable for reimplementation on any platform (SwiftUI / Flutter / web etc.).
- Output is a 13-section markdown in product-first order: §§1-7 Product behavior, §§8-9 Open Questions + Known Defects, §§10-12 Technical integration, §13 Code map appendix.
- 7-phase process with 5-pass verification (coverage, grounding, identifier-leak, reference integrity, code-map validity) + typo sweep, gated by an 11-item Definition of Done.

## Why
Existing `write-spec` works for new features. There was no symmetric flow for documenting features that already live in code — needed for migrations, rewrites on a new stack, and as a hand-off artifact when a codebase changes hands. Naive "AI summarises the code" output describes the current implementation, not the feature, and is useless for reimplementation. This skill enforces the discipline that produces a usable spec.

## Key mechanics
- **Phase 4.0 mandatory translate-step** converts code-vocabulary findings (class names, sealed-class cases, reactive primitives) into behavior-vocabulary using 13 translation recipes in `behavior-translation.md`.
- **Body is identifier-free** (sections 1-8, 10-11). Pass 3 of verification scans for any token that exists only because the codebase exists. Code identifiers live only in §13 Code map and as evidence in §9 Known defects.
- **§9 Known defects** is dedicated for confirmed bugs in current code (with 4 mandatory fields: what / class / evidence / consequence). Hard rule: ambiguous findings demote to §8 Open questions.
- **Bidirectional `[OQ-N]` cross-refs** between body and §8 Open questions — body claims that depend on unresolved intent are visibly contested.
- **§10.1 Network operations table** consolidates every endpoint with method / URL / trigger / fields in one place.
- **§10.7 Collaborators and consumers** captures cross-feature boundaries (Boundary / Preconditions / Postconditions).
- **§12 Tech-specific constraints** uses 4-question heuristic to decide which tech stays load-bearing; phrased capability-first with acceptable substitutes.

## Files
- `SKILL.md` — 7-phase process
- `references/spec-template.md` — 13-section output template
- `references/behavior-translation.md` — 13 code → behavior recipes
- `references/analysis-checklist.md` — what to extract in static analysis (incl. defect classification rules)
- `references/coverage-verification.md` — 5 verification passes
- `references/definition-of-done.md` — 11 binary gates
- `references/tech-abstraction.md` — load-bearing tech heuristic
- `references/anti-patterns.md` — 10 common failure modes
- `evals/evals.json` + `evals/README.md` — placeholder-templated eval prompts

## Validation
Tested across 4 iterations on the FrameIO authorization feature (KMP/Compose, Adobe IMS OAuth + PKCE, Android/iOS/Desktop):

| Iteration | Change | Pass rate vs no-skill baseline (35%) |
|---|---|---|
| 1 | Initial draft | 90% (+55 pp) — heavy code-identifier leakage in body |
| 2 | Principle 1 rewrite + Phase 4.0 translate-step + Pass 3 identifier scan | 93% (+58 pp) — zero body leaks |
| 4 | New section order + Pass 4/5 + §9 Known Defects + bidirectional `[OQ-N]` | **98% (+63 pp)** — eval-2 and eval-3 perfect 11/11 and 16/16 |

Multi-expert review (business-analyst) cycle 1: 2 critical issues fixed, 4 majors applied (§4.7 H4 restructure, Definition of Done, Phase 0.2 ↔ §4.7 cross-reference, soft scope-threshold gate).

## Plugin standards
`bash scripts/validate.sh` passes — `reverse-spec` frontmatter 916 chars (under 1024 limit). SKILL.md 471 lines (under 500 recommendation).

## Test plan
- [x] `bash scripts/validate.sh` green
- [x] `plugin-validator` agent on `developer-workflow` (manual review of new skill structure)
- [x] Manual run on real codebase (FrameIO) — 4 iterations, 3 evals each
- [ ] CI workflow (`.github/workflows/release.yml`) — runs on tag, not relevant for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)