### PR TITLE
chore: trim coroutines.md reference to non-obvious rules

### DIFF
--- a/plugins/developer-workflow-kotlin/agents/references/coroutines.md
+++ b/plugins/developer-workflow-kotlin/agents/references/coroutines.md
@@ -1,111 +1,42 @@
-# Kotlin Coroutines & Flow — DO / DON'T Reference
+# Kotlin Coroutines & Flow — Non-Obvious Rules
 
-Rules for writing correct, testable, and production-safe coroutine code in Android and KMP projects. Based on official Android best practices and common production pitfalls.
+This file lists only the coroutine and Flow rules a modern Claude model omits or gets wrong without a reminder. Generic idioms — structured concurrency basics, `viewModelScope` for ViewModels, exposing immutable `StateFlow`, `async`/`await`, `flow {}` builders, choosing `suspend` vs `Flow`, catching `IOException` instead of `Exception`, no empty `catch` blocks — are **not** documented here; trust the model and the [official kotlinx.coroutines docs](https://kotlinlang.org/docs/coroutines-guide.html).
 
 ---
 
-## Structured Concurrency
+## Scope Ownership by Layer
 
-**DO:**
-- Use a lifecycle-bound scope (`viewModelScope`, `lifecycleScope`, or an injected `CoroutineScope`)
-- Use `coroutineScope` when all children must succeed — one failure cancels siblings
-- Use `supervisorScope` when children are independent — one failure doesn't affect others
-
-**DON'T:**
-- Never use `GlobalScope` — it bypasses structured concurrency, makes testing hard, and leaks coroutines. If work must outlive the current screen, inject an external `CoroutineScope` scoped to the Application or navigation graph
-- Never use `runBlocking` in production code — it blocks the calling thread and defeats the purpose of coroutines. Acceptable only in `main()` functions and test bridges
-
-**Scope ownership by layer:**
+Models occasionally inject an Application-scoped `CoroutineScope` into a Repository. They shouldn't.
 
 | Layer | Scope | Why |
 |-------|-------|-----|
 | ViewModel | `viewModelScope` | Tied to ViewModel lifecycle, survives config changes |
-| UseCase / Repository | No own scope — inherits caller's | Caller controls cancellation |
-| Work that must outlive screen | Injected `CoroutineScope` (Application-scoped) | Guaranteed completion even if user navigates away |
+| UseCase / Repository | **No own scope — inherits caller's** | Caller controls cancellation |
+| Work that must outlive a screen | Injected `CoroutineScope` (Application-scoped) | Guaranteed completion when the user navigates away mid-write |
 
----
+## Dispatcher Injection — Constructor Param, Not Hardcoded
 
-## Dispatcher Injection
-
-**DO:**
-- Accept `CoroutineDispatcher` as a constructor parameter — makes the class testable with `TestDispatcher`
-- Use `Dispatchers.Default` for CPU-intensive work (sorting, parsing, computation)
-- Use `Dispatchers.IO` for I/O operations (network, disk, database)
-- Use `Dispatchers.Main` for UI updates (ViewModel layer on Android)
-
-**DON'T:**
-- Never hardcode `Dispatchers.IO` or `Dispatchers.Default` inside a class — inject them
+Inject `CoroutineDispatcher` as a constructor parameter. Models default to hardcoded `Dispatchers.IO` inside `withContext` blocks, which makes the class untestable.
 
 ```kotlin
-// DO — testable, configurable
 class DefaultOrderRepository(
     private val api: OrderApi,
-    private val dispatcher: CoroutineDispatcher,
+    @IoDispatcher private val dispatcher: CoroutineDispatcher,
 ) : OrderRepository {
     override suspend fun getOrders(): List<Order> =
         withContext(dispatcher) { api.getOrders().map { it.toOrder() } }
 }
-
-// DON'T — hardcoded, untestable
-class DefaultOrderRepository(
-    private val api: OrderApi,
-) : OrderRepository {
-    override suspend fun getOrders(): List<Order> =
-        withContext(Dispatchers.IO) { api.getOrders().map { it.toOrder() } }
-}
 ```
 
----
+## Suspend Functions Are Main-Safe — Caller Doesn't Wrap
 
-## Suspend Functions Must Be Main-Safe
+Every `suspend fun` in the data/domain layer must be safe to call from the main thread. The function chooses the dispatcher via internal `withContext`. The caller does **not** wrap your function in `withContext` — that breaks the contract and indicates the function did not respect main-safety.
 
-**DO:**
-- Every `suspend fun` in the data/domain layer must be safe to call from the main thread
-- Move blocking work off the main thread using `withContext(dispatcher)` inside the function
-- The function is responsible for choosing the right dispatcher — not the caller
+Models sometimes push dispatcher choice up to the caller. Keep it inside the function.
 
-**DON'T:**
-- Don't force callers to wrap your function in `withContext` — that's the function's job
-- Don't do blocking I/O on the calling dispatcher
+## StateFlow / SharedFlow Lifecycle Pairing
 
-**Why:** Makes the app scalable. Callers don't need to worry about which `Dispatcher` to use.
-
----
-
-## ViewModel Creates Coroutines
-
-**DO:**
-- Launch coroutines in ViewModel using `viewModelScope.launch { }`
-- Expose state as `StateFlow` — not as `suspend fun` for the UI to call
-
-**DON'T:**
-- Don't expose `suspend fun` from ViewModel for business logic — the View shouldn't manage coroutine lifecycle
-- Don't launch business-logic coroutines from the View/Activity/Fragment — delegate to ViewModel
-
-**Exception:** Views can launch coroutines for UI-only work (fetching images, formatting strings).
-
----
-
-## suspend vs Flow
-
-**DO:**
-- Use `suspend fun` for one-shot operations: fetch, save, delete — returns a single value
-- Use `Flow` for multiple values over time: observe database, real-time updates, paginated streams
-- Data and business layer should expose `suspend` functions and `Flow` — callers control execution and lifecycle
-
-**DON'T:**
-- Don't return `Flow` from a function that only emits once — use `suspend` instead
-- Don't use `Flow` for fire-and-forget operations — use `suspend`
-
----
-
-## StateFlow and SharedFlow
-
-**DO:**
-- Use `StateFlow` for UI state — always has a current value, replays the latest to new collectors
-- Use `SharedFlow` for one-shot events (navigation, snackbar) — no replay by default
-- Expose immutable `StateFlow` / `SharedFlow` — keep `MutableStateFlow` / `MutableSharedFlow` private
-- Convert cold `Flow` to hot with `stateIn` / `shareIn`:
+`SharingStarted.WhileSubscribed(5_000)` is the right default for `stateIn` in a ViewModel — and it only works if the UI collects with **lifecycle-aware** APIs. Without lifecycle awareness, the upstream never stops:
 
 ```kotlin
 val orders: StateFlow<List<Order>> = getOrders()
@@ -116,78 +47,44 @@ val orders: StateFlow<List<Order>> = getOrders()
     )
 ```
 
-`WhileSubscribed(5_000)` keeps the upstream active for 5 seconds after the last subscriber disconnects — survives configuration changes without restarting the Flow.
+UI side:
+- Compose: `collectAsStateWithLifecycle()`
+- Views: `flowWithLifecycle()` / `repeatOnLifecycle(Lifecycle.State.STARTED)`
 
-**Android lifecycle awareness:**
-- Use `SharingStarted.WhileSubscribed(stopTimeoutMillis)` when converting cold Flow to StateFlow in ViewModel. The timeout keeps the upstream alive during configuration changes (Activity recreation) so the Flow doesn't restart:
+`SharingStarted.Eagerly` wastes resources unless the state is genuinely always needed. `SharingStarted.Lazily` never stops once started — usually wrong for screen-scoped state.
+
+## Flow Operator Gotchas
+
+Two non-obvious facts the model gets wrong about ordering:
+
+1. **`flowOn(dispatcher)` only affects upstream operators** — calling it twice or after a terminal operator silently does nothing useful. Apply once, at the producer side.
+2. **`retry { }` must be placed BEFORE `catch { }`** in the chain. If `catch` runs first, it consumes the error and `retry` never sees it.
 
 ```kotlin
-val orders: StateFlow<List<Order>> = getOrders()
-    .stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.WhileSubscribed(5_000),
-        initialValue = emptyList(),
-    )
+upstream
+    .map { /* ... */ }
+    .retry(3) { it is IOException }   // first — gets a chance to retry
+    .catch { /* fallback emission */ } // last — handles unrecoverable errors
+    .collect { /* ... */ }
 ```
-
-- `5_000` ms is the common default — long enough to survive a rotation, short enough to stop upstream when the user leaves the screen
-- Collect in the UI layer with `collectAsStateWithLifecycle()` (Compose) or `flowWithLifecycle()` / `repeatOnLifecycle(Lifecycle.State.STARTED)` (Views) — these automatically unsubscribe when the UI goes to the background, and the `WhileSubscribed` timeout starts counting from that moment
-- `SharingStarted.Eagerly` — starts immediately, never stops. Use only for app-wide state that is always needed
-- `SharingStarted.Lazily` — starts on first collector, never stops. Use when you want caching without restart
-
-**DON'T:**
-- Don't expose `MutableStateFlow` directly — callers could mutate state from outside the ViewModel
-- Don't use `SharingStarted.Eagerly` by default — it wastes resources when no one is collecting
-- Don't collect StateFlow with plain `collect { }` in Activities/Fragments — it keeps collecting when the app is in the background. Always use lifecycle-aware collection
-
----
-
-## Flow Operators
-
-**DO:**
-- `flowOn(dispatcher)` to switch the upstream dispatcher — apply once, at the producer side
-- `catch { }` to handle upstream errors — place before terminal operators
-- `retry(n) { cause -> cause is IOException }` for retriable operations — place before `catch`
-- `map`, `filter`, `flatMapLatest`, `debounce`, `distinctUntilChanged` for transformations
-- Prefer terminal operators (`first()`, `single()`, `toList()`) over collecting when only one value is needed
-
-**DON'T:**
-- Don't call `flowOn` multiple times in a chain — it only affects upstream operators
-- Don't use `collect` when a terminal operator would suffice
-
----
 
 ## Avoiding Indefinite Suspension
 
-Terminal operators like `first()`, `single()`, and `Channel.receive()` suspend until data arrives. If the source never emits, the coroutine hangs forever. This is a common production bug with event-driven flows where events may never occur.
-
-**DO:**
-- Bound waiting with `withTimeout` when the source may not emit: `withTimeout(5_000) { events.first() }`
-- Use `firstOrNull()` when absence of data is a valid outcome, not an error
-- Use `Channel.tryReceive()` for non-suspending checks when you can handle "nothing available" immediately
-- Prefer `StateFlow` over `SharedFlow` when a current value is meaningful — `StateFlow.first()` returns immediately
-
-**DON'T:**
-- Don't call `first()` on a `SharedFlow(replay = 0)` without a timeout — new collectors see nothing until the next emission
-- Don't assume an emission will arrive "soon" — always set explicit bounds in production code
-- Don't use bare `Channel.receive()` on event channels where events are infrequent or optional
-
-**Risk levels:**
+Terminal operators like `first()`, `single()`, `Channel.receive()` suspend until data arrives. If the source never emits, the coroutine hangs forever — a common production bug with event-driven flows.
 
 | Source | `first()` risk | Mitigation |
-|--------|---------------|------------|
-| `StateFlow` | Safe — always has value | None needed |
-| `SharedFlow(replay > 0)` | Low — replays last N values | Usually safe, but `withTimeout` for rare events |
-| `SharedFlow(replay = 0)` | High — waits for next emit | Always use `withTimeout` |
-| `Channel` | High — waits for `send()` | Use `tryReceive()` or `withTimeout` |
+|---|---|---|
+| `StateFlow` | Safe — always has a value | None |
+| `SharedFlow(replay > 0)` | Low — replays last N values | `withTimeout` for rare events |
+| `SharedFlow(replay = 0)` | **High** — waits for next emit | Always use `withTimeout` |
+| `Channel` | **High** — waits for `send()` | `tryReceive()` or `withTimeout` |
 | Cold `flow { }` | Depends on producer | `withTimeout` if producer may not emit |
 
----
+Use `firstOrNull()` when absence of data is a valid outcome rather than an error.
 
-## Cancellation
+## Cancellation — `CancellationException` Must Propagate
 
-**DO:**
-- Always re-throw `CancellationException` — it signals structured cancellation:
+Every `catch` that catches `Exception` or `Throwable` must re-throw `CancellationException` first. Models forget this constantly:
 
 ```kotlin
 try {
@@ -199,7 +96,7 @@ try {
 }
 ```
 
-When using `runCatching`, check in `onFailure`:
+`runCatching { }` swallows `CancellationException` — never use bare `runCatching` in suspend code. Either re-throw inside `onFailure`, or use explicit `try/catch`:
 
 ```kotlin
 runCatching { api.fetchData() }
@@ -209,63 +106,41 @@ runCatching { api.fetchData() }
     }
 ```
 
-- Use `ensureActive()` or `yield()` in long-running loops for cooperative cancellation
-- Use `withTimeout(millis)` for time-bounded operations
-- Use `withContext(NonCancellable)` only in `finally` blocks for cleanup that must complete
-- Parallel processing: `coroutineScope { items.map { async { process(it) } }.awaitAll() }`
+## `withContext(NonCancellable)` — Only in `finally`
 
-**DON'T:**
-- Never swallow `CancellationException` — it breaks structured concurrency
-- Never catch generic `Exception` or `Throwable` without re-throwing `CancellationException` first
-- Don't use `withContext(NonCancellable)` outside of cleanup — it prevents cancellation
-
----
-
-## Error Handling in Coroutines
-
-**DO:**
-- Catch specific exception types (`IOException`, `HttpException`) rather than generic `Exception`
-- Use `Result<T>` or a project-specific sealed type for expected failures at layer boundaries
-- Map errors as they cross layer boundaries — don't leak `HttpException` to the domain layer
-- In ViewModel: catch exceptions from `viewModelScope.launch` and update UI state
-
-**DON'T:**
-- Never have an empty `catch (e: Exception) {}` — every catch must handle or re-throw
-- Never catch `CancellationException` (see Cancellation section)
-- Don't let implementation exceptions (Retrofit, Room) propagate to the presentation layer
-
----
-
-## Testing Coroutines
-
-**DO:**
-- Use `runTest` for all coroutine tests — it provides a `TestCoroutineScheduler`
-- Inject `TestDispatcher` instead of real dispatchers — enables deterministic tests
-- `UnconfinedTestDispatcher` — dispatches eagerly, simpler for most tests
-- `StandardTestDispatcher` — queues dispatches, gives explicit control via `advanceUntilIdle()`
-- All `TestDispatchers` in a test must share the same scheduler
-- Use Turbine for testing Flow emissions:
+`NonCancellable` disables cancellation for everything inside. Use it **only in cleanup that must complete after a coroutine is being cancelled**:
 
 ```kotlin
-@Test
-fun `state emits loading then data`() = runTest {
-    val viewModel = createViewModel()
-
-    viewModel.state.test {
-        val loading = awaitItem()
-        assertTrue(loading.isLoading)
-
-        val loaded = awaitItem()
-        assertFalse(loaded.isLoading)
-        assertEquals(2, loaded.orders.size)
-
-        cancelAndIgnoreRemainingEvents()
-    }
+try {
+    work()
+} finally {
+    withContext(NonCancellable) { releaseResources() } // valid
 }
 ```
 
-- Replace `viewModelScope` dispatcher in tests using `Dispatchers.setMain(testDispatcher)`
+Anywhere else it's a bug — disables cooperative cancellation in the calling chain.
 
-**DON'T:**
-- Don't use `delay()` or `Thread.sleep()` in tests to wait for coroutines — use `advanceUntilIdle()` or Turbine
-- Don't hardcode dispatchers — it makes `TestDispatcher` injection impossible
+## Error Mapping at Layer Boundaries
+
+Don't leak `HttpException`, `SQLiteException`, or other implementation exceptions to the domain or presentation layer. Map them at the data → domain boundary into a project-specific error type or `Result<T>`.
+
+## Testing
+
+Three rules the model misses:
+
+1. **All `TestDispatchers` in a single test must share the same scheduler** — otherwise `advanceUntilIdle()` doesn't propagate. Pass the same `TestCoroutineScheduler` to each dispatcher.
+2. **Replace the `Main` dispatcher** before testing anything that uses `viewModelScope`: `Dispatchers.setMain(testDispatcher)` in `@Before`, `Dispatchers.resetMain()` in `@After`.
+3. **`UnconfinedTestDispatcher` vs `StandardTestDispatcher`** — `Unconfined` runs eagerly (simpler for most tests; assertions see latest state after each suspending call). `Standard` queues; advance via `advanceUntilIdle()` or `runCurrent()` — use when you need explicit control over scheduling order.
+
+Use Turbine for Flow assertions:
+
+```kotlin
+viewModel.state.test {
+    assertTrue(awaitItem().isLoading)
+    val loaded = awaitItem()
+    assertFalse(loaded.isLoading)
+    cancelAndIgnoreRemainingEvents()
+}
+```
+
+Do not use `delay()` or `Thread.sleep()` to wait for coroutines in tests.


### PR DESCRIPTION
## Summary

Continue the agent-cleanup pattern (#166 kotlin-engineer pilot, #167 compose-developer) into the coroutines reference. Cut every rule the model writes by default; keep only what the model gets wrong without a reminder.

## What changed

| File | Before | After | Delta |
|---|---|---|---|
| `references/coroutines.md` | 271 lines / 8.5K | 146 / ~5K | **-46%** |

## Cuts

Generic / model-default / lint-caught / kotlinx.coroutines-docs duplicate:
- Structured concurrency DO/DON'T (no GlobalScope, no runBlocking)
- Dispatcher descriptions (IO / Default / Main)
- "ViewModel creates coroutines" section — pure Android default
- `suspend vs Flow` choice — idiomatic
- "Expose immutable StateFlow" — idiomatic
- Two duplicated `stateIn(WhileSubscribed)` code blocks (collapsed to one)
- Flow operator catalog (`map`, `filter`, `debounce`, `distinctUntilChanged`)
- Empty-catch warnings — lint catches
- `IOException` vs `Exception` distinction — model default
- Basic `runTest` example shape

## Kept (10 non-obvious rules)

1. Scope ownership by layer — Repository owns no scope
2. Dispatcher injection as constructor parameter
3. Suspend functions are main-safe; caller does not wrap in `withContext`
4. `WhileSubscribed(5_000)` requires lifecycle-aware collection (`collectAsStateWithLifecycle`, `repeatOnLifecycle`)
5. `flowOn` is upstream-only; `retry` must precede `catch` in the chain
6. Indefinite-suspension risk table (`first()` on `SharedFlow(replay=0)`, bare `Channel.receive()`)
7. `CancellationException` must propagate — including the `runCatching` swallow gotcha
8. `withContext(NonCancellable)` only inside `finally`
9. Error mapping at layer boundaries
10. Testing — shared scheduler across `TestDispatcher`s, `Dispatchers.setMain`, `Unconfined` vs `Standard` distinction

## Why no separate A/B test

References are loaded by agents (kotlin-engineer, compose-developer), not invoked directly. The agents are the test surface — already validated in #166 and #167. Adding a third A/B for a reference-only change would burn tokens without new signal.

## Test plan

- [x] `bash scripts/validate.sh` — green
- [ ] Real-world validation — once #166 and #167 are in production use, observe whether the trimmed coroutines reference still produces correct coroutine code in kotlin-engineer and compose-developer outputs

## Out of scope

- swift-engineer / swiftui-developer / swift references — separate PRs
- developer-workflow-experts agents — separate audit pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)