### PR TITLE
Trim duplicate Behavioral Rules from writer subagents

### DIFF
--- a/plugins/developer-workflow-kotlin/agents/compose-developer.md
+++ b/plugins/developer-workflow-kotlin/agents/compose-developer.md
@@ -194,13 +194,7 @@ References are authoritative — when memory disagrees, trust them. **Project co
 
 ## Behavioral Rules
 
-- **Real code, not pseudocode** — every output is a complete, compilable file
-- **UI layer only** — no business logic. Note out-of-scope changes as suggestions, do not do them
 - **Migration brief = ground truth** — patterns, theme, components are pre-decided; implement, don't reinvent
-- **One question per round** when clarification needed
-- **Confirm tree + state/action in standalone mode** before implementing
-- **Build before delivering** — fix compile failures before reporting completion
-- **Project conventions override generic rules**
 
 For Compose stability, phase-deferral, accessibility, and KMP rules — see the references above; do not duplicate them here.
 

--- a/plugins/developer-workflow-kotlin/agents/kotlin-engineer.md
+++ b/plugins/developer-workflow-kotlin/agents/kotlin-engineer.md
@@ -311,16 +311,7 @@ References are authoritative — when memory disagrees, trust them. **Project co
 
 ## Behavioral Rules
 
-- **Real code, not pseudocode** — every output is a complete, compilable file
-- **Never touch UI code** — Compose belongs to `compose-developer`. Note follow-ups when ViewModel state shape changes
-- **Project conventions override generic rules** — if the project does it differently, follow the project
-- **One question per round** when clarification needed
-- **Confirm multi-file design** before implementing
-- **Build and test before delivering** — fix failures before reporting completion
-- **Inside-out implementation** — domain → data → use case → ViewModel
-- **Tests** — coverage scope and patterns in Step 3.7
-
-For visibility, KMP, and architectural rules — see the references above; do not duplicate them here.
+For visibility, KMP, coroutine, and architectural rules — see the references above; do not duplicate them here.
 
 ---
 

--- a/plugins/developer-workflow-swift/agents/swift-engineer.md
+++ b/plugins/developer-workflow-swift/agents/swift-engineer.md
@@ -216,13 +216,6 @@ Don't leak `URLError`, `DecodingError`, `SwiftDataError` to the domain or presen
 
 ## Behavioral Rules
 
-- **Real code, not pseudocode** — every output is a complete, compilable file
-- **No UI code** — `swiftui-developer` owns views, screens, modifiers, previews, UI state
-- **One question per round** when clarification needed
-- **Confirm multi-file design** before implementing
-- **Build and test before delivering** — fix failures before reporting completion
-- **Project conventions override generic rules**
-
 For Swift Concurrency and Swift Testing rules — see the references above; do not duplicate them here.
 
 ---

--- a/plugins/developer-workflow-swift/agents/swiftui-developer.md
+++ b/plugins/developer-workflow-swift/agents/swiftui-developer.md
@@ -217,12 +217,7 @@ When a UI change requires a service-layer change, note it as a follow-up rather 
 
 ## Behavioral Rules
 
-- **Real code, not pseudocode** — every output is a complete, compilable file
 - **Migration brief = ground truth** — patterns, theme, components are pre-decided; implement, do not reinvent
-- **One question per round** when clarification needed
-- **Confirm tree + state in standalone mode** before implementing
-- **Build before delivering** — fix failures before reporting completion
-- **Project conventions override generic rules**
 
 For state property wrappers, view-identity, performance, and design-system rules — see the references above; do not duplicate them here.
 


### PR DESCRIPTION
## Summary

Apply the **CC-4** finding from the recent subagent content audit: each writer subagent's `## Behavioral Rules` section repeated bullets already stated in the agent header, in Step headings (Step 2/3/4), or as generic Claude Code rules.

Quick win on the `feedback_subagent_minimalism` filter — keep only non-obvious, project-specific behavior plus the anti-duplication footer pointing at references.

### Changes per file

| File | Before | After | Cut |
|---|---|---|---|
| `kotlin-engineer.md` | 8 bullets + footer | footer (extended w/ "coroutine") | 8 bullets |
| `compose-developer.md` | 6 bullets + footer | "Migration brief = ground truth" + footer | 6 bullets |
| `swift-engineer.md` | 6 bullets + footer | footer only | 6 bullets |
| `swiftui-developer.md` | 5 bullets + footer | "Migration brief = ground truth" + footer | 5 bullets |

### What was cut and why

Every removed bullet falls in one of three categories — all already asserted earlier in the same file:

1. **Repeats agent header** — "Real code, not pseudocode", "No UI code / UI layer only", "Project conventions override generic rules"
2. **Repeats Step heading** — "Confirm multi-file design" (Step 2), "Build before delivering" (Step 4/5), "Inside-out implementation" (Step 3 heading), "Tests — see Step 3.7"
3. **Generic Claude Code rule** — "One question per round"

`Migration brief = ground truth` kept in `compose-developer` and `swiftui-developer` — it's a non-obvious behavioral assertion (model tends to "improve" the brief instead of executing it) that no Step heading conveys directly.

### Net

−28 lines, +1 line. No behavioral coverage lost.

## Validation

- `bash scripts/validate.sh` — passed
- All 4 subagents preserve their `## Behavioral Rules` heading as an extension point for project-specific rules
- Anti-duplication footer pointing at references kept everywhere

## Test plan

- [ ] CI green
- [ ] Spot-check 1 real Kotlin task with the trimmed `kotlin-engineer` — verify no behavioral regression (still does Step 1 discovery, still confirms multi-file designs, still builds before reporting)
- [ ] Spot-check 1 real SwiftUI task with the trimmed `swiftui-developer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)