### PR TITLE
Release v0.12.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.11.1",
+      "version": "0.12.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/maven-mcp/plugin"
@@ -23,7 +23,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.11.1",
+      "version": "0.12.0",
       "category": "security",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/sensitive-guard"
@@ -34,7 +34,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.11.1",
+      "version": "0.12.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow"
@@ -45,7 +45,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.11.1",
+      "version": "0.12.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-experts"
@@ -56,7 +56,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.11.1",
+      "version": "0.12.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-kotlin"
@@ -67,7 +67,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.11.1",
+      "version": "0.12.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-swift"

--- a/plugins/developer-workflow-experts/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-experts/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-experts",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Reusable expert agents for code review, architecture, security, performance, UX, build, DevOps, business analysis, and debugging. Safe to install standalone \u2014 no skills, no hooks, no MCP servers.",
   "author": {
     "name": "kirich1409"

--- a/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-kotlin",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Kotlin, Android, and KMP specialist agents and migration skills \u2014 kotlin-engineer, compose-developer, code-migration, kmp-migration, migrate-to-compose. Extends developer-workflow for Kotlin/Android projects.",
   "author": {
     "name": "kirich1409"
@@ -18,11 +18,11 @@
   "dependencies": [
     {
       "name": "developer-workflow",
-      "version": "^0.11.1"
+      "version": "^0.12.0"
     },
     {
       "name": "developer-workflow-experts",
-      "version": "^0.11.1"
+      "version": "^0.12.0"
     }
   ]
 }

--- a/plugins/developer-workflow-swift/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-swift/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-swift",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Swift, iOS, and macOS specialist agents \u2014 swift-engineer and swiftui-developer, with references covering Swift concurrency, testing, and SwiftUI patterns/state/performance. Extends developer-workflow for Apple platforms.",
   "author": {
     "name": "kirich1409"
@@ -17,11 +17,11 @@
   "dependencies": [
     {
       "name": "developer-workflow",
-      "version": "^0.11.1"
+      "version": "^0.12.0"
     },
     {
       "name": "developer-workflow-experts",
-      "version": "^0.11.1"
+      "version": "^0.12.0"
     }
   ]
 }

--- a/plugins/developer-workflow/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Developer workflow pipeline \u2014 research, decomposition, specification, multiexpert review, implementation, debugging, QA (test plans, acceptance, bug hunt, retroactive tests), PR creation and autonomous drive-to-merge (CI monitor, review handler, re-request, poll), feature-flow and bugfix-flow orchestrators. Platform-neutral; platform-specific engineers live in developer-workflow-kotlin and developer-workflow-swift.",
   "author": {
     "name": "kirich1409"
@@ -18,7 +18,7 @@
   "dependencies": [
     {
       "name": "developer-workflow-experts",
-      "version": "^0.11.1"
+      "version": "^0.12.0"
     }
   ]
 }

--- a/plugins/maven-mcp/package-lock.json
+++ b/plugins/maven-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@krozov/maven-central-mcp",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/plugins/maven-mcp/package.json
+++ b/plugins/maven-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "MCP server for Maven Central dependency intelligence",
   "main": "./dist/index.js",
   "type": "module",

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maven-mcp",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps, /latest-version, and /dependency-changes skills",
   "author": {
     "name": "kirich1409"
@@ -19,7 +19,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@krozov/maven-central-mcp@^0.11.0"
+        "@krozov/maven-central-mcp@^0.12.0"
       ]
     }
   }

--- a/plugins/sensitive-guard/.claude-plugin/plugin.json
+++ b/plugins/sensitive-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sensitive-guard",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Prevents sensitive data (secrets, PII) from reaching AI servers by scanning files before they are read into conversation",
   "author": {
     "name": "kirich1409"


### PR DESCRIPTION
## Summary

Bumps all 8 version locations to **0.12.0** and widens family `dependencies` ranges to `^0.12.0`.

### Changes since v0.11.1

- **#165** — Refactor `code-migration` into thin orchestrator, extract `snapshot` skill
- **#172** — Enforce English for all extension content (new Non-negotiable + `docs/` exception)
- **#171** — Trim duplicate Behavioral Rules from writer subagents (-28 lines)
- **#170** — Trim `swiftui-developer` prompt and SwiftUI references
- **#169** — Trim `swift-engineer` prompt and Swift references
- **#168** — Trim `coroutines.md` to non-obvious rules only
- **#167** — Trim `compose-developer` prompt and restructure `compose-rules`
- **#166** — Trim `kotlin-engineer` prompt and `kotlin-style` reference (pilot)

Net effect: ~3170 lines cut from subagent prompts, English-only policy codified, new `snapshot` skill split out of `code-migration`.

### Bumped files (8)
- `plugins/maven-mcp/package.json`
- `plugins/maven-mcp/plugin/.claude-plugin/plugin.json` (+ `mcpServers.maven-mcp` npx range `^0.11.0` → `^0.12.0`)
- `plugins/sensitive-guard/.claude-plugin/plugin.json`
- `plugins/developer-workflow/.claude-plugin/plugin.json` (+ deps range)
- `plugins/developer-workflow-experts/.claude-plugin/plugin.json`
- `plugins/developer-workflow-kotlin/.claude-plugin/plugin.json` (+ deps ranges)
- `plugins/developer-workflow-swift/.claude-plugin/plugin.json` (+ deps ranges)
- `.claude-plugin/marketplace.json`

## Test plan
- [x] `bash scripts/validate.sh` — passes
- [x] `npm run build` (maven-mcp) — passes
- [x] `npm test` (maven-mcp) — 291/291 tests pass
- [x] `npm run lint` (maven-mcp) — clean
- [ ] Tag `v0.12.0` after merge — triggers `.github/workflows/release.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)