### PR TITLE
developer-workflow: min-bar checklist for new orchestrator stages

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-stage-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/new-stage-proposal.yml
@@ -1,0 +1,101 @@
+name: New Orchestrator Stage Proposal
+description: Propose adding a new stage to feature-flow or bugfix-flow
+labels: ["enhancement", "stage-proposal"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template only for **new stages** in `feature-flow` or `bugfix-flow`.
+        For sub-phases inside an existing skill, pattern-trigger extensions, or new
+        `multiexpert-review` profiles — open a regular Feature Request instead.
+
+        Read the [Min-bar for a new orchestrator stage](https://github.com/kirich1409/krozov-ai-tools/blob/main/plugins/developer-workflow/docs/ORCHESTRATION.md#min-bar-for-a-new-orchestrator-stage)
+        before filling this in. A proposal that fails any criterion below is labeled
+        `wontfix-as-stage` and redirected to the cheaper alternative.
+
+  - type: dropdown
+    id: target-flow
+    attributes:
+      label: Target flow
+      options:
+        - feature-flow
+        - bugfix-flow
+        - both
+    validations:
+      required: true
+
+  - type: textarea
+    id: stage-name
+    attributes:
+      label: Proposed stage name and position
+      description: Where does it fit in the state machine? (e.g. "After Research, before Decompose")
+    validations:
+      required: true
+
+  - type: textarea
+    id: contract
+    attributes:
+      label: Stage contract
+      description: |
+        - Input artifact(s) consumed
+        - Output artifact written to `swarm-report/`
+        - Skip conditions
+        - Backward-edge cap (if any)
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: min-bar
+    attributes:
+      label: Min-bar checklist
+      description: All five must be checked. If any cannot be checked, this is not a stage proposal — see the redirect note in each item.
+      options:
+        - label: "**Cross-skill orchestration required.** Coordinates ≥ 2 skills/agents with receipt-based gating. (If one skill suffices → sub-phase, not a stage.)"
+          required: true
+        - label: "**Measurable KPI named.** A concrete metric is given in the proposal (merge-rate, time-to-merge, regression-rate, security-finding count, PlanReview-FAIL-rate, etc.)."
+          required: true
+        - label: "**Does not duplicate an existing path.** Extension via pattern triggers / `multiexpert-review` profile / artifact-template section was considered and ruled out — explicitly stated in the proposal."
+          required: true
+        - label: "**Does not conflict with flow contracts.** Thin orchestrator (no code), preconditions are caller's responsibility, three-tier dependency policy, Tier-3 approval per change."
+          required: true
+        - label: "**Evidence provided.** Flow-telemetry data, industry source with link, or internal case-study. (`Feels useful` is not evidence.)"
+          required: true
+
+  - type: textarea
+    id: kpi
+    attributes:
+      label: KPI definition
+      description: Name the metric, the baseline, and what change you expect after the stage ships.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives ruled out
+      description: |
+        Which cheaper paths were considered and why they are not enough?
+        - Extend `finalize` Phase D triggers
+        - New `multiexpert-review` profile
+        - Section in an existing artifact template (`<slug>-test-plan.md`, PR body, …)
+        - Sub-phase inside an existing skill
+        - Standalone skill (user-invoked, not a stage)
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Flow-telemetry numbers, links, or a concrete past incident.
+    validations:
+      required: true
+
+  - type: textarea
+    id: contract-impact
+    attributes:
+      label: Flow-contract impact
+      description: |
+        Does this stage stay thin (no code in the orchestrator)? Does it require new caller preconditions? Does it introduce a Tier-3 dependency?
+    validations:
+      required: true

--- a/plugins/developer-workflow/CLAUDE.md
+++ b/plugins/developer-workflow/CLAUDE.md
@@ -44,6 +44,7 @@ Skills in this plugin delegate to engineer agents (kotlin-engineer / compose-dev
 - Workspace directories (`*-workspace/`) are runtime artifacts, not skills. Gitignored.
 - Pipeline orchestration rules (task profiling, Research Consortium, Quality Loop gates, State Machine, receipt-based gating) ship with this plugin at [`docs/ORCHESTRATION.md`](docs/ORCHESTRATION.md) — skills and the core feature-flow/bugfix-flow orchestrators read from there.
 - Quality Loop gates are defined in `docs/ORCHESTRATION.md`, not in any individual skill.
+- New stages for `feature-flow` / `bugfix-flow` must pass the [Min-bar checklist](docs/ORCHESTRATION.md#min-bar-for-a-new-orchestrator-stage) (5 criteria + alternative-redirect). Failing candidates are redirected to the cheaper path (extend triggers, profile, artifact template, or standalone skill); they are not merged as stages.
 
 ## Skills roster (18)
 

--- a/plugins/developer-workflow/docs/ORCHESTRATION.md
+++ b/plugins/developer-workflow/docs/ORCHESTRATION.md
@@ -321,3 +321,35 @@ At every stage boundary:
 3. Validate the artifact before advancing: does it address the original task? Is it concrete (file paths, findings, code), not generic filler?
 4. Run `/compact` only for Large/Migration tasks or when context is noticeably degraded. Skip for Small/Medium tasks.
 
+## Min-bar for a new orchestrator stage
+
+`feature-flow` and `bugfix-flow` are intentionally thin. Stage proposals arrive regularly (Clarify, Changelog, Telemetry, Observability, Post-mortem, …); each looks reasonable in isolation, but the cumulative effect is a 30-step checklist that buries the user in stop-points and duplicates skills that already exist.
+
+Before opening a stage proposal — and before merging one — the candidate must pass **all five** of the criteria below. A failing candidate is not "rejected"; it is redirected to the cheaper alternative (extend a pattern trigger, add a profile, expand an artifact template, ship a standalone skill, sub-phase inside an existing skill).
+
+### Criteria
+
+1. **Cross-skill orchestration is required.** The work coordinates **two or more** skills or agents with receipt-based gating. If a single skill suffices, it is a sub-phase inside that skill, not a stage.
+2. **Measurable KPI exists.** A concrete metric must be nameable up front — merge-rate, time-to-merge, regression-rate, security-finding count, user-facing incidents, PlanReview-FAIL-rate, etc. Without a KPI the stage cannot be evaluated, kept, or removed on evidence.
+3. **Does not duplicate an existing path.** If the same outcome is reachable by extending pattern triggers of an existing stage (e.g. `finalize` Phase D), adding a `multiexpert-review` profile, or expanding an artifact template (e.g. a section in `<slug>-test-plan.md`) — choose the extension. New stages only when no extension fits.
+4. **Does not conflict with flow contracts.** Thin orchestrators (no code), preconditions are the caller's responsibility (branches, worktrees, fresh base), three-tier dependency policy with Tier-3 approval per change. A stage that breaks any of these is a blocker until the contract itself is renegotiated explicitly.
+5. **Evidence is provided.** Flow-telemetry data, an industry source with link, or an internal case-study. "Feels useful" is not evidence. Without evidence, propose as an experiment behind a flag, not as a default-on stage.
+
+### Application
+
+- Run the checklist **before** opening the issue. The new-stage proposal template at [`.github/ISSUE_TEMPLATE/new-stage-proposal.yml`](../../../.github/ISSUE_TEMPLATE/new-stage-proposal.yml) embeds it.
+- An issue or PR that fails any criterion is labeled `wontfix-as-stage` and routed to the cheaper alternative recorded on the issue.
+- The criteria themselves are revised when a real proposal exposes a blind spot. Update the section, do not bend it case-by-case.
+
+### Examples
+
+**PASS — Clarify pit-stop (issue #141, shipped).** Cross-skill: lives between `research` and `decompose-feature`, with receipt `<slug>-clarify.md`. KPI: PlanReview-FAIL-rate after Plan was reachable in zero clarify-loops vs one. Not a duplicate: `write-spec` is heavyweight and standalone; `research` produces findings, not locked requirements. No contract conflict — adds one optional artifact, has explicit skip and backward-edge-cap. Evidence: recurring PlanReview FAILs caused by un-locked acceptance criteria. → Stage admitted.
+
+**FAIL — alternative — "Security review stage" before Acceptance.** Cross-skill: yes, but `security-expert` is already the Phase D conditional reviewer in `finalize`. Existing path: extend the `security-expert` pattern triggers (auth, encryption, network, tokens, etc.) and let Phase D fire automatically. Evidence: the trigger list is incomplete, not the absence of a stage. → Redirected to issue #143 (extend `security-expert` triggers in finalize Phase D), no new stage.
+
+**FAIL — alternative — "Release notes / changelog stage" in feature-flow** (issue #144). Cross-skill: only `create-pr` writes the user-facing artifact, so a separate stage with its own receipt is overkill. Existing path: extend `create-pr` to append a `## Release Notes` section to the PR body when the spec or commit messages flag user-visible changes; or add a `release-notes:` field to the existing PR receipt. KPI candidate ("entries shipped per release") is real, but reachable from the PR artifact without a new stage. → Redirected to a `create-pr` enhancement, not a new orchestrator stage.
+
+### Audit of existing stages
+
+The current set of `feature-flow` / `bugfix-flow` stages was added before this checklist. A retroactive audit is a separate follow-up issue — not in scope here. If an existing stage is later found to fail the min-bar, the path is the same: redirect, not "patch the checklist".
+


### PR DESCRIPTION
## Summary

Closes #148.

- Add **Min-bar for a new orchestrator stage** section to `plugins/developer-workflow/docs/ORCHESTRATION.md` — five criteria (cross-skill orchestration, measurable KPI, no duplication, contract compliance, evidence) plus three worked examples (Clarify PASS, security-stage redirect, changelog-stage redirect).
- Reference the checklist from `plugins/developer-workflow/CLAUDE.md` so it lands in skill context whenever a stage proposal is being discussed.
- New `.github/ISSUE_TEMPLATE/new-stage-proposal.yml` with the five criteria as required checkboxes plus structured fields (target flow, contract, KPI, alternatives, evidence, contract impact).

## Acceptance criteria mapping (from #148)

- [x] `docs/ORCHESTRATION.md` contains `## Min-bar for a new orchestrator stage` with five criteria and three examples (PASS / FAIL-redirect / FAIL-redirect).
- [x] `plugins/developer-workflow/CLAUDE.md` references the section.
- [x] `.github/ISSUE_TEMPLATE/new-stage-proposal.yml` exists and uses the checklist.
- [x] Open stage-proposal issues annotated:
  - #144 (Changelog stage) → [redirect to `create-pr` enhancement](https://github.com/kirich1409/krozov-ai-tools/issues/144#issuecomment-4363781157)
  - #149 (Write Regression Tests) → [does not yet pass; alternative + evidence required](https://github.com/kirich1409/krozov-ai-tools/issues/149#issuecomment-4363781558)
- [x] Follow-up audit issue filed: #176 (audit existing stages against min-bar; depends on this PR + #145).

## Out of scope

- **Retroactive audit** of every existing `feature-flow` / `bugfix-flow` stage against the checklist — explicit non-goal of #148; tracked as #176.
- **`skill-reviewer` / `plugin-validator` prompt updates.** Those agents live in the external `plugin-dev` plugin and are not editable from this repo. The min-bar section and the issue template carry the load.
- No tooling — no linter / no CI gate. Convention-only, by design (#148 Non-goals).

## Test plan

- [x] `bash scripts/validate.sh` — green.
- [x] YAML syntax of new-stage-proposal.yml validated (`ruby -ryaml`).
- [ ] Render check on GitHub: anchor `#min-bar-for-a-new-orchestrator-stage` resolves from CLAUDE.md link (manual after merge).
- [ ] Issue template renders correctly in GitHub UI (manual visual check after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)