### PR TITLE
developer-workflow: structure debug.md template (Reproduce → Severity → RCA → Blast-radius)

### DIFF
--- a/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
@@ -100,13 +100,28 @@ Invoke `developer-workflow:debug` with the bug description.
 
 Wait for `swarm-report/<slug>-debug.md`.
 
-The debug artifact includes a **Reproduction Steps** section in `swarm-report/<slug>-debug.md`.
-This section is persistent state — survives context compaction. Re-read it before any
-action that depends on reproduction steps.
+The debug artifact follows the canonical template at
+[`debug/references/debug-template.md`](../debug/references/debug-template.md). Three
+fields are read by this orchestrator:
+
+- **`Severity` (P0 | P1 | P2 | P3)** — surfaced in announce-transitions and the draft PR
+  body. Severity does NOT branch the state machine on its own (the existing trivial-fix
+  shortcut at Phase 0.2 is the only Setup-level fast-lane), but it modulates downstream
+  decisions:
+  - **P0 / P1** → Phase 2.5 Finalize tightens (no Phase D skip even when no trigger
+    matches; treat WARN findings as block-equivalent on auth, data, and concurrency).
+    Phase 3 Blast-radius coverage is enforced strictly — every "Fix all" site MUST land
+    in the diff, no orchestrator-level forgiveness.
+  - **P3 + Fix direction `Simple`** → eligible for a Phase 2.2 regression-test skip with
+    a one-line user confirmation (instead of the diagnosis-then-confirm path). The
+    skip-condition list still applies; Severity only sets the bar lower for asking.
+- **`Status`** — drives routing.
+- **Reproduction Steps** (Section 1) — persistent state, survives context compaction.
+  Re-read before any action that depends on reproduction steps.
 
 **Route by status:**
-- **Diagnosed, simple fix** (single file, clear direction) → **Stage: Debug → Implement.**
-- **Diagnosed, complex fix** (multiple files, architectural impact, unclear approach) → **Stage: Debug → Plan.**
+- **Diagnosed, simple fix** (Fix direction `Simple` — single file, clear direction) → **Stage: Debug → Implement.**
+- **Diagnosed, complex fix** (Fix direction `Complex` — multiple files, architectural impact, unclear approach) → **Stage: Debug → Plan.**
 - **Not Reproducible** → report to user, ask for more info. Stop.
 - **Escalated** → report findings, stop. Bug needs user decision.
 
@@ -298,6 +313,26 @@ Invoke `developer-workflow:acceptance` with:
 
 The acceptance skill saves an E2E scenario to `swarm-report/<slug>-e2e-scenario.md`.
 This file uses checkboxes — completed checks (`[x]`) survive compaction and are NOT repeated.
+
+### 3.1 Blast-radius coverage check
+
+Before reading the acceptance verdict, the orchestrator checks Section 4 (Blast-radius)
+of `swarm-report/<slug>-debug.md` against the diff:
+
+- **Decision was "Fix all"** — every site listed under "Matches found" must appear in
+  the diff. Missing sites → record in the PR body and route **Acceptance → Implement**
+  (counted against the cap of 2) so the remaining sites are addressed before promotion.
+- **Decision was "Fix this site only"** — the recorded reason must still hold. If the
+  fix changed scope and now logically applies elsewhere, request the user before
+  promoting.
+- **Decision was "Open follow-ups"** — confirm the linked issues exist; record their
+  numbers in the PR body. If they are missing, file them now (one issue per remaining
+  site) before promotion.
+- **Section is `N/A: not reproducible`** — skip the check; only the symptom verification
+  applies.
+
+This check runs once per Acceptance round and does not consume a backward-edge cap on
+its own; it only triggers a route-back if a "Fix all" decision is incomplete.
 
 Wait for `swarm-report/<slug>-acceptance.md`.
 

--- a/plugins/developer-workflow/skills/debug/SKILL.md
+++ b/plugins/developer-workflow/skills/debug/SKILL.md
@@ -137,39 +137,55 @@ Escalate to user when:
 
 ## Report
 
-Save findings to `swarm-report/<slug>-debug.md`:
+Save findings to `swarm-report/<slug>-debug.md` using the canonical template at
+[`references/debug-template.md`](references/debug-template.md). The template is
+mandatory — every section is required, with `N/A: <reason>` allowed when a section
+genuinely does not apply (e.g. RCA on `Not Reproducible`).
+
+### Required structure (summary — full details in `references/debug-template.md`)
+
+Frontmatter triplet:
 
 ```
-## Symptom
-What was observed — error message, failing test, unexpected behavior
-
-## Reproduction Steps
-Exact steps to trigger the bug consistently
-
-## Investigation Path
-What was checked, what was eliminated (binary search log)
-
-## Root Cause
-What actually causes it — with evidence (file:line, stack trace, data flow)
-
-## Recommended Fix Direction
-What needs to change and where — NOT the implementation, just the direction
-
-## Status
-Diagnosed / Escalated / Not Reproducible
+Started: <ISO-8601 timestamp>
+Severity: P0 | P1 | P2 | P3
+Status: Reproduced | Not Reproducible | Diagnosed | Escalated
 ```
+
+Body sections (in order):
+
+1. **Reproduce** — steps, environment, expected vs observed, frequency
+2. **Severity classification** — impact, urgency, workaround, justification of the
+   chosen tier (rubric in the references file)
+3. **Root-cause analysis** — 5-whys chain, single-sentence root cause, `file:line`
+   localisation
+4. **Blast-radius** — pattern-search query, matches found, fix-all / fix-here-only /
+   open-follow-ups decision
+5. **Fix direction** — Simple | Complex | Not Reproducible | Escalated, plus a
+   one-paragraph what/where (not how)
+6. **Next step** — Implement | Plan | Report | Escalate (filled by the orchestrator)
+
+### Why the structure is fixed
+
+- `Severity` is read by `bugfix-flow` Phase 1 to choose between simple and complex
+  fix routing, and surfaces in the PR body.
+- `Blast-radius` makes the pattern-search step explicit so a fix closes every
+  reachable instance of the defect, not only the reported one.
+- Separating Reproduce / RCA / Blast-radius prevents symptom-only patches and the
+  "fix one site, ignore three identical ones" failure mode.
 
 ### Chat output
 
 After saving, post a chat summary (≤15 lines):
 
-1. One sentence: what the bug is and what causes it (Root Cause in one line).
+1. One sentence: what the bug is and what causes it (Root Cause in one line) plus
+   the chosen Severity tier.
 2. Bullets (max 4):
    - Symptom (one line — what the user observed)
-   - Root cause location: file:line or component
+   - Root cause location: `file:line` or component
    - Fix direction (one line — what needs to change, not how)
-   - Any side effects or adjacent code at risk (one line, only if relevant)
+   - Blast-radius outcome (one line — "1 site only", "3 sites covered", or "follow-ups #N, #M")
 3. If reproduction requires specific steps or environment: ONE question to confirm.
 4. One line: "Recommended next step: implement the fix via `/implement`" (or `/bugfix-flow` if in standalone context).
 
-Do NOT post the full investigation log or hypothesis list in chat — those are in the file.
+Do NOT post the full investigation log, 5-whys chain, or hypothesis list in chat — those are in the file.

--- a/plugins/developer-workflow/skills/debug/references/debug-template.md
+++ b/plugins/developer-workflow/skills/debug/references/debug-template.md
@@ -1,0 +1,197 @@
+# Debug Artifact Template
+
+Canonical structure for `swarm-report/<slug>-debug.md`. Every section is required —
+write `N/A: <reason>` when a section does not apply (e.g. Not Reproducible has no
+RCA), do not delete the heading.
+
+```markdown
+# Debug: <slug>
+
+Started: <ISO-8601 timestamp>
+Severity: P0 | P1 | P2 | P3
+Status: Reproduced | Not Reproducible | Diagnosed | Escalated
+
+## 1. Reproduce
+
+- Steps to reproduce (numbered list, copy-paste-runnable)
+- Environment: device / OS / build / data state
+- Expected behaviour vs observed behaviour
+- Frequency: always | intermittent (rate) | once
+
+## 2. Severity classification
+
+- Impact: users / revenue / data integrity / security / dev velocity
+- Urgency: immediate (hotfix) | this-sprint | next-release
+- Workaround: yes/no, one-line description
+- → Severity: P0 | P1 | P2 | P3 + one-line justification
+
+## 3. Root-cause analysis
+
+5-whys (truncate when the chain bottoms out earlier):
+
+- Why 1: <symptom> happens because <observation>
+- Why 2: <observation> happens because <next-level cause>
+- Why 3: ...
+- Why 4: ...
+- Why 5: ...
+- **Root cause:** one precise sentence — the actual fault
+
+Localisation: `path/to/file.ext:LINE`, additional file:line entries when the cause
+spans more than one site.
+
+## 4. Blast-radius
+
+Where else in the codebase the same defect-pattern is reachable.
+
+- Search query used: `ast-index <query>` or `grep -nrE '<pattern>'` (record the
+  exact command so the search can be reproduced)
+- Matches found: `path/to/file:LINE` list
+- Decision:
+  - **Fix all** — covered by this fix; itemise sites being touched
+  - **Fix this site only** — explicit reason (different lifecycle, owner, scope)
+  - **Open follow-ups** — link new issues for the remaining sites
+
+## Fix direction
+
+Simple | Complex | Not Reproducible | Escalated.
+One paragraph: what needs to change and where, NOT how. The implementation belongs
+to the `implement` stage.
+
+## Next step
+
+Implement | Plan | Report | Escalate. Filled in by the orchestrator when it consumes
+this artifact.
+```
+
+## Section rules
+
+- **Frontmatter triplet (`Started` / `Severity` / `Status`) is mandatory.** Downstream
+  stages key on `Severity` for routing decisions and on `Status` for the receipt-based
+  gate.
+- **`Severity` is a judgement, not an automation.** The Severity classification section
+  must justify the chosen tier in one line.
+- **`Status: Not Reproducible`** → sections 3 (RCA) and 4 (Blast-radius) are written as
+  `N/A: not reproducible — see Reproduce section`. Do not invent a root cause from
+  guesswork.
+- **`Status: Escalated`** → fill what was learned up to the escalation point; mark
+  remaining sections `N/A: escalated, awaiting <decision>`.
+- **Blast-radius is mandatory even when only one site is affected.** Record the search
+  query and "Matches found: only the original site" — this proves the search was
+  performed, not skipped.
+- **Localisation lines must be `file:line` (or `file:start-end`) — agent-readable.**
+  Free-form descriptions ("around the auth handler") are not enough for downstream
+  stages to act on.
+
+## Severity rubric (concise)
+
+| Tier | Trigger |
+|------|---------|
+| P0 | Production outage, data loss, security breach, blocked release |
+| P1 | Major feature broken for many users, no workaround, regression on a core flow |
+| P2 | Feature broken for some users, workaround exists, or non-core flow regression |
+| P3 | Cosmetic / typo / minor degradation, no functional impact |
+
+The rubric is a quick reference; the Severity classification section in the artifact
+is still the source of truth.
+
+## Worked examples
+
+### Example A — P1 reproducible regression with broad blast-radius
+
+```markdown
+# Debug: token-refresh-loop
+
+Started: 2026-04-30T14:22:00Z
+Severity: P1
+Status: Diagnosed
+
+## 1. Reproduce
+
+1. Sign in with an account whose refresh token expires within 60 seconds
+2. Wait 65 seconds with the app foregrounded
+3. Trigger any authenticated request
+
+- Environment: pixel-7 / Android 14 / build 0.9.0 / staging
+- Expected: silent re-authentication, request succeeds
+- Observed: infinite loop of 401 → refresh → 401, app freezes
+- Frequency: always
+
+## 2. Severity classification
+
+- Impact: every user with a near-expiry token; affects core flow (any authed request)
+- Urgency: this-sprint — release branch cuts on Thursday
+- Workaround: kill and relaunch the app
+- → Severity: P1 — core flow broken, workaround is intrusive but not destructive
+
+## 3. Root-cause analysis
+
+- Why 1: 401 responses keep firing because the retry interceptor re-issues the same expired token
+- Why 2: The interceptor uses the cached token because the refresh path never persists the new token
+- Why 3: `TokenStore.update()` is called inside a coroutine that is cancelled when the parent scope dies
+- Why 4: The parent scope is `viewModelScope`, which dies on configuration change during the refresh
+- **Root cause:** token persistence runs in `viewModelScope`, so the new token is dropped if the user rotates the device mid-refresh.
+
+Localisation: `auth/TokenRefreshInterceptor.kt:118`, `auth/TokenStore.kt:42`
+
+## 4. Blast-radius
+
+- Search query: `ast-index callers TokenStore.update`
+- Matches found:
+  - `auth/TokenRefreshInterceptor.kt:118` — original site
+  - `auth/Logout.kt:54` — same `viewModelScope` pattern
+  - `auth/SilentSignIn.kt:31` — uses `applicationScope`, not affected
+- Decision: fix all — itemised in the fix direction below
+
+## Fix direction
+
+Persist token writes on `applicationScope` (or another long-lived dispatcher) so they
+survive UI lifecycle transitions. Audit `TokenStore.update` callers identified above.
+
+## Next step
+
+Plan — touches three call sites, needs an architectural choice on which scope is the
+right long-lived owner.
+```
+
+### Example B — Not Reproducible
+
+```markdown
+# Debug: intermittent-crash-on-launch
+
+Started: 2026-04-29T09:10:00Z
+Severity: P2
+Status: Not Reproducible
+
+## 1. Reproduce
+
+- Steps from the report: cold start of the app (no specific data state)
+- Environment: 1 user report, Samsung S22 / Android 13 / build 0.8.4
+- Expected: app launches
+- Observed: SIGSEGV before the splash screen
+- Frequency: once, not reproduced on local Pixel 7 across 30 cold starts
+
+## 2. Severity classification
+
+- Impact: 1 known user, possibly OEM-specific
+- Urgency: next-release; collect more crash reports first
+- Workaround: relaunch
+- → Severity: P2 — single-report crash, no clear pattern yet
+
+## 3. Root-cause analysis
+
+N/A: not reproducible — see Reproduce section.
+
+## 4. Blast-radius
+
+N/A: not reproducible.
+
+## Fix direction
+
+Not Reproducible. Add structured logging at startup boundaries
+(`Application.onCreate`, `MainActivity.onCreate`) and ship a debug build to the
+reporting user before resuming RCA.
+
+## Next step
+
+Report — return to user with instrumentation request.
+```

--- a/plugins/developer-workflow/skills/feature-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/feature-flow/SKILL.md
@@ -430,16 +430,18 @@ regression, not the original feature work.
 
 Invoke `developer-workflow:debug` with the collected context.
 
-Wait for `swarm-report/<slug>-debug.md`. Same convention as bugfix-flow —
-the file includes a **Reproduction Steps** section, is persistent state, and
-survives context compaction. Re-read it before any downstream action.
+Wait for `swarm-report/<slug>-debug.md`. The artifact follows the canonical template at
+[`debug/references/debug-template.md`](../debug/references/debug-template.md) — same
+convention as bugfix-flow. Re-read Section 1 (Reproduce) and the `Severity` /
+`Status` frontmatter before any downstream action; both survive context compaction.
 
-**Route by status:**
-- **Diagnosed, simple fix** → **Stage: Debug → Implement.** Pass `<slug>-debug.md` as
-  the anchor so the next Implement retry acts on the root cause, not the symptom.
-- **Diagnosed, complex fix** (multiple files, architectural impact) → surface to the
-  user; feature-flow does not have a mid-pipeline Plan stage, so a complex acceptance
-  regression is escalated rather than looped through Plan.
+**Route by status (read `Status` and `Fix direction` from the artifact):**
+- **Diagnosed, simple fix** (`Fix direction: Simple`) → **Stage: Debug → Implement.** Pass
+  `<slug>-debug.md` as the anchor so the next Implement retry acts on the root cause,
+  not the symptom.
+- **Diagnosed, complex fix** (`Fix direction: Complex` — multiple files, architectural
+  impact) → surface to the user; feature-flow does not have a mid-pipeline Plan stage,
+  so a complex acceptance regression is escalated rather than looped through Plan.
 - **Not Reproducible** → report to user, ask for more info. Stop.
 - **Escalated** → report findings, stop.
 


### PR DESCRIPTION
## Summary

Closes #146.

- New canonical template `plugins/developer-workflow/skills/debug/references/debug-template.md` — required frontmatter (`Started` / `Severity` / `Status`), four numbered body sections (Reproduce, Severity classification, Root-cause analysis with 5-whys, Blast-radius), Fix direction, Next step. Includes a P0–P3 severity rubric and two worked examples.
- `debug/SKILL.md` "Report" section rewritten to require the canonical template and reference it. Chat-output rules updated to surface the chosen Severity tier and the Blast-radius outcome.
- `bugfix-flow` Phase 1: documents that the orchestrator reads `Severity`, `Status`, and Reproduction Steps. New Phase 3.1 Blast-radius coverage check.
- `feature-flow` Phase 2.4 recovery: references the canonical template, routes by `Fix direction`.

## Acceptance criteria mapping (from #146)

- [x] `debug/SKILL.md` documents the four required sections + Fix direction + Next step (template lives in `references/debug-template.md`).
- [x] `debug/references/debug-template.md` exists and is referenced from `SKILL.md`.
- [ ] Real run produces a `<slug>-debug.md` with all four sections (or explicit `N/A: reason`) — first user run after merge will validate.
- [x] `bugfix-flow` Phase 1 reads Severity (modulates Phase 2.2 / 2.5 / 3, does not branch the state machine — see "Interpretation notes" below).
- [x] `bugfix-flow` Phase 3 verifies Blast-radius coverage.
- [x] `feature-flow` Phase 2.4 references the template.

## Interpretation notes (for review)

1. **Severity routing.** The issue says "Phase 1 reads Severity for fast-lane vs full pipeline." I read this as a routing influence rather than a state-machine branch — adding new Severity-keyed transitions would conflict with the min-bar (#148/#175) and bloat the diagram. Instead Severity modulates downstream decisions inside existing stages: P0/P1 tightens Finalize Phase D + Blast-radius enforcement, P3+Simple lowers the regression-test-skip confirmation bar via the existing Phase 2.2 path. The pre-existing trivial-fix shortcut at Phase 0.2 remains the only Setup-level fast-lane. Push back if you want explicit Severity-keyed transitions instead.
2. **Phase 3.1 Blast-radius check.** This is new orchestrator logic that reads the debug artifact and the `git diff` to gate Acceptance promotion. It is a routing decision derived from a subagent artifact — fits the Phase 2.2 regression-diagnosis precedent the orchestrator already calls out as an explicit exception ("short gating diagnoses derived directly from subagent artifacts … a routing decision, not independent analysis"). Worth a careful read.

## Out of scope

- Pre-existing `feature-flow` >500-line WARN — unrelated to this change.
- Severity-driven new transitions in the state machine — see Interpretation note 1.
- Auto-detection of Severity / automated Blast-radius search — both are non-goals (#146 Non-goals).

## Test plan

- [x] `bash scripts/validate.sh` — green.
- [ ] Manual: trigger `/bugfix-flow` on a real bug post-merge and confirm the produced `debug.md` follows the template.
- [ ] Manual: confirm GitHub anchors resolve from sibling SKILL.md links (`../debug/references/debug-template.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)