### PR TITLE
developer-workflow: author fixes broken tests in same PR (non-negotiable)

### DIFF
--- a/plugins/developer-workflow/CLAUDE.md
+++ b/plugins/developer-workflow/CLAUDE.md
@@ -6,6 +6,7 @@ Rules that are not open for discussion. Violating these is an error, not a judgm
 
 - **Non-QA skills must not hardcode MCP tool names.** They must run (with reduced capability) when an MCP server is absent. Exception: QA-execution skills (`manual-tester`, live parts of `acceptance`, `bug-hunt`) that require real device/browser automation may fail fast with an install/enable message — graceful degradation is impossible there.
 - **Tier-3 hard-dep escalation requires explicit user approval per change.** Proposing is allowed; editing `plugin.json` `dependencies` or `.mcp.json` without explicit go-ahead is not.
+- **The author of a change that breaks tests fixes those tests in the same PR.** No `--skip-test-fix`, no "TODO fix later", no "merge red". `/check` is the gate; if tests fail, `implement` does not exit. The only escape hatch is an explicit, justified test skip-marker plus a follow-up issue — treated as an exception, not a routine. Detailed disambiguation (intentional behaviour change vs unintentional break vs pre-existing failure) lives in [`docs/TESTING-STRATEGY.md`](docs/TESTING-STRATEGY.md#author-fixes-broken-tests-non-negotiable).
 
 ## Structure
 

--- a/plugins/developer-workflow/skills/finalize/SKILL.md
+++ b/plugins/developer-workflow/skills/finalize/SKILL.md
@@ -25,6 +25,8 @@ This skill exists because agent-written code carries recurring patterns worth po
 | **`finalize`** | Is the code written well? | this skill |
 | `acceptance` | Does the feature solve the user's problem? | functional verification via `manual-tester` |
 
+**Author fixes broken tests (non-negotiable).** A `/check` invocation between phases that surfaces test failures triggers an inline fix in the same Finalize round — owned by the engineer agent that produced the change. Round-end exit is impossible while tests remain red. See [`docs/TESTING-STRATEGY.md`](../../docs/TESTING-STRATEGY.md#author-fixes-broken-tests-non-negotiable) for disambiguation rules and the single skip-marker escape hatch.
+
 ---
 
 ## Inputs

--- a/plugins/developer-workflow/skills/implement/SKILL.md
+++ b/plugins/developer-workflow/skills/implement/SKILL.md
@@ -111,6 +111,8 @@ Summary for this skill's callers:
 - Gate 2 is the intent check — re-read task + plan, verify the diff addresses them; scope creep or drift → fix or flag; also verify no `## Non-negotiables` rule from applicable `CLAUDE.md` files is violated — a violation is treated as DRIFT and triggers a fix cycle
 - A gate failure triggers a fix cycle; total loop is capped per ORCHESTRATION.md
 
+**Author fixes broken tests (non-negotiable).** When the diff breaks existing tests, the engineer agent that wrote the change fixes those tests in the same Implement run before Gate 1 can PASS. There is no `--skip-test-fix`. Disambiguation between "intentional behaviour change → update assertions", "unintentional break → diagnose root cause", and "pre-existing failure on main → not this PR's responsibility, surface to user" lives in [`docs/TESTING-STRATEGY.md`](../../docs/TESTING-STRATEGY.md#author-fixes-broken-tests-non-negotiable). Skip-marker + follow-up issue is the only escape hatch and must be surfaced explicitly in the Implement artifact.
+
 Do not duplicate gate details here — read ORCHESTRATION.md before executing. If ORCHESTRATION.md is missing, escalate rather than guessing the current rules.
 
 ---

--- a/plugins/developer-workflow/skills/write-tests/SKILL.md
+++ b/plugins/developer-workflow/skills/write-tests/SKILL.md
@@ -14,6 +14,12 @@ delegates to a platform engineer agent: `kotlin-engineer` / `compose-developer` 
 Kotlin/Android targets, or `swift-engineer` / `swiftui-developer` for Swift/iOS targets.
 The skill's job is discovery, planning, delegation, and verification.
 
+**Author fixes broken tests (non-negotiable).** When a generated or extended test exposes a
+pre-existing failure in the same file or a directly adjacent test, the engineer agent fixes
+those tests in the same `write-tests` run; results are surfaced in the final report. Skipping
+or `@Ignore`-ing without a recorded follow-up issue is not allowed. Disambiguation rules and
+the single skip-marker escape hatch live in [`docs/TESTING-STRATEGY.md`](../../docs/TESTING-STRATEGY.md#author-fixes-broken-tests-non-negotiable).
+
 ---
 
 ## Phase 1: Scope Target

--- a/plugins/developer-workflow/skills/write-tests/SKILL.md
+++ b/plugins/developer-workflow/skills/write-tests/SKILL.md
@@ -14,11 +14,7 @@ delegates to a platform engineer agent: `kotlin-engineer` / `compose-developer` 
 Kotlin/Android targets, or `swift-engineer` / `swiftui-developer` for Swift/iOS targets.
 The skill's job is discovery, planning, delegation, and verification.
 
-**Author fixes broken tests (non-negotiable).** When a generated or extended test exposes a
-pre-existing failure in the same file or a directly adjacent test, the engineer agent fixes
-those tests in the same `write-tests` run; results are surfaced in the final report. Skipping
-or `@Ignore`-ing without a recorded follow-up issue is not allowed. Disambiguation rules and
-the single skip-marker escape hatch live in [`docs/TESTING-STRATEGY.md`](../../docs/TESTING-STRATEGY.md#author-fixes-broken-tests-non-negotiable).
+**Author fixes broken tests (non-negotiable).** Any test broken by the changes this skill produces — the new test, the file it covers, or a directly adjacent test whose behaviour shifted because of the new assertions — is fixed by the engineer agent in the same `write-tests` run. Tests already failing on `main` before this run are NOT in scope; surface them in the final report and continue. Skipping or `@Ignore`-ing the in-scope set without a recorded follow-up issue is not allowed. Disambiguation rules (intentional behaviour change vs unintentional break vs pre-existing failure on `main`) and the single skip-marker escape hatch live in [`docs/TESTING-STRATEGY.md`](../../docs/TESTING-STRATEGY.md#author-fixes-broken-tests-non-negotiable).
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #157.

- `plugins/developer-workflow/CLAUDE.md` adds the rule under Non-negotiables: a change that breaks tests is fixed by its author in the same PR; `/check` is the gate, there is no `--skip-test-fix`, the only escape hatch is a single explicit test skip-marker plus a follow-up issue.
- `implement/SKILL.md` Phase 3 Quality Loop reinforces the rule — Gate 1 cannot PASS while tests remain red.
- `finalize/SKILL.md` reinforces the rule at the round-end exit decision.
- `write-tests/SKILL.md` reinforces the rule when a generated/extended test exposes pre-existing failures in adjacent tests.

Disambiguation (intentional behaviour change vs unintentional break vs pre-existing failure on main) lives in `docs/TESTING-STRATEGY.md` (#151 / PR #178) to avoid duplicating the contract across four files. Cross-link is forward-looking: it resolves once #178 lands.

## Acceptance criteria mapping (from #157)

- [x] Rule documented in CLAUDE.md (project) with explicit wording.
- [x] `implement/SKILL.md` references the rule in the Quality Loop.
- [x] `finalize/SKILL.md` references the rule.
- [x] `write-tests/SKILL.md` references the rule.
- [ ] Smoke test: an engineer agent that pushes red tests is blocked by `/check` — verifiable on the next real implement run after merge.

## Out of scope

- Automated CI enforcement (#157 Non-goals — follow-up).
- Per-language test-skip-marker format spec (#157 Non-goals — each platform has its own convention; rule references the convention without prescribing one).
- Promoting the rule into the global / repo-root `CLAUDE.md` Non-negotiables section — depends on #142, deferred.

## Dependencies

- Forward link to `docs/TESTING-STRATEGY.md` resolves once PR #178 (#151) is merged. Both PRs are independent and can land in either order.

## Test plan

- [x] `bash scripts/validate.sh` — green.
- [ ] Manual confirmation that the cross-link to TESTING-STRATEGY.md anchor resolves after #178 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)