### PR TITLE
developer-workflow: TC type field + selection heuristic per TC

### DIFF
--- a/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
@@ -169,6 +169,34 @@ markdown), the phase-segmentation worked example, and the rules for when each va
 
 ## Field Definitions
 
+### Type
+
+Every test case declares an explicit `Type` plus a one-line `Type rationale` (see `references/format-templates.md`). Downstream stages (`finalize` Phase D coverage audit, `multiexpert-review` test-plan profile, engineer agents in `implement`) read this field — it is not optional.
+
+| Type | Scope | Pick when |
+|------|-------|-----------|
+| `unit` | One class/function with mocked collaborators | Pure logic, transform, validator, mapper, parser, state-holder math |
+| `integration` | Several classes plus real / in-memory dependencies | Repository + DB, service + test API, data pipeline, multi-class interaction |
+| `ui-instrumentation` | One UI component inside its framework (Compose UI test, XCUITest single screen, ViewInspector) | Single screen / component user action with visible state assertion |
+| `ui-scenario` | Running app driven by `mobile` / `playwright` MCP, re-runnable scripted journey | Multi-screen user journey, cross-platform critical flow |
+| `screenshot` | Visual render comparison (Paparazzi, swift-snapshot-testing) | Visual fidelity is part of the contract — additive, never the sole coverage |
+| `e2e` / `application` | Whole application end-to-end | Release-critical journey that cannot be split into smaller types — keep the count small |
+
+#### Selection heuristic
+
+Per acceptance criterion: pick the **smallest scope that catches a real failure of that AC**. Climb only when needed. When in doubt, prefer the cheaper type.
+
+| AC shape | Type |
+|---|---|
+| Value transform / pure computation | `unit` |
+| Component interaction with real or fake collaborators | `integration` |
+| Single-screen user action with visible state change | `ui-instrumentation` |
+| Multi-screen journey | `ui-scenario` |
+| Release-critical journey + visual fidelity matters | `screenshot` (additive) and/or `e2e` |
+| Release-critical end-to-end flow that cannot be split | `e2e` |
+
+The same heuristic appears in [`docs/TESTING-STRATEGY.md`](../../docs/TESTING-STRATEGY.md#selection-heuristic) — this section is its application inside `generate-test-plan`. When the strategy doc and this section disagree, the strategy doc is authoritative.
+
 ### Priority
 
 | Priority | Meaning | Guideline |

--- a/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
@@ -178,9 +178,9 @@ Every test case declares an explicit `Type` plus a one-line `Type rationale` (se
 | `unit` | One class/function with mocked collaborators | Pure logic, transform, validator, mapper, parser, state-holder math |
 | `integration` | Several classes plus real / in-memory dependencies | Repository + DB, service + test API, data pipeline, multi-class interaction |
 | `ui-instrumentation` | One UI component inside its framework (Compose UI test, XCUITest single screen, ViewInspector) | Single screen / component user action with visible state assertion |
-| `ui-scenario` | Running app driven by `mobile` / `playwright` MCP, re-runnable scripted journey | Multi-screen user journey, cross-platform critical flow |
+| `ui-scenario` | Running app driven by an MCP-based device / browser automation runner, re-runnable scripted journey | Multi-screen user journey, cross-platform critical flow |
 | `screenshot` | Visual render comparison (Paparazzi, swift-snapshot-testing) | Visual fidelity is part of the contract — additive, never the sole coverage |
-| `e2e` / `application` | Whole application end-to-end | Release-critical journey that cannot be split into smaller types — keep the count small |
+| `e2e` | Whole application end-to-end | Release-critical journey that cannot be split into smaller types — keep the count small |
 
 #### Selection heuristic
 

--- a/plugins/developer-workflow/skills/generate-test-plan/references/format-templates.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/references/format-templates.md
@@ -56,6 +56,8 @@ Group related test cases by feature area, screen, or workflow
 
 | Field | Value |
 |-------|-------|
+| **Type** | unit / integration / ui-instrumentation / ui-scenario / screenshot / e2e |
+| **Type rationale** | One short line — why this type catches the AC failure with the smallest scope |
 | **Priority** | P0 Critical / P1 High / P2 Medium / P3 Low |
 | **Tier** | Smoke / Feature / Regression |
 | **Preconditions** | What must be true before starting |
@@ -149,6 +151,8 @@ Example for a feature with two phases:
 #### TC-1: Successful login with valid credentials
 | Field | Value |
 |-------|-------|
+| **Type** | ui-instrumentation |
+| **Type rationale** | Single screen; assertions on visible state after a user action. Smaller scope (`unit`) cannot cover the screen-level state transition. |
 | **Priority** | P0 Critical |
 | **Tier** | Smoke |
 | **Preconditions** | User account exists, email is verified |
@@ -167,6 +171,8 @@ Example for a feature with two phases:
 #### TC-4: Request reset email from login screen
 | Field | Value |
 |-------|-------|
+| **Type** | ui-scenario |
+| **Type rationale** | Multi-screen journey (login → forgot → confirmation); cheaper to maintain as a re-runnable scripted scenario than a full e2e suite. |
 | **Priority** | P0 Critical |
 | **Tier** | Feature |
 | **Preconditions** | User account exists |
@@ -194,12 +200,16 @@ for non-interactive surfaces.
 
 ```markdown
 #### TC-[N]: [Short title]
+| **Type** | unit / integration |
+| **Type rationale** | Why this scope catches the AC failure with the smallest cost |
 | **Priority** | P0/P1/P2/P3 |
 | **Tier** | Smoke/Feature/Regression |
 | **Preconditions** | [state] |
 | **Scenario (Given/When/Then)** | Given X, When Y, Then Z |
 | **Source** | [Spec §section / inferred from code] |
 ```
+
+Non-UI features are typically `unit` or `integration`. UI types (`ui-instrumentation`, `ui-scenario`, `screenshot`, `e2e`) do not appear in the lightweight template — if a UI type is needed, switch back to the full TC template.
 
 Example:
 

--- a/plugins/developer-workflow/skills/generate-test-plan/references/format-templates.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/references/format-templates.md
@@ -215,6 +215,8 @@ Example:
 
 ```markdown
 #### TC-3: Token refresh succeeds before expiry
+| **Type** | integration |
+| **Type rationale** | Real `TokenManager` + test HTTP server to assert end-to-end refresh + scope preservation; pure-unit scope cannot reach the network call |
 | **Priority** | P0 Critical |
 | **Tier** | Feature |
 | **Preconditions** | Valid refresh token stored, access token within 60s of expiry |

--- a/plugins/developer-workflow/skills/multiexpert-review/profiles/test-plan.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/profiles/test-plan.md
@@ -66,7 +66,7 @@ A single critical from any agent with medium-or-higher confidence is enough to t
 
 ## Prompt augmentation
 
-Every agent reviewing a test-plan receives the following checklist verbatim in their Step 3 prompt (the engine substitutes this section into `{PROFILE_PROMPT_AUGMENTATION}` literally — not by reference to the Rubric section above). Each agent must explicitly report the status of each item (satisfied / violated, with rationale). The engine parses these into the severity mapping.
+Every agent reviewing a test-plan receives the following 7-item checklist verbatim in their Step 3 prompt (the engine substitutes this section into `{PROFILE_PROMPT_AUGMENTATION}` literally — not by reference to the Rubric section above). Each agent must explicitly report the status of each item (satisfied / violated, with rationale). The engine parses these into the severity mapping.
 
 ---
 
@@ -88,7 +88,7 @@ After Step 4 synthesis, the engine updates `swarm-report/<slug>-test-plan.md` (t
 
 - `review_verdict: PASS | WARN | FAIL`
 - On WARN: `review_warnings:` list enumerating violated items from `(d)`, `(e)`, `(g)` with one-line rationale each
-- On FAIL: `review_blockers:` list enumerating violated items from `(a)–(c)` with the blocking finding and suggested fix
+- On FAIL: `review_blockers:` list enumerating violated items from `(a)`, `(b)`, `(c)`, `(f)` with the blocking finding and suggested fix
 
 The receipt format is owned by the `generate-test-plan` skill — this profile only writes the three fields listed in `receipt.fields_to_update`.
 

--- a/plugins/developer-workflow/skills/multiexpert-review/profiles/test-plan.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/profiles/test-plan.md
@@ -1,6 +1,6 @@
 ---
 name: test-plan
-description: Profile for test-plan artifacts (docs/testplans/<slug>-test-plan.md and swarm-report/<slug>-test-plan.md receipts). Verdict alphabet PASS/WARN/FAIL with 6-item checklist (a, b, c, d, e, g). Primary reviewer business-analyst; adds domain specialists when spec invokes their concerns.
+description: Profile for test-plan artifacts (docs/testplans/<slug>-test-plan.md and swarm-report/<slug>-test-plan.md receipts). Verdict alphabet PASS/WARN/FAIL with 7-item checklist (a, b, c, d, e, f, g). Primary reviewer business-analyst; adds domain specialists when spec invokes their concerns.
 
 detect:
   frontmatter_type: [test-plan, test-plan-receipt]
@@ -27,7 +27,7 @@ allow_single_reviewer: true
 verdicts: [PASS, WARN, FAIL]
 
 severity_mapping:
-  - items: ["a", "b", "c"]
+  - items: ["a", "b", "c", "f"]
     severity: critical
   - items: ["d", "e", "g"]
     severity: major
@@ -44,22 +44,23 @@ receipt:
 
 ## Rubric
 
-Every reviewer must evaluate the test-plan against these items and report the status of each one explicitly in their response. Copy the items verbatim into the review prompt so findings are comparable across agents:
+Every reviewer must evaluate the test-plan against these seven items and report the status of each one explicitly in their response. Copy the items verbatim into the review prompt so findings are comparable across agents:
 
 - **(a) AC coverage** — every Acceptance Criterion from the linked spec has ≥1 Test Case that verifies it. Missing or weak mapping is a violation.
 - **(b) Negative balance** — every happy-path (positive) TC has ≥2 unhappy/negative TCs covering the same flow (invalid input, error states, boundary violations, concurrent or race conditions). A plan that is mostly happy paths violates this item.
 - **(c) Edge cases present** — at least one TC is explicitly tagged as an edge case (boundary value, empty/null, maximum size, timezone/locale boundaries, concurrency, resource exhaustion, etc.). If the plan has no edge-case TC at all, this item is violated.
 - **(d) Non-functional scenarios where applicable** — if the linked spec mentions any of {SLA, latency budget, throughput, a11y, auth, encryption, PII, resource limits, rate limits}, there must be ≥1 non-functional TC covering that concern (performance, accessibility, security). Applicability is driven by spec content — if the spec mentions none of these triggers, this item is trivially satisfied.
 - **(e) Priority-risk alignment** — priorities (P0–P3) are consistent with risk assessment: any high-risk flow (data loss, auth, payment, destructive actions) is at P0–P1; any user-facing critical path is at P0–P1; trivial/informational cases are at P2–P3. Mismatch between stated risk and assigned priority violates this item.
+- **(f) Type field present and valid** — every Test Case declares an explicit `Type` field with a value from {`unit`, `integration`, `ui-instrumentation`, `ui-scenario`, `screenshot`, `e2e`} and a non-empty one-line `Type rationale`. A missing `Type`, an unknown value, or an empty rationale violates this item. The selection heuristic in `generate-test-plan/SKILL.md#type` is the reference; reviewers do not re-classify TCs, only check that the field exists and the rationale is plausible.
 - **(g) Instrumentation declared** — when the spec / task is `user-facing` or `prod-bound`, or the feature touches an observability hot-path (network calls, payments, background jobs, auth, data migrations), the test plan ends with a `## Non-functional / Instrumentation` section that lists Log events / Metrics / Traces / Alerts / Dashboards (or sub-headings filled with concrete declarations). For internal / dev-only / pure-refactor work, an explicit `N/A: <reason>` (one line) is acceptable. A missing section, or one labelled simply `TBD` / `?` / blank, violates this item.
 
 ## Verdict policy
 
 | Verdict | Trigger | Exit condition |
 |---------|---------|----------------|
-| **FAIL** (blocker) | Any of items **(a)**, **(b)**, **(c)** is violated | Plan MUST be revised. Engine drives the revise-loop up to 3 cycles. After 3 cycles still FAIL → escalate to user. Pipeline is blocked. |
-| **WARN** (non-blocking) | Items (a)–(c) all satisfied, but **(d)**, **(e)**, or **(g)** is violated | Pipeline continues. Engine records `review_verdict: WARN` in the receipt with the explicit list of violated items. No revise-loop required. |
-| **PASS** (clean) | Every item satisfied | Pipeline continues unconditionally. Engine records `review_verdict: PASS` in the receipt. |
+| **FAIL** (blocker) | Any of items **(a)**, **(b)**, **(c)**, **(f)** is violated | Plan MUST be revised. Engine drives the revise-loop up to 3 cycles. After 3 cycles still FAIL → escalate to user. Pipeline is blocked. |
+| **WARN** (non-blocking) | Items (a), (b), (c), (f) all satisfied, but **(d)**, **(e)**, or **(g)** is violated | Pipeline continues. Engine records `review_verdict: WARN` in the receipt with the explicit list of violated items. No revise-loop required. |
+| **PASS** (clean) | All seven items satisfied | Pipeline continues unconditionally. Engine records `review_verdict: PASS` in the receipt. |
 
 A single critical from any agent with medium-or-higher confidence is enough to trigger FAIL, matching the engine's aggregation rules.
 
@@ -76,6 +77,7 @@ Every agent reviewing a test-plan receives the following checklist verbatim in t
 - **(c) Edge cases present** — at least one TC is explicitly tagged as an edge case (boundary value, empty/null, maximum size, timezone/locale boundaries, concurrency, resource exhaustion, etc.). If the plan has no edge-case TC at all, this item is violated.
 - **(d) Non-functional scenarios where applicable** — if the linked spec mentions any of {SLA, latency budget, throughput, a11y, auth, encryption, PII, resource limits, rate limits}, there must be ≥1 non-functional TC covering that concern (performance, accessibility, security). Applicability is driven by spec content — if the spec mentions none of these triggers, this item is trivially satisfied.
 - **(e) Priority-risk alignment** — priorities (P0–P3) are consistent with risk assessment: any high-risk flow (data loss, auth, payment, destructive actions) is at P0–P1; any user-facing critical path is at P0–P1; trivial/informational cases are at P2–P3. Mismatch between stated risk and assigned priority violates this item.
+- **(f) Type field present and valid** — every Test Case declares an explicit `Type` field with a value from {`unit`, `integration`, `ui-instrumentation`, `ui-scenario`, `screenshot`, `e2e`} and a non-empty one-line `Type rationale`. A missing `Type`, an unknown value, or an empty rationale violates this item.
 - **(g) Instrumentation declared** — when the spec / task is `user-facing` or `prod-bound`, or the feature touches an observability hot-path (network calls, payments, background jobs, auth, data migrations), the test plan ends with a `## Non-functional / Instrumentation` section that lists Log events / Metrics / Traces / Alerts / Dashboards (or sub-headings filled with concrete declarations). For internal / dev-only / pure-refactor work, an explicit `N/A: <reason>` (one line) is acceptable. A missing section, or one labelled simply `TBD` / `?` / blank, violates this item.
 
 For every Issue you raise, use the item ID as the title stem — e.g. `(a) AC coverage: API X has no test case`. This keeps synthesizer aggregation greppable.


### PR DESCRIPTION
## Summary

Closes #153.

- `generate-test-plan/SKILL.md` adds a **Type** Field Definition with valid types (`unit`, `integration`, `ui-instrumentation`, `ui-scenario`, `screenshot`, `e2e`) and a per-AC selection heuristic ("smallest scope that catches a real failure"). The heuristic mirrors `docs/TESTING-STRATEGY.md` (#151) which is the authoritative source.
- `generate-test-plan/references/format-templates.md` adds **Type** and **Type rationale** rows to both the standard TC template and the lightweight non-UI template, plus updated worked examples.
- `multiexpert-review/profiles/test-plan.md` grows to a 6-item checklist: new item **(f) Type field present and valid** is critical-severity (FAIL on violation). Items (a)–(c) and (f) are blockers; (d)/(e) remain WARN-only. Profile description updated.

## Acceptance criteria mapping (from #153)

- [x] TC template in `generate-test-plan/SKILL.md` (and `references/format-templates.md`) contains `Type` and `Type rationale`.
- [x] Selection heuristic documented with examples (worked TC-1 `ui-instrumentation` and TC-4 `ui-scenario`).
- [x] `test-plan` profile checklist contains type-field validation (item f, critical severity).
- [ ] Smoke test: generate a test-plan for a feature with UI + logic ACs → every TC has `Type` — verifiable on the next real run.
- [ ] Smoke test: a test-plan without `Type` → `multiexpert-review` returns FAIL — verifiable on the next real run.

## Out of scope

- Numerical coverage target (#153 Non-goals).
- Auto-generating tests from the test-plan (#153 Non-goals — the plan is a declaration; engineers implement).

## Dependencies

- The strategy doc (`docs/TESTING-STRATEGY.md`, #151 / PR #178) is referenced as authoritative for the heuristic. Both PRs are independent and resolve once both land.
- The `ui-scenario` type is listed here; the new skill that operates that type lives in #155 (PR pending).

## Test plan

- [x] `bash scripts/validate.sh` — green.
- [ ] Manual: a freshly generated test-plan emits the new Type field at the expected position in the TC table.
- [ ] Manual: `multiexpert-review` test-plan profile flags a test-plan with a missing `Type` field as FAIL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)