### PR TITLE
developer-workflow: ui-scenario skill (re-runnable UI scenarios via MCP)

### DIFF
--- a/plugins/developer-workflow/CLAUDE.md
+++ b/plugins/developer-workflow/CLAUDE.md
@@ -10,7 +10,7 @@ Rules that are not open for discussion. Violating these is an error, not a judgm
 ## Structure
 
 ```
-skills/<name>/SKILL.md    # 18 lifecycle skills, each a directory with YAML frontmatter
+skills/<name>/SKILL.md    # 19 lifecycle skills, each a directory with YAML frontmatter
 agents/manual-tester.md   # only agent in core (QA executor)
 docs/WORKFLOW.md          # Full pipeline documentation with diagrams
 docs/ORCHESTRATORS.md     # feature-flow and bugfix-flow diagrams
@@ -22,7 +22,7 @@ This plugin is part of a split family. Depending on the task, Claude Code will h
 
 | Plugin | Contributes |
 |---|---|
-| `developer-workflow` (this) | 18 lifecycle skills + `manual-tester` |
+| `developer-workflow` (this) | 19 lifecycle skills + `manual-tester` |
 | `developer-workflow-experts` | `code-reviewer`, `architecture-expert`, `security-expert`, `performance-expert`, `ux-expert`, `build-engineer`, `devops-expert`, `business-analyst`, `debugging-expert` — required, auto-installed as a dependency |
 | `developer-workflow-kotlin` | `kotlin-engineer`, `compose-developer`; skills `code-migration`, `kmp-migration`, `migrate-to-compose` — install for Kotlin/Android/KMP work |
 | `developer-workflow-swift` | `swift-engineer`, `swiftui-developer` — install for Swift/iOS/macOS work |
@@ -47,12 +47,12 @@ Skills in this plugin delegate to engineer agents (kotlin-engineer / compose-dev
 - New stages for `feature-flow` / `bugfix-flow` must pass the [Min-bar checklist](docs/ORCHESTRATION.md#min-bar-for-a-new-orchestrator-stage) (5 criteria + alternative-redirect). Failing candidates are redirected to the cheaper path (extend triggers, profile, artifact template, or standalone skill); they are not merged as stages.
 - Test coverage policy (single-phase, test types, framework detection, audit, skip rules, "author fixes broken tests") is documented in [`docs/TESTING-STRATEGY.md`](docs/TESTING-STRATEGY.md). `implement`, `write-tests`, `generate-test-plan`, `finalize`, and `acceptance` read from there.
 
-## Skills roster (18)
+## Skills roster (19)
 
 - Planning/research: `research`, `clarify` (lightweight Q&A pit-stop — locks requirements between Research and Decompose), `decompose-feature`, `write-spec`, `multiexpert-review`, `design-options` (optional pre-multiexpert-review stage — generates 2-3 architectural alternatives for high-arch-risk tasks)
 - Implementation: `implement`, `write-tests`, `debug`
 - Verification utility: `check` — reusable mechanical-check runner (build + lint + typecheck + tests), invoked by `implement`, `finalize`, and any code-modifying skill
 - Code-quality pass: `finalize` — multi-round review-and-fix loop (code-reviewer → /simplify → optional pr-review-toolkit trio → expert reviews) that runs between `implement` and `acceptance`. The `pr-review-toolkit` trio is a soft-reference: installed → Phase C runs; absent → Phase C is skipped with a log entry.
-- QA: `generate-test-plan`, `acceptance`, `bug-hunt`
+- QA: `generate-test-plan`, `acceptance`, `bug-hunt`, `ui-scenario` (re-runnable UI tests via `mobile` / `playwright` MCP — write / run / update modes; honoured by `acceptance` when a persistent scenario exists for the slug)
 - PR: `create-pr`, `drive-to-merge`
 - Orchestrators: `feature-flow`, `bugfix-flow`

--- a/plugins/developer-workflow/skills/acceptance/SKILL.md
+++ b/plugins/developer-workflow/skills/acceptance/SKILL.md
@@ -99,13 +99,18 @@ wrong fields) becomes a P1 acceptance finding routed through the standard FAILED
 loop. An explicit `N/A: <reason>` in the test-plan section skips this check.
 
 **Persistent UI scenario reuse.** When the chosen test plan contains a Test Case typed
-`ui-scenario`, before driving `manual-tester` for that TC, look up
-`tests/ui-scenarios/<scenario-from-tc>.md`. If the file exists, invoke the
+`ui-scenario`, before driving `manual-tester` for that TC, derive the scenario file name:
+read the TC's optional `Scenario:` field if present; otherwise slugify the TC title
+(lowercase, non-alphanumeric → `-`, collapse runs, trim leading/trailing `-`). Look up
+`tests/ui-scenarios/<scenario-name>.md`. If the file exists, invoke the
 [`ui-scenario`](../ui-scenario/SKILL.md) skill in `run` mode and consume its receipt
-(`swarm-report/<slug>-ui-scenario-<name>.md`) as the verification evidence for that TC. The
-acceptance receipt records `test_plan_source: ui-scenario` plus the scenario file path
-when this path is taken; otherwise the standard one-shot `manual-tester` flow runs as
-before.
+(`swarm-report/<slug>-ui-scenario-<name>.md`) as the verification evidence for that TC.
+Record the resolved scenario path on the per-TC evidence entry as `ui_scenario_path`
+(separate from `test_plan_source`, which keeps its existing values
+`receipt | mounted | on-the-fly | absent` describing how the test plan itself was
+sourced). When the scenario file does not exist, the standard one-shot `manual-tester`
+flow runs as before; emit a one-line note pointing to the missing file path so authors
+can decide whether to write the scenario.
 
 ---
 

--- a/plugins/developer-workflow/skills/acceptance/SKILL.md
+++ b/plugins/developer-workflow/skills/acceptance/SKILL.md
@@ -98,6 +98,15 @@ fires when its tested behavior runs. Mismatch (declared but not emitted, or emit
 wrong fields) becomes a P1 acceptance finding routed through the standard FAILED → Implement
 loop. An explicit `N/A: <reason>` in the test-plan section skips this check.
 
+**Persistent UI scenario reuse.** When the chosen test plan contains a Test Case typed
+`ui-scenario`, before driving `manual-tester` for that TC, look up
+`tests/ui-scenarios/<scenario-from-tc>.md`. If the file exists, invoke the
+[`ui-scenario`](../ui-scenario/SKILL.md) skill in `run` mode and consume its receipt
+(`swarm-report/<slug>-ui-scenario-<name>.md`) as the verification evidence for that TC. The
+acceptance receipt records `test_plan_source: ui-scenario` plus the scenario file path
+when this path is taken; otherwise the standard one-shot `manual-tester` flow runs as
+before.
+
 ---
 
 ## Step 1.5: Source-Missing Gate

--- a/plugins/developer-workflow/skills/ui-scenario/SKILL.md
+++ b/plugins/developer-workflow/skills/ui-scenario/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: ui-scenario
+description: >-
+  Author, run, or update re-runnable UI scenarios — markdown scripts executed
+  on a live app or browser through the `mobile` / `playwright` MCP servers.
+  Operator behind the `ui-scenario` test type declared in `generate-test-plan`
+  and `docs/TESTING-STRATEGY.md`.
+
+  Three modes: **write** (transcribe a journey into a persistent scenario file),
+  **run** (execute an existing scenario, produce a pass/fail report), **update**
+  (heal a scenario failing because the UI changed, with confirmation per change).
+
+  Use when: "write a UI scenario", "run scenario X", "execute the checkout
+  scenario", "the checkout scenario is failing — update it", "add a re-runnable
+  UI test for the login flow", "regression UI scenario".
+  Do NOT use for: Compose UI tests / XCUITest / ViewInspector code (engineer
+  agents during `implement` / `write-tests`), one-shot manual QA against a spec
+  (use `acceptance`), undirected exploratory QA (use `bug-hunt`), or visual
+  snapshot tests (use the project's screenshot framework via `write-tests`).
+disable-model-invocation: true
+---
+
+# UI Scenario
+
+Re-runnable UI tests that execute against a real running app or browser through `mobile` (Android / iOS) and `playwright` (web) MCP servers. The output is a markdown file that lives in the project (`tests/ui-scenarios/<scenario-name>.md`) and can be re-run on any branch — by `acceptance`, by the user, or in future by a CI runner — without rewriting it for each release.
+
+This skill is **QA-execution**: it is allowed to reference `mobile` / `playwright` MCP tool names directly and to fail fast with an install/enable message when those servers are not available. Graceful degradation without real device automation is impossible. See `developer-workflow/CLAUDE.md` Conventions for the QA-execution exception.
+
+## Three modes
+
+The caller picks the mode in the invocation prompt; defaults to `run` when an existing scenario name is referenced.
+
+| Mode | Trigger | Outcome |
+|---|---|---|
+| **write** | "write a scenario for X", "transcribe this journey", or no scenario file exists yet | Engineer describes the journey; this skill produces a `tests/ui-scenarios/<name>.md` file matching the format in [`references/scenario-format.md`](references/scenario-format.md) |
+| **run** | Scenario file exists; caller asks to execute | Skill reads the scenario, executes step-by-step against a connected device / browser via the matching MCP, produces `swarm-report/<slug>-ui-scenario-<name>.md` with pass / fail and evidence |
+| **update** | Existing scenario fails because the UI changed (rename, restructure, copy change) | Skill diffs the failing step against the current UI tree, proposes minimal changes (selector replacement, step reorder, assertion update) per change. Each change is confirmed with the user before being persisted |
+
+## Phase 1: Identify mode and locate scenario
+
+1. **Mode** — read the caller's prompt:
+   - "write" / "create" / "transcribe" / "add scenario" → `write`
+   - "run" / "execute" / "play" / "verify" / no verb but a scenario name is given → `run`
+   - "update" / "heal" / "fix selectors" / "the scenario is broken because the UI changed" → `update`
+2. **Locate** the scenario file:
+   - Convention: `tests/ui-scenarios/<scenario-name>.md`. Slug-style file names (kebab-case, descriptive — `checkout-happy-path.md`, not `tc-1.md`).
+   - `write` mode — choose a name from the journey description; ask the user once if a file with that name already exists.
+   - `run` / `update` modes — fail fast if the file does not exist (with the path that was looked up).
+3. **Detect the platform target** from the scenario's `Platforms:` line and the running environment:
+   - `android` / `ios` → use the `mobile` MCP server.
+   - `web` → use the `playwright` MCP server.
+   - If the caller's environment does not have the matching MCP enabled, stop with an install/enable message.
+
+## Phase 2 (write mode): Transcribe the journey
+
+The engineer describes the journey in natural language. The skill produces the markdown file.
+
+1. Read the description; resolve any ambiguous step (which screen, which button, which assertion) by **one** clarifying question per ambiguity, batched at the end.
+2. Choose selectors using the priority list in [`references/scenario-format.md`](references/scenario-format.md#selector-priority):
+   1. `id` / `accessibility-id` / `resource-id` (preferred — stable across UI restructuring).
+   2. `text` (acceptable — fragile to copy / localisation changes).
+   3. `xpath` / complex queries (discouraged — only when the first two are not available).
+3. Write the file at `tests/ui-scenarios/<name>.md` following the format spec.
+4. **Do NOT execute the scenario in `write` mode.** The author validates the scenario by invoking `run` mode after the file is saved.
+
+The `write` mode does not assume an app is running. It produces a file; running it is the caller's next step.
+
+## Phase 3 (run mode): Execute and report
+
+For each step in the scenario:
+
+1. Resolve the selector to a current UI element via `mobile` / `playwright` (use the cheapest read first — `ui` tree before `screen` capture).
+2. Apply the action (`tap`, `fill`, `swipe`, `wait`, …) mapped to the matching MCP tool.
+3. Evaluate every assertion attached to the step.
+4. On the first assertion failure or element-not-found, stop and produce a failure report with:
+   - The failing step and its assertions.
+   - The actual UI state at the moment of failure (text excerpt of the relevant tree subset; one screenshot only if the tree is insufficient — keeps token cost down).
+   - A short explanation: why the assertion failed (literal mismatch, element absent, timeout, navigation drift).
+
+Successful steps are recorded as `[PASS] <step text>` in the report; the body of the running report uses checkboxes so completed steps survive context compaction.
+
+Save the report to `swarm-report/<slug>-ui-scenario-<name>.md`. The verdict is one of:
+
+- **PASS** — every step's assertions satisfied, no timeouts.
+- **FAIL** — at least one assertion mismatch or element-not-found. Report names the first failing step and its evidence.
+- **PARTIAL** — only emitted when the caller passes `--continue-on-fail`; lists every failing step.
+
+## Phase 4 (update mode): Heal a failing scenario
+
+Update mode is destructive (it edits the persistent scenario file). Always confirm changes with the user before persisting.
+
+1. Run the scenario with `run` mode internally to identify the first failing step.
+2. Diff the failing selector against the current UI tree:
+   - Rename detected (same role, different `id` / `text`) → propose the new selector.
+   - Element moved into a different parent → propose updated step or suggest reorder.
+   - Element removed entirely → ask the user whether the scenario step is still valid (delete the step, replace with an alternative path, or mark the scenario as a known regression).
+3. Surface the proposed change to the user as `<old> → <new>` with the reason. Apply only after confirmation.
+4. Re-run the scenario after every confirmed change to find the next failing step. Loop until PASS or the user opts out.
+
+Update mode is not for migrating a scenario across a major UI redesign — that is a `write` from scratch.
+
+## Integration with `acceptance`
+
+`acceptance` Branch 2 (test-plan-driven verification) checks for a persistent scenario before falling back to one-shot manual-tester execution:
+
+1. For each `ui-scenario`-typed Test Case in the test plan, look up `tests/ui-scenarios/<scenario-from-tc>.md`.
+2. If the file exists, invoke `ui-scenario` `run` mode and consume its receipt as the verification evidence for that TC.
+3. If the file does not exist, fall back to the one-shot `manual-tester` flow already documented in `acceptance/SKILL.md`.
+
+The acceptance skill records `test_plan_source: ui-scenario` (with the scenario file path) when the persistent scenario was used.
+
+## Output artifacts
+
+| Mode | Artifact | Path |
+|---|---|---|
+| write | Persistent scenario file | `tests/ui-scenarios/<name>.md` |
+| run | Run report | `swarm-report/<slug>-ui-scenario-<name>.md` |
+| update | Modified persistent scenario file + run report | same paths as above |
+
+## Escalation
+
+Stop and report when:
+
+- The required MCP server (`mobile` for `android`/`ios`, `playwright` for `web`) is not available in the environment — give the install / enable message and do not try alternatives.
+- No connected device / running app for the requested platform — ask the user to start the simulator / emulator / browser and try again.
+- More than three consecutive `update`-mode confirmations are needed in one run (signals UI redesign rather than scenario drift) — recommend a full `write` rewrite.
+- An `update`-mode change would alter the meaning of the scenario (e.g. removing a critical assertion) — refuse to apply silently; raise to user.
+
+## Selector priority and other rules
+
+See [`references/scenario-format.md`](references/scenario-format.md) for the full grammar (preconditions / steps / assertions / cleanup), the MCP-tool-to-action mapping, the Platforms field, and a worked example.

--- a/plugins/developer-workflow/skills/ui-scenario/SKILL.md
+++ b/plugins/developer-workflow/skills/ui-scenario/SKILL.md
@@ -103,11 +103,11 @@ Update mode is not for migrating a scenario across a major UI redesign — that 
 
 `acceptance` Branch 2 (test-plan-driven verification) checks for a persistent scenario before falling back to one-shot manual-tester execution:
 
-1. For each `ui-scenario`-typed Test Case in the test plan, look up `tests/ui-scenarios/<scenario-from-tc>.md`.
+1. For each `ui-scenario`-typed Test Case in the test plan, resolve the scenario file name from the TC's `Scenario:` field if present, otherwise slugify the TC title. Look up `tests/ui-scenarios/<scenario-name>.md`.
 2. If the file exists, invoke `ui-scenario` `run` mode and consume its receipt as the verification evidence for that TC.
 3. If the file does not exist, fall back to the one-shot `manual-tester` flow already documented in `acceptance/SKILL.md`.
 
-The acceptance skill records `test_plan_source: ui-scenario` (with the scenario file path) when the persistent scenario was used.
+The acceptance skill records the resolved scenario path on the per-TC evidence entry as `ui_scenario_path`. The receipt's `test_plan_source` field is unchanged by this path — it keeps its existing values `receipt | mounted | on-the-fly | absent` describing how the test plan itself was sourced, not how an individual TC was verified.
 
 ## Output artifacts
 

--- a/plugins/developer-workflow/skills/ui-scenario/references/scenario-format.md
+++ b/plugins/developer-workflow/skills/ui-scenario/references/scenario-format.md
@@ -1,0 +1,170 @@
+# UI Scenario Format
+
+Canonical structure for `tests/ui-scenarios/<name>.md`. Every scenario is a markdown file with three sections — **header**, **steps**, **cleanup** — plus an optional **fixtures** block. The format is human-readable AND machine-parseable: the running agent reads each step verbatim and maps actions to MCP tool calls.
+
+## File layout
+
+```markdown
+# UI Scenario: <human title>
+
+Platforms: android, ios, web        # one or more, comma-separated
+Device profile: default              # optional — see "Device profiles" below
+Tags: smoke, checkout, regression    # optional — used by acceptance/CI to filter
+Timeout: 60s                          # optional — overall scenario timeout
+
+## Preconditions
+
+- App installed and launched (or browser open at the start URL)
+- User logged in as test_user
+- Cart contains exactly 1 item: SKU-001
+
+## Fixtures
+
+- test_user: email = qa+test@example.com, password = $TEST_USER_PASSWORD
+- card_number: 4242 4242 4242 4242
+
+## Steps
+
+1. tap element: id="checkout_button"
+   assert: screen visible "Payment"
+
+2. fill field: id="card_number" value="$fixtures.card_number"
+   fill field: id="cvv" value="123"
+
+3. tap element: text="Pay"
+   wait for: 5s
+   assert: screen visible "Order confirmed"
+   assert: text visible "Order #"
+
+## Cleanup
+
+- Reset cart via test API
+- Log out
+```
+
+## Header rules
+
+| Field | Required | Notes |
+|---|---|---|
+| Title (`# UI Scenario: ...`) | yes | Human-readable; not used by the runner |
+| `Platforms:` | yes | One or more of `android`, `ios`, `web`. Determines which MCP server (`mobile` / `playwright`) executes the scenario |
+| `Device profile:` | no | Defaults to `default`. Project-specific profiles can declare locale, screen size, network throttle |
+| `Tags:` | no | Free-form list, comma-separated. `acceptance` and CI runners filter on these |
+| `Timeout:` | no | Overall wall-clock cap. Defaults to 120s for `mobile`, 60s for `playwright`. Per-step waits do NOT count against this — only total wall time |
+
+## Selector priority
+
+The runner picks the most stable form first. Authors must follow the same order:
+
+1. **`id="..."`** / **`accessibility-id="..."`** / **`resource-id="..."`** — preferred. Survives copy changes, restructuring, localisation. Use whenever the project provides one.
+2. **`text="..."`** — acceptable when no stable id exists. Fragile to copy edits and i18n.
+3. **`xpath="..."`** / complex queries — discouraged. Only when (1) and (2) cannot identify the element. Document why in a comment on the step.
+
+A scenario that uses `xpath` for more than one step in ten is a sign the screen needs `accessibilityIdentifier` / `testTag` / `data-testid` attributes — open a follow-up issue rather than papering over with brittle selectors.
+
+## Step grammar
+
+Each step is a numbered list item containing:
+
+- One or more **actions** — verbs that drive the UI: `tap`, `fill`, `swipe`, `scroll to`, `long-press`, `wait for`, `back`, `navigate`, `key press`, …
+- Zero or more **assertions** — `assert:` lines that must hold before the next step runs.
+
+Each line is `<verb>: <selector-or-target>` followed by optional named arguments (`value="..."`, `direction="up"`, etc.).
+
+### Common actions
+
+| Verb | Selector / target | Notes |
+|---|---|---|
+| `tap element` | id / text / xpath | Default tap on the centre of the matched element |
+| `long-press element` | id / text / xpath | `duration="<seconds>"` optional |
+| `fill field` | id / text | `value="..."` required. Use `$fixtures.<name>` to inject from the Fixtures section |
+| `swipe` | id / text / `screen` | `direction="up|down|left|right"`, `distance="..."` optional |
+| `scroll to` | id / text | Scroll until the element is visible; honours direction inference |
+| `wait for` | id / text / `<seconds>` | Wait until element is visible OR the literal duration. `<seconds>` form is `wait for: 5s` |
+| `key press` | platform key code (`back`, `enter`, `escape`, `tab`) | Web maps to keyboard, mobile to system back / IME |
+| `navigate` | URL (web only) | Sets the browser to a specific URL — equivalent to clicking a link |
+
+### Common assertions
+
+| Assert | Form | Meaning |
+|---|---|---|
+| `screen visible "..."` | text or screen identifier | The current screen / route matches the value (text contains, route equals) |
+| `text visible "..."` | substring match anywhere on the visible UI | Use sparingly — prefer matching against a specific element |
+| `element visible: <selector>` | id / text / xpath | The element is present and visible |
+| `element absent: <selector>` | id / text / xpath | The element is NOT present (timeout-aware) |
+| `field has value: <selector> value="..."` | id / text | Input field's current value equals the literal |
+| `count: <selector> = N` | id / text | Element count satisfies the relation (`=`, `>=`, `<=`, `between A..B`) |
+
+## Fixtures
+
+The `## Fixtures` section is optional. Variables declared there can be referenced in step values via `$fixtures.<name>`. Secrets must come from environment variables, written as `$TEST_USER_PASSWORD` (the runner reads from the process environment, never from the file).
+
+## Pass / fail semantics
+
+- **PASS** — every step ran without failure and every assertion attached to those steps was satisfied.
+- **FAIL** — first assertion mismatch, element-not-found timeout, or unexpected platform error. The runner stops at the first failure unless `--continue-on-fail` is passed by the caller.
+- **PARTIAL** — only with `--continue-on-fail`. Reports every failed step, but does not stand in for PASS.
+
+The run report at `swarm-report/<slug>-ui-scenario-<name>.md` keeps the verdict as the last fenced block:
+
+```
+verdict: FAIL
+passed_steps: [1]
+failed_step: 2
+failure_reason: element not found — id="card_number"
+evidence: <relative path to UI tree dump or screenshot>
+```
+
+## Worked example — checkout happy path
+
+```markdown
+# UI Scenario: Checkout happy path
+
+Platforms: android, ios
+Tags: smoke, checkout
+Timeout: 60s
+
+## Preconditions
+
+- App installed and launched
+- User logged in as test_user
+- Cart contains exactly 1 item: SKU-001
+
+## Fixtures
+
+- card_number: 4242 4242 4242 4242
+
+## Steps
+
+1. tap element: id="cart_button"
+   assert: screen visible "Cart"
+
+2. tap element: id="checkout_button"
+   assert: screen visible "Payment"
+
+3. fill field: id="card_number" value="$fixtures.card_number"
+   fill field: id="card_expiry" value="12/30"
+   fill field: id="card_cvv" value="123"
+
+4. tap element: id="pay_button"
+   wait for: id="confirmation_screen"
+   assert: screen visible "Order confirmed"
+   assert: element visible: id="order_number"
+
+## Cleanup
+
+- Tap "Done" to return to the catalogue
+- Reset cart via test API endpoint POST /test/reset-cart
+```
+
+## Anti-patterns
+
+- **Long sequence of taps without assertions.** Every 3–4 actions should have at least one assertion that anchors the runner to a known state.
+- **`xpath` everywhere.** Add `accessibilityIdentifier` / `testTag` / `data-testid` attributes to the production code and use those instead.
+- **Hard-coded waits.** Prefer `wait for: <selector>` over `wait for: 10s`. The literal-duration form is the escape hatch, not the default.
+- **Implicit fixtures in plain text.** If a value depends on environment, declare it in `## Fixtures` (or as `$ENV_VAR`) — never inline a secret in `value="..."`.
+- **Branching logic in steps.** Scenarios are linear; conditional flows are separate scenarios that share fixtures.
+
+## Conformance with the testing strategy
+
+This format is the canonical implementation of the `ui-scenario` test type listed in [`docs/TESTING-STRATEGY.md`](../../../docs/TESTING-STRATEGY.md#test-types) and in the `generate-test-plan` Type field. A test case typed `ui-scenario` in `<slug>-test-plan.md` references a file under `tests/ui-scenarios/`; `acceptance` honours that mapping (see `ui-scenario/SKILL.md` § Integration with `acceptance`).

--- a/plugins/developer-workflow/skills/ui-scenario/references/scenario-format.md
+++ b/plugins/developer-workflow/skills/ui-scenario/references/scenario-format.md
@@ -1,6 +1,6 @@
 # UI Scenario Format
 
-Canonical structure for `tests/ui-scenarios/<name>.md`. Every scenario is a markdown file with three sections — **header**, **steps**, **cleanup** — plus an optional **fixtures** block. The format is human-readable AND machine-parseable: the running agent reads each step verbatim and maps actions to MCP tool calls.
+Canonical structure for `tests/ui-scenarios/<name>.md`. Every scenario is a markdown file with four required sections — **header**, **preconditions**, **steps**, **cleanup** — plus an optional **fixtures** block. The format is human-readable AND machine-parseable: the running agent reads each step verbatim and maps actions to MCP tool calls.
 
 ## File layout
 
@@ -8,9 +8,9 @@ Canonical structure for `tests/ui-scenarios/<name>.md`. Every scenario is a mark
 # UI Scenario: <human title>
 
 Platforms: android, ios, web        # one or more, comma-separated
-Device profile: default              # optional — see "Device profiles" below
-Tags: smoke, checkout, regression    # optional — used by acceptance/CI to filter
-Timeout: 60s                          # optional — overall scenario timeout
+Device profile: default              # optional — runner-defined profile name
+Tags: smoke, checkout, regression    # optional — informational only
+Timeout: 60s                          # optional — overall scenario timeout (wall-clock)
 
 ## Preconditions
 
@@ -47,10 +47,10 @@ Timeout: 60s                          # optional — overall scenario timeout
 | Field | Required | Notes |
 |---|---|---|
 | Title (`# UI Scenario: ...`) | yes | Human-readable; not used by the runner |
-| `Platforms:` | yes | One or more of `android`, `ios`, `web`. Determines which MCP server (`mobile` / `playwright`) executes the scenario |
-| `Device profile:` | no | Defaults to `default`. Project-specific profiles can declare locale, screen size, network throttle |
-| `Tags:` | no | Free-form list, comma-separated. `acceptance` and CI runners filter on these |
-| `Timeout:` | no | Overall wall-clock cap. Defaults to 120s for `mobile`, 60s for `playwright`. Per-step waits do NOT count against this — only total wall time |
+| `Platforms:` | yes | One or more of `android`, `ios`, `web`. Determines which MCP-based runner (device / browser automation) executes the scenario |
+| `Device profile:` | no | Defaults to `default`. Runner-defined profile name (locale, screen size, network throttle). The set of available profiles is project-specific; reserved for future runner extensions |
+| `Tags:` | no | Free-form list, comma-separated. **Informational only** — reserved for future filtering by `acceptance` and CI runners; nothing consumes this field today |
+| `Timeout:` | no | Overall wall-clock cap on the entire scenario. Defaults: 120s for mobile platforms, 60s for `web`. When `Platforms:` lists multiple targets, the runner uses the highest default for the executing platform unless `Timeout:` is set explicitly. **Everything counts as wall time** — including explicit `wait for: 5s` steps and `wait for: <selector>` polls. The runner measures `now() - scenario_start` and trips the cap regardless of where the time was spent |
 
 ## Selector priority
 


### PR DESCRIPTION
## Summary

Closes #155.

- New skill `plugins/developer-workflow/skills/ui-scenario/` with three modes:
  - **write** — transcribe a journey into a persistent scenario file at `tests/ui-scenarios/<name>.md`
  - **run** — execute on a connected device / browser via the `mobile` (Android / iOS) or `playwright` (web) MCP server, produce `swarm-report/<slug>-ui-scenario-<name>.md` with PASS / FAIL / PARTIAL verdict
  - **update** — heal a scenario failing because the UI changed, with per-change user confirmation
- `references/scenario-format.md` is the canonical format spec — header (Platforms / Tags / Timeout), Preconditions, Fixtures, Steps with verbs (`tap` / `fill` / `swipe` / `wait` / `assert: ...`) and selector priority (`id` / `accessibility-id` > `text` > `xpath` discouraged), Cleanup. Includes a worked checkout-happy-path example and an anti-pattern list.
- `acceptance/SKILL.md` Step 1 sourcing notes that, when a Test Case is typed `ui-scenario`, acceptance prefers the persistent scenario at `tests/ui-scenarios/<name>.md` over a one-shot `manual-tester` run, recording `test_plan_source: ui-scenario` plus the file path.
- `developer-workflow/CLAUDE.md` skills count bumped 18 → 19; QA roster gains `ui-scenario`.

## Acceptance criteria mapping (from #155)

- [x] `ui-scenario/SKILL.md` exists with `write` / `run` / `update` modes.
- [x] Format documented in `references/scenario-format.md`.
- [x] At least one sample scenario inside the docs (worked checkout-happy-path example in `scenario-format.md`).
- [x] `acceptance` honours persistent scenarios when matched by slug / scenario name.
- [x] `generate-test-plan` already lists `ui-scenario` as a valid type (PR #181 / #153).
- [ ] Smoke test (PASS): write a scenario for a simple flow → run via `mobile` MCP → PASS — verifiable on the next real run.
- [ ] Smoke test (FAIL): run a scenario against a broken app → FAIL with readable report — verifiable on the next real run.

## Notes for review

- **QA-execution skill.** `ui-scenario` references `mobile` and `playwright` MCP tool names directly. This is allowed under the documented QA-execution exception in `developer-workflow/CLAUDE.md` Conventions — graceful degradation without real device automation is impossible. The skill fails fast with an install/enable message when the matching MCP is not available.
- **Not a new orchestrator stage.** `ui-scenario` is a standalone skill consumed by `acceptance` and by the user. No `feature-flow` / `bugfix-flow` state-machine change. The min-bar checklist (#148 / #175) does not apply — it is for stages, not for skills.
- **No tests scaffolding.** The skill ships docs only; the smoke tests in the acceptance criteria require a real running app and are explicit follow-ups on first use.

## Out of scope

- CI runner (#155 Non-goals) — `ui-scenario` runs on demand against a live device / browser; running scenarios on a device farm is a follow-up.
- Visual regression — that is the `screenshot` test type (separate framework — Paparazzi, swift-snapshot-testing).
- Replacement of unit / integration tests — `ui-scenario` is for journeys, not for transforms or component logic.

## Dependencies

- Forward link to `docs/TESTING-STRATEGY.md` (#151 / PR #178) resolves once #178 lands.
- `ui-scenario` as a valid `Type` field in `generate-test-plan` is delivered by PR #181 / #153.

## Test plan

- [x] `bash scripts/validate.sh` — green.
- [ ] Manual: invoke `/ui-scenario` write mode for a simple flow on a connected emulator.
- [ ] Manual: invoke `/ui-scenario` run mode against the produced file.
- [ ] Manual: in `acceptance` Branch 2 with a TC typed `ui-scenario`, verify acceptance prefers the persistent file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)