### PR TITLE
developer-workflow: extend security-expert pattern triggers in finalize Phase D

### DIFF
--- a/plugins/developer-workflow/docs/ORCHESTRATION.md
+++ b/plugins/developer-workflow/docs/ORCHESTRATION.md
@@ -260,7 +260,7 @@ Review these changes and produce a structured verdict.
 
 | Expert | Trigger — files touch any of: |
 |--------|-------------------------------|
-| `security-expert` | Auth, encryption, token/secret storage, network requests, permissions, user data handling |
+| `security-expert` | Either (a) the spec / plan declares `risk_areas` containing any of `auth`, `payment`, `pii`, `data-migration`; or (b) the diff matches the [pattern-trigger table](../skills/finalize/SKILL.md#security-expert-pattern-triggers) — any **narrow** pattern, or **two or more broad** patterns. A single broad pattern fires a scoped review (e.g. "audit the network layer for regressions"), not a full audit. |
 | `performance-expert` | RecyclerView/LazyColumn adapters, database queries, image loading, coroutine dispatchers, hot loops, large collections |
 | `architecture-expert` | New modules created, dependency direction changed, public API modified, new abstractions introduced |
 | `test-coverage-expert` (engineer-agent role, no separate file) | New public API in the diff with no matching test, `<slug>-test-plan.md` declares Test Cases not implemented in the test code, data layer / repository / service files modified without new test files, or `--coverage-audit` override |

--- a/plugins/developer-workflow/docs/ORCHESTRATION.md
+++ b/plugins/developer-workflow/docs/ORCHESTRATION.md
@@ -258,10 +258,10 @@ Review these changes and produce a structured verdict.
 
 ### Phase D expert-review triggers
 
-| Expert | Trigger — files touch any of: |
-|--------|-------------------------------|
-| `security-expert` | Either (a) the spec / plan declares `risk_areas` containing any of `auth`, `payment`, `pii`, `data-migration`; or (b) the diff matches the [pattern-trigger table](../skills/finalize/SKILL.md#security-expert-pattern-triggers) — any **narrow** pattern, or **two or more broad** patterns. A single broad pattern fires a scoped review (e.g. "audit the network layer for regressions"), not a full audit. |
-| `performance-expert` | RecyclerView/LazyColumn adapters, database queries, image loading, coroutine dispatchers, hot loops, large collections |
+| Expert | Trigger |
+|--------|---------|
+| `security-expert` | Either (a) the spec / plan declares `risk_areas` containing any of `auth`, `payment`, `pii`, `data-migration`; or (b) the diff matches the [pattern-trigger table](../skills/finalize/SKILL.md#security-expert-pattern-triggers) — any **narrow** pattern, or **two or more broad** patterns (file paths and diff content). A single broad pattern fires a scoped review (e.g. "audit the network layer for regressions"), not a full audit. |
+| `performance-expert` | Diff touches RecyclerView/LazyColumn adapters, database queries, image loading, coroutine dispatchers, hot loops, large collections |
 | `architecture-expert` | New modules created, dependency direction changed, public API modified, new abstractions introduced |
 | `test-coverage-expert` (engineer-agent role, no separate file) | New public API in the diff with no matching test, `<slug>-test-plan.md` declares Test Cases not implemented in the test code, data layer / repository / service files modified without new test files, or `--coverage-audit` override |
 

--- a/plugins/developer-workflow/skills/finalize/SKILL.md
+++ b/plugins/developer-workflow/skills/finalize/SKILL.md
@@ -38,12 +38,9 @@ The caller (orchestrator or user) provides:
   - `--allow-warn` — stop after 1 round even if WARN findings remain (default: still exit PASS on WARN-only, but keep iterating BLOCKs until resolved or round budget runs out)
   - `--skip-experts` — omit Phase D (rarely useful; experts auto-skip if no triggers match)
   - `--max-rounds N` — override the default 3-round cap. Use when the user wants one more round after an ESCALATE, without restarting the whole stage. Must be ≥ 1.
-<<<<<<< HEAD
   - `--coverage-audit` — force-on the Phase D `test-coverage-expert` trigger even when none of the diff conditions match. Useful for explicit pre-release coverage sweeps.
   - `--skip-coverage-audit` — turn off the Phase D `test-coverage-expert` trigger for this round. Discouraged; recorded verbatim with the user reason in the finalize report's `acknowledged risks` section.
-=======
-  - `--skip-security-review` — turn off both the `risk_areas`-based and the pattern-based `security-expert` triggers for this round. Discouraged; recorded verbatim with the user reason in the finalize report's `acknowledged risks` section. Other Phase D experts still fire on their own triggers.
->>>>>>> 8ed44a8 (finalize Phase D: security-expert pattern triggers)
+  - `--skip-security-review "<reason>"` — turn off both the `risk_areas`-based and the pattern-based `security-expert` triggers for this round. The reason is a one-line free-text argument captured verbatim in the finalize report's `acknowledged risks` section (no separate prompt). Discouraged; other Phase D experts still fire on their own triggers.
 
 ---
 
@@ -154,7 +151,7 @@ Fixes for test-quality findings (e.g., "this test doesn't cover the failure path
 
 Trigger experts only when the diff matches their domain. Launch the matching ones in **parallel**.
 
-Trigger matrix lives in [`docs/ORCHESTRATION.md` § Phase D expert-review triggers](../../docs/ORCHESTRATION.md#phase-d-expert-review-triggers) — that document is the single source of truth. Do not duplicate it here; read the matrix before executing.
+The high-level trigger matrix (which expert fires under which condition) lives in [`docs/ORCHESTRATION.md` § Phase D expert-review triggers](../../docs/ORCHESTRATION.md#phase-d-expert-review-triggers) — that document is the orchestrator-facing summary and the source of truth for the **set of experts and their high-level triggers**. The pattern-level detail for `security-expert` (the broad / narrow patterns and the threshold rules) is the responsibility of `finalize`, since it is procedural detail of how Phase D fires within a round; it lives in this file's [Security-expert pattern triggers](#security-expert-pattern-triggers) section, and the ORCHESTRATION matrix points back to it. Read both before executing — the matrix tells you whether `security-expert` fires; this file tells you whether the trigger is full-audit or scoped.
 
 No trigger matched → skip Phase D entirely for this round.
 
@@ -175,12 +172,12 @@ The default `risk_areas`-based trigger only fires when the spec or plan explicit
 
 - **At least one narrow pattern** → full security review (same as `risk_areas` trigger).
 - **Two or more broad patterns** → full security review.
-- **Exactly one broad pattern, no narrow** → **scoped review** — launch `security-expert` with a narrowed prompt that names the specific surface (e.g. "audit the network layer for regressions only"), not a full audit. Cuts false-positive review time roughly in half.
+- **Exactly one broad pattern, no narrow** → **scoped review** — launch `security-expert` with a narrowed prompt that names the specific surface (e.g. "audit the network layer for regressions only"), not a full audit. The intent is to reduce false-positive review cost on diffs that touch a security-relevant area only incidentally.
 - **No pattern + no `risk_areas`** → security-expert does not fire. Other Phase D experts may still trigger.
 
 **Override.** `--skip-security-review` on `finalize` (Tolerance flags above) turns off both `risk_areas` and pattern-based security triggers for the round. Recorded verbatim in `<slug>-finalize.md`'s `acknowledged risks` section with the user's reason. Discouraged.
 
-**Source.** Patterns are evaluated against the unified diff between the remote default branch's merge-base and `HEAD` (same derivation as Phase A's diff materialisation). Renames are followed; pure rename-without-content-change does not trigger.
+**Source.** Patterns are evaluated against the unified diff between the remote default branch's merge-base and `HEAD` (same derivation as Phase A's diff materialisation). Generate the diff with rename detection enabled (`git diff -M`) so a moved file appears under its new path. Path-based patterns match against the **new** path of each diff entry. Diff-content patterns match only against added/modified hunks — a pure rename without content change inserts no hunks, so it cannot match content patterns; it can, however, match path patterns when the rename moves the file into a security-relevant directory (e.g. into `/auth/`). Pure rename metadata alone (mode change, perms) is not a content trigger.
 
 ### Handling expert findings
 

--- a/plugins/developer-workflow/skills/finalize/SKILL.md
+++ b/plugins/developer-workflow/skills/finalize/SKILL.md
@@ -38,8 +38,12 @@ The caller (orchestrator or user) provides:
   - `--allow-warn` — stop after 1 round even if WARN findings remain (default: still exit PASS on WARN-only, but keep iterating BLOCKs until resolved or round budget runs out)
   - `--skip-experts` — omit Phase D (rarely useful; experts auto-skip if no triggers match)
   - `--max-rounds N` — override the default 3-round cap. Use when the user wants one more round after an ESCALATE, without restarting the whole stage. Must be ≥ 1.
+<<<<<<< HEAD
   - `--coverage-audit` — force-on the Phase D `test-coverage-expert` trigger even when none of the diff conditions match. Useful for explicit pre-release coverage sweeps.
   - `--skip-coverage-audit` — turn off the Phase D `test-coverage-expert` trigger for this round. Discouraged; recorded verbatim with the user reason in the finalize report's `acknowledged risks` section.
+=======
+  - `--skip-security-review` — turn off both the `risk_areas`-based and the pattern-based `security-expert` triggers for this round. Discouraged; recorded verbatim with the user reason in the finalize report's `acknowledged risks` section. Other Phase D experts still fire on their own triggers.
+>>>>>>> 8ed44a8 (finalize Phase D: security-expert pattern triggers)
 
 ---
 
@@ -153,6 +157,30 @@ Trigger experts only when the diff matches their domain. Launch the matching one
 Trigger matrix lives in [`docs/ORCHESTRATION.md` § Phase D expert-review triggers](../../docs/ORCHESTRATION.md#phase-d-expert-review-triggers) — that document is the single source of truth. Do not duplicate it here; read the matrix before executing.
 
 No trigger matched → skip Phase D entirely for this round.
+
+### `security-expert` pattern triggers
+
+The default `risk_areas`-based trigger only fires when the spec or plan explicitly declared `auth` / `payment` / `pii` / `data-migration`. Bug fixes, trivial features, and any task that arrives without a spec slip through. To close that gap, Phase D additionally fires `security-expert` when the diff matches the patterns below.
+
+| Category | Pattern (path or diff content) | Tier |
+|---|---|---|
+| Network layer | path under `/network/`, `/api/`, `/http/`, `/rpc/`, `/graphql/` | broad |
+| Auth / Crypto | path under `/auth/`, `/crypto/`, `/token/`, `/session/` | narrow |
+| Credential storage | diff mentions `SharedPreferences`, `EncryptedSharedPreferences`, `Keychain`, `UserDefaults`, `localStorage`, `sessionStorage`, `document.cookie`, `KeyStore` | narrow |
+| Supply chain | new dependency line added in `build.gradle*`, `Podfile`, `Package.swift`, `package.json`, `pom.xml`, `Cargo.toml`, `requirements.txt`, `pyproject.toml`, `go.mod` | narrow |
+| DB migrations | path under `migrations/`, `*.sql`, `Migration.kt`, `schema.prisma`, Flyway / Liquibase configs, `alembic/` | narrow |
+| Deserialization | Jackson / Gson / `kotlinx.serialization` config blocks; unsafe Python-pickle usage, `XMLDecoder`, `ObjectInputStream` in diff | narrow |
+
+**Threshold (false-positive control):**
+
+- **At least one narrow pattern** → full security review (same as `risk_areas` trigger).
+- **Two or more broad patterns** → full security review.
+- **Exactly one broad pattern, no narrow** → **scoped review** — launch `security-expert` with a narrowed prompt that names the specific surface (e.g. "audit the network layer for regressions only"), not a full audit. Cuts false-positive review time roughly in half.
+- **No pattern + no `risk_areas`** → security-expert does not fire. Other Phase D experts may still trigger.
+
+**Override.** `--skip-security-review` on `finalize` (Tolerance flags above) turns off both `risk_areas` and pattern-based security triggers for the round. Recorded verbatim in `<slug>-finalize.md`'s `acknowledged risks` section with the user's reason. Discouraged.
+
+**Source.** Patterns are evaluated against the unified diff between the remote default branch's merge-base and `HEAD` (same derivation as Phase A's diff materialisation). Renames are followed; pure rename-without-content-change does not trigger.
 
 ### Handling expert findings
 


### PR DESCRIPTION
## Summary

Closes #143.

- `finalize/SKILL.md` Phase D adds a **`security-expert` pattern triggers** subsection. Six pattern categories — network layer, auth/crypto, credential storage, supply chain, DB migrations, deserialization — classified as **broad** or **narrow** with concrete examples per language / framework.
- Threshold rule controls false-positives:
  - any narrow pattern → full security review,
  - 2+ broad patterns → full security review,
  - exactly 1 broad pattern → **scoped review** (narrowed prompt naming the surface, e.g. "audit the network layer for regressions only"),
  - no pattern + no `risk_areas` → no security review.
- Source: unified diff between merge-base of remote default branch and `HEAD`. Renames followed; pure rename-without-content-change does not trigger.
- New `--skip-security-review` tolerance flag — discouraged, recorded with the user reason in the finalize report's `acknowledged risks` section.
- `docs/ORCHESTRATION.md` Phase D trigger table updated to describe the dual trigger (`risk_areas` OR pattern-match) with a link to the pattern table.

## Acceptance criteria mapping (from #143)

- [x] Phase D in `finalize/SKILL.md` describes both `security-expert` triggers (`risk_areas` and pattern-based).
- [x] Pattern table with broad / narrow categories and threshold documented.
- [x] Override `--skip-security-review` documented in Tolerance flags.
- [x] `docs/ORCHESTRATION.md` summary trigger row updated.
- [ ] Smoke test (positive): a diff that adds `implementation("io.ktor:ktor-client-core")` triggers `security-expert` — verifiable on the next real run.
- [ ] Smoke test (false-positive): renaming a variable in a file under `/network/` without logical changes does not trigger a full review (threshold not met) — verifiable on the next real run.
- [ ] Smoke test (override): `finalize --skip-security-review` skips the stage and records the fact in the finalize artifact — verifiable on the next real run.

## Out of scope

- CI-side hook enforcement (#143 Non-goals — convention-only).
- Custom SAST replacing `security-expert` (#143 Non-goals).
- Patterns outside the security hot-path categories (#143 Non-goals).

## Dependencies

- None hard. Complementary to `finalize` Phase D `test-coverage-expert` (#152 / PR #184) — both extend Phase D conditional triggers with diff-based heuristics.

## Test plan

- [x] `bash scripts/validate.sh` — green.
- [ ] Manual: introduce a Gradle dependency add → run `finalize` → confirm `security-expert` fires with full review prompt.
- [ ] Manual: edit a file under `/network/` with no logical change → confirm only scoped review fires (or none, depending on broad-pattern count).
- [ ] Manual: pass `--skip-security-review` → confirm skip is recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)