### PR TITLE
developer-workflow: Non-functional / Instrumentation section in test-plan

### DIFF
--- a/plugins/developer-workflow/skills/acceptance/SKILL.md
+++ b/plugins/developer-workflow/skills/acceptance/SKILL.md
@@ -90,11 +90,11 @@ consumers (including the `surfaces` invariant guards) live in
 [`references/source-branches.md`](references/source-branches.md). Record the selected
 branch as `test_plan_source` in the receipt.
 
-**Instrumentation verification.** When the test plan ends with a non-empty
-`## Non-functional / Instrumentation` section (Log events / Metrics / Traces / Alerts /
-Dashboards — see [`generate-test-plan` Field Definitions](../generate-test-plan/SKILL.md#non-functional--instrumentation-mandatory-for-user-facing--prod-bound)),
+**Instrumentation verification.** When the test plan ends with a `## Non-functional /
+Instrumentation` section that exists and is not `N/A: <reason>` (Log events / Metrics /
+Traces / Alerts / Dashboards — see [`generate-test-plan` Field Definitions](../generate-test-plan/SKILL.md#non-functional--instrumentation-mandatory-for-user-facing--prod-bound)),
 acceptance verifies, against the running app, that each declared event / metric / span
-fires when its tested behaviour runs. Mismatch (declared but not emitted, or emitted with
+fires when its tested behavior runs. Mismatch (declared but not emitted, or emitted with
 wrong fields) becomes a P1 acceptance finding routed through the standard FAILED → Implement
 loop. An explicit `N/A: <reason>` in the test-plan section skips this check.
 

--- a/plugins/developer-workflow/skills/acceptance/SKILL.md
+++ b/plugins/developer-workflow/skills/acceptance/SKILL.md
@@ -90,6 +90,14 @@ consumers (including the `surfaces` invariant guards) live in
 [`references/source-branches.md`](references/source-branches.md). Record the selected
 branch as `test_plan_source` in the receipt.
 
+**Instrumentation verification.** When the test plan ends with a non-empty
+`## Non-functional / Instrumentation` section (Log events / Metrics / Traces / Alerts /
+Dashboards — see [`generate-test-plan` Field Definitions](../generate-test-plan/SKILL.md#non-functional--instrumentation-mandatory-for-user-facing--prod-bound)),
+acceptance verifies, against the running app, that each declared event / metric / span
+fires when its tested behaviour runs. Mismatch (declared but not emitted, or emitted with
+wrong fields) becomes a P1 acceptance finding routed through the standard FAILED → Implement
+loop. An explicit `N/A: <reason>` in the test-plan section skips this check.
+
 ---
 
 ## Step 1.5: Source-Missing Gate

--- a/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
@@ -199,14 +199,14 @@ markdown), the phase-segmentation worked example, and the rules for when each va
 
 Every plan ends with a `## Non-functional / Instrumentation` section that declares observability **before** implementation, not after the first incident. Required when the spec / task is tagged `user-facing` or `prod-bound`, or when the feature touches an observability hot-path: network calls, payments, background jobs, auth, data migrations.
 
-`N/A: <reason>` (one line) is allowed for internal / developer-only tooling and for pure refactors with no change to observable behaviour. Never delete the heading.
+`N/A: <reason>` (one line) is allowed for internal / developer-only tooling and for pure refactors with no change to observable behavior. Never delete the heading.
 
 The section covers five subsections — Log events / Metrics / Traces / Alerts / Dashboards (full template in [`references/format-templates.md`](references/format-templates.md#non-functional--instrumentation)). The skill reads naming and stack conventions (OpenTelemetry, Prometheus, StatsD, vendor-specific) from the project's `CLAUDE.md` and reuses them; it does not prescribe a stack. If the project has no convention, the skill asks one question and records the answer.
 
 Downstream stages consume this section:
 
 - `multiexpert-review` test-plan profile checks the section is filled or carries an explicit `N/A: <reason>`.
-- `acceptance` verifies, against the running app, that declared events / metrics actually fire when the tested behaviour runs.
+- `acceptance` verifies, against the running app, that declared events / metrics actually fire when the tested behavior runs.
 
 ## Guidelines
 

--- a/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
@@ -195,6 +195,19 @@ markdown), the phase-segmentation worked example, and the rules for when each va
 | Code path | backtick-wrapped path with line | `src/auth/LoginViewModel.kt:87` |
 | Inferred | `[inferred from code]` | Behavior derived from code with no spec backing |
 
+### Non-functional / Instrumentation (mandatory for user-facing / prod-bound)
+
+Every plan ends with a `## Non-functional / Instrumentation` section that declares observability **before** implementation, not after the first incident. Required when the spec / task is tagged `user-facing` or `prod-bound`, or when the feature touches an observability hot-path: network calls, payments, background jobs, auth, data migrations.
+
+`N/A: <reason>` (one line) is allowed for internal / developer-only tooling and for pure refactors with no change to observable behaviour. Never delete the heading.
+
+The section covers five subsections — Log events / Metrics / Traces / Alerts / Dashboards (full template in [`references/format-templates.md`](references/format-templates.md#non-functional--instrumentation)). The skill reads naming and stack conventions (OpenTelemetry, Prometheus, StatsD, vendor-specific) from the project's `CLAUDE.md` and reuses them; it does not prescribe a stack. If the project has no convention, the skill asks one question and records the answer.
+
+Downstream stages consume this section:
+
+- `multiexpert-review` test-plan profile checks the section is filled or carries an explicit `N/A: <reason>`.
+- `acceptance` verifies, against the running app, that declared events / metrics actually fire when the tested behaviour runs.
+
 ## Guidelines
 
 - Number test cases sequentially: TC-1, TC-2, TC-3, ...

--- a/plugins/developer-workflow/skills/generate-test-plan/references/format-templates.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/references/format-templates.md
@@ -91,6 +91,41 @@ Test cases that are good candidates for automated testing.
 | TC-[N] | [why this is a good automation candidate] |
 
 > Omit this section if no test cases are suitable for automation.
+
+---
+
+## Non-functional / Instrumentation
+
+> **Mandatory** when the spec / task is `user-facing` or `prod-bound`, or the
+> feature touches an observability hot-path (network calls, payments,
+> background jobs, auth, data migrations). Internal / dev-only / pure refactor
+> tasks may set the section to `N/A: <reason>` (one line) — never delete the
+> heading.
+
+### Log events
+- Event: `<namespace>.<action>` — when fired, key fields (NO PII)
+
+### Metrics
+- Counter: `<name>` — increments on ..., labels ...
+- Histogram: `<name>` — observes ..., bucket strategy ...
+- Gauge: `<name>` — tracks ...
+
+### Traces
+- Span: `<operation>` — entry point, child spans, key attributes
+- Parent context: where the trace-id originates
+
+### Alerts
+- Alert: `<name>` — condition, severity, route (oncall / Slack / email)
+- Runbook: `runbooks/<slug>.md` (if the project follows that convention)
+
+### Dashboards
+- Existing to update: URL / id
+- New needed: yes / no, owner
+
+> Naming, namespacing, and stack (OTel, Prometheus, StatsD, vendor-specific) are
+> read from the project's `CLAUDE.md`. The skill does not prescribe a stack —
+> it records what the project already uses, or asks one question if the
+> project has none.
 ```
 
 ## Phase Segmentation

--- a/plugins/developer-workflow/skills/multiexpert-review/profiles/test-plan.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/profiles/test-plan.md
@@ -1,6 +1,6 @@
 ---
 name: test-plan
-description: Profile for test-plan artifacts (docs/testplans/<slug>-test-plan.md and swarm-report/<slug>-test-plan.md receipts). Verdict alphabet PASS/WARN/FAIL with 5-item checklist. Primary reviewer business-analyst; adds domain specialists when spec invokes their concerns.
+description: Profile for test-plan artifacts (docs/testplans/<slug>-test-plan.md and swarm-report/<slug>-test-plan.md receipts). Verdict alphabet PASS/WARN/FAIL with 6-item checklist (a, b, c, d, e, g). Primary reviewer business-analyst; adds domain specialists when spec invokes their concerns.
 
 detect:
   frontmatter_type: [test-plan, test-plan-receipt]
@@ -85,7 +85,7 @@ For every Issue you raise, use the item ID as the title stem — e.g. `(a) AC co
 After Step 4 synthesis, the engine updates `swarm-report/<slug>-test-plan.md` (the receipt, not the permanent file at `docs/testplans/<slug>-test-plan.md`) with:
 
 - `review_verdict: PASS | WARN | FAIL`
-- On WARN: `review_warnings:` list enumerating violated items `(d)`, `(e)` with one-line rationale each
+- On WARN: `review_warnings:` list enumerating violated items from `(d)`, `(e)`, `(g)` with one-line rationale each
 - On FAIL: `review_blockers:` list enumerating violated items from `(a)–(c)` with the blocking finding and suggested fix
 
 The receipt format is owned by the `generate-test-plan` skill — this profile only writes the three fields listed in `receipt.fields_to_update`.

--- a/plugins/developer-workflow/skills/multiexpert-review/profiles/test-plan.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/profiles/test-plan.md
@@ -29,7 +29,7 @@ verdicts: [PASS, WARN, FAIL]
 severity_mapping:
   - items: ["a", "b", "c"]
     severity: critical
-  - items: ["d", "e"]
+  - items: ["d", "e", "g"]
     severity: major
 
 source_routing:
@@ -44,27 +44,28 @@ receipt:
 
 ## Rubric
 
-Every reviewer must evaluate the test-plan against these five items and report the status of each one explicitly in their response. Copy the items verbatim into the review prompt so findings are comparable across agents:
+Every reviewer must evaluate the test-plan against these items and report the status of each one explicitly in their response. Copy the items verbatim into the review prompt so findings are comparable across agents:
 
 - **(a) AC coverage** — every Acceptance Criterion from the linked spec has ≥1 Test Case that verifies it. Missing or weak mapping is a violation.
 - **(b) Negative balance** — every happy-path (positive) TC has ≥2 unhappy/negative TCs covering the same flow (invalid input, error states, boundary violations, concurrent or race conditions). A plan that is mostly happy paths violates this item.
 - **(c) Edge cases present** — at least one TC is explicitly tagged as an edge case (boundary value, empty/null, maximum size, timezone/locale boundaries, concurrency, resource exhaustion, etc.). If the plan has no edge-case TC at all, this item is violated.
 - **(d) Non-functional scenarios where applicable** — if the linked spec mentions any of {SLA, latency budget, throughput, a11y, auth, encryption, PII, resource limits, rate limits}, there must be ≥1 non-functional TC covering that concern (performance, accessibility, security). Applicability is driven by spec content — if the spec mentions none of these triggers, this item is trivially satisfied.
 - **(e) Priority-risk alignment** — priorities (P0–P3) are consistent with risk assessment: any high-risk flow (data loss, auth, payment, destructive actions) is at P0–P1; any user-facing critical path is at P0–P1; trivial/informational cases are at P2–P3. Mismatch between stated risk and assigned priority violates this item.
+- **(g) Instrumentation declared** — when the spec / task is `user-facing` or `prod-bound`, or the feature touches an observability hot-path (network calls, payments, background jobs, auth, data migrations), the test plan ends with a `## Non-functional / Instrumentation` section that lists Log events / Metrics / Traces / Alerts / Dashboards (or sub-headings filled with concrete declarations). For internal / dev-only / pure-refactor work, an explicit `N/A: <reason>` (one line) is acceptable. A missing section, or one labelled simply `TBD` / `?` / blank, violates this item.
 
 ## Verdict policy
 
 | Verdict | Trigger | Exit condition |
 |---------|---------|----------------|
 | **FAIL** (blocker) | Any of items **(a)**, **(b)**, **(c)** is violated | Plan MUST be revised. Engine drives the revise-loop up to 3 cycles. After 3 cycles still FAIL → escalate to user. Pipeline is blocked. |
-| **WARN** (non-blocking) | Items (a)–(c) all satisfied, but **(d)** or **(e)** is violated | Pipeline continues. Engine records `review_verdict: WARN` in the receipt with the explicit list of violated items. No revise-loop required. |
-| **PASS** (clean) | All five items satisfied | Pipeline continues unconditionally. Engine records `review_verdict: PASS` in the receipt. |
+| **WARN** (non-blocking) | Items (a)–(c) all satisfied, but **(d)**, **(e)**, or **(g)** is violated | Pipeline continues. Engine records `review_verdict: WARN` in the receipt with the explicit list of violated items. No revise-loop required. |
+| **PASS** (clean) | Every item satisfied | Pipeline continues unconditionally. Engine records `review_verdict: PASS` in the receipt. |
 
 A single critical from any agent with medium-or-higher confidence is enough to trigger FAIL, matching the engine's aggregation rules.
 
 ## Prompt augmentation
 
-Every agent reviewing a test-plan receives the following 5-item checklist verbatim in their Step 3 prompt (the engine substitutes this section into `{PROFILE_PROMPT_AUGMENTATION}` literally — not by reference to the Rubric section above). Each agent must explicitly report the status of each item (satisfied / violated, with rationale). The engine parses these into the severity mapping.
+Every agent reviewing a test-plan receives the following checklist verbatim in their Step 3 prompt (the engine substitutes this section into `{PROFILE_PROMPT_AUGMENTATION}` literally — not by reference to the Rubric section above). Each agent must explicitly report the status of each item (satisfied / violated, with rationale). The engine parses these into the severity mapping.
 
 ---
 
@@ -75,6 +76,7 @@ Every agent reviewing a test-plan receives the following 5-item checklist verbat
 - **(c) Edge cases present** — at least one TC is explicitly tagged as an edge case (boundary value, empty/null, maximum size, timezone/locale boundaries, concurrency, resource exhaustion, etc.). If the plan has no edge-case TC at all, this item is violated.
 - **(d) Non-functional scenarios where applicable** — if the linked spec mentions any of {SLA, latency budget, throughput, a11y, auth, encryption, PII, resource limits, rate limits}, there must be ≥1 non-functional TC covering that concern (performance, accessibility, security). Applicability is driven by spec content — if the spec mentions none of these triggers, this item is trivially satisfied.
 - **(e) Priority-risk alignment** — priorities (P0–P3) are consistent with risk assessment: any high-risk flow (data loss, auth, payment, destructive actions) is at P0–P1; any user-facing critical path is at P0–P1; trivial/informational cases are at P2–P3. Mismatch between stated risk and assigned priority violates this item.
+- **(g) Instrumentation declared** — when the spec / task is `user-facing` or `prod-bound`, or the feature touches an observability hot-path (network calls, payments, background jobs, auth, data migrations), the test plan ends with a `## Non-functional / Instrumentation` section that lists Log events / Metrics / Traces / Alerts / Dashboards (or sub-headings filled with concrete declarations). For internal / dev-only / pure-refactor work, an explicit `N/A: <reason>` (one line) is acceptable. A missing section, or one labelled simply `TBD` / `?` / blank, violates this item.
 
 For every Issue you raise, use the item ID as the title stem — e.g. `(a) AC coverage: API X has no test case`. This keeps synthesizer aggregation greppable.
 


### PR DESCRIPTION
## Summary

Closes #147.

- `generate-test-plan/references/format-templates.md` adds a `## Non-functional / Instrumentation` template — Log events / Metrics / Traces / Alerts / Dashboards. Mandatory for `user-facing` / `prod-bound` features and observability hot-paths (network, payments, background jobs, auth, data migrations). Explicit `N/A: <reason>` allowed for internal / dev-only / pure-refactor work.
- `generate-test-plan/SKILL.md` Field Definitions describe the section, activation rule, and downstream consumers. Naming and stack come from the project's `CLAUDE.md` — the skill records what is already in use, asks one question only when the project has no convention.
- `multiexpert-review/profiles/test-plan.md` gains item **(g) Instrumentation declared** — major severity (WARN, not blocking), consistent with items (d) / (e). Severity mapping updated.
- `acceptance/SKILL.md` adds an Instrumentation verification note: when the test plan declares events / metrics, acceptance verifies they actually fire against the running app; mismatch is a P1 finding routed through the standard FAILED → Implement loop.

## Acceptance criteria mapping (from #147)

- [x] Test-plan template contains the section with all five subsections.
- [x] Skill fills the section automatically from `research.md` / `plan.md`, or marks an explicit `N/A: <reason>`.
- [x] `multiexpert-review` test-plan profile checks the section.
- [x] `acceptance` for user-facing features verifies declared events / metrics on the running app.
- [ ] Smoke test: a test plan for a user-facing feature emits a non-empty section — verifiable on the next real run.
- [ ] Smoke test: a test plan for an internal refactor emits `N/A: internal refactor, no observable behavior` — verifiable on the next real run.

## Notes for review

- **Letter (g) on the multiexpert checklist**, not (f). Letter (f) is in flight in PR #181 (#153 — TC type field). Both PRs touch `multiexpert-review/profiles/test-plan.md`; using `(g)` here keeps the change orthogonal at the line level. The `severity_mapping` references items by id, not by sequence — order does not matter.
- **No new orchestrator stage.** Per the parent strategy (#151), this is an extension of an existing artifact, not a new stage.

## Out of scope

- Writing OpenTelemetry SDK or vendor selection (#147 Non-goals).
- Adding a separate `observability-plan` orchestrator stage (#147 Non-goals — the min-bar #148/#175 redirects this kind of proposal to artifact extension).
- Forcing observability stack on projects without one (#147 Non-goals — `N/A: <reason>` is a valid answer).

## Dependencies

- Coexists with PR #181 (#153 type field). If PR #181 merges first, this PR's `(g)` simply lands after `(f)`. If this PR merges first, PR #181's `(f)` lands without conflict.

## Test plan

- [x] `bash scripts/validate.sh` — green.
- [ ] Manual: trigger `generate-test-plan` for a `user-facing` task — confirm the section is generated with concrete events / metrics.
- [ ] Manual: trigger `generate-test-plan` for an internal refactor — confirm the section emits `N/A: <reason>`.
- [ ] Manual: confirm `multiexpert-review` flags a missing / blank instrumentation section as WARN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)