### PR TITLE
developer-workflow: create-pr emits Release Notes section for user-visible changes (#144 redirect)

### DIFF
--- a/plugins/developer-workflow/skills/create-pr/SKILL.md
+++ b/plugins/developer-workflow/skills/create-pr/SKILL.md
@@ -175,7 +175,7 @@ Body composition is mode-aware.
 
 ### 7.1 Section bank
 
-The body is composed from a catalog of optional sections: What changed, Why / motivation, Artifacts, How to test, Status, Screenshots / demo, Checklist, and a trailing Claude Code footer. Include only the sections that apply for the current mode and available artifacts.
+The body is composed from a catalog of optional sections: What changed, Why / motivation, Artifacts, How to test, **Release Notes** (when user-visible changes are detected), Status, Screenshots / demo, Checklist, and a trailing Claude Code footer. Include only the sections that apply for the current mode and available artifacts.
 
 See [`references/body-sections.md`](references/body-sections.md) for the full section-bank templates with example content and status-table formatting.
 
@@ -187,9 +187,33 @@ See [`references/body-sections.md`](references/body-sections.md) for the full se
 | Why / motivation | ✅ | ✅ | ✅ | ✅ |
 | Artifacts | ✅ (as they appear) | ✅ (keeps current) | ✅ | ✅ if exist |
 | How to test | from plan if exists | from test-plan if exists | full | ✅ |
+| Release Notes | placeholder + open question if user-facing | refresh from spec/test-plan if user-visible signals | final entry per detected changelog format | ✅ when user-visible |
 | Status | "Implement: in progress" | updated from latest artifacts | all PASS | optional |
 | Screenshots | placeholder + prompt user | keep as-is | verify filled | prompt |
 | Checklist | unchecked | keep user edits | verify items consistent | unchecked |
+
+### 7.2.1 Release Notes section (user-visible changes)
+
+The Release Notes section captures what users of the plugin / library / app will see, in a form ready to paste into the project's changelog at release time. The section appears in the PR body when at least one of the following signals is true:
+
+- The spec / clarify / plan declares any of: `user-facing: true`, `prod-bound: true`, `breaking: true`, `release_notes:` block in frontmatter.
+- The diff touches a public API surface (`/api/`, public functions, exported types in barrel files, plugin manifests, marketplace metadata).
+- The user passed `--release-notes "..."` to `create-pr`.
+
+When emitted, the section follows the format the repo already uses — detect by file presence:
+
+| Repo file | Format used in PR body |
+|---|---|
+| `CHANGELOG.md` (root or per-plugin) | Keep-a-Changelog bullet, classified as one of `Added` / `Changed` / `Fixed` / `Deprecated` / `Removed` / `Security`. Breaking changes flagged with a leading `**Breaking:**` |
+| `.changeset/` directory | A `type: patch \| minor \| major` block plus the one-line summary (matches Changesets convention) |
+| `RELEASE_NOTES.md` or `docs/CHANGELOG.md` | Same Keep-a-Changelog format as `CHANGELOG.md` |
+| None of the above | Plain bullet list under `## Release Notes` — the project owner copies it into whichever changelog mechanism they adopt later |
+
+The section is text only — `create-pr` does NOT modify `CHANGELOG.md`, `.changeset/`, or any release-notes file in the repo. Writing to those files is the project owner's choice at release time. Including the entry in the PR body keeps the change visible at review time without committing format-specific files (which would conflict with release tooling that owns those files).
+
+`--skip-release-notes` opts out of the section even when signals match — recorded in the PR body as `Release notes: skipped (<reason>)`.
+
+The PR receipt records `release_notes: emitted | skipped: <reason> | not-applicable` so downstream stages and audits can tell which path was taken.
 
 ### 7.3 Detect visual changes
 

--- a/plugins/developer-workflow/skills/create-pr/SKILL.md
+++ b/plugins/developer-workflow/skills/create-pr/SKILL.md
@@ -196,16 +196,16 @@ See [`references/body-sections.md`](references/body-sections.md) for the full se
 
 The Release Notes section captures what users of the plugin / library / app will see, in a form ready to paste into the project's changelog at release time. The section appears in the PR body when at least one of the following signals is true:
 
-- The spec / clarify / plan declares any of: `user-facing: true`, `prod-bound: true`, `breaking: true`, `release_notes:` block in frontmatter.
-- The diff touches a public API surface (`/api/`, public functions, exported types in barrel files, plugin manifests, marketplace metadata).
-- The user passed `--release-notes "..."` to `create-pr`.
+- **Optional custom frontmatter fields** in the spec / clarify / plan declare any of: `user-facing: true`, `prod-bound: true`, `breaking: true`, or a `release_notes:` block. These keys are **not** part of the canonical `write-spec` template (see `skills/write-spec/references/spec-template.md`); they are optional add-ons that callers may put into their spec frontmatter to force the section. Stages upstream of `create-pr` are not required to emit them.
+- The diff touches a public API surface (`/api/`, public functions, exported types in barrel files, plugin manifests, marketplace metadata) — the default automatic-detection path when no custom frontmatter is set.
+- The user passed `--release-notes "..."` to `create-pr` (always wins).
 
 When emitted, the section follows the format the repo already uses — detect by file presence:
 
 | Repo file | Format used in PR body |
 |---|---|
 | `CHANGELOG.md` (root or per-plugin) | Keep-a-Changelog bullet, classified as one of `Added` / `Changed` / `Fixed` / `Deprecated` / `Removed` / `Security`. Breaking changes flagged with a leading `**Breaking:**` |
-| `.changeset/` directory | A `type: patch \| minor \| major` block plus the one-line summary (matches Changesets convention) |
+| `.changeset/` directory | PR-body shorthand: a `type: patch \| minor \| major` line plus the one-line summary. **This is a PR-body representation only, not a valid `.changeset/` entry**; the actual `.changeset/*.md` file (if any) is created at release time and uses the standard `---` frontmatter mapping packages to bump levels per the [Changesets format](https://github.com/changesets/changesets/blob/main/docs/intro-to-using-changesets.md). Do not paste this snippet directly into a changeset file. |
 | `RELEASE_NOTES.md` or `docs/CHANGELOG.md` | Same Keep-a-Changelog format as `CHANGELOG.md` |
 | None of the above | Plain bullet list under `## Release Notes` — the project owner copies it into whichever changelog mechanism they adopt later |
 

--- a/plugins/developer-workflow/skills/create-pr/references/body-sections.md
+++ b/plugins/developer-workflow/skills/create-pr/references/body-sections.md
@@ -25,15 +25,20 @@ Available sections (include only those that apply):
 ## Release Notes
 <!--
   Emitted when the change is user-visible (see SKILL.md §7.2.1).
-  Format follows the project's existing changelog convention; choose ONE form:
+  Format follows the project's existing changelog convention. PR body is text only —
+  do NOT modify CHANGELOG.md, .changeset/, RELEASE_NOTES.md, or docs/CHANGELOG.md.
+  Choose ONE form for the PR body:
 
-  Keep-a-Changelog (CHANGELOG.md / RELEASE_NOTES.md):
+  Keep-a-Changelog (CHANGELOG.md / RELEASE_NOTES.md / docs/CHANGELOG.md):
   ### Added
   - Short user-facing description (#NNN)
 
-  Changesets (.changeset/):
+  Changesets (.changeset/) — PR-body shorthand only, NOT the actual changeset format:
   type: minor
   Short user-facing description.
+
+  (The real .changeset/*.md file uses --- frontmatter mapping packages to bump levels;
+  this PR-body snippet is just for review-time visibility.)
 
   No project changelog yet — plain bullet:
   - **<Area>:** short user-facing description.

--- a/plugins/developer-workflow/skills/create-pr/references/body-sections.md
+++ b/plugins/developer-workflow/skills/create-pr/references/body-sections.md
@@ -22,6 +22,29 @@ Available sections (include only those that apply):
 - [ ] Scenario 1
 - [ ] Scenario 2
 
+## Release Notes
+<!--
+  Emitted when the change is user-visible (see SKILL.md §7.2.1).
+  Format follows the project's existing changelog convention; choose ONE form:
+
+  Keep-a-Changelog (CHANGELOG.md / RELEASE_NOTES.md):
+  ### Added
+  - Short user-facing description (#NNN)
+
+  Changesets (.changeset/):
+  type: minor
+  Short user-facing description.
+
+  No project changelog yet — plain bullet:
+  - **<Area>:** short user-facing description.
+
+  Breaking change marker (any format):
+  **Breaking:** describe what users must do to migrate.
+
+  When the section is intentionally skipped:
+  > Release notes: skipped (<reason>)
+-->
+
 ## Status
 <!-- Table: Implement / Finalize / Acceptance stages, pass/fail/pending from artifacts -->
 | Stage | Result | Notes |


### PR DESCRIPTION
## Summary

Closes #144 — implementing the **min-bar redirect** the parent issue was given in #148 / PR #175. The original proposal of a new Changelog orchestrator stage in `feature-flow` failed criterion 3 (no duplication — reachable by extending `create-pr`); this PR delivers that extension.

- `create-pr/SKILL.md` §7.1 adds **Release Notes** to the section bank. §7.2 maps it across `--draft` / `--refresh` / `--promote` / default modes.
- New §7.2.1 Release Notes section:
  - **Trigger signals**: spec frontmatter `user-facing` / `prod-bound` / `breaking`, public-API surface in the diff (`/api/`, public exports, plugin manifests, marketplace metadata), or explicit `--release-notes "…"` argument.
  - **Format detection** by repo files: Keep-a-Changelog (`CHANGELOG.md` / `RELEASE_NOTES.md`), Changesets (`.changeset/`), or plain bullet when no convention exists.
  - **`--skip-release-notes`** opt-out — recorded as `Release notes: skipped (<reason>)` in the body.
  - **PR receipt field** `release_notes: emitted | skipped: <reason> | not-applicable`.
- `references/body-sections.md` gains the Release Notes block with three format snippets and a breaking-change marker.

**Important contract:** `create-pr` does NOT modify `CHANGELOG.md` / `.changeset/` / `RELEASE_NOTES.md` files in the repo. The entry sits in the PR body for review; the project owner copies it into the changelog mechanism at release time. This avoids conflicting with release tooling that owns those files (e.g. Changesets generates `CHANGELOG.md` from `.changeset/` entries during versioning).

## Acceptance criteria mapping (from #144 — redirected)

The original AC asked for a new `changelog-entry` skill with file detection and Phase 2.3a in `feature-flow`. Per the min-bar redirect, the AC for this PR is:

- [x] `create-pr` emits a Release Notes section in the PR body when user-visible signals match.
- [x] The section's format follows the project's existing changelog convention (Keep-a-Changelog / Changesets / plain bullet).
- [x] `--skip-release-notes` opt-out works and is recorded.
- [x] PR receipt records `release_notes:` so downstream stages can audit.
- [ ] Smoke test: PR for a user-facing change → Release Notes section appears with correct format — verifiable on the next real `create-pr` run.
- [ ] Smoke test: PR for an internal refactor → Release Notes section absent (or marked `not-applicable`) — verifiable on the next real `create-pr` run.

## Out of scope

- New `changelog-entry` skill (#148 redirect).
- New orchestrator stage in `feature-flow` (#148 / #175).
- Auto-commit of `CHANGELOG.md` / `.changeset/` files (avoids conflict with release tooling).
- `bugfix-flow` integration (the parent issue explicitly excluded `bugfix-flow`; bug changelog usually aggregates at release).

## Dependencies

- Builds on the min-bar checklist (#148 / PR #175 — merged).
- Independent of cluster A PRs.

## Test plan

- [x] `bash scripts/validate.sh` — green.
- [ ] Manual: create a PR for a user-facing change → confirm Release Notes section is generated.
- [ ] Manual: pass `--skip-release-notes` → confirm body records the skip and reason.
- [ ] Manual: confirm `create-pr` does not touch `CHANGELOG.md` in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)