### PR TITLE
developer-workflow: feature-flow / bugfix-flow post-run telemetry hook

### DIFF
--- a/plugins/developer-workflow/README.md
+++ b/plugins/developer-workflow/README.md
@@ -126,7 +126,7 @@ Full pipeline with diagrams and gate-level detail:
 
 ## Aggregating run telemetry
 
-Both orchestrators write `swarm-report/<slug>-metrics.json` after every run (best-effort, local-only — full schema in the linked document). Three baseline `jq` queries to mine the local history:
+Both orchestrators write `swarm-report/<slug>-metrics.json` after every run (best-effort, local-only — full schema in the linked document). Three baseline `jq` queries to mine the local history (each requires at least one metrics file under `swarm-report/`; with no files the shell may pass the literal glob to `jq` and produce a confusing error — run the queries after at least one orchestrator run completes):
 
 Average wall-clock seconds across all runs:
 

--- a/plugins/developer-workflow/README.md
+++ b/plugins/developer-workflow/README.md
@@ -122,6 +122,29 @@ Full pipeline with diagrams and gate-level detail:
 - [`docs/WORKFLOW.md`](docs/WORKFLOW.md) — stages, artifacts, decision points
 - [`docs/ORCHESTRATORS.md`](docs/ORCHESTRATORS.md) — feature-flow and bugfix-flow state diagrams
 - [`docs/ORCHESTRATION.md`](docs/ORCHESTRATION.md) — task profiling, Research Consortium, re-anchoring, State Machine, Receipt-Based Gating, Quality Loop gates
+- [`docs/METRICS-SCHEMA.md`](docs/METRICS-SCHEMA.md) — schema for the `swarm-report/<slug>-metrics.json` file emitted after every `feature-flow` / `bugfix-flow` run
+
+## Aggregating run telemetry
+
+Both orchestrators write `swarm-report/<slug>-metrics.json` after every run (best-effort, local-only — full schema in the linked document). Three baseline `jq` queries to mine the local history:
+
+Average wall-clock seconds across all runs:
+
+```
+jq -s 'map(.wall_clock_seconds) | add/length' swarm-report/*-metrics.json
+```
+
+Most frequent backward-transition pairs:
+
+```
+jq -r '.backward_transitions[] | "\(.from) -> \(.to)"' swarm-report/*-metrics.json | sort | uniq -c | sort -rn | head
+```
+
+Percentage of runs that used at least one override:
+
+```
+jq -s '(map(select(.overrides | length > 0)) | length) / length * 100' swarm-report/*-metrics.json
+```
 
 ## License
 

--- a/plugins/developer-workflow/docs/METRICS-SCHEMA.md
+++ b/plugins/developer-workflow/docs/METRICS-SCHEMA.md
@@ -1,0 +1,96 @@
+# Flow Metrics Schema
+
+Schema for `swarm-report/<slug>-metrics.json`, the post-run telemetry artifact written by `feature-flow` and `bugfix-flow` after every run (success, escalation, or user-interrupted). Local only — never sent off the machine.
+
+## When the file is written
+
+- **Success** (VERIFIED → Merged) — at the end of the run.
+- **Escalation** — when the orchestrator stops with an escalation reason.
+- **User interruption** — best-effort write inside the orchestrator's cleanup hook (`/exit`, `Ctrl+C`, abandoned worktree, etc.). Missing fields are recorded as `null` rather than omitted.
+
+A failure to write the metrics file **does not break the orchestrator**. The run completes as it would have without telemetry; the failure is logged once to the chat output.
+
+## Top-level fields
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `slug` | string | yes | The run's task slug |
+| `flow` | string enum | yes | `feature-flow` \| `bugfix-flow` |
+| `started_at` | ISO-8601 string | yes | First stage start |
+| `ended_at` | ISO-8601 string | yes | Last stage end (or interruption moment) |
+| `wall_clock_seconds` | integer | yes | `ended_at − started_at`, total seconds |
+| `outcome` | string enum | yes | `merged` \| `escalated` \| `interrupted` |
+| `escalation_reason` | string \| null | yes (null when not escalated) | One short line |
+| `stages` | array of stage records | yes | One entry per stage, in execution order |
+| `backward_transitions` | array of transition records | yes | Empty array if none |
+| `overrides` | array of strings | yes | E.g. `["--skip-test-plan", "--skip-coverage-audit"]` |
+| `review_verdicts` | object | yes | Map of review-stage name → `PASS` \| `WARN` \| `FAIL` |
+| `finalize_rounds` | integer \| null | yes (null when finalize did not run) | Count of rounds executed |
+| `acceptance_verdict` | string \| null | yes (null when acceptance did not run) | `VERIFIED` \| `FAILED` \| `PARTIAL` |
+| `pr_number` | integer \| null | yes (null when no PR) | GitHub / GitLab PR / MR number |
+| `drive_to_merge_rounds` | integer \| null | yes (null when drive-to-merge did not run) | Round count |
+| `schema_version` | string | yes | `"1"` for the format described in this document |
+
+## Stage record
+
+```json
+{
+  "name": "Research",
+  "started_at": "2026-04-21T10:00:00Z",
+  "ended_at": "2026-04-21T10:02:00Z",
+  "duration_seconds": 120,
+  "status": "completed",
+  "skip_reason": null
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | string | Canonical stage name (`Research`, `Clarify`, `Plan`, `TestPlan`, `Implement`, `Finalize`, `Acceptance`, `PR`, `Debug`, `RegressionTest`, …) |
+| `started_at` | ISO-8601 string | When the orchestrator entered the stage |
+| `ended_at` | ISO-8601 string | When the stage produced its receipt or was skipped |
+| `duration_seconds` | integer | Convenience precomputation |
+| `status` | string enum | `completed` \| `skipped` \| `failed` |
+| `skip_reason` | string \| null | Required when `status` is `skipped` |
+
+## Backward-transition record
+
+```json
+{
+  "from": "Acceptance",
+  "to": "Implement",
+  "reason": "P1 bug: empty cart triggers infinite spinner",
+  "at": "2026-04-21T11:00:00Z"
+}
+```
+
+`reason` is a short one-liner — full context lives in the relevant artifact (e.g. `<slug>-acceptance.md`). The schema captures only what is needed to count and trace.
+
+## Privacy
+
+- Metrics are **local-only** by default. The file lives under `swarm-report/`, which is gitignored.
+- Do not store user names, secrets, or repo-internal identifiers beyond what already lives in `swarm-report/` artifacts.
+- `escalation_reason` and stage `skip_reason` are short text strings — keep them factual, not anecdotal.
+
+## Schema versioning
+
+`schema_version` starts at `"1"`. Breaking changes (renaming fields, removing fields) bump to `"2"` and ship behind a release; downstream `jq` examples in the README are versioned alongside.
+
+## jq cookbook (in `developer-workflow/README.md`)
+
+Three baseline examples that any consumer can copy:
+
+1. Average `wall_clock_seconds` over recent runs:
+   ```
+   jq -s 'map(.wall_clock_seconds) | add/length' swarm-report/*-metrics.json
+   ```
+2. Top backward-transition pairs by count:
+   ```
+   jq -r '.backward_transitions[] | "\(.from) -> \(.to)"' swarm-report/*-metrics.json | sort | uniq -c | sort -rn | head
+   ```
+3. Percentage of runs with at least one override:
+   ```
+   jq -s '(map(select(.overrides | length > 0)) | length) / length * 100' swarm-report/*-metrics.json
+   ```
+
+These examples are reproduced in the plugin README so users can paste them without reading this document first.

--- a/plugins/developer-workflow/docs/METRICS-SCHEMA.md
+++ b/plugins/developer-workflow/docs/METRICS-SCHEMA.md
@@ -4,7 +4,7 @@ Schema for `swarm-report/<slug>-metrics.json`, the post-run telemetry artifact w
 
 ## When the file is written
 
-- **Success** (VERIFIED → Merged) — at the end of the run.
+- **Success** — at the end of the run, when the orchestrator transitions `VERIFIED → stage Merged` (outcome: `merged`). Note the case distinction: `Merged` is a stage label in the orchestrator state machine; `merged` (lowercase) is the value of the `outcome` enum.
 - **Escalation** — when the orchestrator stops with an escalation reason.
 - **User interruption** — best-effort write inside the orchestrator's cleanup hook (`/exit`, `Ctrl+C`, abandoned worktree, etc.). Missing fields are recorded as `null` rather than omitted.
 
@@ -24,7 +24,7 @@ A failure to write the metrics file **does not break the orchestrator**. The run
 | `stages` | array of stage records | yes | One entry per stage, in execution order |
 | `backward_transitions` | array of transition records | yes | Empty array if none |
 | `overrides` | array of strings | yes | E.g. `["--skip-test-plan", "--skip-coverage-audit"]` |
-| `review_verdicts` | object | yes | Map of review-stage name → `PASS` \| `WARN` \| `FAIL` |
+| `review_verdicts` | object | yes | Map of review-stage name → `PASS` \| `WARN` \| `FAIL`. Empty object `{}` when no review stages ran (e.g. `bugfix-flow` runs that skip `PlanReview` / `TestPlanReview`). Consumers must treat `{}` as "no review stages executed", not as a schema violation |
 | `finalize_rounds` | integer \| null | yes (null when finalize did not run) | Count of rounds executed |
 | `acceptance_verdict` | string \| null | yes (null when acceptance did not run) | `VERIFIED` \| `FAILED` \| `PARTIAL` |
 | `pr_number` | integer \| null | yes (null when no PR) | GitHub / GitLab PR / MR number |
@@ -46,7 +46,7 @@ A failure to write the metrics file **does not break the orchestrator**. The run
 
 | Field | Type | Notes |
 |---|---|---|
-| `name` | string | Canonical stage name (`Research`, `Clarify`, `Plan`, `TestPlan`, `Implement`, `Finalize`, `Acceptance`, `PR`, `Debug`, `RegressionTest`, …) |
+| `name` | string | Canonical stage name. Examples (non-exhaustive — orchestrators may add stages over time): `Research`, `Clarify`, `DesignOptions`, `Decompose`, `Plan`, `PlanReview`, `TestPlan`, `TestPlanReview`, `Implement`, `Finalize`, `Acceptance`, `PR`, `DriveToMerge`, `Debug`, `RegressionTest`. Canonical names are owned by the orchestrator definitions in `skills/feature-flow/` and `skills/bugfix-flow/`; aggregation across runs should treat unknown names as opaque labels rather than error out |
 | `started_at` | ISO-8601 string | When the orchestrator entered the stage |
 | `ended_at` | ISO-8601 string | When the stage produced its receipt or was skipped |
 | `duration_seconds` | integer | Convenience precomputation |

--- a/plugins/developer-workflow/docs/ORCHESTRATION.md
+++ b/plugins/developer-workflow/docs/ORCHESTRATION.md
@@ -356,3 +356,7 @@ Before opening a stage proposal — and before merging one — the candidate mus
 
 The current set of `feature-flow` / `bugfix-flow` stages was added before this checklist. A retroactive audit is a separate follow-up issue — not in scope here. If an existing stage is later found to fail the min-bar, the path is the same: redirect, not "patch the checklist".
 
+## Post-run Telemetry
+
+Both orchestrators write `swarm-report/<slug>-metrics.json` after every run as a best-effort post-hook (success, escalation, or interruption). The artifact is local-only and does NOT change the orchestrator's terminal verdict — a write failure logs once and the run completes as it would have otherwise. Schema lives in [`METRICS-SCHEMA.md`](METRICS-SCHEMA.md); it is shared between `feature-flow` and `bugfix-flow` and feeds the `jq`-based local aggregation snippets in the plugin README (`Aggregating run telemetry` section).
+

--- a/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
@@ -411,6 +411,17 @@ Each backward transition:
 
 ---
 
+## Post-run Telemetry (best-effort hook)
+
+After the run terminates — `Merged`, escalated, or interrupted — the orchestrator writes `swarm-report/<slug>-metrics.json`. The schema is shared with `feature-flow` and lives in [`docs/METRICS-SCHEMA.md`](../../docs/METRICS-SCHEMA.md).
+
+- Local-only artifact under the gitignored `swarm-report/` directory. Not sent off the machine.
+- Best-effort: a write failure logs once to chat and **does not break the orchestrator**. The run's outcome is unaffected.
+- `flow: bugfix-flow` — the schema's required fields are filled where they apply; `pr_number` and `drive_to_merge_rounds` are `null` when escalation happens before PR creation. `outcome` covers `merged` / `escalated` / `interrupted` the same way as `feature-flow`.
+- The orchestrator updates the in-memory record at every stage transition so the file can be flushed at any point. The single write happens on terminal transition or in the cleanup hook for interruptions.
+
+---
+
 ## Stop Points
 
 The orchestrator **stops and waits for the user** at:

--- a/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/bugfix-flow/SKILL.md
@@ -413,7 +413,7 @@ Each backward transition:
 
 ## Post-run Telemetry (best-effort hook)
 
-After the run terminates — `Merged`, escalated, or interrupted — the orchestrator writes `swarm-report/<slug>-metrics.json`. The schema is shared with `feature-flow` and lives in [`docs/METRICS-SCHEMA.md`](../../docs/METRICS-SCHEMA.md).
+After the run terminates (outcome: `merged` / `escalated` / `interrupted`) — i.e. the orchestrator reaches stage `Merged`, hits an escalation Stop Point, or is cut by the user — the orchestrator writes `swarm-report/<slug>-metrics.json`. Stage labels (e.g. `Merged`) are TitleCase; outcome enum values (e.g. `merged`) are lowercase. The schema is shared with `feature-flow` and lives in [`docs/METRICS-SCHEMA.md`](../../docs/METRICS-SCHEMA.md).
 
 - Local-only artifact under the gitignored `swarm-report/` directory. Not sent off the machine.
 - Best-effort: a write failure logs once to chat and **does not break the orchestrator**. The run's outcome is unaffected.

--- a/plugins/developer-workflow/skills/feature-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/feature-flow/SKILL.md
@@ -526,6 +526,19 @@ Each backward transition:
 
 ---
 
+## Post-run Telemetry (best-effort hook)
+
+After the run terminates — `Merged`, escalated, or interrupted — the orchestrator writes `swarm-report/<slug>-metrics.json`. The schema lives in [`docs/METRICS-SCHEMA.md`](../../docs/METRICS-SCHEMA.md) and is shared with `bugfix-flow`.
+
+- Local-only artifact under the gitignored `swarm-report/` directory. Not sent off the machine.
+- Best-effort: a write failure logs once to chat and **does not break the orchestrator**. The run's main outcome is unaffected.
+- Required at minimum: `slug`, `flow: feature-flow`, `started_at`, `ended_at`, `wall_clock_seconds`, `outcome` (`merged` / `escalated` / `interrupted`), `escalation_reason` (or `null`), `stages` array, `backward_transitions` array, `overrides`, `review_verdicts`, `finalize_rounds`, `acceptance_verdict`, `pr_number`, `drive_to_merge_rounds`, `schema_version: "1"`.
+- Outcomes:
+  - `merged` — `drive-to-merge` confirmed merge.
+  - `escalated` — orchestrator stopped at an explicit Stop Point or hit a backward-edge cap; `escalation_reason` is filled.
+  - `interrupted` — user cut the run (e.g. abandoned worktree, `/exit`, `Ctrl+C`); fields not yet known are `null`.
+- The orchestrator updates the in-memory record at every stage transition so the file can be flushed at any point. The single write happens on terminal transition or in the cleanup hook for interruptions.
+
 ## Stop Points
 
 The orchestrator **stops and waits for the user** at:

--- a/plugins/developer-workflow/skills/feature-flow/SKILL.md
+++ b/plugins/developer-workflow/skills/feature-flow/SKILL.md
@@ -528,7 +528,7 @@ Each backward transition:
 
 ## Post-run Telemetry (best-effort hook)
 
-After the run terminates — `Merged`, escalated, or interrupted — the orchestrator writes `swarm-report/<slug>-metrics.json`. The schema lives in [`docs/METRICS-SCHEMA.md`](../../docs/METRICS-SCHEMA.md) and is shared with `bugfix-flow`.
+After the run terminates (outcome: `merged` / `escalated` / `interrupted`) — i.e. the orchestrator reaches stage `Merged`, hits an escalation Stop Point, or is cut by the user — the orchestrator writes `swarm-report/<slug>-metrics.json`. Note the case distinction: stage labels (e.g. `Merged`) are TitleCase in the state machine; outcome enum values (e.g. `merged`) are lowercase in the schema. The schema lives in [`docs/METRICS-SCHEMA.md`](../../docs/METRICS-SCHEMA.md) and is shared with `bugfix-flow`.
 
 - Local-only artifact under the gitignored `swarm-report/` directory. Not sent off the machine.
 - Best-effort: a write failure logs once to chat and **does not break the orchestrator**. The run's main outcome is unaffected.


### PR DESCRIPTION
## Summary

Closes #145.

- New `plugins/developer-workflow/docs/METRICS-SCHEMA.md` documents the shared schema for `swarm-report/<slug>-metrics.json`: top-level fields (slug, flow, started/ended_at, wall_clock_seconds, outcome ∈ {merged, escalated, interrupted}, escalation_reason, stages, backward_transitions, overrides, review_verdicts, finalize_rounds, acceptance_verdict, pr_number, drive_to_merge_rounds, schema_version), stage and backward-transition record shapes, plus privacy and versioning rules.
- `feature-flow/SKILL.md` and `bugfix-flow/SKILL.md` gain a **Post-run Telemetry (best-effort hook)** section that fires on terminal transition or in the cleanup hook on interruption. Best-effort: a write failure logs once and the run's outcome is unaffected.
- `docs/ORCHESTRATION.md` ends with a `Post-run Telemetry` pointer to the schema doc so callers can find it from the orchestration manual.
- `developer-workflow/README.md` adds an `Aggregating run telemetry` section with three baseline `jq` examples (average wall-clock, most-frequent backward-transitions, % of runs with overrides).

## Acceptance criteria mapping (from #145)

- [x] Schema documented in `docs/METRICS-SCHEMA.md`.
- [x] `feature-flow` and `bugfix-flow` write `swarm-report/<slug>-metrics.json` after every run (success, escalation, interruption).
- [x] Required fields documented (15 top-level + stage + backward-transition shapes).
- [x] At escalation: `outcome: escalated` and `escalation_reason` populated.
- [x] On interruption: best-effort partial write with unknown fields as `null`.
- [x] Failure to write does not break the orchestrator (best-effort + single chat log).
- [x] README contains 3 `jq` aggregation examples.
- [ ] Smoke test (success): run feature-flow → metrics.json exists with all required fields and validates as JSON — verifiable on the next real run.
- [ ] Smoke test (escalation): trigger an escalation → metrics.json captures `outcome: escalated` + `escalation_reason` — verifiable on the next real run.

## Out of scope

- External sink / dashboard / vendor integration (#145 Non-goals — Tier-3, follow-up).
- CI hook to upload metrics on merge (#145 Non-goals).
- Schema beyond ~15 fields (#145 Non-goals — explicit cap to prevent sprawl).
- MCP tool to read / write the file (#145 Non-goals — `jq` is enough for now).

## Dependencies

- None hard. Builds atop the existing orchestrator artifact convention (`swarm-report/`).

## Test plan

- [x] `bash scripts/validate.sh` — green.
- [ ] Manual: run a feature-flow end-to-end → confirm `swarm-report/<slug>-metrics.json` is created and `jq . <file>` exits 0.
- [ ] Manual: trigger an escalation → confirm `outcome: escalated` and `escalation_reason` are populated.
- [ ] Manual: interrupt a run → confirm best-effort partial file with `outcome: interrupted`.
- [ ] Manual: run the three README `jq` snippets across a few real runs and confirm sensible output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)