### PR TITLE
Release v0.13.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.12.0",
+      "version": "0.13.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/maven-mcp/plugin"
@@ -23,7 +23,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.12.0",
+      "version": "0.13.0",
       "category": "security",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/sensitive-guard"
@@ -34,7 +34,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.12.0",
+      "version": "0.13.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow"
@@ -45,7 +45,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.12.0",
+      "version": "0.13.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-experts"
@@ -56,7 +56,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.12.0",
+      "version": "0.13.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-kotlin"
@@ -67,7 +67,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.12.0",
+      "version": "0.13.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-swift"

--- a/plugins/developer-workflow-experts/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-experts/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-experts",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Reusable expert agents for code review, architecture, security, performance, UX, build, DevOps, business analysis, and debugging. Safe to install standalone \u2014 no skills, no hooks, no MCP servers.",
   "author": {
     "name": "kirich1409"

--- a/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-kotlin",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Kotlin, Android, and KMP specialist agents and migration skills \u2014 kotlin-engineer, compose-developer, code-migration, kmp-migration, migrate-to-compose. Extends developer-workflow for Kotlin/Android projects.",
   "author": {
     "name": "kirich1409"
@@ -18,11 +18,11 @@
   "dependencies": [
     {
       "name": "developer-workflow",
-      "version": "^0.12.0"
+      "version": "^0.13.0"
     },
     {
       "name": "developer-workflow-experts",
-      "version": "^0.12.0"
+      "version": "^0.13.0"
     }
   ]
 }

--- a/plugins/developer-workflow-swift/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-swift/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-swift",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Swift, iOS, and macOS specialist agents \u2014 swift-engineer and swiftui-developer, with references covering Swift concurrency, testing, and SwiftUI patterns/state/performance. Extends developer-workflow for Apple platforms.",
   "author": {
     "name": "kirich1409"
@@ -17,11 +17,11 @@
   "dependencies": [
     {
       "name": "developer-workflow",
-      "version": "^0.12.0"
+      "version": "^0.13.0"
     },
     {
       "name": "developer-workflow-experts",
-      "version": "^0.12.0"
+      "version": "^0.13.0"
     }
   ]
 }

--- a/plugins/developer-workflow/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Developer workflow pipeline \u2014 research, decomposition, specification, multiexpert review, implementation, debugging, QA (test plans, acceptance, bug hunt, retroactive tests), PR creation and autonomous drive-to-merge (CI monitor, review handler, re-request, poll), feature-flow and bugfix-flow orchestrators. Platform-neutral; platform-specific engineers live in developer-workflow-kotlin and developer-workflow-swift.",
   "author": {
     "name": "kirich1409"
@@ -18,7 +18,7 @@
   "dependencies": [
     {
       "name": "developer-workflow-experts",
-      "version": "^0.12.0"
+      "version": "^0.13.0"
     }
   ]
 }

--- a/plugins/maven-mcp/package-lock.json
+++ b/plugins/maven-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@krozov/maven-central-mcp",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/plugins/maven-mcp/package.json
+++ b/plugins/maven-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "MCP server for Maven Central dependency intelligence",
   "main": "./dist/index.js",
   "type": "module",

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -19,7 +19,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@krozov/maven-central-mcp@^0.12.0"
+        "@krozov/maven-central-mcp@^0.13.0"
       ]
     }
   }

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maven-mcp",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps, /latest-version, and /dependency-changes skills",
   "author": {
     "name": "kirich1409"

--- a/plugins/sensitive-guard/.claude-plugin/plugin.json
+++ b/plugins/sensitive-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sensitive-guard",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Prevents sensitive data (secrets, PII) from reaching AI servers by scanning files before they are read into conversation",
   "author": {
     "name": "kirich1409"


### PR DESCRIPTION
## Summary

Bump version 0.12.0 → 0.13.0 across all 8 manifests + 5 family dependency ranges (developer-workflow→experts; kotlin→{workflow,experts}; swift→{workflow,experts}). Sync `package-lock.json` and `mcpServers.args` pin in maven-mcp.

## Changes since v0.12.0 (15 commits)

**developer-workflow:**
- reverse-spec skill (#164) — code → tech-agnostic feature spec
- ui-scenario skill (#183) — re-runnable UI tests via mobile/playwright MCP
- TC type field + selection heuristic (#181)
- Non-functional / Instrumentation section in test-plan (#186)
- security-expert pattern triggers extended in finalize Phase D (#185)
- feature-flow / bugfix-flow post-run telemetry hook (#188)
- /check public-API coverage gate default-on (#182)
- write-tests framework detection algorithm (#180)
- finalize Phase D: test-coverage-expert conditional trigger (#184)
- create-pr emits Release Notes section (#187)
- "author fixes broken tests in same PR" non-negotiable (#179)
- Min-bar checklist for new orchestrator stages (#175)
- Test coverage strategy doc (#178)
- Structured debug.md template (#177)

**deps:** postcss 8.5.8 → 8.5.13 in maven-mcp (#174)

## Test plan

- [x] `bash scripts/validate.sh` — green
- [x] `cd plugins/maven-mcp && npm run build` — green
- [x] `cd plugins/maven-mcp && npm test` — 291/291 green
- [ ] After merge: tag `v0.13.0`, push tag, GitHub Actions handles npm publish + per-plugin tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)