### PR TITLE
reverse-spec: translate remaining Russian content to English

### DIFF
--- a/plugins/developer-workflow/skills/reverse-spec/SKILL.md
+++ b/plugins/developer-workflow/skills/reverse-spec/SKILL.md
@@ -117,10 +117,10 @@ Then **propose** a boundary to the user in one line:
 - **Out of scope** — unrelated modules surfaced by the scout but not part of this
   feature.
 
-Ask the user for confirmation with a single question: *"Вот что я отношу к фиче: [in
-scope]. Зависимости: [deps]. Вне скоупа: [out]. Подтверждаешь границы?"*. Adjust based
-on the answer before proceeding. A wrong boundary at this step cascades: too narrow
-misses behaviors, too wide drowns the spec in unrelated detail.
+Ask the user for confirmation with a single question: *"Here is what I'm including in
+the feature: [in scope]. Dependencies: [deps]. Out of scope: [out]. Do these boundaries
+look right?"*. Adjust based on the answer before proceeding. A wrong boundary at this
+step cascades: too narrow misses behaviors, too wide drowns the spec in unrelated detail.
 
 **Scope sanity check** (soft gate). After the boundary is confirmed, evaluate against
 these heuristics:
@@ -132,10 +132,10 @@ these heuristics:
 - Scope includes **more than one screen** with distinct purposes (onboarding carousel
   across 4 screens is one flow; sign-in + profile-edit + settings is three).
 
-If any of these trip, surface to the user: *"Scope на [N flows / N features / N
-screens] — это, скорее, набор фич, чем одна. Хочешь одну большую спеку или
-per-flow спеки? Рекомендация — разбить: каждая отдельная спека полезнее
-реимплементатору, чем аггрегат."*. A large aggregate spec produces a Phase 1 state
+If any of these trip, surface to the user: *"This scope covers [N flows / N features
+/ N screens] — that's more like a set of features than one. Do you want one big spec
+or per-flow specs? Recommendation: split — each separate spec is more useful to the
+re-implementer than an aggregate."*. A large aggregate spec produces a Phase 1 state
 file and §10.1 Network operations table that are unusable in practice. Split first,
 then spec each piece.
 
@@ -155,8 +155,8 @@ context compaction and holds:
 
 **If the state file already exists** when the skill starts — that means this feature
 has been started before. Read the file and present a one-line summary to the user:
-*"Нашёл незавершённый state на фичу `<slug>` (Phase N, queue: K open questions).
-Продолжить с того же места или начать заново?"*. Default is **continue**; restart wipes
+*"Found an unfinished state for feature `<slug>` (Phase N, queue: K open questions).
+Continue from where we left off, or start over?"*. Default is **continue**; restart wipes
 answers already given and is rarely what the user wants.
 
 If the user confirms restart, delete the old state file and start fresh. Otherwise
@@ -173,8 +173,9 @@ Check the project for signals of working language:
 - CLAUDE.md — any language directive?
 
 Pick the dominant project language as the default. Announce it to the user in one line
-and offer to override: *"По умолчанию пишу спеку на русском (как остальные доки проекта).
-Другой язык?"* A single yes/no check is enough; do not escalate if the user says nothing.
+and offer to override: *"Defaulting to <language> for the spec (matching the rest of the
+project docs). Different language?"* A single yes/no check is enough; do not escalate if
+the user says nothing.
 
 ### 0.5 Output path
 
@@ -196,7 +197,7 @@ Full protocol — when to check, what the overview contains, how the feature spe
 short-circuits when an overview exists, update discipline — in
 `references/project-overview-protocol.md`.
 
-Override: *"пропусти project-overview"* skips this phase entirely.
+Override: *"skip project-overview"* (or any equivalent phrasing) skips this phase entirely.
 
 ---
 
@@ -262,11 +263,11 @@ interviews — it produces better questions because each follow-up is informed b
 previous answer.
 
 **Before the first question, set expectation.** Announce the queue size in one line so
-the user can make an informed choice about pacing: *"Нашёл ~N пробелов после анализа.
-Пойду по одному вопросу за раунд (так лучше формируются следующие вопросы). Скажи
-«батчем» если хочешь получить всё сразу."*. This prevents the common failure mode where
-the user patiently answers 10 questions in a row, then at the end says "could have done
-that in one message".
+the user can make an informed choice about pacing: *"Found ~N gaps after the analysis.
+I'll go one question per round (follow-ups land better that way). Say "batch" if you'd
+rather get them all at once."*. This prevents the common failure mode where the user
+patiently answers 10 questions in a row, then at the end says "could have done that in
+one message".
 
 For each open question in the state queue:
 
@@ -277,14 +278,14 @@ For each open question in the state queue:
 3. Ask it, with a **pre-filled default** derived from the code or from project
    convention. Example: *"Retry count is 3 in code. Is that an intentional product
    requirement, or an implementation default? (default: intentional — keep in spec as
-   requirement)"*. The user accepts, overrides, or says "не знаю" (which itself is a
+   requirement)"*. The user accepts, overrides, or says "don't know" (which itself is a
    valid answer and goes into Open Questions).
 4. Update the state file with the answer.
 5. Repeat until the queue is empty.
 
 If the queue is large (>8 questions) and the user signals impatience or explicitly asks
-to batch ("задавай всё сразу"), switch to batched mode for the remainder. Always respect
-an explicit override.
+to batch ("ask them all at once" / "batch"), switch to batched mode for the remainder.
+Always respect an explicit override.
 
 Question categories that typically need user input:
 
@@ -464,7 +465,7 @@ The spec already lives at `docs/spec/<slug>.md`. Final steps:
 - Confirm the file exists and is readable.
 - Delete the state file (`./swarm-report/reverse-spec-<slug>-state.md`) — operational,
   no longer needed.
-- Offer to commit: *"Спека сохранена в `docs/spec/<slug>.md`. Закоммитить?"*. Do not
+- Offer to commit: *"Spec saved to `docs/spec/<slug>.md`. Want me to commit it?"*. Do not
   commit without explicit confirmation.
 - **Hygiene artefact (optional).** If the analysis surfaced implementation-level
   concerns that did not qualify for §9 Known Defects (hardcoded strings, weak PRNG

--- a/plugins/developer-workflow/skills/reverse-spec/evals/evals.json
+++ b/plugins/developer-workflow/skills/reverse-spec/evals/evals.json
@@ -4,69 +4,69 @@
     {
       "id": 1,
       "name": "eval-path-input-complex-screen",
-      "prompt": "Сделай reverse-spec на фичу авторизации в FrameIO. Код UI лежит в features/auth/ (AuthScreen, AuthComponent, AuthState, DefaultAuthComponent, AuthUseCase, AuthKoin). OAuth-движок — в модуле oauth/. Это самодостаточная фича с несколькими состояниями, интеграциями и навигацией — нужна полная спека для возможной перереализации на другом стеке.",
-      "expected_output": "Полная спека в auth-spec.md. Содержит все 13 секций шаблона (включая явные N/A). Тело стек-нейтрально (Compose/Decompose/Koin/Ktor не упоминаются вне Code Map/§10). Code Map с path:line granularity. §8 Open questions не пустая. Покрывает PKCE, token storage, token refresh, process-death recovery.",
-      "principle": "path input — полный путь, сложная фича, проверка покрытия и tech-abstraction",
+      "prompt": "Run reverse-spec on the FrameIO authentication feature. UI code lives in features/auth/ (AuthScreen, AuthComponent, AuthState, DefaultAuthComponent, AuthUseCase, AuthKoin). The OAuth engine lives in the oauth/ module. This is a self-contained feature with multiple states, integrations, and navigation — produce a full spec usable for re-implementation on a different stack.",
+      "expected_output": "Full spec at auth-spec.md. Contains all 13 template sections (including explicit N/A entries). The body is stack-neutral (Compose/Decompose/Koin/Ktor are not mentioned outside the Code Map / §10). Code Map uses path:line granularity. §8 Open questions is non-empty. Covers PKCE, token storage, token refresh, and process-death recovery.",
+      "principle": "path input — full path, complex feature, verifying coverage and tech-abstraction",
       "files": [],
       "assertions": [
         {
-          "text": "spec_has_all_13_sections — auth-spec.md содержит все 13 секций шаблона (Overview, User-facing behavior, UI description, Data & integrations, States, Analytics & logging, Localization & accessibility, Navigation, Platform capabilities, Tech-specific constraints, Open questions, Code map)",
+          "text": "spec_has_all_13_sections — auth-spec.md contains all 13 template sections (Overview, User-facing behavior, UI description, Data & integrations, States, Analytics & logging, Localization & accessibility, Navigation, Platform capabilities, Tech-specific constraints, Open questions, Code map)",
           "type": "structural"
         },
         {
-          "text": "body_is_tech_agnostic — тело спеки (секции 1-8) не упоминает Jetpack Compose, Decompose, Koin, Ktor Client, kotlinx.serialization; эти упоминания допустимы только в §10 (Data & integrations, load-bearing tech), §11 (Platform capabilities), §12 (Tech-specific constraints), §12.5 (External references) или §13 (Code map)",
+          "text": "body_is_tech_agnostic — the spec body (sections 1-8) does not mention Jetpack Compose, Decompose, Koin, Ktor Client, kotlinx.serialization; such mentions are only allowed in §10 (Data & integrations, load-bearing tech), §11 (Platform capabilities), §12 (Tech-specific constraints), §12.5 (External references), or §13 (Code map)",
           "type": "quality"
         },
         {
-          "text": "code_map_uses_line_ranges — Code Map (§13) содержит записи формата path:line или path:start-end, а не только путей к файлам",
+          "text": "code_map_uses_line_ranges — Code Map (§13) contains entries in path:line or path:start-end format, not just file paths",
           "type": "quality"
         },
         {
-          "text": "open_questions_has_entries — §8 Open questions содержит ≥3 записи (в non-interactive прогоне без интервью реально незакрытых вопросов всегда остаётся несколько; пустой §8 = спекуляция)",
+          "text": "open_questions_has_entries — §8 Open questions contains ≥3 entries (in a non-interactive run without an interview, several genuinely unresolved questions always remain; an empty §8 means speculation)",
           "type": "quality"
         },
         {
-          "text": "covers_oauth_flow_end_to_end — спека описывает PKCE challenge/verifier, authorization URL, redirect + code exchange, access/refresh token storage, token refresh path",
+          "text": "covers_oauth_flow_end_to_end — the spec describes PKCE challenge/verifier, authorization URL, redirect + code exchange, access/refresh token storage, and the token refresh path",
           "type": "coverage"
         },
         {
-          "text": "covers_process_death_recovery — спека упоминает сохранение/восстановление OAuth state при смерти процесса (недавний commit в проекте про это)",
+          "text": "covers_process_death_recovery — the spec mentions saving/restoring OAuth state across process death (a recent commit in the project addresses this)",
           "type": "coverage"
         },
         {
-          "text": "coverage_report_has_both_passes — state-файл `swarm-report/reverse-spec-<slug>-state.md` содержит итоги Pass 1 (code → spec) и Pass 2 (spec → code) с конкретными числами покрытия",
+          "text": "coverage_report_has_both_passes — the state file `swarm-report/reverse-spec-<slug>-state.md` contains the results of Pass 1 (code → spec) and Pass 2 (spec → code) with concrete coverage numbers",
           "type": "process"
         },
         {
-          "text": "state_file_has_phase_checklist — state-файл `swarm-report/reverse-spec-<slug>-state.md` содержит чеклист фаз (Phase 0-5) с отметками выполнения и зафиксированными findings из Phase 1/2",
+          "text": "state_file_has_phase_checklist — the state file `swarm-report/reverse-spec-<slug>-state.md` contains a phase checklist (Phase 0-5) with completion marks and recorded findings from Phase 1/2",
           "type": "process"
         },
         {
-          "text": "no_code_identifiers_in_body — в секциях 1-8 отсутствуют имена из кодовой базы: OAuthClient, OAuthTokens, OAuthResult, OAuthException, AuthState, AuthComponent, AuthUseCase, TokenStorage, OAuthBrowser, FrameClient, StateFlow, а также любые другие CamelCase-идентификаторы классов/типов/методов из features/auth и oauth модулей",
+          "text": "no_code_identifiers_in_body — sections 1-8 do not contain codebase names: OAuthClient, OAuthTokens, OAuthResult, OAuthException, AuthState, AuthComponent, AuthUseCase, TokenStorage, OAuthBrowser, FrameClient, StateFlow, or any other CamelCase class/type/method identifiers from the features/auth and oauth modules",
           "type": "quality"
         },
         {
-          "text": "section_9_known_defects_present — спека содержит §9 Known defects с заголовком-соответствием и либо ≥1 записью, либо явным N/A",
+          "text": "section_9_known_defects_present — the spec contains §9 Known defects with a matching heading and either ≥1 entry or an explicit N/A",
           "type": "structural"
         },
         {
-          "text": "section_9_entries_structured — каждая запись в §9 содержит все 4 поля: what / class / evidence (path:line) / consequence",
+          "text": "section_9_entries_structured — every §9 entry contains all 4 fields: what / class / evidence (path:line) / consequence",
           "type": "quality"
         },
         {
-          "text": "defect_koin_not_wired — §9 содержит запись про authFeatureKoinModule / AuthUseCase DI wiring (crash на login tap)",
+          "text": "defect_koin_not_wired — §9 contains an entry about authFeatureKoinModule / AuthUseCase DI wiring (crash on login tap)",
           "type": "correctness"
         },
         {
-          "text": "defect_sign_up_dead_link — §9 содержит запись про dead link на accounts.frame.io/welcome (no registered deep-link handler)",
+          "text": "defect_sign_up_dead_link — §9 contains an entry about the dead link to accounts.frame.io/welcome (no registered deep-link handler)",
           "type": "correctness"
         },
         {
-          "text": "hygiene_hardcoded_cancel — `<slug>-hygiene.md` содержит запись про hardcoded 'Cancel' (localization-readiness hygiene per references/analysis-checklist.md §14 — feature behaves correctly today, gap manifests only when project ships another locale)",
+          "text": "hygiene_hardcoded_cancel — `<slug>-hygiene.md` contains an entry about the hardcoded 'Cancel' string (localization-readiness hygiene per references/analysis-checklist.md §14 — the feature behaves correctly today; the gap manifests only when the project ships another locale)",
           "type": "correctness"
         },
         {
-          "text": "section_13_is_code_map — в переименованной §13 лежит Code Map с path:line записями",
+          "text": "section_13_is_code_map — the renamed §13 contains the Code Map with path:line entries",
           "type": "structural"
         }
       ]
@@ -74,53 +74,53 @@
     {
       "id": 2,
       "name": "eval-prose-input-discovery",
-      "prompt": "В проекте FrameIO есть экран авторизации — не помню точно как называется класс, но это фича где юзер логинится через OAuth. Собери по коду спеку чтобы я потом мог эту фичу переписать на другом стеке.",
-      "expected_output": "Skill сначала находит фичу через discovery-pass, документирует кандидаты в state-file, затем делает полную спеку на правильный target (features/auth). Все структурные/качественные требования как в eval 1.",
-      "principle": "prose input — проверка discovery-pass и подтверждения перед анализом",
+      "prompt": "FrameIO has an authentication screen — I don't remember the exact class name, but it's the feature where the user signs in via OAuth. Build a spec from the code so I can later re-implement this feature on a different stack.",
+      "expected_output": "The skill first locates the feature via a discovery pass, documents the candidates in the state file, then produces the full spec for the correct target (features/auth). All structural and quality requirements as in eval 1.",
+      "principle": "prose input — verifying the discovery pass and confirmation before analysis",
       "files": [],
       "assertions": [
         {
-          "text": "state_file_documents_discovery — state-файл `swarm-report/reverse-spec-<slug>-state.md` содержит явную секцию с 1+ кандидатами из Phase 0.1, с evidence (имена файлов/классов, ключевые слова-совпадения) для каждого",
+          "text": "state_file_documents_discovery — the state file `swarm-report/reverse-spec-<slug>-state.md` contains an explicit section with 1+ candidates from Phase 0.1, with evidence (file/class names, keyword matches) for each",
           "type": "process"
         },
         {
-          "text": "discovery_landed_on_features_auth — итоговый target — features/auth/ (либо явный пакет dev.androidbroadcast.frameio.features.auth)",
+          "text": "discovery_landed_on_features_auth — the resolved target is features/auth/ (or the explicit package dev.androidbroadcast.frameio.features.auth)",
           "type": "correctness"
         },
         {
-          "text": "spec_has_all_13_sections — auth-spec.md содержит все 13 секций шаблона",
+          "text": "spec_has_all_13_sections — auth-spec.md contains all 13 template sections",
           "type": "structural"
         },
         {
-          "text": "body_is_tech_agnostic — тело не упоминает Compose/Decompose/Koin/Ktor кроме §10 / §11 / §12 / §13",
+          "text": "body_is_tech_agnostic — the body does not mention Compose/Decompose/Koin/Ktor outside §10 / §11 / §12 / §13",
           "type": "quality"
         },
         {
-          "text": "code_map_uses_line_ranges — Code Map с path:line granularity",
+          "text": "code_map_uses_line_ranges — Code Map uses path:line granularity",
           "type": "quality"
         },
         {
-          "text": "open_questions_has_entries — §8 ≥3 записи",
+          "text": "open_questions_has_entries — §8 has ≥3 entries",
           "type": "quality"
         },
         {
-          "text": "no_code_identifiers_in_body — в секциях 1-8 отсутствуют имена из кодовой базы (CamelCase-классы/типы/методы из features/auth и oauth модулей; имена sealed-class кейсов вроде Authenticated/Unauthenticated/Error)",
+          "text": "no_code_identifiers_in_body — sections 1-8 do not contain codebase names (CamelCase classes/types/methods from the features/auth and oauth modules; sealed-class case names like Authenticated/Unauthenticated/Error)",
           "type": "quality"
         },
         {
-          "text": "section_9_known_defects_present — спека содержит §9 Known defects (или явный N/A)",
+          "text": "section_9_known_defects_present — the spec contains §9 Known defects (or an explicit N/A)",
           "type": "structural"
         },
         {
-          "text": "section_9_entries_structured — каждая запись §9 содержит what / class / evidence (path:line) / consequence",
+          "text": "section_9_entries_structured — every §9 entry contains what / class / evidence (path:line) / consequence",
           "type": "quality"
         },
         {
-          "text": "defect_sign_up_dead_link — §9 упоминает dead link на accounts.frame.io/welcome",
+          "text": "defect_sign_up_dead_link — §9 mentions the dead link to accounts.frame.io/welcome",
           "type": "correctness"
         },
         {
-          "text": "section_13_is_code_map — §13 = Code Map с path:line",
+          "text": "section_13_is_code_map — §13 = Code Map with path:line entries",
           "type": "structural"
         }
       ]
@@ -128,73 +128,73 @@
     {
       "id": 3,
       "name": "eval-load-bearing-tech",
-      "prompt": "Сделай reverse-spec на OAuth-часть авторизации в FrameIO (oauth/ модуль). Там PKCE и специфика под платформы (Android Chrome Custom Tabs, iOS ASWebAuthenticationSession, Desktop — локальный redirect server). Это важно сохранить на любой другой реализации, потому что иначе безопасность/UX OAuth потеряется.",
-      "expected_output": "Спека корректно идентифицирует PKCE и platform browser integration как load-bearing, помещает их в §10 с capability-first phrasing. В теле не упоминаются Ktor/Koin/kotlinx.serialization — только capability-level требования. State-файл `swarm-report/reverse-spec-<slug>-state.md` явно перечисляет 4-question test для каждой рассмотренной технологии.",
-      "principle": "load-bearing technology — проверка tech-abstraction.md heuristic на практике",
+      "prompt": "Run reverse-spec on the OAuth portion of FrameIO authentication (the oauth/ module). It uses PKCE and platform-specific browser integration (Android Chrome Custom Tabs, iOS ASWebAuthenticationSession, Desktop — a local redirect server). These need to be preserved in any re-implementation, otherwise the security/UX of OAuth is lost.",
+      "expected_output": "The spec correctly identifies PKCE and platform browser integration as load-bearing and places them in §10 with capability-first phrasing. The body does not mention Ktor/Koin/kotlinx.serialization — only capability-level requirements. The state file `swarm-report/reverse-spec-<slug>-state.md` explicitly lists the 4-question test for each technology considered.",
+      "principle": "load-bearing technology — verifying the tech-abstraction.md heuristic in practice",
       "files": [],
       "assertions": [
         {
-          "text": "pkce_classified_load_bearing — PKCE явно описан как load-bearing и помещён в §10 Tech-specific constraints",
+          "text": "pkce_classified_load_bearing — PKCE is explicitly described as load-bearing and placed in §10 Tech-specific constraints",
           "type": "correctness"
         },
         {
-          "text": "platform_browser_classified_load_bearing — Chrome Custom Tabs / ASWebAuthenticationSession / desktop local redirect server в §10 с указанием, что конкретные механизмы важны для security+UX OAuth",
+          "text": "platform_browser_classified_load_bearing — Chrome Custom Tabs / ASWebAuthenticationSession / desktop local redirect server appear in §10 with a note that the specific mechanisms matter for OAuth security + UX",
           "type": "correctness"
         },
         {
-          "text": "ktor_not_in_body — Ktor не упоминается в теле спеки (секции 1-8) — только в §10/§11/§12/§13 (где разрешены tech-named упоминания) или вообще отсутствует",
+          "text": "ktor_not_in_body — Ktor is not mentioned in the spec body (sections 1-8) — only in §10/§11/§12/§13 (where tech-named mentions are allowed) or absent altogether",
           "type": "quality"
         },
         {
-          "text": "koin_not_in_body — Koin не упоминается в теле спеки (только code map или отсутствует)",
+          "text": "koin_not_in_body — Koin is not mentioned in the spec body (code map only, or absent)",
           "type": "quality"
         },
         {
-          "text": "kotlinx_serialization_not_in_body — kotlinx.serialization не упоминается в теле (только code map или отсутствует)",
+          "text": "kotlinx_serialization_not_in_body — kotlinx.serialization is not mentioned in the body (code map only, or absent)",
           "type": "quality"
         },
         {
-          "text": "secure_storage_abstracted — Settings-библиотека абстрагирована до capability 'platform secure storage' / 'защищённое хранилище', а не прямая ссылка на `Settings`/`multiplatform-settings` в теле",
+          "text": "secure_storage_abstracted — the Settings library is abstracted to the capability 'platform secure storage' rather than a direct reference to `Settings` / `multiplatform-settings` in the body",
           "type": "quality"
         },
         {
-          "text": "four_question_test_documented — state-файл `swarm-report/reverse-spec-<slug>-state.md` содержит явные ответы на 4-question test (behavior dependency, integration rework, unique capability, cost/licensing) для каждой рассмотренной технологии",
+          "text": "four_question_test_documented — the state file `swarm-report/reverse-spec-<slug>-state.md` contains explicit answers to the 4-question test (behavior dependency, integration rework, unique capability, cost/licensing) for each technology considered",
           "type": "process"
         },
         {
-          "text": "capability_first_phrasing — §10 записи используют паттерн '[capability] — currently provided by [tech], any equivalent is acceptable that preserves [property]' или эквивалентный",
+          "text": "capability_first_phrasing — §10 entries use the pattern '[capability] — currently provided by [tech], any equivalent is acceptable that preserves [property]' or an equivalent",
           "type": "quality"
         },
         {
-          "text": "spec_has_all_13_sections — oauth-spec.md содержит все 13 секций шаблона",
+          "text": "spec_has_all_13_sections — oauth-spec.md contains all 13 template sections",
           "type": "structural"
         },
         {
-          "text": "no_code_identifiers_in_body — в секциях 1-8 отсутствуют имена из кодовой базы: OAuthClient, OAuthTokens, OAuthResult, OAuthException, OAuthBrowser, PKCEGenerator, TokenStorage, OAuthStateStorage, AuthorizationUrlBuilder и другие CamelCase-типы из oauth модуля; состояния описаны в бизнес-терминах, а не именами sealed-class кейсов",
+          "text": "no_code_identifiers_in_body — sections 1-8 do not contain codebase names: OAuthClient, OAuthTokens, OAuthResult, OAuthException, OAuthBrowser, PKCEGenerator, TokenStorage, OAuthStateStorage, AuthorizationUrlBuilder, and other CamelCase types from the oauth module; states are described in business terms, not by sealed-class case names",
           "type": "quality"
         },
         {
-          "text": "section_9_known_defects_present — спека содержит §9 Known defects (или явный N/A)",
+          "text": "section_9_known_defects_present — the spec contains §9 Known defects (or an explicit N/A)",
           "type": "structural"
         },
         {
-          "text": "section_9_entries_structured — каждая запись §9 содержит what / class / evidence (path:line) / consequence",
+          "text": "section_9_entries_structured — every §9 entry contains what / class / evidence (path:line) / consequence",
           "type": "quality"
         },
         {
-          "text": "hygiene_weak_prng — `<slug>-hygiene.md` содержит запись про слабый PRNG (kotlin.random.Random вместо SecureRandom) для PKCE state или code_verifier (security-posture hygiene per references/analysis-checklist.md §14 — feature flow completes successfully; problem is the strength of the secret, not feature behavior)",
+          "text": "hygiene_weak_prng — `<slug>-hygiene.md` contains an entry about a weak PRNG (kotlin.random.Random instead of SecureRandom) for the PKCE state or code_verifier (security-posture hygiene per references/analysis-checklist.md §14 — the feature flow completes successfully; the issue is the strength of the secret, not feature behavior)",
           "type": "correctness"
         },
         {
-          "text": "hygiene_nonsecure_token_storage — `<slug>-hygiene.md` содержит запись про токены в non-encrypted storage (multiplatform-settings) как security-posture hygiene (per references/analysis-checklist.md §14 — feature works; risk is about device-compromise threat models, not feature behavior)",
+          "text": "hygiene_nonsecure_token_storage — `<slug>-hygiene.md` contains an entry about tokens in non-encrypted storage (multiplatform-settings) as security-posture hygiene (per references/analysis-checklist.md §14 — the feature works; the risk concerns device-compromise threat models, not feature behavior)",
           "type": "correctness"
         },
         {
-          "text": "defect_process_death_asymmetry — §9 отмечает что process-death recovery только на Android (iOS/Desktop теряют in-flight auth)",
+          "text": "defect_process_death_asymmetry — §9 notes that process-death recovery is implemented on Android only (iOS/Desktop lose in-flight auth)",
           "type": "correctness"
         },
         {
-          "text": "section_13_is_code_map — §13 = Code Map с path:line",
+          "text": "section_13_is_code_map — §13 = Code Map with path:line entries",
           "type": "structural"
         }
       ]

--- a/plugins/developer-workflow/skills/reverse-spec/references/analysis-checklist.md
+++ b/plugins/developer-workflow/skills/reverse-spec/references/analysis-checklist.md
@@ -385,9 +385,9 @@ final spec writes itself.
 
 ### States
 - loading: spinner centered, no copy; triggered while order fetch is in flight
-- error (network): ErrorBanner with "Не удалось загрузить заказ. Проверьте интернет.";
+- error (network): ErrorBanner with "Failed to load order. Check your connection.";
   retry action present
-- error (order not found): full-screen empty state with "Заказ не найден" and "Назад"
+- error (order not found): full-screen empty state with "Order not found" and "Back"
 …
 ```
 

--- a/plugins/developer-workflow/skills/reverse-spec/references/anti-patterns.md
+++ b/plugins/developer-workflow/skills/reverse-spec/references/anti-patterns.md
@@ -36,9 +36,9 @@ downstream when someone treats it as truth.
 ## Batching questions on the first pass
 
 The user's preference by default is one question per round, because later questions
-depend on earlier answers. Batch only when the user explicitly asks ("задавай всё
-сразу"). Batching feels efficient but commonly produces shallower clarifications and
-a queue of questions that needed the previous answers to formulate.
+depend on earlier answers. Batch only when the user explicitly asks ("ask them all at
+once" / "batch"). Batching feels efficient but commonly produces shallower clarifications
+and a queue of questions that needed the previous answers to formulate.
 
 ## Hiding absent conventions
 
@@ -81,6 +81,6 @@ to be done anyway — but now mid-document, which is harder.
 
 Phase 3 is the live interview with the user — questions get answers and close
 immediately. §8 Open Questions is the section for questions that could *not* be
-resolved in interview (user said "не знаю", no authoritative source available). Do
-not dump every Phase 3 question into §8 — only the ones that remain open after the
-interview.
+resolved in interview (user said "don't know", no authoritative source available).
+Do not dump every Phase 3 question into §8 — only the ones that remain open after
+the interview.

--- a/plugins/developer-workflow/skills/reverse-spec/references/behavior-translation.md
+++ b/plugins/developer-workflow/skills/reverse-spec/references/behavior-translation.md
@@ -316,7 +316,7 @@ effect.
 
 The translation rule drops *code identifiers*. It does not drop:
 
-- **Exact user-visible copy** — quote verbatim: `"Cancel"`, `"Не удалось загрузить заказ"`.
+- **Exact user-visible copy** — quote verbatim: `"Cancel"`, `"Failed to load order"`.
 - **Exact numbers** — retry count 3, timeout 5 minutes, buffer 60 seconds.
 - **Exact external contracts** — URL patterns, query parameter names (they are the
   *contract* with an external system, not internal code).

--- a/plugins/developer-workflow/skills/reverse-spec/references/coverage-verification.md
+++ b/plugins/developer-workflow/skills/reverse-spec/references/coverage-verification.md
@@ -246,12 +246,12 @@ Any failure blocks the DoD gate for §13.
 
 A trailing pass, light but mandatory. Run through the body and catch:
 
-- stray orphan spaces inside words (`«не заверш ается»`)
+- stray orphan spaces inside words (`"does not fin ish"`)
 - common misspellings in the document's working language
 - inconsistent punctuation around code spans / quotes
-- accidentally doubled words ("the the", "для для")
-- mixed Latin / Cyrillic characters that look identical (e.g., Latin `a` inside a
-  Cyrillic word)
+- accidentally doubled words (`"the the"`, `"and and"`)
+- mixed Latin / non-Latin characters that look identical (e.g., a Cyrillic `a`
+  (U+0430) inside a Latin word, only relevant when the document mixes scripts)
 
 This is not a rigorous spell-check pass — it is the equivalent of a quick proofread.
 A spec with typos in the body reads as sloppy and erodes reader trust in the more

--- a/plugins/developer-workflow/skills/reverse-spec/references/project-overview-protocol.md
+++ b/plugins/developer-workflow/skills/reverse-spec/references/project-overview-protocol.md
@@ -89,9 +89,9 @@ In Phase 0.6 (between output-path resolution and static analysis), the skill:
    b. Captures relevant excerpts in the state file.
    c. Notes the path so the feature spec can cross-reference instead of duplicate.
 3. If not found:
-   a. Tells the user — *"Не нашёл project-overview в `docs/project-overview.md` или
-      аналогах. Хотел бы предложить набросок (минут на 5 чтения), чтобы фича-спека
-      могла на него ссылаться вместо дублирования. Создать?"*
+   a. Tells the user — *"No project-overview found at `docs/project-overview.md` or
+      its aliases. I'd like to draft one (about 5 minutes of reading) so the feature
+      spec can reference it instead of duplicating context. Create it?"*
    b. If the user agrees, the skill drafts a project-overview from what it can
       observe in the repo (README, package metadata, top-level config files, source
       layout). The draft is **explicit about confidence** — every claim is sourced
@@ -129,16 +129,16 @@ content (e.g., the overview says "supported languages: en, ru" but the app added
 de), the skill:
 
 1. Flags the discrepancy in the state file.
-2. Mentions it once in the handoff: *"Замечено в project-overview.md: <field> может
-   быть устаревшим — наблюдаемое в коде <X>, в документе <Y>. Обновлять не стал —
-   это вне scope текущей фичи."*
+2. Mentions it once in the handoff: *"Noticed in project-overview.md: <field> may be
+   stale — observed in code: <X>, document says: <Y>. Did not update — out of scope for
+   the current feature."*
 
 The skill never silently edits the project overview. Updates are user-driven, like
 the document's initial creation.
 
 ## When to skip Phase 0.6
 
-- The user explicitly says "пропусти project-overview" or "у меня одиночный спек".
+- The user explicitly says "skip project-overview" / "single-feature repo, no overview needed" (or any equivalent phrasing).
 - The repo is a single-feature library (no cross-feature context to share).
 - The skill is being run for retrospective documentation of a feature in a repo
   that has no plans for additional features.


### PR DESCRIPTION
## Summary

Closes the residual i18n debt that blocks the v0.14.0 release per the **"all extension content must be in English"** non-negotiable in `CLAUDE.md`. Surfaced during Copilot review on PR #192 — Copilot flagged 2 spots in the diff, but a full audit (`rg '[А-Яа-я]' plugins/`) showed 83 lines across 7 files in `reverse-spec` (out of scope for #192's cleanup).

## Changes

- `SKILL.md` — translates handoff/prompt samples in Phases 0/1/3/7 (scope-boundary confirmation, scope sanity check, state-resume prompt, language-override prompt, pacing announcement, "don't know" answer, batch override, commit prompt).
- `references/project-overview-protocol.md` — overview-creation prompt + outdated-field handoff line + "skip project-overview" override.
- `references/anti-patterns.md` — batch-trigger phrasing + §8 Open Questions trigger ("don't know").
- `references/coverage-verification.md` — typo-sweep examples re-cast in English (with the Cyrillic confusable example expressed via U+0430).
- `references/analysis-checklist.md` + `references/behavior-translation.md` — example user-visible copy translated to English in the illustrative state-file capture.
- `evals/evals.json` — full rewrite in English: 3 evals, 41 assertions. All code identifiers, package names, API parameter names, and assertion `text` formats preserved.

## Verification

- `rg '[А-Яа-я]' plugins/` → no matches (only U+0430 inside a code span on coverage-verification.md, expressly documenting a confusable, no Russian prose).
- `python3 -c "import json; json.load(...)" evals.json` → valid JSON.
- `bash scripts/validate.sh` → green.

No version bumps — this PR ships as part of the 0.14.0 release alongside #192. Tag `v0.14.0` to be pushed only after this lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)