### PR TITLE
research: tighten triggers, add min-2-tracks rule, conditional Web/auto-review

### DIFF
--- a/plugins/developer-workflow/skills/create-pr/SKILL.md
+++ b/plugins/developer-workflow/skills/create-pr/SKILL.md
@@ -104,7 +104,7 @@ Look for artifacts in `./swarm-report/` that match the current branch/task slug.
 
 | Artifact | Location | Purpose in body |
 |---|---|---|
-| research | `swarm-report/<slug>-research.md` | Link + 1-sentence abstract in "Context" section |
+| research | `swarm-report/research/research-<slug>.md` | Link + 1-sentence abstract in "Context" section |
 | spec | `docs/specs/<YYYY-MM-DD>-<slug>.md` (written by `write-spec`) | Reference as "Specification" |
 | plan | `swarm-report/<slug>-plan.md` | Reference as "Plan"; acceptance criteria extracted for "How to test" |
 | debug | `swarm-report/<slug>-debug.md` | Root cause + reproduction steps — primary context for bug-fix PRs |

--- a/plugins/developer-workflow/skills/research/SKILL.md
+++ b/plugins/developer-workflow/skills/research/SKILL.md
@@ -10,9 +10,15 @@ Parallel expert investigation of a topic before implementation. The Research Con
 launches up to 5 domain agents simultaneously, each investigating their slice independently,
 then synthesizes findings into a single structured report.
 
-**Synthesis-bias prevention:** the agents that gather data never synthesize it. Each runs in
-isolation with no visibility into the others. A separate reviewer (business-analyst) challenges
-the merged synthesis afterwards. This separation is the core value of the skill — preserve it.
+**Synthesis-bias prevention.** The core invariant: **agents that gather data never synthesize
+it.** Each gather-agent runs in isolation with no visibility into the others — only the
+orchestrator merges their findings. This gather/synthesize separation is what makes the
+consortium worth the cost; preserve it across every change.
+
+A second, optional layer is the post-synthesis review: in product-angled topics a separate
+`business-analyst` agent challenges the merged report (Phase 4 `business-analyst` mode);
+in purely technical topics the orchestrator runs a self-check against a fixed checklist
+(`tech-sanity` mode). The reviewer layer is a defence-in-depth, not the core value.
 
 ---
 
@@ -28,10 +34,19 @@ Select expert tracks:
 | Track | Include when |
 |---|---|
 | **Codebase** | Topic touches existing code, patterns, or modules |
-| **Web** | Topic compares against industry practices outside our code; involves external libraries/frameworks/protocols whose best practices may diverge from the codebase; benchmarks, post-mortems, or articles on similar problems are needed; or the question explicitly asks about "industry consensus" / "how big projects do it". Skip when all signals are internal-only |
+| **Web** | See criteria below — conditional, skip for purely internal topics |
 | **Docs** | Topic involves specific libraries/frameworks with external documentation |
 | **Dependencies** | Topic involves adding, replacing, or evaluating JVM/KMP deps |
 | **Architecture** | Topic affects module boundaries, layer design, or API contracts |
+
+**Web track inclusion** — launch when ANY of the following holds, otherwise skip:
+- Topic compares against industry practices outside our code.
+- Involves external libraries/frameworks/protocols whose best practices may diverge from the codebase.
+- Benchmarks, post-mortems, or articles on similar problems are needed.
+- The question explicitly asks about "industry consensus" / "how big projects do it".
+
+Skipping Web on purely internal topics avoids generic web noise and saves a track for
+something that adds signal.
 
 **If scope is genuinely ambiguous** (multiple valid interpretations), state the assumed scope and ask **one** clarifying question. Otherwise proceed — the auto-review step catches major gaps.
 
@@ -48,6 +63,13 @@ If the topic resolves to **only one** expert track after applying selection crit
 | Web only | Answer inline with `WebSearch` / `WebFetch` |
 
 Report the redirect in one line ("Topic is narrow — handing off to {target} instead of running the consortium"), then exit. Do not create state or report artifacts for redirected topics.
+
+**Caller contract.** Skills that invoke `research` as a subroutine (e.g. `write-spec` Phase 1)
+must handle two outcomes: (a) full report at `./swarm-report/<slug>-research.md` — proceed
+normally; (b) inline redirect notice with no artifact — fold the redirect target's output
+into the caller's flow inline, do not block waiting for a file. Callers that cannot accept
+the inline outcome must either widen their input to ensure ≥2 tracks or pre-validate scope
+before invoking research.
 
 Generate kebab-case slug from the topic (e.g., `ktor-migration`, `push-notifications`):
 - Artifact: `./swarm-report/<slug>-research.md`
@@ -177,6 +199,13 @@ Use **`tech-sanity`** (lightweight self-check, no agent launch) when the topic i
 technical with no product angle — e.g. "which DI", "which serializer", "which test runner",
 "sync vs async retries". Running business-analyst here adds tokens and latency without
 producing actionable output.
+
+**Tiebreaker.** When the topic could plausibly fit either mode (e.g. "Coil vs Glide" where
+the technical pick subtly affects app size and MVP scope), default to `tech-sanity`. Promote
+to `business-analyst` only if the report's recommendation materially depends on a product /
+scope judgement that the gatherers did not make. The cost asymmetry is real — `tech-sanity`
+is free, `business-analyst` is a full agent launch — so bias toward the cheaper option when
+in doubt.
 
 ### Mode `business-analyst`
 

--- a/plugins/developer-workflow/skills/research/SKILL.md
+++ b/plugins/developer-workflow/skills/research/SKILL.md
@@ -79,7 +79,7 @@ Report the redirect in one line ("Topic is narrow — handing off to {target} in
 
 Generate kebab-case slug from the topic (e.g., `ktor-migration`, `push-notifications`):
 - Artifact: `./swarm-report/research/research-<slug>.md`
-- State: `./swarm-report/research/research-<slug>-state.md`
+- State: `./swarm-report/research-<slug>-state.md`
 
 ---
 
@@ -94,7 +94,7 @@ Architecture) with their tools and required structure.
 
 ### State persistence
 
-Before launching, create `./swarm-report/research/research-<slug>-state.md`:
+Before launching, create `./swarm-report/research-<slug>-state.md`:
 
 ```markdown
 # Research State: {topic}
@@ -120,14 +120,18 @@ Started: {date}
 not user-facing)
 ```
 
-The state file and any other temp files under `./swarm-report/research/` are for the
-orchestrator's internal use: progress tracking, inter-phase info passing, expert-output
-buffering for compaction resilience. Update the checklist as each agent completes and
-fold raw findings here if it helps survive a compaction.
+The state file and any other temp files live at the `./swarm-report/` **root** —
+that's the temp/working area. Use them freely for the orchestrator's internal needs:
+progress tracking, inter-phase info passing, expert-output buffering for compaction
+resilience. Update the checklist as each agent completes and fold raw findings here if
+it helps survive a compaction.
+
+The `./swarm-report/research/` subdirectory is reserved for **finished deliverables**
+only — the polished report from Phase 5.2 lands there, nothing else.
 
 **What does not go into any file** is the user-facing dialogue — clarification questions
 and the user's answers from Phase 1 / Phase 5.1 round-loops live exclusively in the chat
-session. The polished, finished report lands on disk only in Phase 5.2.
+session.
 
 ---
 
@@ -135,9 +139,9 @@ session. The polished, finished report lands on disk only in Phase 5.2.
 
 Combine findings into a structured synthesis held primarily in working memory. The
 synthesis is mutable until Phase 5 closes the clarification round-loop, so **do not write
-the final report here** — that is exclusively Phase 5.2. Internal temp files under
-`./swarm-report/research/` (state file, inter-phase buffers) are allowed if they help
-survive compaction. Cross-reference findings for:
+the final report here** — that is exclusively Phase 5.2. Internal temp files at the
+`./swarm-report/` root (state file, inter-phase buffers) are allowed if they help survive
+compaction. Cross-reference findings for:
 - **Convergence** — multiple experts independently agree (strongest signal)
 - **Contradictions** — surface explicitly, do not paper over
 - **Gaps** — what no expert covered
@@ -352,7 +356,7 @@ Stop and escalate when:
 | Artifact | Path | Purpose |
 |---|---|---|
 | Research report | `./swarm-report/research/research-<slug>.md` | Final synthesized findings |
-| State file | `./swarm-report/research/research-<slug>-state.md` | Compaction-resilient progress tracking |
+| State file | `./swarm-report/research-<slug>-state.md` | Compaction-resilient progress tracking |
 | Chat summary | — | ≤30-line user-facing post-save output |
 
 The research report is the primary deliverable. The state file is operational and may be

--- a/plugins/developer-workflow/skills/research/SKILL.md
+++ b/plugins/developer-workflow/skills/research/SKILL.md
@@ -64,14 +64,6 @@ If the topic resolves to **only one** expert track after applying selection crit
 
 Report the redirect in one line ("Topic is narrow — handing off to {target} instead of running the consortium"), then exit. Do not create state or report artifacts for redirected topics.
 
-**Caller contract.** No skill currently invokes `research` as a subroutine — `write-spec`
-runs its own research orchestration inline. This contract is defensive documentation for
-any future subskill caller. Such a caller must handle two outcomes: (a) full report at
-`./swarm-report/<slug>-research.md` — proceed normally; (b) inline redirect notice with no
-artifact — fold the redirect target's output into the caller's flow inline, do not block
-waiting for a file. Callers that cannot accept the inline outcome must either widen their
-input to ensure ≥2 tracks or pre-validate scope before invoking research.
-
 Generate kebab-case slug from the topic (e.g., `ktor-migration`, `push-notifications`):
 - Artifact: `./swarm-report/<slug>-research.md`
 - State: `./swarm-report/research-<slug>-state.md`

--- a/plugins/developer-workflow/skills/research/SKILL.md
+++ b/plugins/developer-workflow/skills/research/SKILL.md
@@ -73,7 +73,7 @@ If the topic resolves to **only one** expert track after applying selection crit
 | Docs only | Use a library-docs lookup tool (Context7-style) directly |
 | Dependencies only | Use a dependency/version lookup tool directly (e.g. the `maven-mcp` skill family if installed) |
 | Architecture only | Delegate to `architecture-expert` agent directly |
-| Web only | Answer inline with the available web-search tool |
+| Web only | Answer inline with the available web-search tool; if none is available, answer from training knowledge and explicitly note the limitation |
 
 Report the redirect in one line ("Topic is narrow — handing off to {target} instead of running the consortium"), then exit. Do not create state or report artifacts for redirected topics.
 

--- a/plugins/developer-workflow/skills/research/SKILL.md
+++ b/plugins/developer-workflow/skills/research/SKILL.md
@@ -114,20 +114,30 @@ Started: {date}
 - [ ] Docs — {launched | skipped: reason}
 - [ ] Dependencies — {launched | skipped: reason}
 - [ ] Architecture — {launched | skipped: reason}
+
+## Findings
+(populated as each agent reports back — internal working storage for the orchestrator,
+not user-facing)
 ```
 
-The state file is a **progress checklist only** — track which expert launched/finished,
-status (`investigating` / `done`), and a slug for resume. Do **not** dump expert findings
-or clarification answers here; those live in working memory and only the finished report
-ever lands on disk. Update the checklist as each agent completes.
+The state file and any other temp files under `./swarm-report/research/` are for the
+orchestrator's internal use: progress tracking, inter-phase info passing, expert-output
+buffering for compaction resilience. Update the checklist as each agent completes and
+fold raw findings here if it helps survive a compaction.
+
+**What does not go into any file** is the user-facing dialogue — clarification questions
+and the user's answers from Phase 1 / Phase 5.1 round-loops live exclusively in the chat
+session. The polished, finished report lands on disk only in Phase 5.2.
 
 ---
 
 ## Phase 3: Synthesize Findings
 
-Combine findings into a structured synthesis held in working memory. **Do not write any
-file in this phase** — the synthesis is mutable until Phase 5 closes the clarification
-round-loop. Cross-reference findings for:
+Combine findings into a structured synthesis held primarily in working memory. The
+synthesis is mutable until Phase 5 closes the clarification round-loop, so **do not write
+the final report here** — that is exclusively Phase 5.2. Internal temp files under
+`./swarm-report/research/` (state file, inter-phase buffers) are allowed if they help
+survive compaction. Cross-reference findings for:
 - **Convergence** — multiple experts independently agree (strongest signal)
 - **Contradictions** — surface explicitly, do not paper over
 - **Gaps** — what no expert covered
@@ -284,9 +294,10 @@ round**, wait for the answer, fold it into the synthesis, then check if any bloc
 remains. Multiple rounds are fine; multiple questions in one round are not. Stop the
 moment no blocker remains.
 
-The dialogue lives in chat, not in any file. Don't park "pending" questions in the report
-or the state file — those are working buffers for findings, not for unresolved
-clarifications. State-file `Status: investigating` covers the in-progress signal.
+The dialogue lives in chat. Internal temp files (state file, inter-phase buffers) may
+record that a clarification round is in progress via `Status: awaiting-clarification`,
+but the actual question text and the user's answer are not parked there — they belong to
+the chat session.
 
 What does **not** belong in the round-loop:
 - Stylistic preferences that don't change the recommendation.

--- a/plugins/developer-workflow/skills/research/SKILL.md
+++ b/plugins/developer-workflow/skills/research/SKILL.md
@@ -316,10 +316,11 @@ What does **not** belong in the round-loop:
 
 ### 5.2 Save the final report
 
-Once the loop exits, write `./swarm-report/research/research-<slug>.md`. The report is a finished
-deliverable, not a scratchpad — every section reflects the post-clarification synthesis,
-and Open Questions contains only the genuinely-not-resolvable-by-research items from
-above. Mark the state file `Status: done`.
+Once the loop exits, ensure `./swarm-report/research/` exists (`mkdir -p` it if needed —
+fresh repos won't have the nested subdir), then write `./swarm-report/research/research-<slug>.md`.
+The report is a finished deliverable, not a scratchpad — every section reflects the
+post-clarification synthesis, and Open Questions contains only the
+genuinely-not-resolvable-by-research items from above. Mark the state file `Status: done`.
 
 ### 5.3 Chat summary
 

--- a/plugins/developer-workflow/skills/research/SKILL.md
+++ b/plugins/developer-workflow/skills/research/SKILL.md
@@ -78,8 +78,8 @@ If the topic resolves to **only one** expert track after applying selection crit
 Report the redirect in one line ("Topic is narrow — handing off to {target} instead of running the consortium"), then exit. Do not create state or report artifacts for redirected topics.
 
 Generate kebab-case slug from the topic (e.g., `ktor-migration`, `push-notifications`):
-- Artifact: `./swarm-report/<slug>-research.md`
-- State: `./swarm-report/research-<slug>-state.md`
+- Artifact: `./swarm-report/research/research-<slug>.md`
+- State: `./swarm-report/research/research-<slug>-state.md`
 
 ---
 
@@ -94,7 +94,7 @@ Architecture) with their tools and required structure.
 
 ### State persistence
 
-Before launching, create `./swarm-report/research-<slug>-state.md`:
+Before launching, create `./swarm-report/research/research-<slug>-state.md`:
 
 ```markdown
 # Research State: {topic}
@@ -136,7 +136,7 @@ round-loop. Cross-reference findings for:
 ### Report structure
 
 Use this exact structure when Phase 5.2 writes the final report to
-`./swarm-report/<slug>-research.md`:
+`./swarm-report/research/research-<slug>.md`:
 
 ```markdown
 # Research: {topic}
@@ -297,7 +297,7 @@ What does **not** belong in the round-loop:
 
 ### 5.2 Save the final report
 
-Once the loop exits, write `./swarm-report/<slug>-research.md`. The report is a finished
+Once the loop exits, write `./swarm-report/research/research-<slug>.md`. The report is a finished
 deliverable, not a scratchpad — every section reflects the post-clarification synthesis,
 and Open Questions contains only the genuinely-not-resolvable-by-research items from
 above. Mark the state file `Status: done`.
@@ -340,8 +340,8 @@ Stop and escalate when:
 
 | Artifact | Path | Purpose |
 |---|---|---|
-| Research report | `./swarm-report/<slug>-research.md` | Final synthesized findings |
-| State file | `./swarm-report/research-<slug>-state.md` | Compaction-resilient progress tracking |
+| Research report | `./swarm-report/research/research-<slug>.md` | Final synthesized findings |
+| State file | `./swarm-report/research/research-<slug>-state.md` | Compaction-resilient progress tracking |
 | Chat summary | — | ≤30-line user-facing post-save output |
 
 The research report is the primary deliverable. The state file is operational and may be

--- a/plugins/developer-workflow/skills/research/SKILL.md
+++ b/plugins/developer-workflow/skills/research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research
-description: "Research Consortium — parallel expert investigation of a topic, idea, problem, or technology before implementation. Launches up to 5 domain experts simultaneously (codebase, web, docs, dependencies, architecture), synthesizes findings into a structured report, auto-reviews via business-analyst. Use when: \"research\", \"investigate\", \"explore this idea\", \"technical spike\", \"feasibility\", \"can we do X?\", \"what are the options for\", \"compare approaches\", \"evaluate alternatives\", \"pros and cons of\", \"before we start — let's understand\", \"what do we need to know before\". Do NOT use for: code review (use code-reviewer agent), multiexpert review (use multiexpert-review), library version lookup (use maven-mcp:latest-version), debugging existing bugs."
+description: "Research Consortium — parallel expert investigation of a topic, idea, problem, or technology before implementation. Launches up to 5 domain experts simultaneously (codebase, web, docs, dependencies, architecture), synthesizes findings into a structured report, optionally auto-reviews via business-analyst. Use when: \"research\", \"investigate options\", \"investigate approaches\", \"explore this idea\", \"technical spike\", \"feasibility\", \"can we do X?\", \"what are the options for\", \"compare approaches\", \"evaluate alternatives\", \"pros and cons of\", \"before we start — let's understand\", \"what do we need to know before\". Do NOT use for: code review (use code-reviewer agent), multiexpert review (use multiexpert-review), narrow codebase lookup (\"how is X done in our code\" — use Explore agent directly), single-library version or changelog lookup (use maven-mcp:latest-version / dependency-changes), debugging existing bugs."
 disable-model-invocation: true
 ---
 
@@ -28,12 +28,26 @@ Select expert tracks:
 | Track | Include when |
 |---|---|
 | **Codebase** | Topic touches existing code, patterns, or modules |
-| **Web** | Always (mandatory — every research must produce ≥1 web-sourced insight) |
+| **Web** | Topic compares against industry practices outside our code; involves external libraries/frameworks/protocols whose best practices may diverge from the codebase; benchmarks, post-mortems, or articles on similar problems are needed; or the question explicitly asks about "industry consensus" / "how big projects do it". Skip when all signals are internal-only |
 | **Docs** | Topic involves specific libraries/frameworks with external documentation |
 | **Dependencies** | Topic involves adding, replacing, or evaluating JVM/KMP deps |
 | **Architecture** | Topic affects module boundaries, layer design, or API contracts |
 
 **If scope is genuinely ambiguous** (multiple valid interpretations), state the assumed scope and ask **one** clarifying question. Otherwise proceed — the auto-review step catches major gaps.
+
+### Minimum-2-tracks rule
+
+If the topic resolves to **only one** expert track after applying selection criteria, do NOT launch the consortium. The synthesis-bias prevention machinery only pays off when ≥2 independent perspectives are merged. Redirect instead:
+
+| Single track | Redirect to |
+|---|---|
+| Codebase only | Delegate to a single `Explore` agent inline |
+| Docs only | Use `Context7` / library-docs lookup directly |
+| Dependencies only | Use `maven-mcp:check-deps` or `latest-version` |
+| Architecture only | Delegate to `architecture-expert` agent directly |
+| Web only | Answer inline with `WebSearch` / `WebFetch` |
+
+Report the redirect in one line ("Topic is narrow — handing off to {target} instead of running the consortium"), then exit. Do not create state or report artifacts for redirected topics.
 
 Generate kebab-case slug from the topic (e.g., `ktor-migration`, `push-notifications`):
 - Artifact: `./swarm-report/<slug>-research.md`
@@ -68,7 +82,7 @@ Started: {date}
 
 ## Expert Tracks
 - [ ] Codebase — {launched | skipped: reason}
-- [ ] Web — launched (mandatory)
+- [ ] Web — {launched | skipped: reason}
 - [ ] Docs — {launched | skipped: reason}
 - [ ] Dependencies — {launched | skipped: reason}
 - [ ] Architecture — {launched | skipped: reason}
@@ -98,6 +112,7 @@ Save to `./swarm-report/<slug>-research.md`:
 
 Date: {date}
 Experts consulted: {tracks that ran}
+Auto-review mode: {business-analyst | tech-sanity}
 
 ## Problem / Question Summary
 {2–3 sentences: what was investigated and why}
@@ -148,6 +163,23 @@ Skip the table when one approach dominates on every dimension.
 
 ## Phase 4: Auto-Review
 
+Pick the review mode based on the topic profile, then record it in the report header as
+`Auto-review mode: business-analyst | tech-sanity`.
+
+### Mode selection
+
+Use **`business-analyst`** when the topic has a product / scope angle:
+- Decision affects feature scope, MVP boundaries, time-to-market, or user-facing trade-offs.
+- The question contains an implicit or explicit "what to build" component (not only "how to build").
+- The decision touches SLA / SLO / cost / business risk.
+
+Use **`tech-sanity`** (lightweight self-check, no agent launch) when the topic is purely
+technical with no product angle — e.g. "which DI", "which serializer", "which test runner",
+"sync vs async retries". Running business-analyst here adds tokens and latency without
+producing actionable output.
+
+### Mode `business-analyst`
+
 Launch the `business-analyst` agent against the synthesized report. The reviewer holds a
 distinct perspective from the gatherers — they check completeness, product sense,
 practical viability:
@@ -169,7 +201,24 @@ List gaps with severity (critical / major / minor).
 Respond in the same language as the research topic description.
 ```
 
-Handle findings:
+### Mode `tech-sanity`
+
+Run a self-check pass on the report against this checklist (no agent — direct verification):
+
+1. **Approaches evaluated ≥2** — at least two viable options laid out side-by-side, or an
+   explicit justification why only one survived.
+2. **Risks listed** — each approach has its risks called out with severity.
+3. **Recommendation justified** — the chosen option cites specific expert findings, not
+   "feels right".
+4. **Sources cited** — every non-obvious claim links to a codebase location, doc URL, or
+   dependency coordinate.
+
+If any item fails, fix the report before saving (re-run a track or fill the gap from the
+existing findings). Do not promote to `business-analyst` mode just because the checklist
+fails — the failure is a content gap, not a mode mismatch.
+
+### Handle findings (both modes)
+
 - **No issues** → save artifact
 - **Minor** → incorporate inline, note changes
 - **Major/critical, fillable** → re-run the relevant expert track

--- a/plugins/developer-workflow/skills/research/SKILL.md
+++ b/plugins/developer-workflow/skills/research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research
-description: "Research Consortium — parallel expert investigation of a topic, idea, problem, or technology before implementation. Launches up to 5 domain experts simultaneously (codebase, web, docs, dependencies, architecture), synthesizes findings into a structured report, optionally auto-reviews via business-analyst. Use when: \"research\", \"investigate options\", \"investigate approaches\", \"explore this idea\", \"technical spike\", \"feasibility\", \"can we do X?\", \"what are the options for\", \"compare approaches\", \"evaluate alternatives\", \"pros and cons of\", \"before we start — let's understand\", \"what do we need to know before\". Do NOT use for: code review (use code-reviewer agent), multiexpert review (use multiexpert-review), narrow codebase lookup (\"how is X done in our code\" — use Explore agent directly), single-library version or changelog lookup (use maven-mcp:latest-version / dependency-changes), debugging existing bugs."
+description: "Research Consortium — parallel expert investigation of a topic, idea, problem, or technology before implementation. Launches up to 5 domain experts simultaneously (codebase, web, docs, dependencies, architecture), synthesizes findings into a structured report, optionally auto-reviews via business-analyst (product-angled topics) or a tech-sanity self-check (purely technical topics). Use when: \"research\", \"investigate options\", \"investigate approaches\", \"explore this idea\", \"technical spike\", \"feasibility\", \"can we do X?\", \"what are the options for\", \"compare approaches\", \"evaluate alternatives\", \"pros and cons of\", \"before we start — let's understand\", \"what do we need to know before\". Do NOT use for: code review (use code-reviewer agent), multiexpert review (use multiexpert-review), narrow codebase lookup (\"how is X done in our code\" — use Explore agent directly), single-library version or changelog lookup (use a dependency/version lookup tool directly), debugging existing bugs."
 disable-model-invocation: true
 ---
 
@@ -18,7 +18,7 @@ consortium worth the cost; preserve it across every change.
 A second, optional layer is the post-synthesis review: in product-angled topics a separate
 `business-analyst` agent challenges the merged report (Phase 4 `business-analyst` mode);
 in purely technical topics the orchestrator runs a self-check against a fixed checklist
-(`tech-sanity` mode). The reviewer layer is a defence-in-depth, not the core value.
+(`tech-sanity` mode). The reviewer layer is a defense-in-depth, not the core value.
 
 ---
 
@@ -70,20 +70,22 @@ If the topic resolves to **only one** expert track after applying selection crit
 | Single track | Redirect to |
 |---|---|
 | Codebase only | Delegate to a single `Explore` agent inline |
-| Docs only | Use `Context7` / library-docs lookup directly |
-| Dependencies only | Use `maven-mcp:check-deps` or `latest-version` |
+| Docs only | Use a library-docs lookup tool (Context7-style) directly |
+| Dependencies only | Use a dependency/version lookup tool directly (e.g. the `maven-mcp` skill family if installed) |
 | Architecture only | Delegate to `architecture-expert` agent directly |
-| Web only | Answer inline with `WebSearch` / `WebFetch` |
+| Web only | Answer inline with the available web-search tool |
 
 Report the redirect in one line ("Topic is narrow — handing off to {target} instead of running the consortium"), then exit. Do not create state or report artifacts for redirected topics.
-
-Generate kebab-case slug from the topic (e.g., `ktor-migration`, `push-notifications`):
-- Artifact: `./swarm-report/research/research-<slug>.md`
-- State: `./swarm-report/research-<slug>-state.md`
 
 ---
 
 ## Phase 2: Launch Research Consortium
+
+Generate a kebab-case slug from the topic (e.g., `ktor-migration`, `push-notifications`)
+— this is the first thing that happens once the consortium is committed (post-redirect).
+Paths:
+- Artifact: `./swarm-report/research/research-<slug>.md`
+- State:    `./swarm-report/research-<slug>-state.md`
 
 Launch all selected agents **in a single message** for maximum parallelism. Each works
 independently — never share findings between agents.
@@ -156,7 +158,7 @@ Use this exact structure when Phase 5.2 writes the final report to
 
 Date: {date}
 Experts consulted: {tracks that ran}
-Auto-review mode: {business-analyst | tech-sanity}
+Auto-review mode: {business-analyst or tech-sanity}
 
 ## Problem / Question Summary
 {2–3 sentences: what was investigated and why}

--- a/plugins/developer-workflow/skills/research/SKILL.md
+++ b/plugins/developer-workflow/skills/research/SKILL.md
@@ -125,7 +125,9 @@ Update as each agent completes.
 
 ## Phase 3: Synthesize Findings
 
-Combine findings into a structured report. Cross-reference for:
+Combine findings into a structured synthesis held in working memory. **Do not write any
+file in this phase** — the synthesis is mutable until Phase 5 closes the clarification
+round-loop. Cross-reference findings for:
 - **Convergence** — multiple experts independently agree (strongest signal)
 - **Contradictions** — surface explicitly, do not paper over
 - **Gaps** — what no expert covered
@@ -133,7 +135,8 @@ Combine findings into a structured report. Cross-reference for:
 
 ### Report structure
 
-Save to `./swarm-report/<slug>-research.md`:
+Use this exact structure when Phase 5.2 writes the final report to
+`./swarm-report/<slug>-research.md`:
 
 ```markdown
 # Research: {topic}

--- a/plugins/developer-workflow/skills/research/SKILL.md
+++ b/plugins/developer-workflow/skills/research/SKILL.md
@@ -139,9 +139,8 @@ session.
 
 Combine findings into a structured synthesis held primarily in working memory. The
 synthesis is mutable until Phase 5 closes the clarification round-loop, so **do not write
-the final report here** — that is exclusively Phase 5.2. Internal temp files at the
-`./swarm-report/` root (state file, inter-phase buffers) are allowed if they help survive
-compaction. Cross-reference findings for:
+the final report here** — that is exclusively Phase 5.2. (Internal temp files allowed at
+the `./swarm-report/` root per the Phase 2 rules.) Cross-reference findings for:
 - **Convergence** — multiple experts independently agree (strongest signal)
 - **Contradictions** — surface explicitly, do not paper over
 - **Gaps** — what no expert covered
@@ -273,12 +272,16 @@ If any item fails, fix the report before saving (re-run a track or fill the gap 
 existing findings). Do not promote to `business-analyst` mode just because the checklist
 fails — the failure is a content gap, not a mode mismatch.
 
+The self-check produces no chat output; any fixes go into the synthesis silently. The
+report's prose stays in the same language as the research topic description (consistent
+with the gather-agent prompts).
+
 ### Handle findings (both modes)
 
 - **No issues** → proceed to Phase 5
 - **Minor** → incorporate inline, note changes, proceed to Phase 5
 - **Major/critical, fillable** → re-run the relevant expert track, then re-review
-- **Major/critical, not fillable from research alone** → record in the synthesis as an Open Question (item that genuinely cannot be resolved without an external decision or future input — not a question to ask the user in dialogue right now)
+- **Major/critical, not fillable from research alone** → record in the synthesis as an Open Question (semantics defined in the report template — not a chat-time clarification)
 
 The report is not saved at this phase; saving happens in Phase 5 after any user-blocking
 clarifications have been resolved in dialogue.
@@ -292,8 +295,8 @@ is on disk yet. This phase walks through three steps in order.
 
 ### 5.1 Clarification round-loop (dialogue)
 
-If the synthesis surfaces a question whose answer would change the recommendation or any
-top-3 finding, ask it in chat — same plan-mode round-loop as Phase 1: **one question per
+If the synthesis surfaces a question whose answer would materially change the recommendation
+or a key finding, ask it in chat — same plan-mode round-loop as Phase 1: **one question per
 round**, wait for the answer, fold it into the synthesis, then check if any blocker
 remains. Multiple rounds are fine; multiple questions in one round are not. Stop the
 moment no blocker remains.
@@ -306,9 +309,8 @@ the chat session.
 What does **not** belong in the round-loop:
 - Stylistic preferences that don't change the recommendation.
 - Mild gaps the consortium could plausibly fill on a re-run (re-run instead).
-- Items that genuinely cannot be resolved without external input (decisions only the user
-  can make, future deps, external SLAs) — those land in the report's Open Questions
-  section as the artifact's record of unresolved-by-design items.
+- Items unresolvable-by-research → land in the report's Open Questions (semantics in the
+  report template).
 
 ### 5.2 Save the final report
 
@@ -333,7 +335,7 @@ lets the user decide without opening the file:
 | Feature is clear, single task, ready to build | Plan mode + start implementing |
 | Complex approach, needs validation | Plan mode → `/multiexpert-review` |
 | Research revealed a bug, not a feature need | Plan mode for the fix |
-| Open questions block progress | List, ask user to resolve |
+| Open Questions remain (by-design unresolvable by research) | Note them in the summary, suggest who/when can resolve |
 | Multiple viable approaches, no clear winner | Present trade-offs, ask user to pick |
 
 Frame as actionable proposal, not a question.

--- a/plugins/developer-workflow/skills/research/SKILL.md
+++ b/plugins/developer-workflow/skills/research/SKILL.md
@@ -64,12 +64,13 @@ If the topic resolves to **only one** expert track after applying selection crit
 
 Report the redirect in one line ("Topic is narrow — handing off to {target} instead of running the consortium"), then exit. Do not create state or report artifacts for redirected topics.
 
-**Caller contract.** Skills that invoke `research` as a subroutine (e.g. `write-spec` Phase 1)
-must handle two outcomes: (a) full report at `./swarm-report/<slug>-research.md` — proceed
-normally; (b) inline redirect notice with no artifact — fold the redirect target's output
-into the caller's flow inline, do not block waiting for a file. Callers that cannot accept
-the inline outcome must either widen their input to ensure ≥2 tracks or pre-validate scope
-before invoking research.
+**Caller contract.** No skill currently invokes `research` as a subroutine — `write-spec`
+runs its own research orchestration inline. This contract is defensive documentation for
+any future subskill caller. Such a caller must handle two outcomes: (a) full report at
+`./swarm-report/<slug>-research.md` — proceed normally; (b) inline redirect notice with no
+artifact — fold the redirect target's output into the caller's flow inline, do not block
+waiting for a file. Callers that cannot accept the inline outcome must either widen their
+input to ensure ≥2 tracks or pre-validate scope before invoking research.
 
 Generate kebab-case slug from the topic (e.g., `ktor-migration`, `push-notifications`):
 - Artifact: `./swarm-report/<slug>-research.md`
@@ -185,8 +186,9 @@ Skip the table when one approach dominates on every dimension.
 
 ## Phase 4: Auto-Review
 
-Pick the review mode based on the topic profile, then record it in the report header as
-`Auto-review mode: business-analyst | tech-sanity`.
+Pick the review mode based on the topic profile, then record it in the report header
+`Auto-review mode:` field as one of `business-analyst` or `tech-sanity` (not the literal
+pipe — pick one).
 
 ### Mode selection
 

--- a/plugins/developer-workflow/skills/research/SKILL.md
+++ b/plugins/developer-workflow/skills/research/SKILL.md
@@ -48,7 +48,20 @@ Select expert tracks:
 Skipping Web on purely internal topics avoids generic web noise and saves a track for
 something that adds signal.
 
-**If scope is genuinely ambiguous** (multiple valid interpretations), state the assumed scope and ask **one** clarifying question. Otherwise proceed — the auto-review step catches major gaps.
+### Clarifying questions (round-loop)
+
+Use plan-mode pacing for any clarification: **one question per round**, wait for the answer, then re-evaluate. Multiple rounds are fine; multiple questions in one round are not. Each question must be the single most blocking ambiguity right now — not a checklist of mild curiosities.
+
+When to ask:
+- **Scope is genuinely ambiguous** (multiple valid interpretations that lead to different expert tracks or different success criteria).
+- **A constraint is missing without which the redirect / consortium decision flips** (e.g. KMP-only vs Android-only changes which tracks are relevant).
+
+When NOT to ask:
+- Mild gaps the consortium can fill itself (let agents gather, surface gaps in Open Questions).
+- Stylistic preferences that don't change the recommendation.
+- Anything the auto-review step (Phase 4) would catch.
+
+State the assumed scope when proceeding without asking. Resume Phase 1 from the top after each answered round in case the answer reshuffles track selection or triggers the min-2-tracks redirect.
 
 ### Minimum-2-tracks rule
 
@@ -257,8 +270,11 @@ Post a chat summary that lets the user decide without opening the file:
 
 1. One sentence: topic, tracks ran, overall recommendation.
 2. 3–5 bullets: most decision-relevant findings/blockers/constraints.
-3. If open questions block next steps: ask exactly ONE now, labeled "Question 1 of N:".
-   Save the rest in the report — present subsequent questions only after the user answers.
+3. If open questions block the next step: enter the same plan-mode round-loop as Phase 1
+   — ask exactly ONE now, labeled `"Question 1 of N:"`, wait for the answer, then ask the
+   next blocker on the next round. The rest stay in the report's Open Questions until
+   their round comes. Stop the loop the moment no blockers remain — non-blocking gaps
+   ride along in the report.
 4. One line: suggested next step.
 
 **Hard limit:** ≤30 lines in chat. No tables, no source lists, no inline citations.

--- a/plugins/developer-workflow/skills/research/SKILL.md
+++ b/plugins/developer-workflow/skills/research/SKILL.md
@@ -50,7 +50,7 @@ something that adds signal.
 
 ### Clarifying questions (round-loop)
 
-Use plan-mode pacing for any clarification: **one question per round**, wait for the answer, then re-evaluate. Multiple rounds are fine; multiple questions in one round are not. Each question must be the single most blocking ambiguity right now — not a checklist of mild curiosities.
+Use plan-mode pacing for any clarification: **one question per round** in chat, wait for the answer, then re-evaluate. Multiple rounds are fine; multiple questions in one round are not. Each question must be the single most blocking ambiguity right now — not a checklist of mild curiosities. The dialogue stays in chat — questions and answers are not parked in any artifact.
 
 When to ask:
 - **Scope is genuinely ambiguous** (multiple valid interpretations that lead to different expert tracks or different success criteria).
@@ -181,7 +181,10 @@ Skip the table when one approach dominates on every dimension.
 {Preferred approach with reasoning, citing specific expert findings.}
 
 ## Open Questions
-- {What needs user decision or could not be determined}
+- {Items the research itself cannot answer — user decisions, external SLA/cost data,
+  future-dated dependencies, etc. NOT a parking lot for clarifications already resolved
+  in dialogue, and NOT a queue of pending questions — those are handled in Phase 5.1 and
+  do not survive into the final report.}
 
 ## Sources
 - {URLs, doc references, codebase locations}
@@ -255,29 +258,55 @@ fails — the failure is a content gap, not a mode mismatch.
 
 ### Handle findings (both modes)
 
-- **No issues** → save artifact
-- **Minor** → incorporate inline, note changes
-- **Major/critical, fillable** → re-run the relevant expert track
-- **Major/critical, not fillable** → add to Open Questions, flag for user
+- **No issues** → proceed to Phase 5
+- **Minor** → incorporate inline, note changes, proceed to Phase 5
+- **Major/critical, fillable** → re-run the relevant expert track, then re-review
+- **Major/critical, not fillable from research alone** → record in the synthesis as an Open Question (item that genuinely cannot be resolved without an external decision or future input — not a question to ask the user in dialogue right now)
+
+The report is not saved at this phase; saving happens in Phase 5 after any user-blocking
+clarifications have been resolved in dialogue.
 
 ---
 
-## Phase 5: Save & Summarize
+## Phase 5: Resolve, Save, Summarize
 
-Save the report to `./swarm-report/<slug>-research.md`. Mark state file `done`.
+The synthesis from Phase 3 (refined by Phase 4) is held in working memory only — nothing
+is on disk yet. This phase walks through three steps in order.
 
-Post a chat summary that lets the user decide without opening the file:
+### 5.1 Clarification round-loop (dialogue)
+
+If the synthesis surfaces a question whose answer would change the recommendation or any
+top-3 finding, ask it in chat — same plan-mode round-loop as Phase 1: **one question per
+round**, wait for the answer, fold it into the synthesis, then check if any blocker
+remains. Multiple rounds are fine; multiple questions in one round are not. Stop the
+moment no blocker remains.
+
+The dialogue lives in chat, not in any file. Don't park "pending" questions in the report
+or the state file — those are working buffers for findings, not for unresolved
+clarifications. State-file `Status: investigating` covers the in-progress signal.
+
+What does **not** belong in the round-loop:
+- Stylistic preferences that don't change the recommendation.
+- Mild gaps the consortium could plausibly fill on a re-run (re-run instead).
+- Items that genuinely cannot be resolved without external input (decisions only the user
+  can make, future deps, external SLAs) — those land in the report's Open Questions
+  section as the artifact's record of unresolved-by-design items.
+
+### 5.2 Save the final report
+
+Once the loop exits, write `./swarm-report/<slug>-research.md`. The report is a finished
+deliverable, not a scratchpad — every section reflects the post-clarification synthesis,
+and Open Questions contains only the genuinely-not-resolvable-by-research items from
+above. Mark the state file `Status: done`.
+
+### 5.3 Chat summary
+
+Post a compact summary (≤30 lines, no tables, no source lists, no inline citations) that
+lets the user decide without opening the file:
 
 1. One sentence: topic, tracks ran, overall recommendation.
-2. 3–5 bullets: most decision-relevant findings/blockers/constraints.
-3. If open questions block the next step: enter the same plan-mode round-loop as Phase 1
-   — ask exactly ONE now, labeled `"Question 1 of N:"`, wait for the answer, then ask the
-   next blocker on the next round. The rest stay in the report's Open Questions until
-   their round comes. Stop the loop the moment no blockers remain — non-blocking gaps
-   ride along in the report.
-4. One line: suggested next step.
-
-**Hard limit:** ≤30 lines in chat. No tables, no source lists, no inline citations.
+2. 3–5 bullets: most decision-relevant findings / blockers / constraints.
+3. One line: suggested next step.
 
 ### Suggest next action
 

--- a/plugins/developer-workflow/skills/research/SKILL.md
+++ b/plugins/developer-workflow/skills/research/SKILL.md
@@ -114,12 +114,12 @@ Started: {date}
 - [ ] Docs — {launched | skipped: reason}
 - [ ] Dependencies — {launched | skipped: reason}
 - [ ] Architecture — {launched | skipped: reason}
-
-## Findings
-(populated as agents report back)
 ```
 
-Update as each agent completes.
+The state file is a **progress checklist only** — track which expert launched/finished,
+status (`investigating` / `done`), and a slug for resume. Do **not** dump expert findings
+or clarification answers here; those live in working memory and only the finished report
+ever lands on disk. Update the checklist as each agent completes.
 
 ---
 

--- a/plugins/developer-workflow/skills/research/references/expert-prompts.md
+++ b/plugins/developer-workflow/skills/research/references/expert-prompts.md
@@ -31,7 +31,7 @@ then findings grouped by category.
 
 ## Web Expert
 
-Mandatory track. If web search is unavailable, note it as a limitation in the report.
+Conditional track — launch only when the topic needs an external perspective (industry practices, third-party library best practices, benchmarks, post-mortems). Skip for purely internal questions. If web search is unavailable but the track was selected, note it as a limitation in the report.
 
 ```
 Research: {topic}


### PR DESCRIPTION
## Summary

Tightens the `research` skill so it stops being invoked for narrow lookups and stops paying the full consortium cost on questions that don't need it.

- **Triggers (description).** Drop bare `"investigate"` (caught debug-style and lookup queries); require qualified forms (`"investigate options"` / `"investigate approaches"`). Add explicit redirects for narrow codebase lookup → Explore, single-library version/changelog → maven-mcp.
- **Phase 1 — Minimum-2-tracks rule.** If the topic resolves to only one expert track, do NOT launch the consortium — redirect to the single appropriate tool (Explore / Context7 / maven-mcp / architecture-expert / WebSearch) and exit. Synthesis-bias prevention only pays off with ≥2 perspectives.
- **Phase 2 — Web Expert is conditional.** Was mandatory; now launched only when the topic needs an external perspective (industry practices, third-party best practices, benchmarks). Saves a track on internal-only topics.
- **Phase 4 — auto-review has two modes.** `business-analyst` for product-angled topics (scope, MVP, time-to-market, SLA/cost). `tech-sanity` (lightweight self-check, no agent launch) for purely technical topics ("which DI", "which serializer"). Tiebreaker: when in doubt → `tech-sanity` (cost asymmetry — full agent vs free self-check). Report header records the chosen mode for audit.
- **Documentation hygiene.** Reframe "core value" as gather/synthesize separation (invariant across both review modes); reviewer is defence-in-depth. Lift Web inclusion criteria out of the table cell into a paragraph. Document the caller contract for any future subskill that calls `/research`.

## Out of scope

- `disable-model-invocation: true` stays on — auto-routing isn't enabled, so the trigger cleanup improves onboarding-doc quality, not runtime behaviour. Flipping that is a separate decision.
- No changes to callers: `write-spec` runs its own research orchestration inline; nobody currently invokes `/research` as a subskill, so no caller breakage from the redirect contract. The caller contract block is defensive documentation for future use.

## Test plan

- [x] `bash scripts/validate.sh` — green (research description 919/1024 ch).
- [ ] Dry-check description triggers against 5 sample phrasings (per plan):
  - "исследуй варианты офлайн-режима" → catches.
  - "what version of Coil is latest" → does NOT catch.
  - "debug this null pointer" → does NOT catch.
  - "как у нас сейчас сделана навигация" → does NOT catch.
  - "sync vs async retries — что лучше" → catches.
- [ ] Real `/research` runs across 3 topic profiles (internal-only, external-tech-no-product, product+tech) — expect: redirect, full consortium without business-analyst, full consortium with business-analyst.
- [ ] `/write-spec` smoke test — Phase 1 still produces a research-equivalent artefact (independent path, should be unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)