### PR TITLE
research: chat-first clarification policy + v0.17.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.16.0",
+      "version": "0.17.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/maven-mcp/plugin"
@@ -23,7 +23,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.16.0",
+      "version": "0.17.0",
       "category": "security",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/sensitive-guard"
@@ -34,7 +34,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.16.0",
+      "version": "0.17.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow"
@@ -45,7 +45,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.16.0",
+      "version": "0.17.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-experts"
@@ -56,7 +56,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.16.0",
+      "version": "0.17.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-kotlin"
@@ -67,7 +67,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.16.0",
+      "version": "0.17.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-swift"

--- a/plugins/developer-workflow-experts/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-experts/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-experts",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Reusable expert agents for code review, architecture, security, performance, UX, build, DevOps, business analysis, and debugging. Safe to install standalone \u2014 no skills, no hooks, no MCP servers.",
   "author": {
     "name": "kirich1409"

--- a/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-kotlin",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Kotlin, Android, and KMP specialist agents and migration skills \u2014 kotlin-engineer, compose-developer, kmp-migration, migrate-to-compose, snapshot. Extends developer-workflow for Kotlin/Android projects.",
   "author": {
     "name": "kirich1409"
@@ -18,11 +18,11 @@
   "dependencies": [
     {
       "name": "developer-workflow",
-      "version": "^0.16.0"
+      "version": "^0.17.0"
     },
     {
       "name": "developer-workflow-experts",
-      "version": "^0.16.0"
+      "version": "^0.17.0"
     }
   ]
 }

--- a/plugins/developer-workflow-swift/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-swift/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-swift",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Swift, iOS, and macOS specialist agents \u2014 swift-engineer and swiftui-developer, with references covering Swift concurrency, testing, and SwiftUI patterns/state/performance. Extends developer-workflow for Apple platforms.",
   "author": {
     "name": "kirich1409"
@@ -17,11 +17,11 @@
   "dependencies": [
     {
       "name": "developer-workflow",
-      "version": "^0.16.0"
+      "version": "^0.17.0"
     },
     {
       "name": "developer-workflow-experts",
-      "version": "^0.16.0"
+      "version": "^0.17.0"
     }
   ]
 }

--- a/plugins/developer-workflow/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Developer workflow toolbox \u2014 on-demand skills for research, specification (write-spec, reverse-spec), multiexpert review, retroactive tests, code-quality finalize, mechanical /check, QA (test plans, acceptance), PR creation, and autonomous drive-to-merge (CI monitor, review handler, re-request, poll). Exploratory QA without a spec is performed by calling the manual-tester agent directly. Platform-neutral; platform-specific engineers live in developer-workflow-kotlin and developer-workflow-swift.",
   "author": {
     "name": "kirich1409"
@@ -18,7 +18,7 @@
   "dependencies": [
     {
       "name": "developer-workflow-experts",
-      "version": "^0.16.0"
+      "version": "^0.17.0"
     }
   ]
 }

--- a/plugins/developer-workflow/skills/research/SKILL.md
+++ b/plugins/developer-workflow/skills/research/SKILL.md
@@ -271,7 +271,12 @@ Check:
 2. Any obvious alternatives missed?
 3. Do risks cover both technical and product concerns?
 4. Is the recommendation well-supported by evidence?
-5. Are open questions the right ones — nothing critical missing?
+5. Does the "Known Unknowns" section list only external factual gaps that no party in the
+   chat session could resolve right now (vendor SLA, unpublished pricing, future-dated
+   GA, etc.) — and contain NO questions directed at the user, NO "TBD — ask user"
+   placeholders, NO rhetorical asks? Any user-resolvable trade-off must have been
+   surfaced in Phase 5.1 chat dialogue via `AskUserQuestion` and folded into the
+   recommendation, not parked in the report.
 6. Does the recommendation align with practical constraints (time, team skills, maintenance)?
 
 List gaps with severity (critical / major / minor).

--- a/plugins/developer-workflow/skills/research/SKILL.md
+++ b/plugins/developer-workflow/skills/research/SKILL.md
@@ -20,6 +20,16 @@ A second, optional layer is the post-synthesis review: in product-angled topics 
 in purely technical topics the orchestrator runs a self-check against a fixed checklist
 (`tech-sanity` mode). The reviewer layer is a defense-in-depth, not the core value.
 
+**Communication policy — non-negotiable.** All clarification with the user happens in the
+chat session via the `AskUserQuestion` tool — never through files. The saved report under
+`./swarm-report/research/` is a **handoff artifact** consumed by downstream skills/agents
+(`/write-spec`, `/multiexpert-review`, Plan Mode, a future research re-run); the user does
+not have to open it to participate in the research. The in-chat summary at Phase 5.3 is what
+the user reads to make decisions. Every blocker the user can answer is resolved in dialogue
+**before** the report is written; the file is never a parking lot for pending questions,
+draft hedges, or "TBD — ask user" placeholders. If something needs the user's input, fire
+`AskUserQuestion` now — do not write it to disk and hope the user opens it.
+
 ---
 
 ## Phase 1: Scope the Research
@@ -50,14 +60,22 @@ something that adds signal.
 
 ### Clarifying questions (round-loop)
 
-Use plan-mode pacing for any clarification: **one question per round** in chat, wait for the answer, then re-evaluate. Multiple rounds are fine; multiple questions in one round are not. Each question must be the single most blocking ambiguity right now — not a checklist of mild curiosities. The dialogue stays in chat — questions and answers are not parked in any artifact.
+Use the `AskUserQuestion` tool for clarification — never plain prose that the user has to
+parse and answer in their own format, and never a written question parked in any file.
+`AskUserQuestion` with 2–4 concrete options surfaces the decision space and gives a
+machine-checkable answer; use free-text (the implicit "Other" option) only when the option
+space is genuinely open. **One question per round** still applies — fire `AskUserQuestion`
+with exactly one question, wait for the answer, fold it into the scope, then fire the next
+round only if a blocker still remains. Multiple rounds are fine; multiple questions in one
+round are not. Each question must be the single most blocking ambiguity right now — not a
+checklist of mild curiosities.
 
 When to ask:
 - **Scope is genuinely ambiguous** (multiple valid interpretations that lead to different expert tracks or different success criteria).
 - **A constraint is missing without which the redirect / consortium decision flips** (e.g. KMP-only vs Android-only changes which tracks are relevant).
 
 When NOT to ask:
-- Mild gaps the consortium can fill itself (let agents gather, surface gaps in Open Questions).
+- Mild gaps the consortium can fill itself (let agents gather, surface anything blocking later in Phase 5.1 dialogue).
 - Stylistic preferences that don't change the recommendation.
 - Anything the auto-review step (Phase 4) would catch.
 
@@ -198,11 +216,13 @@ Skip the table when one approach dominates on every dimension.
 ## Recommendation
 {Preferred approach with reasoning, citing specific expert findings.}
 
-## Open Questions
-- {Items the research itself cannot answer — user decisions, external SLA/cost data,
-  future-dated dependencies, etc. NOT a parking lot for clarifications already resolved
-  in dialogue, and NOT a queue of pending questions — those are handled in Phase 5.1 and
-  do not survive into the final report.}
+## Known Unknowns
+- {External factual gaps that no party in the chat session could resolve right now — e.g.
+  "vendor SLA pending contract renegotiation", "library Y v3 GA date TBD", "pricing not
+  publicly available". Each entry names what is unknown and who/when could resolve it.
+  Omit this section entirely if there are no such gaps. NEVER use this section to record
+  questions for the user — those are always resolved via `AskUserQuestion` in Phase 5.1
+  before the report is written.}
 
 ## Sources
 - {URLs, doc references, codebase locations}
@@ -282,8 +302,12 @@ with the gather-agent prompts).
 
 - **No issues** → proceed to Phase 5
 - **Minor** → incorporate inline, note changes, proceed to Phase 5
-- **Major/critical, fillable** → re-run the relevant expert track, then re-review
-- **Major/critical, not fillable from research alone** → record in the synthesis as an Open Question (semantics defined in the report template — not a chat-time clarification)
+- **Major/critical, fillable from research** → re-run the relevant expert track, then re-review
+- **Major/critical, the user can resolve** → carry into Phase 5.1 and ask via
+  `AskUserQuestion` in chat; never pre-park the question in any file under `./swarm-report/`
+- **Major/critical, no party in the session can resolve right now** (e.g. pending vendor SLA,
+  unpublished pricing) → record under "Known Unknowns" in the final report as a factual gap,
+  not as a question for anyone
 
 The report is not saved at this phase; saving happens in Phase 5 after any user-blocking
 clarifications have been resolved in dialogue.
@@ -298,29 +322,36 @@ is on disk yet. This phase walks through three steps in order.
 ### 5.1 Clarification round-loop (dialogue)
 
 If the synthesis surfaces a question whose answer would materially change the recommendation
-or a key finding, ask it in chat — same plan-mode round-loop as Phase 1: **one question per
-round**, wait for the answer, fold it into the synthesis, then check if any blocker
-remains. Multiple rounds are fine; multiple questions in one round are not. Stop the
-moment no blocker remains.
+or a key finding, ask it in chat via the `AskUserQuestion` tool — 2–4 concrete options when
+the option space is enumerable, free-text "Other" otherwise. Same pacing as Phase 1: **one
+question per round**, wait for the answer, fold it into the synthesis, then check if any
+blocker remains. Stop the moment no blocker remains. Multiple rounds are fine; multiple
+questions in one round are not.
 
-The dialogue lives in chat. Internal temp files (state file, inter-phase buffers) may
-record that a clarification round is in progress via `Status: awaiting-clarification`,
-but the actual question text and the user's answer are not parked there — they belong to
-the chat session.
+The dialogue lives in chat. The state file may flip to `Status: awaiting-clarification` as
+process metadata, but the question text and the user's answer are never written to any file
+under `./swarm-report/`. Writing a question into a file and waiting for the user to open it
+is a violation of the communication policy — fire `AskUserQuestion` instead.
 
 What does **not** belong in the round-loop:
 - Stylistic preferences that don't change the recommendation.
 - Mild gaps the consortium could plausibly fill on a re-run (re-run instead).
-- Items unresolvable-by-research → land in the report's Open Questions (semantics in the
-  report template).
+- Items no party in the session can answer right now (pending vendor SLA, unpublished
+  pricing, future-dated dependency GA) → surface them in the report's "Known Unknowns"
+  section as factual gaps, not as questions for anyone.
 
 ### 5.2 Save the final report
 
 Once the loop exits, ensure `./swarm-report/research/` exists (`mkdir -p` it if needed —
 fresh repos won't have the nested subdir), then write `./swarm-report/research/research-<slug>.md`.
-The report is a finished deliverable, not a scratchpad — every section reflects the
-post-clarification synthesis, and Open Questions contains only the
-genuinely-not-resolvable-by-research items from above. Mark the state file `Status: done`.
+The report is a finished deliverable for downstream consumers (`/write-spec`,
+`/multiexpert-review`, Plan Mode, a future research re-run) — not a scratchpad and not a
+discussion vehicle with the user. Every section reflects the post-clarification synthesis;
+"Known Unknowns" holds only external factual gaps from above (and is omitted entirely when
+empty); no section contains a question, "TBD — ask user" marker, or any other hook that
+would force the user to open the file to make progress. If you catch yourself wanting to
+write such a hook, return to Phase 5.1 and fire `AskUserQuestion` instead. Mark the state
+file `Status: done`.
 
 ### 5.3 Chat summary
 
@@ -338,7 +369,7 @@ lets the user decide without opening the file:
 | Feature is clear, single task, ready to build | Plan mode + start implementing |
 | Complex approach, needs validation | Plan mode → `/multiexpert-review` |
 | Research revealed a bug, not a feature need | Plan mode for the fix |
-| Open Questions remain (by-design unresolvable by research) | Note them in the summary, suggest who/when can resolve |
+| Known Unknowns remain (external factual gaps no party in the session could resolve) | Surface them in the summary, suggest who/when could fill them |
 | Multiple viable approaches, no clear winner | Present trade-offs, ask user to pick |
 
 Frame as actionable proposal, not a question.
@@ -360,9 +391,9 @@ Stop and escalate when:
 
 | Artifact | Path | Purpose |
 |---|---|---|
-| Research report | `./swarm-report/research/research-<slug>.md` | Final synthesized findings |
+| Research report | `./swarm-report/research/research-<slug>.md` | Handoff artifact for downstream skills/agents (not a user-facing discussion vehicle) |
 | State file | `./swarm-report/research-<slug>-state.md` | Compaction-resilient progress tracking |
-| Chat summary | — | ≤30-line user-facing post-save output |
+| Chat summary | — | ≤30-line user-facing post-save output — the primary thing the user reads |
 
-The research report is the primary deliverable. The state file is operational and may be
-deleted after completion.
+The chat summary is what the user consumes; the research report is what the next skill
+or agent consumes. The state file is operational and may be deleted after completion.

--- a/plugins/developer-workflow/skills/research/evals/evals.json
+++ b/plugins/developer-workflow/skills/research/evals/evals.json
@@ -1,0 +1,21 @@
+{
+  "skill_name": "research",
+  "evals": [
+    {
+      "id": "kmp-sync",
+      "name": "kmp-data-sync-with-user-blockers",
+      "prompt": "Research data sync approaches for our existing Kotlin Multiplatform app (Android + iOS). We have local-only storage (Room on Android, SwiftData on iOS), no sync today. Compare: SQLDelight with custom sync layer, Realm Atlas, Firebase Firestore, and a custom REST backend with conflict resolution. Constraint: must work offline-first.",
+      "expected_behavior": "After synthesis, skill must surface user-resolvable trade-offs (e.g. real-time vs eventual consistency, self-hosted vs managed, expected data size) via AskUserQuestion in chat. Final report under ./swarm-report/research/ must NOT contain any question directed at the user, no 'TBD — ask user' placeholders, and use 'Known Unknowns' (not 'Open Questions') only for external factual gaps.",
+      "assertions": [
+        {"text": "Final report file exists at ./swarm-report/research/research-<slug>.md"},
+        {"text": "Final report has no '## Open Questions' heading"},
+        {"text": "Final report has '## Known Unknowns' only if external factual gaps exist; otherwise omitted"},
+        {"text": "Final report contains no 'TBD — ask user' or '(ask user)' or 'needs user input' phrases"},
+        {"text": "Final report contains no rhetorical questions targeting the user (e.g. 'What is your preference for X?')"},
+        {"text": "Subagent surfaced at least one WOULD_ASK_USER entry covering a real user trade-off (proxy for AskUserQuestion invocation)"},
+        {"text": "Subagent did NOT write any user-directed question into any file under swarm-report/"}
+      ],
+      "files": []
+    }
+  ]
+}

--- a/plugins/maven-mcp/package-lock.json
+++ b/plugins/maven-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@krozov/maven-central-mcp",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/plugins/maven-mcp/package.json
+++ b/plugins/maven-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "MCP server for Maven Central dependency intelligence",
   "main": "./dist/index.js",
   "type": "module",

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maven-mcp",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps, /latest-version, and /dependency-changes skills",
   "author": {
     "name": "kirich1409"
@@ -19,7 +19,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@krozov/maven-central-mcp@^0.16.0"
+        "@krozov/maven-central-mcp@^0.17.0"
       ]
     }
   }

--- a/plugins/sensitive-guard/.claude-plugin/plugin.json
+++ b/plugins/sensitive-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sensitive-guard",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Prevents sensitive data (secrets, PII) from reaching AI servers by scanning files before they are read into conversation",
   "author": {
     "name": "kirich1409"


### PR DESCRIPTION
## Summary

- **Research skill** now resolves clarifications in chat via `AskUserQuestion` instead of leaving "Open Questions" in the saved report. The artifact under `./swarm-report/research/` is reframed as a strict handoff for downstream skills/agents (`/write-spec`, `/multiexpert-review`, Plan Mode) — never a discussion vehicle with the user.
- New eval fixture under `plugins/developer-workflow/skills/research/evals/evals.json` validates the chat-first behavior end-to-end on a KMP-data-sync topic that intentionally surfaces a user-resolvable trade-off after synthesis.
- **Release v0.17.0** — version bumped across all 8 locations + internal `^0.17.0` dep ranges in the `developer-workflow-*` family.

## Key skill changes

- **Communication policy** block at the top of `SKILL.md`: `AskUserQuestion` in chat, never park questions on disk, file is a handoff artifact.
- **Phase 1 / Phase 5.1 round-loops** now fire `AskUserQuestion` with 2–4 options (one question per round still applies).
- **Phase 4 handle-findings** splits user-resolvable findings (escalate to Phase 5.1 chat) from no-one-can-resolve findings (record under Known Unknowns).
- **Report template**: `Open Questions` → `Known Unknowns` — factual external gaps only, omit when empty, never questions to the user.
- **Phase 5.2** explicitly bars `TBD — ask user` placeholders in the saved file.
- **Output Format table**: chat summary is the user-facing deliverable; report is for downstream consumers.

## Test plan

- [x] `bash scripts/validate.sh` — green
- [x] Eval `kmp-data-sync-with-user-blockers` run end-to-end via subagent — all 7 assertions PASS:
  - Report saved at expected path
  - No `## Open Questions` heading
  - `## Known Unknowns` contains one external factual gap only (gitlive wrapper release cadence)
  - No `TBD — ask user` / `(ask user)` / `needs user input` phrases
  - No rhetorical questions targeting the user in the file
  - Subagent surfaced a `WOULD_ASK_USER` entry (proxy for `AskUserQuestion`) covering the real trade-off
  - No user-directed question written to any file under `swarm-report/`
- [ ] CI green
- [ ] `plugin-dev:plugin-validator` agent on each plugin in `marketplace.json` — PASS or only Minor (pre-release gate)

## Release notes

Single feature: research skill is now chat-first. No user-visible breaking changes for downstream consumers — the report structure renames the `Open Questions` section to `Known Unknowns` with stricter semantics; consumers that scraped the previous header should be updated to expect the new one.