### PR TITLE
Add /check-deps-vulnerabilities skill + multi-module audit (v0.18.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,11 +8,11 @@
   "plugins": [
     {
       "name": "maven-mcp",
-      "description": "Maven dependency intelligence \u2014 auto-registers MCP server, provides /check-deps, /latest-version, and /dependency-changes skills",
+      "description": "Maven dependency intelligence \u2014 auto-registers MCP server, provides /check-deps, /check-deps-vulnerabilities, /latest-version, and /dependency-changes skills",
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.17.0",
+      "version": "0.18.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/maven-mcp/plugin"
@@ -23,7 +23,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.17.0",
+      "version": "0.18.0",
       "category": "security",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/sensitive-guard"
@@ -34,7 +34,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.17.0",
+      "version": "0.18.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow"
@@ -45,7 +45,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.17.0",
+      "version": "0.18.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-experts"
@@ -56,7 +56,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.17.0",
+      "version": "0.18.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-kotlin"
@@ -67,7 +67,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.17.0",
+      "version": "0.18.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-swift"

--- a/plugins/developer-workflow-experts/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-experts/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-experts",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Reusable expert agents for code review, architecture, security, performance, UX, build, DevOps, business analysis, and debugging. Safe to install standalone \u2014 no skills, no hooks, no MCP servers.",
   "author": {
     "name": "kirich1409"

--- a/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-kotlin",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Kotlin, Android, and KMP specialist agents and migration skills \u2014 kotlin-engineer, compose-developer, kmp-migration, migrate-to-compose, snapshot. Extends developer-workflow for Kotlin/Android projects.",
   "author": {
     "name": "kirich1409"
@@ -18,11 +18,11 @@
   "dependencies": [
     {
       "name": "developer-workflow",
-      "version": "^0.17.0"
+      "version": "^0.18.0"
     },
     {
       "name": "developer-workflow-experts",
-      "version": "^0.17.0"
+      "version": "^0.18.0"
     }
   ]
 }

--- a/plugins/developer-workflow-swift/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-swift/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-swift",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Swift, iOS, and macOS specialist agents \u2014 swift-engineer and swiftui-developer, with references covering Swift concurrency, testing, and SwiftUI patterns/state/performance. Extends developer-workflow for Apple platforms.",
   "author": {
     "name": "kirich1409"
@@ -17,11 +17,11 @@
   "dependencies": [
     {
       "name": "developer-workflow",
-      "version": "^0.17.0"
+      "version": "^0.18.0"
     },
     {
       "name": "developer-workflow-experts",
-      "version": "^0.17.0"
+      "version": "^0.18.0"
     }
   ]
 }

--- a/plugins/developer-workflow/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Developer workflow toolbox \u2014 on-demand skills for research, specification (write-spec, reverse-spec), multiexpert review, retroactive tests, code-quality finalize, mechanical /check, QA (test plans, acceptance), PR creation, and autonomous drive-to-merge (CI monitor, review handler, re-request, poll). Exploratory QA without a spec is performed by calling the manual-tester agent directly. Platform-neutral; platform-specific engineers live in developer-workflow-kotlin and developer-workflow-swift.",
   "author": {
     "name": "kirich1409"
@@ -18,7 +18,7 @@
   "dependencies": [
     {
       "name": "developer-workflow-experts",
-      "version": "^0.17.0"
+      "version": "^0.18.0"
     }
   ]
 }

--- a/plugins/maven-mcp/README.md
+++ b/plugins/maven-mcp/README.md
@@ -26,6 +26,8 @@ An MCP server registers tools that Claude can call during a conversation. The se
 |-------|-------------|
 | `/latest-version <groupId:artifactId>` | Find latest version of a Maven artifact |
 | `/check-deps` | Scan project for outdated dependencies and update them |
+| `/check-deps-vulnerabilities` | Scan project dependencies for known CVEs/GHSA via OSV (includes Gradle/Maven submodules) |
+| `/dependency-changes` | Show release notes/changelog between two versions of a Maven/Gradle dependency |
 
 ### Supported build systems
 

--- a/plugins/maven-mcp/package-lock.json
+++ b/plugins/maven-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@krozov/maven-central-mcp",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/plugins/maven-mcp/package.json
+++ b/plugins/maven-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "MCP server for Maven Central dependency intelligence",
   "main": "./dist/index.js",
   "type": "module",

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "maven-mcp",
-  "version": "0.17.0",
-  "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps, /latest-version, and /dependency-changes skills",
+  "version": "0.18.0",
+  "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps, /check-deps-vulnerabilities, /latest-version, and /dependency-changes skills",
   "author": {
     "name": "kirich1409"
   },
@@ -19,7 +19,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@krozov/maven-central-mcp@^0.17.0"
+        "@krozov/maven-central-mcp@^0.18.0"
       ]
     }
   }

--- a/plugins/maven-mcp/plugin/skills/check-deps-vulnerabilities/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/check-deps-vulnerabilities/SKILL.md
@@ -155,4 +155,11 @@ State these once at the top of the report when relevant:
   build files. A direct dependency that pulls a vulnerable transitive will
   not appear in the report; investigate via `./gradlew dependencies` /
   `mvn dependency:tree` when in doubt.
+- Android variant-prefixed configurations (`releaseImplementation`,
+  `debugImplementation`, `<flavor>ReleaseImplementation`, etc.) ship in the
+  final artifact but are not recognized by the underlying parser today, so
+  CVEs declared only on variant-specific configurations are silently
+  invisible to this scan. Workaround: declare security-critical deps on
+  plain `implementation` / `api`, or run `./gradlew dependencies` for the
+  target variant and audit the result manually.
 - OSV does not cover shaded/uber JARs.

--- a/plugins/maven-mcp/plugin/skills/check-deps-vulnerabilities/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/check-deps-vulnerabilities/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: check-deps-vulnerabilities
+description: >-
+  This skill should be used when the user asks to "check vulnerabilities",
+  "scan CVEs", "check dependency vulnerabilities", "are my dependencies
+  vulnerable", "security audit dependencies", "find CVEs in deps", "OSV scan",
+  or wants to know which Maven/Gradle dependencies have known CVE/GHSA
+  advisories. Scans build files (including Gradle/Maven submodules) and reports
+  vulnerabilities via OSV.dev.
+---
+
+# Check Dependency Vulnerabilities
+
+Scan the current Maven/Gradle project for known CVE/GHSA advisories on its
+declared dependencies (including submodules), grouped by severity, and offer
+remediation through targeted version updates.
+
+## Preflight
+
+Before doing anything else, confirm the `audit_project_dependencies` MCP tool
+is available. If it is not, stop and tell the user:
+
+> The maven-mcp plugin is required for this skill. Install it with
+> `claude plugin add maven-mcp`, then retry.
+
+Do not attempt to fall back to manual web searches — this skill requires the
+MCP server.
+
+## Steps
+
+1. Call the MCP tool with the default flags:
+
+   ```json
+   {
+     "includeVulnerabilities": true,
+     "productionOnly": true
+   }
+   ```
+
+   Do not pass any other parameters unless the user explicitly asks for
+   test/build configurations (then set `productionOnly: false`).
+
+2. Filter the response to entries where `vulnerabilities` is non-empty. Drop
+   the rest from the report (still mention the total scanned count in the
+   summary).
+
+3. Sort findings by severity desc, then by `groupId:artifactId` asc:
+
+   - `CRITICAL` → `HIGH` → `MEDIUM` → `LOW` → unknown (`undefined`)
+   - Within a band: lexicographic order of `groupId:artifactId`.
+
+4. Render the findings as a markdown table. One row per `(module, finding)`:
+
+   | Module | Artifact | Current | Severity | CVE/GHSA | Fixed in |
+   |--------|----------|---------|----------|----------|----------|
+   | `:app` | `org.apache.logging.log4j:log4j-core` | 2.14.1 | CRITICAL | GHSA-jfh8-c2jp-5v3q | 2.17.1 |
+
+   - `Module`: `dep.module` if set; otherwise `(root)`.
+   - `Artifact`: `groupId:artifactId`.
+   - `CVE/GHSA`: the OSV `id` (link it if the chat client renders Markdown links).
+   - `Fixed in`: `dep.vulnerabilities[*].fixedVersion`; if absent, write
+     `(no fixed version)`.
+
+5. Print a one-line summary after the table:
+
+   `Total: N findings across M packages (X critical, Y high, Z medium, W low).`
+
+   `M` counts distinct `groupId:artifactId` strings (a single package
+   accumulating multiple CVEs counts once).
+
+6. If `vulnerabilities` is empty for every dependency, print:
+
+   `No known vulnerabilities found in production dependencies. (Test/build configurations were excluded.)`
+
+   Then stop — no remediation prompt.
+
+7. Print this disclaimer verbatim once, immediately after the summary:
+
+   > Note: OSV does not cover shaded/uber JARs. Dependencies bundled inside
+   > a fat JAR may carry CVEs that this scan will not surface.
+
+## Remediation
+
+When at least one finding exists, ask the user with `AskUserQuestion` — one
+question, exactly four options, in this order:
+
+1. **Update all** — upgrade every vulnerable package to its recommended fixed
+   version.
+2. **Update CRITICAL + HIGH only** — leave MEDIUM/LOW for later.
+3. **Show details for a specific CVE/GHSA** — when chosen, ask which one,
+   then call `get_dependency_vulnerabilities` for that single GAV and present
+   the full advisory text + reference URL.
+4. **Report only** — make no changes.
+
+### Recommended fixed version per package
+
+Per package, the recommended fixed version is `max(fixedVersion)` across all
+findings for that `groupId:artifactId` — a single bump must close every CVE
+the package carries. If a finding has no `fixedVersion`, exclude that finding
+from the max computation; if every finding for the package lacks a
+`fixedVersion`, the package cannot be auto-remediated — list it under a
+"Manual upgrade required" subsection instead of editing.
+
+## After updating versions
+
+When the user picks option 1 or 2:
+
+1. Edit the build files (`gradle/libs.versions.toml`, `build.gradle[.kts]`,
+   or `pom.xml`) to apply the recommended versions. Touch only the lines that
+   own the vulnerable dependency — do not reformat or reorder unrelated
+   entries.
+
+2. **MANDATORY: Run the project build to verify compatibility.** Do NOT skip
+   this step.
+
+   - Gradle: `./gradlew build` (or `./gradlew assembleDebug` for Android).
+   - Maven: `mvn compile`.
+   - Wait for the build to complete fully.
+
+3. **If the build succeeds:** report success, list which dependencies were
+   updated and which CVE/GHSA each upgrade closes.
+
+4. **If the build fails:**
+   - Read the build error output carefully.
+   - Identify which upgraded dependency caused the incompatibility.
+   - Try to fix the incompatibility (API changes, import updates, deprecation
+     replacements).
+   - If the fix is non-trivial, revert that specific dependency to its
+     previous version and surface the CVE as "manual upgrade required".
+   - Re-run the build to confirm it passes.
+   - Report which packages were updated, which were reverted, and why.
+
+5. **Never report "vulnerabilities patched" without a passing build.** The
+   remediation is not complete until the project compiles successfully.
+
+## Language
+
+This SKILL.md is in English. The runtime output (tables, summary, prompts)
+should follow the user's chat language. CVE/GHSA identifiers, package
+coordinates, and version numbers stay in their original form regardless of
+language.
+
+## Known limitations
+
+State these once at the top of the report when relevant:
+
+- Test, build, and annotation-processor configurations (`testImplementation`,
+  `kapt`, `ksp`, `annotationProcessor`, etc.) are excluded by default. Pass
+  `productionOnly: false` to include them.
+- Submodule discovery uses default Gradle layout (`:foo:bar` →
+  `foo/bar/build.gradle[.kts]`). Modules with
+  `project(":foo").projectDir = file(...)` overrides and Gradle composite
+  builds (`includeBuild`) are not scanned.
+- Transitive dependencies are not enumerated — only direct declarations in
+  build files. A direct dependency that pulls a vulnerable transitive will
+  not appear in the report; investigate via `./gradlew dependencies` /
+  `mvn dependency:tree` when in doubt.
+- OSV does not cover shaded/uber JARs.

--- a/plugins/maven-mcp/src/dependencies/__tests__/maven-modules-parser.test.ts
+++ b/plugins/maven-mcp/src/dependencies/__tests__/maven-modules-parser.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { parseMavenModules } from "../maven-modules-parser.js";
+
+describe("parseMavenModules", () => {
+  it("extracts <module> entries from <modules>", () => {
+    const content = `
+<project>
+  <modules>
+    <module>core</module>
+    <module>app</module>
+  </modules>
+</project>
+`;
+    expect(parseMavenModules(content)).toEqual(["core", "app"]);
+  });
+
+  it("returns empty array when no <modules> section", () => {
+    const content = `<project><artifactId>solo</artifactId></project>`;
+    expect(parseMavenModules(content)).toEqual([]);
+  });
+
+  it("handles multiple <modules> blocks (e.g. profiles)", () => {
+    const content = `
+<project>
+  <modules>
+    <module>core</module>
+  </modules>
+  <profiles>
+    <profile>
+      <modules>
+        <module>integration-tests</module>
+      </modules>
+    </profile>
+  </profiles>
+</project>
+`;
+    expect(parseMavenModules(content)).toEqual(["core", "integration-tests"]);
+  });
+});

--- a/plugins/maven-mcp/src/dependencies/__tests__/settings-gradle-parser.test.ts
+++ b/plugins/maven-mcp/src/dependencies/__tests__/settings-gradle-parser.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { parseSettingsGradleModules } from "../settings-gradle-parser.js";
+
+describe("parseSettingsGradleModules", () => {
+  it("parses Kotlin DSL include(\":app\", \":lib:core\")", () => {
+    const content = `
+rootProject.name = "demo"
+include(":app", ":lib:core")
+`;
+    expect(parseSettingsGradleModules(content)).toEqual([":app", ":lib:core"]);
+  });
+
+  it("parses Groovy include ':app', ':lib'", () => {
+    const content = `
+rootProject.name = 'demo'
+include ':app', ':lib'
+`;
+    expect(parseSettingsGradleModules(content)).toEqual([":app", ":lib"]);
+  });
+
+  it("returns empty array when no include() calls", () => {
+    expect(parseSettingsGradleModules(`rootProject.name = "demo"`)).toEqual([]);
+  });
+
+  it("deduplicates repeated module paths", () => {
+    const content = `
+include(":app")
+include(":app", ":lib")
+`;
+    expect(parseSettingsGradleModules(content)).toEqual([":app", ":lib"]);
+  });
+
+  it("handles single-quoted Kotlin-style and mixed include calls", () => {
+    const content = `
+include(':app')
+include ":lib:core", ":feature:auth"
+`;
+    expect(parseSettingsGradleModules(content)).toEqual([":app", ":lib:core", ":feature:auth"]);
+  });
+});

--- a/plugins/maven-mcp/src/dependencies/__tests__/settings-gradle-parser.test.ts
+++ b/plugins/maven-mcp/src/dependencies/__tests__/settings-gradle-parser.test.ts
@@ -37,4 +37,13 @@ include ":lib:core", ":feature:auth"
 `;
     expect(parseSettingsGradleModules(content)).toEqual([":app", ":lib:core", ":feature:auth"]);
   });
+
+  it("ignores commented-out include calls", () => {
+    const content = `
+// include(":legacy")
+/* include(":blocked") */
+include(":app")
+`;
+    expect(parseSettingsGradleModules(content)).toEqual([":app"]);
+  });
 });

--- a/plugins/maven-mcp/src/dependencies/gradle-deps-parser.ts
+++ b/plugins/maven-mcp/src/dependencies/gradle-deps-parser.ts
@@ -7,13 +7,16 @@ export interface GradleDependency {
   catalogRef?: string;
 }
 
-const CONFIGURATIONS = [
+export const PRODUCTION_CONFIGURATIONS = [
   "implementation", "api", "compileOnly", "runtimeOnly",
+] as const;
+
+export const NON_PRODUCTION_CONFIGURATIONS = [
   "testImplementation", "testCompileOnly", "testRuntimeOnly",
   "kapt", "ksp", "annotationProcessor",
-];
+] as const;
 
-const CONFIG_PATTERN = CONFIGURATIONS.join("|");
+const CONFIG_PATTERN = [...PRODUCTION_CONFIGURATIONS, ...NON_PRODUCTION_CONFIGURATIONS].join("|");
 
 export function parseGradleDependencies(content: string, source: string = "build.gradle.kts"): GradleDependency[] {
   const deps: GradleDependency[] = [];

--- a/plugins/maven-mcp/src/dependencies/maven-modules-parser.ts
+++ b/plugins/maven-mcp/src/dependencies/maven-modules-parser.ts
@@ -1,9 +1,4 @@
-// Extracts Maven submodule directory names from a parent pom.xml — the
-// <module> entries inside <modules>. Regex-based, mirroring the idiom in
-// discovery/maven-parser.ts. Limitations: profile-activated <modules> blocks
-// are still scanned (worst case = false-positive scan), but the resulting
-// paths must exist on disk to be picked up.
-
+// Profile-activated <modules> blocks are also returned; non-existent paths are filtered later.
 export function parseMavenModules(content: string): string[] {
   const modulesBlockRegex = /<modules>([\s\S]*?)<\/modules>/g;
   const out: string[] = [];

--- a/plugins/maven-mcp/src/dependencies/maven-modules-parser.ts
+++ b/plugins/maven-mcp/src/dependencies/maven-modules-parser.ts
@@ -1,0 +1,23 @@
+// Extracts Maven submodule directory names from a parent pom.xml — the
+// <module> entries inside <modules>. Regex-based, mirroring the idiom in
+// discovery/maven-parser.ts. Limitations: profile-activated <modules> blocks
+// are still scanned (worst case = false-positive scan), but the resulting
+// paths must exist on disk to be picked up.
+
+export function parseMavenModules(content: string): string[] {
+  const modulesBlockRegex = /<modules>([\s\S]*?)<\/modules>/g;
+  const out: string[] = [];
+  let blockMatch: RegExpExecArray | null;
+
+  while ((blockMatch = modulesBlockRegex.exec(content)) !== null) {
+    const inner = blockMatch[1];
+    const moduleRegex = /<module>([^<]+)<\/module>/g;
+    let m: RegExpExecArray | null;
+    while ((m = moduleRegex.exec(inner)) !== null) {
+      const name = m[1].trim();
+      if (name) out.push(name);
+    }
+  }
+
+  return [...new Set(out)];
+}

--- a/plugins/maven-mcp/src/dependencies/scan.ts
+++ b/plugins/maven-mcp/src/dependencies/scan.ts
@@ -4,6 +4,8 @@ import { parseGradleDependencies } from "./gradle-deps-parser.js";
 import { parseMavenDependencies } from "./maven-deps-parser.js";
 import { parseVersionCatalog } from "./toml-parser.js";
 import type { CatalogEntry } from "./toml-parser.js";
+import { parseSettingsGradleModules } from "./settings-gradle-parser.js";
+import { parseMavenModules } from "./maven-modules-parser.js";
 
 export interface ScannedDependency {
   groupId: string;
@@ -11,6 +13,7 @@ export interface ScannedDependency {
   version: string | null;
   configuration: string;
   source: string;
+  module?: string;
 }
 
 export interface ScanResult {
@@ -18,29 +21,41 @@ export interface ScanResult {
   dependencies: ScannedDependency[];
 }
 
+const GRADLE_BUILD_FILES = ["build.gradle.kts", "build.gradle"] as const;
+const GRADLE_SETTINGS_FILES = ["settings.gradle.kts", "settings.gradle"] as const;
+
+// Cap recursion depth for Maven aggregator chains so a circular / malformed
+// <modules> tree cannot lock the scanner up.
+const MAX_MODULE_DEPTH = 5;
+
 function resolveCatalogRef(ref: string, catalog: Map<string, CatalogEntry>): CatalogEntry | undefined {
   const dashed = ref.replace(/\./g, "-");
   return catalog.get(dashed) ?? catalog.get(ref);
 }
 
-export function scanDependencies(projectRoot: string): ScanResult {
-  const deps: ScannedDependency[] = [];
-  const gradleFiles = ["build.gradle.kts", "build.gradle"];
-  let buildSystem: ScanResult["buildSystem"] = "unknown";
+function readCatalog(projectRoot: string): Map<string, CatalogEntry> {
+  const catalogPath = join(projectRoot, "gradle", "libs.versions.toml");
+  if (!existsSync(catalogPath)) return new Map();
+  return parseVersionCatalog(readFileSync(catalogPath, "utf-8"));
+}
 
-  for (const file of gradleFiles) {
-    const path = join(projectRoot, file);
+// Scans a single module directory. The `label` is propagated as ScannedDependency.module —
+// undefined for the root project, ":foo" / ":foo:bar" for Gradle subprojects, and the relative
+// directory name (possibly nested as "core/sub") for Maven modules. The shared `catalog`
+// (libs.versions.toml) belongs to the root and is reused across all Gradle subprojects.
+function scanSingleModule(
+  modulePath: string,
+  label: string | undefined,
+  catalog: Map<string, CatalogEntry>,
+): ScannedDependency[] {
+  const deps: ScannedDependency[] = [];
+
+  for (const file of GRADLE_BUILD_FILES) {
+    const path = join(modulePath, file);
     if (!existsSync(path)) continue;
-    buildSystem = "gradle";
 
     const content = readFileSync(path, "utf-8");
     const gradleDeps = parseGradleDependencies(content, file);
-
-    const catalogPath = join(projectRoot, "gradle", "libs.versions.toml");
-    let catalog = new Map<string, CatalogEntry>();
-    if (existsSync(catalogPath)) {
-      catalog = parseVersionCatalog(readFileSync(catalogPath, "utf-8"));
-    }
 
     for (const dep of gradleDeps) {
       if (dep.catalogRef) {
@@ -52,6 +67,7 @@ export function scanDependencies(projectRoot: string): ScanResult {
             version: entry.version,
             configuration: dep.configuration,
             source: "libs.versions.toml",
+            module: label,
           });
         }
       } else if (dep.groupId && dep.artifactId) {
@@ -61,20 +77,94 @@ export function scanDependencies(projectRoot: string): ScanResult {
           version: dep.version,
           configuration: dep.configuration,
           source: file,
+          module: label,
         });
       }
     }
-    break;
+    return deps;
   }
 
-  if (buildSystem === "unknown") {
-    const pomPath = join(projectRoot, "pom.xml");
-    if (existsSync(pomPath)) {
-      buildSystem = "maven";
-      const content = readFileSync(pomPath, "utf-8");
-      deps.push(...parseMavenDependencies(content));
+  const pomPath = join(modulePath, "pom.xml");
+  if (existsSync(pomPath)) {
+    const content = readFileSync(pomPath, "utf-8");
+    for (const dep of parseMavenDependencies(content)) {
+      deps.push({ ...dep, module: label });
     }
   }
 
-  return { buildSystem, dependencies: deps };
+  return deps;
+}
+
+function detectBuildSystem(projectRoot: string): ScanResult["buildSystem"] {
+  for (const file of [...GRADLE_BUILD_FILES, ...GRADLE_SETTINGS_FILES]) {
+    if (existsSync(join(projectRoot, file))) return "gradle";
+  }
+  if (existsSync(join(projectRoot, "pom.xml"))) return "maven";
+  return "unknown";
+}
+
+export function scanDependencies(projectRoot: string): ScanResult {
+  const catalog = readCatalog(projectRoot);
+  const buildSystem = detectBuildSystem(projectRoot);
+  const dependencies = scanSingleModule(projectRoot, undefined, catalog);
+  return { buildSystem, dependencies };
+}
+
+export function scanProjectWithSubmodules(projectRoot: string): ScanResult {
+  const buildSystem = detectBuildSystem(projectRoot);
+  const catalog = readCatalog(projectRoot);
+  const dependencies: ScannedDependency[] = [];
+
+  if (buildSystem === "gradle") {
+    const settingsContent = readGradleSettings(projectRoot);
+    if (settingsContent) {
+      const modules = parseSettingsGradleModules(settingsContent);
+      for (const modulePath of modules) {
+        const dir = gradleModulePathToDir(projectRoot, modulePath);
+        dependencies.push(...scanSingleModule(dir, modulePath, catalog));
+      }
+    }
+    // Root build.gradle[.kts] is still scanned — multi-module Gradle projects often keep
+    // platform / convention dependencies at the root.
+    dependencies.push(...scanSingleModule(projectRoot, undefined, catalog));
+  } else if (buildSystem === "maven") {
+    scanMavenRecursive(projectRoot, undefined, dependencies, 0);
+  }
+
+  return { buildSystem, dependencies };
+}
+
+function readGradleSettings(projectRoot: string): string | null {
+  for (const file of GRADLE_SETTINGS_FILES) {
+    const path = join(projectRoot, file);
+    if (existsSync(path)) return readFileSync(path, "utf-8");
+  }
+  return null;
+}
+
+// Gradle module path ":foo:bar" → projectRoot/foo/bar (default layout). Layout overrides
+// via project(":foo").projectDir = ... are not supported — rare and a non-goal for v1.
+function gradleModulePathToDir(projectRoot: string, modulePath: string): string {
+  const parts = modulePath.replace(/^:/, "").split(":").filter(Boolean);
+  return join(projectRoot, ...parts);
+}
+
+function scanMavenRecursive(
+  modulePath: string,
+  label: string | undefined,
+  acc: ScannedDependency[],
+  depth: number,
+): void {
+  acc.push(...scanSingleModule(modulePath, label, new Map()));
+  if (depth >= MAX_MODULE_DEPTH) return;
+
+  const pomPath = join(modulePath, "pom.xml");
+  if (!existsSync(pomPath)) return;
+
+  const submodules = parseMavenModules(readFileSync(pomPath, "utf-8"));
+  for (const sub of submodules) {
+    const childPath = join(modulePath, sub);
+    const childLabel = label == null ? sub : `${label}/${sub}`;
+    scanMavenRecursive(childPath, childLabel, acc, depth + 1);
+  }
 }

--- a/plugins/maven-mcp/src/dependencies/scan.ts
+++ b/plugins/maven-mcp/src/dependencies/scan.ts
@@ -13,6 +13,9 @@ export interface ScannedDependency {
   version: string | null;
   configuration: string;
   source: string;
+  // Submodule label: ":foo" / ":foo:bar" for Gradle subprojects, "foo" / "foo/sub" for Maven
+  // submodules, undefined for the root project. Formats differ because Gradle paths are
+  // colon-separated by spec; consumers must handle both shapes.
   module?: string;
 }
 

--- a/plugins/maven-mcp/src/dependencies/scan.ts
+++ b/plugins/maven-mcp/src/dependencies/scan.ts
@@ -24,8 +24,7 @@ export interface ScanResult {
 const GRADLE_BUILD_FILES = ["build.gradle.kts", "build.gradle"] as const;
 const GRADLE_SETTINGS_FILES = ["settings.gradle.kts", "settings.gradle"] as const;
 
-// Cap recursion depth for Maven aggregator chains so a circular / malformed
-// <modules> tree cannot lock the scanner up.
+// Guards against circular / malformed <modules> trees in Maven reactor projects.
 const MAX_MODULE_DEPTH = 5;
 
 function resolveCatalogRef(ref: string, catalog: Map<string, CatalogEntry>): CatalogEntry | undefined {
@@ -39,10 +38,8 @@ function readCatalog(projectRoot: string): Map<string, CatalogEntry> {
   return parseVersionCatalog(readFileSync(catalogPath, "utf-8"));
 }
 
-// Scans a single module directory. The `label` is propagated as ScannedDependency.module —
-// undefined for the root project, ":foo" / ":foo:bar" for Gradle subprojects, and the relative
-// directory name (possibly nested as "core/sub") for Maven modules. The shared `catalog`
-// (libs.versions.toml) belongs to the root and is reused across all Gradle subprojects.
+// `label` becomes ScannedDependency.module: undefined for the root, ":foo" / "core/sub" for
+// Gradle / Maven submodules. `catalog` is the root's libs.versions.toml shared across modules.
 function scanSingleModule(
   modulePath: string,
   label: string | undefined,
@@ -124,8 +121,7 @@ export function scanProjectWithSubmodules(projectRoot: string): ScanResult {
         dependencies.push(...scanSingleModule(dir, modulePath, catalog));
       }
     }
-    // Root build.gradle[.kts] is still scanned — multi-module Gradle projects often keep
-    // platform / convention dependencies at the root.
+    // Root build.gradle[.kts] often carries platform / convention deps in multi-module setups.
     dependencies.push(...scanSingleModule(projectRoot, undefined, catalog));
   } else if (buildSystem === "maven") {
     scanMavenRecursive(projectRoot, undefined, dependencies, 0);
@@ -142,8 +138,7 @@ function readGradleSettings(projectRoot: string): string | null {
   return null;
 }
 
-// Gradle module path ":foo:bar" → projectRoot/foo/bar (default layout). Layout overrides
-// via project(":foo").projectDir = ... are not supported — rare and a non-goal for v1.
+// Default Gradle layout only — `project(":foo").projectDir = ...` overrides are not supported.
 function gradleModulePathToDir(projectRoot: string, modulePath: string): string {
   const parts = modulePath.replace(/^:/, "").split(":").filter(Boolean);
   return join(projectRoot, ...parts);
@@ -155,14 +150,17 @@ function scanMavenRecursive(
   acc: ScannedDependency[],
   depth: number,
 ): void {
-  acc.push(...scanSingleModule(modulePath, label, new Map()));
-  if (depth >= MAX_MODULE_DEPTH) return;
-
   const pomPath = join(modulePath, "pom.xml");
   if (!existsSync(pomPath)) return;
 
-  const submodules = parseMavenModules(readFileSync(pomPath, "utf-8"));
-  for (const sub of submodules) {
+  const content = readFileSync(pomPath, "utf-8");
+  for (const dep of parseMavenDependencies(content)) {
+    acc.push({ ...dep, module: label });
+  }
+
+  if (depth >= MAX_MODULE_DEPTH) return;
+
+  for (const sub of parseMavenModules(content)) {
     const childPath = join(modulePath, sub);
     const childLabel = label == null ? sub : `${label}/${sub}`;
     scanMavenRecursive(childPath, childLabel, acc, depth + 1);

--- a/plugins/maven-mcp/src/dependencies/settings-gradle-parser.ts
+++ b/plugins/maven-mcp/src/dependencies/settings-gradle-parser.ts
@@ -1,8 +1,4 @@
-// Extracts Gradle submodule paths (e.g. ":app", ":lib:core") from
-// settings.gradle / settings.gradle.kts. Regex-based — same idiom as
-// discovery/gradle-parser.ts. Limitations: composite builds (includeBuild),
-// project layout overrides (project(":foo").projectDir = ...) are not supported.
-
+// Composite builds (`includeBuild`) and layout overrides are not supported.
 export function parseSettingsGradleModules(content: string): string[] {
   const modules: string[] = [];
 

--- a/plugins/maven-mcp/src/dependencies/settings-gradle-parser.ts
+++ b/plugins/maven-mcp/src/dependencies/settings-gradle-parser.ts
@@ -1,0 +1,30 @@
+// Extracts Gradle submodule paths (e.g. ":app", ":lib:core") from
+// settings.gradle / settings.gradle.kts. Regex-based — same idiom as
+// discovery/gradle-parser.ts. Limitations: composite builds (includeBuild),
+// project layout overrides (project(":foo").projectDir = ...) are not supported.
+
+export function parseSettingsGradleModules(content: string): string[] {
+  const modules: string[] = [];
+
+  // Kotlin DSL: include(":app", ":lib:core") — also matches Groovy include("…")
+  const parenRegex = /\binclude\s*\(([^)]+)\)/g;
+  let match: RegExpExecArray | null;
+  while ((match = parenRegex.exec(content)) !== null) {
+    modules.push(...splitArgs(match[1]));
+  }
+
+  // Groovy DSL: include ':app', ':lib' (bare args, no parentheses)
+  const bareRegex = /\binclude\s+((?:["'][^"']+["']\s*,?\s*)+)/g;
+  while ((match = bareRegex.exec(content)) !== null) {
+    modules.push(...splitArgs(match[1]));
+  }
+
+  return [...new Set(modules)];
+}
+
+function splitArgs(raw: string): string[] {
+  return raw
+    .split(",")
+    .map((s) => s.trim().replace(/^["']|["']$/g, "").trim())
+    .filter((s) => s.length > 0);
+}

--- a/plugins/maven-mcp/src/dependencies/settings-gradle-parser.ts
+++ b/plugins/maven-mcp/src/dependencies/settings-gradle-parser.ts
@@ -1,17 +1,23 @@
 // Composite builds (`includeBuild`) and layout overrides are not supported.
 export function parseSettingsGradleModules(content: string): string[] {
+  // Strip comments first so `// include(":legacy")` or `/* include(":foo") */`
+  // is not picked up as a real submodule.
+  const stripped = content
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/[^\n]*/g, "");
+
   const modules: string[] = [];
 
   // Kotlin DSL: include(":app", ":lib:core") — also matches Groovy include("…")
   const parenRegex = /\binclude\s*\(([^)]+)\)/g;
   let match: RegExpExecArray | null;
-  while ((match = parenRegex.exec(content)) !== null) {
+  while ((match = parenRegex.exec(stripped)) !== null) {
     modules.push(...splitArgs(match[1]));
   }
 
   // Groovy DSL: include ':app', ':lib' (bare args, no parentheses)
   const bareRegex = /\binclude\s+((?:["'][^"']+["']\s*,?\s*)+)/g;
-  while ((match = bareRegex.exec(content)) !== null) {
+  while ((match = bareRegex.exec(stripped)) !== null) {
     modules.push(...splitArgs(match[1]));
   }
 

--- a/plugins/maven-mcp/src/index.ts
+++ b/plugins/maven-mcp/src/index.ts
@@ -169,10 +169,11 @@ server.tool(
 
 server.tool(
   "audit_project_dependencies",
-  "Full project dependency audit: scans build files, compares versions against latest, checks for vulnerabilities. One-stop tool for dependency health check.",
+  "Full project dependency audit: scans build files (including Gradle/Maven submodules), compares versions against latest, checks for vulnerabilities. One-stop tool for dependency health check.",
   {
     projectPath: z.string().optional().describe("Path to project root (default: auto-detect)"),
     includeVulnerabilities: z.boolean().optional().describe("Check for CVEs via OSV (default: true)"),
+    productionOnly: z.boolean().optional().describe("Exclude test/build configurations (default: true)"),
   },
   async (params) => {
     const result = await auditProjectDependenciesHandler(getRepositories(), params);

--- a/plugins/maven-mcp/src/tools/__tests__/audit-project-dependencies.test.ts
+++ b/plugins/maven-mcp/src/tools/__tests__/audit-project-dependencies.test.ts
@@ -29,6 +29,22 @@ function mockGradleProject(content: string) {
   mockedFs.readFileSync.mockReturnValue(content);
 }
 
+// Mock fs for multi-module fixtures: files keyed by absolute path → content.
+// existsSync returns true iff the path exists in the map; readFileSync returns
+// the matching content or throws (mirrors real node:fs behavior).
+function mockFileSystem(files: Record<string, string>) {
+  mockedFs.existsSync.mockImplementation((p: fs.PathLike) =>
+    Object.prototype.hasOwnProperty.call(files, p.toString()),
+  );
+  mockedFs.readFileSync.mockImplementation((p: fs.PathOrFileDescriptor) => {
+    const key = p.toString();
+    if (!Object.prototype.hasOwnProperty.call(files, key)) {
+      throw new Error(`ENOENT: no such file '${key}'`);
+    }
+    return files[key];
+  });
+}
+
 describe("auditProjectDependenciesHandler", () => {
   beforeEach(() => vi.clearAllMocks());
 
@@ -139,6 +155,7 @@ dependencies {
     const result = await auditProjectDependenciesHandler(repos, {
       projectPath: "/project",
       includeVulnerabilities: false,
+      productionOnly: false,
     });
 
     expect(result.dependencies).toHaveLength(2);
@@ -172,6 +189,7 @@ dependencies {
     const result = await auditProjectDependenciesHandler(repos, {
       projectPath: "/project",
       includeVulnerabilities: true,
+      productionOnly: false,
     });
 
     // Only one OSV query should be made (deduplicated)
@@ -183,6 +201,127 @@ dependencies {
     expect(result.dependencies[1].vulnerabilities).toHaveLength(1);
     expect(result.dependencies[1].vulnerabilities![0].id).toBe("GHSA-5678");
     expect(result.summary.vulnerable).toBe(2);
+  });
+
+  it("excludes testImplementation/kapt/ksp when productionOnly is true (default)", async () => {
+    mockGradleProject(`
+dependencies {
+    implementation("io.ktor:ktor-client-core:3.0.0")
+    testImplementation("junit:junit:4.13")
+    kapt("com.google.dagger:dagger-compiler:2.50")
+    ksp("androidx.room:room-compiler:2.6.0")
+}`);
+
+    const repos = [mockRepo(["3.0.0", "3.1.1"])];
+    const result = await auditProjectDependenciesHandler(repos, {
+      projectPath: "/project",
+      includeVulnerabilities: false,
+    });
+
+    expect(result.dependencies).toHaveLength(1);
+    expect(result.dependencies[0].artifactId).toBe("ktor-client-core");
+  });
+
+  it("includes test configurations when productionOnly is false", async () => {
+    mockGradleProject(`
+dependencies {
+    implementation("io.ktor:ktor-client-core:3.0.0")
+    testImplementation("junit:junit:4.13")
+    kapt("com.google.dagger:dagger-compiler:2.50")
+}`);
+
+    const repos = [mockRepo(["3.0.0", "3.1.1"])];
+    const result = await auditProjectDependenciesHandler(repos, {
+      projectPath: "/project",
+      includeVulnerabilities: false,
+      productionOnly: false,
+    });
+
+    expect(result.dependencies).toHaveLength(3);
+    const artifacts = result.dependencies.map((d) => d.artifactId).sort();
+    expect(artifacts).toEqual(["dagger-compiler", "junit", "ktor-client-core"]);
+  });
+
+  it("scans Gradle multi-module project with :app and :lib", async () => {
+    mockFileSystem({
+      "/project/settings.gradle.kts": `include(":app", ":lib")`,
+      "/project/app/build.gradle.kts": `implementation("io.ktor:ktor-client-core:3.0.0")`,
+      "/project/lib/build.gradle.kts": `api("io.ktor:ktor-client-core:3.1.0")`,
+    });
+
+    const repos = [mockRepo(["3.0.0", "3.1.0", "3.1.1"])];
+    const result = await auditProjectDependenciesHandler(repos, {
+      projectPath: "/project",
+      includeVulnerabilities: false,
+    });
+
+    expect(result.buildSystem).toBe("gradle");
+    expect(result.dependencies).toHaveLength(2);
+    const byModule = Object.fromEntries(
+      result.dependencies.map((d) => [d.module, d.currentVersion]),
+    );
+    expect(byModule).toEqual({ ":app": "3.0.0", ":lib": "3.1.0" });
+  });
+
+  it("scans Maven multi-module project with two <module> entries", async () => {
+    mockFileSystem({
+      "/project/pom.xml": `
+<project>
+  <modules>
+    <module>core</module>
+    <module>app</module>
+  </modules>
+</project>`,
+      "/project/core/pom.xml": `
+<project>
+  <dependencies>
+    <dependency>
+      <groupId>io.ktor</groupId>
+      <artifactId>ktor-client-core</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+  </dependencies>
+</project>`,
+      "/project/app/pom.xml": `
+<project>
+  <dependencies>
+    <dependency>
+      <groupId>io.ktor</groupId>
+      <artifactId>ktor-client-core</artifactId>
+      <version>3.1.0</version>
+    </dependency>
+  </dependencies>
+</project>`,
+    });
+
+    const repos = [mockRepo(["3.0.0", "3.1.0", "3.1.1"])];
+    const result = await auditProjectDependenciesHandler(repos, {
+      projectPath: "/project",
+      includeVulnerabilities: false,
+    });
+
+    expect(result.buildSystem).toBe("maven");
+    expect(result.dependencies).toHaveLength(2);
+    const byModule = Object.fromEntries(
+      result.dependencies.map((d) => [d.module, d.currentVersion]),
+    );
+    expect(byModule).toEqual({ core: "3.0.0", app: "3.1.0" });
+  });
+
+  it("propagates module field through audit output", async () => {
+    mockFileSystem({
+      "/project/settings.gradle.kts": `include(":app")`,
+      "/project/app/build.gradle.kts": `implementation("io.ktor:ktor-client-core:3.0.0")`,
+    });
+
+    const repos = [mockRepo(["3.0.0", "3.1.1"])];
+    const result = await auditProjectDependenciesHandler(repos, {
+      projectPath: "/project",
+      includeVulnerabilities: false,
+    });
+
+    expect(result.dependencies).toHaveLength(1);
+    expect(result.dependencies[0].module).toBe(":app");
   });
 
   it("assigns different vulns to correct versioned entries for same GA", async () => {
@@ -216,6 +355,7 @@ dependencies {
     const result = await auditProjectDependenciesHandler(repos, {
       projectPath: "/project",
       includeVulnerabilities: true,
+      productionOnly: false,
     });
 
     expect(mockFetch).toHaveBeenCalledTimes(1);

--- a/plugins/maven-mcp/src/tools/audit-project-dependencies.ts
+++ b/plugins/maven-mcp/src/tools/audit-project-dependencies.ts
@@ -26,6 +26,9 @@ export interface AuditDependency {
   latestVersion?: string;
   upgradeType?: UpgradeType;
   vulnerabilities?: { id: string; severity?: string; fixedVersion?: string }[];
+  // Submodule label: ":foo" / ":foo:bar" for Gradle, "foo" / "foo/sub" for Maven,
+  // undefined for the root project. The two formats differ by design (Gradle paths are
+  // colon-separated by spec); consumers must handle both shapes.
   module?: string;
 }
 

--- a/plugins/maven-mcp/src/tools/audit-project-dependencies.ts
+++ b/plugins/maven-mcp/src/tools/audit-project-dependencies.ts
@@ -1,7 +1,8 @@
 import type { MavenRepository } from "../maven/repository.js";
 import type { MavenMetadata } from "../maven/types.js";
 import type { UpgradeType } from "../version/types.js";
-import { scanDependencies } from "../dependencies/scan.js";
+import { scanProjectWithSubmodules } from "../dependencies/scan.js";
+import type { ScanResult } from "../dependencies/scan.js";
 import { findProjectRoot } from "../project/find-project-root.js";
 import { resolveAll } from "../maven/resolver.js";
 import { findLatestVersionForCurrent } from "../version/classify.js";
@@ -11,7 +12,12 @@ import { queryOsvBatch } from "../vulnerabilities/osv-client.js";
 export interface AuditInput {
   projectPath?: string;
   includeVulnerabilities?: boolean;
+  productionOnly?: boolean;
 }
+
+// Configurations that ship in the final artifact. Test, build-time, and annotation-processor
+// configurations are excluded by default — a CVE in junit/kapt is not a deployed risk.
+const PRODUCTION_CONFIGS = new Set(["implementation", "api", "compileOnly", "runtimeOnly"]);
 
 export interface AuditDependency {
   groupId: string;
@@ -20,10 +26,11 @@ export interface AuditDependency {
   latestVersion?: string;
   upgradeType?: UpgradeType;
   vulnerabilities?: { id: string; severity?: string; fixedVersion?: string }[];
+  module?: string;
 }
 
 export interface AuditResult {
-  buildSystem: ReturnType<typeof scanDependencies>["buildSystem"];
+  buildSystem: ScanResult["buildSystem"];
   dependencies: AuditDependency[];
   summary: {
     total: number;
@@ -40,13 +47,18 @@ export async function auditProjectDependenciesHandler(
   input: AuditInput,
 ): Promise<AuditResult> {
   const projectRoot = input.projectPath ?? findProjectRoot(process.cwd()) ?? process.cwd();
-  const scan = scanDependencies(projectRoot);
+  const scan = scanProjectWithSubmodules(projectRoot);
   const includeVulns = input.includeVulnerabilities !== false;
+  const productionOnly = input.productionOnly !== false;
+
+  const filteredScanDeps = productionOnly
+    ? scan.dependencies.filter((d) => PRODUCTION_CONFIGS.has(d.configuration))
+    : scan.dependencies;
 
   const auditDeps: AuditDependency[] = [];
 
-  const depsWithVersion = scan.dependencies.filter((d) => d.version !== null);
-  const depsWithoutVersion = scan.dependencies.filter((d) => d.version === null);
+  const depsWithVersion = filteredScanDeps.filter((d) => d.version !== null);
+  const depsWithoutVersion = filteredScanDeps.filter((d) => d.version === null);
 
   // Memoize resolveAll per GA to avoid redundant metadata fetches for duplicate deps
   const metadataCache = new Map<string, Promise<MavenMetadata>>();
@@ -75,11 +87,12 @@ export async function auditProjectDependenciesHandler(
       currentVersion: dep.version!,
       latestVersion: latest,
       upgradeType,
+      module: dep.module,
     });
   }
 
   for (const dep of depsWithoutVersion) {
-    auditDeps.push({ groupId: dep.groupId, artifactId: dep.artifactId });
+    auditDeps.push({ groupId: dep.groupId, artifactId: dep.artifactId, module: dep.module });
   }
 
   // Vulnerability check — deduplicate OSV queries by GAV, then map results back

--- a/plugins/maven-mcp/src/tools/audit-project-dependencies.ts
+++ b/plugins/maven-mcp/src/tools/audit-project-dependencies.ts
@@ -3,6 +3,7 @@ import type { MavenMetadata } from "../maven/types.js";
 import type { UpgradeType } from "../version/types.js";
 import { scanProjectWithSubmodules } from "../dependencies/scan.js";
 import type { ScanResult } from "../dependencies/scan.js";
+import { PRODUCTION_CONFIGURATIONS } from "../dependencies/gradle-deps-parser.js";
 import { findProjectRoot } from "../project/find-project-root.js";
 import { resolveAll } from "../maven/resolver.js";
 import { findLatestVersionForCurrent } from "../version/classify.js";
@@ -15,9 +16,8 @@ export interface AuditInput {
   productionOnly?: boolean;
 }
 
-// Configurations that ship in the final artifact. Test, build-time, and annotation-processor
-// configurations are excluded by default — a CVE in junit/kapt is not a deployed risk.
-const PRODUCTION_CONFIGS = new Set(["implementation", "api", "compileOnly", "runtimeOnly"]);
+// CVEs in test / kapt / ksp / annotationProcessor are not deployed risks — exclude by default.
+const PRODUCTION_CONFIGS = new Set<string>(PRODUCTION_CONFIGURATIONS);
 
 export interface AuditDependency {
   groupId: string;

--- a/plugins/maven-mcp/src/vulnerabilities/__tests__/osv-client.test.ts
+++ b/plugins/maven-mcp/src/vulnerabilities/__tests__/osv-client.test.ts
@@ -72,4 +72,85 @@ describe("queryOsvBatch", () => {
     expect(results).toHaveLength(1);
     expect(results[0].vulnerabilities).toHaveLength(0);
   });
+
+  it("normalizes MODERATE severity to MEDIUM", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        results: [{
+          vulns: [{
+            id: "GHSA-mod-erat-eeee",
+            summary: "moderate severity",
+            database_specific: { severity: "MODERATE" },
+            affected: [],
+            references: [],
+          }],
+        }],
+      }),
+    });
+
+    const results = await queryOsvBatch([
+      { groupId: "com.example", artifactId: "lib", version: "1.0.0" },
+    ]);
+
+    expect(results[0].vulnerabilities).toHaveLength(1);
+    expect(results[0].vulnerabilities[0].severity).toBe("MEDIUM");
+  });
+
+  it("rejects unknown severity strings", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        results: [{
+          vulns: [{
+            id: "GHSA-unkn-own1",
+            summary: "unknown severity",
+            database_specific: { severity: "BOGUS" },
+            affected: [],
+            references: [],
+          }],
+        }],
+      }),
+    });
+
+    const results = await queryOsvBatch([
+      { groupId: "com.example", artifactId: "lib", version: "1.0.0" },
+    ]);
+
+    expect(results[0].vulnerabilities[0].severity).toBeUndefined();
+  });
+
+  it("filters out withdrawn vulnerabilities before mapping", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        results: [{
+          vulns: [
+            {
+              id: "GHSA-active-active",
+              summary: "active",
+              database_specific: { severity: "HIGH" },
+              affected: [],
+              references: [],
+            },
+            {
+              id: "GHSA-with-drawn",
+              summary: "withdrawn",
+              database_specific: { severity: "CRITICAL" },
+              withdrawn: "2024-01-01T00:00:00Z",
+              affected: [],
+              references: [],
+            },
+          ],
+        }],
+      }),
+    });
+
+    const results = await queryOsvBatch([
+      { groupId: "com.example", artifactId: "lib", version: "1.0.0" },
+    ]);
+
+    expect(results[0].vulnerabilities).toHaveLength(1);
+    expect(results[0].vulnerabilities[0].id).toBe("GHSA-active-active");
+  });
 });

--- a/plugins/maven-mcp/src/vulnerabilities/osv-client.ts
+++ b/plugins/maven-mcp/src/vulnerabilities/osv-client.ts
@@ -69,8 +69,7 @@ function cvssToSeverity(score: number): string {
 }
 
 function extractSeverity(vuln: OsvVulnerability): string | undefined {
-  // GHSA reports "MODERATE" while OSV CVSS-derived severity uses "MEDIUM" —
-  // normalize so downstream sort/UI never sees both spellings for the same band.
+  // GHSA uses "MODERATE"; CVSS-derived OSV severity uses "MEDIUM" — collapse to one.
   const rawSeverity = vuln.database_specific?.severity?.toUpperCase();
   const dbSeverity = rawSeverity === "MODERATE" ? "MEDIUM" : rawSeverity;
   if (dbSeverity && ["CRITICAL", "HIGH", "MEDIUM", "LOW"].includes(dbSeverity)) {
@@ -123,8 +122,7 @@ export async function queryOsvBatch(deps: DependencyRef[]): Promise<DependencyVu
     const data = (await response.json()) as OsvBatchResponse;
 
     return deps.map((dep, i) => {
-      // Drop withdrawn advisories — once OSV marks a record withdrawn it is
-      // superseded, retracted, or known-incorrect; surfacing it is noise.
+      // Withdrawn = superseded / retracted / known-incorrect; do not surface.
       const vulns = (data.results[i]?.vulns ?? []).filter((v) => v.withdrawn == null);
       return {
         ...dep,

--- a/plugins/maven-mcp/src/vulnerabilities/osv-client.ts
+++ b/plugins/maven-mcp/src/vulnerabilities/osv-client.ts
@@ -54,6 +54,7 @@ interface OsvVulnerability {
   affected?: OsvAffected[];
   references?: OsvReference[];
   database_specific?: { severity?: string };
+  withdrawn?: string;
 }
 
 interface OsvBatchResponse {
@@ -68,8 +69,10 @@ function cvssToSeverity(score: number): string {
 }
 
 function extractSeverity(vuln: OsvVulnerability): string | undefined {
-  // Prefer database_specific.severity (GitHub Advisory provides this)
-  const dbSeverity = vuln.database_specific?.severity?.toUpperCase();
+  // GHSA reports "MODERATE" while OSV CVSS-derived severity uses "MEDIUM" —
+  // normalize so downstream sort/UI never sees both spellings for the same band.
+  const rawSeverity = vuln.database_specific?.severity?.toUpperCase();
+  const dbSeverity = rawSeverity === "MODERATE" ? "MEDIUM" : rawSeverity;
   if (dbSeverity && ["CRITICAL", "HIGH", "MEDIUM", "LOW"].includes(dbSeverity)) {
     return dbSeverity;
   }
@@ -120,7 +123,9 @@ export async function queryOsvBatch(deps: DependencyRef[]): Promise<DependencyVu
     const data = (await response.json()) as OsvBatchResponse;
 
     return deps.map((dep, i) => {
-      const vulns = data.results[i]?.vulns ?? [];
+      // Drop withdrawn advisories — once OSV marks a record withdrawn it is
+      // superseded, retracted, or known-incorrect; surfacing it is noise.
+      const vulns = (data.results[i]?.vulns ?? []).filter((v) => v.withdrawn == null);
       return {
         ...dep,
         vulnerabilities: vulns.map((v) => ({

--- a/plugins/sensitive-guard/.claude-plugin/plugin.json
+++ b/plugins/sensitive-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sensitive-guard",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Prevents sensitive data (secrets, PII) from reaching AI servers by scanning files before they are read into conversation",
   "author": {
     "name": "kirich1409"


### PR DESCRIPTION
## Summary

New user-facing skill **/check-deps-vulnerabilities** for the `maven-mcp` plugin:
scans the project (including Gradle/Maven submodules) for known CVE/GHSA
advisories via OSV.dev, sorts findings by severity, offers remediation through
AskUserQuestion, and runs a mandatory build after any version bump.

Same PR ships four server-side fixes that the skill depends on so the
first-impression flow is not noisy:

- **R1** — `osv-client`: normalize GHSA `MODERATE` → `MEDIUM` so downstream
  sort/UI never sees both spellings for the same band.
- **R4** — `osv-client`: filter withdrawn OSV advisories before mapping.
- **R3** — `audit_project_dependencies`: new `productionOnly` parameter
  (default `true`) excludes `testImplementation` / `kapt` / `ksp` /
  `annotationProcessor`. A CVE in `junit`/`kapt` is not a deployed risk.
- **R8** — multi-module enumeration: new `scanProjectWithSubmodules()` reads
  `settings.gradle[.kts]` (`parseSettingsGradleModules`) and parent
  `pom.xml` `<modules>` (`parseMavenModules`); recurses with depth limit 5.
  `AuditDependency` carries a `module` label (e.g. `":app"`, `"core/sub"`,
  or `undefined` for root).

Bumps all 8 plugins to **0.18.0** and widens the `developer-workflow*` family
`dependencies` semver ranges to `^0.18.0`. `npx` pin updated to
`@krozov/maven-central-mcp@^0.18.0`.

## Test plan

- [x] `npm run build` clean — 0 errors
- [x] `npm run lint` clean — 0 errors
- [x] `npm test` — 307/307 passing (11 new tests: 3× osv-client, 5×
      settings-gradle-parser, 3× maven-modules-parser, 5× audit handler)
- [x] `bash scripts/validate.sh` — all 5 layers green (semver, manifests,
      hooks, frontmatter, JSON syntax)
- [x] `plugin-dev:plugin-validator` on `plugins/maven-mcp/` — PASS, 0 findings
      (Critical/Major/Minor)
- [ ] Manual E2E on a multi-module Android project with a pinned Log4Shell
      version (`org.apache.logging.log4j:log4j-core:2.14.1`) and a test-only
      `junit:junit:4.12` — verify CRITICAL row, Module column, productionOnly
      filter, AskUserQuestion options, build verification after auto-update

## Notes

- Out of scope: OSV response caching, suppression file, shaded/uber JAR
  scanning, non-standard module layouts (`project(":foo").projectDir = ...`,
  Gradle composite builds), transitive-only CVE detection.
- Existing audit tests that mixed `implementation` + `testImplementation` for
  the same GAV are updated to pass `productionOnly: false` — they were
  exercising dedup/mapping logic, which still works; only the default-filter
  contract changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)