### PR TITLE
Add migration skill to developer-workflow-kotlin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -52,7 +52,7 @@
     },
     {
       "name": "developer-workflow-kotlin",
-      "description": "Kotlin, Android, and KMP specialist agents and migration skills \u2014 kotlin-engineer, compose-developer, code-migration, kmp-migration, migrate-to-compose. Extends developer-workflow for Kotlin/Android projects.",
+      "description": "Kotlin, Android, and KMP specialist agents and migration skills \u2014 kotlin-engineer, compose-developer, migration, kmp-migration, migrate-to-compose, snapshot. Extends developer-workflow for Kotlin/Android projects.",
       "author": {
         "name": "kirich1409"
       },

--- a/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "developer-workflow-kotlin",
   "version": "0.18.0",
-  "description": "Kotlin, Android, and KMP specialist agents and migration skills \u2014 kotlin-engineer, compose-developer, kmp-migration, migrate-to-compose, snapshot. Extends developer-workflow for Kotlin/Android projects.",
+  "description": "Kotlin, Android, and KMP specialist agents and migration skills \u2014 kotlin-engineer, compose-developer, migration, kmp-migration, migrate-to-compose, snapshot. Extends developer-workflow for Kotlin/Android projects.",
   "author": {
     "name": "kirich1409"
   },

--- a/plugins/developer-workflow-kotlin/README.md
+++ b/plugins/developer-workflow-kotlin/README.md
@@ -16,6 +16,7 @@ Shared reference material in `agents/references/`:
 
 | Skill | Purpose |
 |---|---|
+| `migration` | Guided 8-phase migration between technologies (DI, async, UI idiom, build plugin) with behavioral parity and old-stack cleanup |
 | `kmp-migration` | Android module → Kotlin Multiplatform — source set restructuring, iOS exposure |
 | `migrate-to-compose` | View-based UI → Jetpack Compose, one screen at a time, with visual baseline |
 | `snapshot` | Capture current behavior of code targets (logic / ui / api) as `behavior-spec.md` before any migration or refactor |

--- a/plugins/developer-workflow-kotlin/skills/migration/SKILL.md
+++ b/plugins/developer-workflow-kotlin/skills/migration/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: migration
+description: "Use for migrating one technology to another in Android/Kotlin/KMP/JVM projects with behavioral parity — Databinding to ViewBinding, Dagger/Hilt to Metro DI, RxJava to Coroutines, KAPT to KSP, Java to Kotlin, Gson to kotlinx.serialization, and similar tech swaps. Triggers: \"migrate X to Y\", \"replace X with Y\", \"swap X for Y\", \"drop X in favor of Y\", \"move off X\", \"decommission X\". Covers studying FROM/TO technologies and their build artifacts, mapping use-sites, fixing current behavior across three planes (code tests + test cases + manual scenarios), agreeing strategy with the user, implementing via one of four approaches (Branch by Abstraction, Strangler Fig, Duplicate-then-delete, Utility refactor), verifying on a real device, and cleaning up the old stack fully. Do NOT use for: Android XML View to Jetpack Compose (use migrate-to-compose), enabling KMP on an Android project (use kmp-migration), bug fixes (use plan mode), or pure library version bumps without API changes (use maven-mcp:check-deps)."
+---
+
+# Migration
+
+## Overview
+
+**Core principle:** Understand both technologies before touching code → fix current behavior across three independent planes → agree the strategy with the user → execute with the chosen approach → verify on device → remove the old stack fully.
+
+Behavioral parity is the contract. Anything that changes intentionally must be agreed in Phase 4 (Strategy gate) and listed in the migration report. Anything else must remain identical FROM and TO.
+
+### Scope discipline — what migration is NOT
+
+Do not do any of the following without explicit user approval:
+- **Fix unrelated bugs** — a bug in the old stack stays as a bug in the new stack until the user asks otherwise. Bugs are tracked separately in the migration report's "Issues found" section.
+- **Refactor adjacent code** — if a class works but is ugly, leave it. Migration is not a cleanup tour.
+- **Modernize patterns** — replace only the technology in scope. Do not add coroutines while migrating DI. Do not introduce DI while migrating UI.
+- **Add features or new states** — no new screens, no new options, no new edge cases.
+- **Migrate multiple technologies in one pass** — UI, DI, and async are three different migrations, even if they look related. If the work expands beyond the agreed scope, stop and renegotiate Phase 4.
+
+When a bug, missing feature, or adjacent improvement surfaces during the work — add it to the migration report and ask. Never silently extend scope.
+
+## Workflow
+
+```
+1. Tech-Study  →  2. Discover  →  3. Behavior-Fix  →  4. Strategy + USER GATE
+                                                              ↓
+8. Final Audit ← 7. Cleanup  ←  6. Device Verify  ←  5. Implement
+```
+
+Phase 4 is the only mandatory gate. Every other phase is a checklist for the user, not a blocking state transition. The skill produces material; the user drives progress. Plan mode is the real orchestrator — this skill only supplies the structure.
+
+If you find yourself building a state machine, requiring strict completion of one phase before starting the next, or invoking other skills from inside this one, stop. That is the failure mode of the deleted `code-migration` orchestrator (v0.14.0) and the reason it was removed. See `references/anti-orchestrator.md` for the five concrete criteria that separate this skill from a forced pipeline.
+
+---
+
+## Phase 1: Tech-Study (FROM and TO)
+
+Before touching the project, understand both technologies as a class. The most common cause of incomplete migrations is treating the technology as a black box and missing what it generates, scans, or hooks into at build time.
+
+Produce `./swarm-report/<slug>-tech-snapshot.md` covering both FROM and TO:
+
+- **Generated artifacts** — what code does it emit (KAPT, KSP, FIR/IR compiler plugin), into which directories (`build/generated/...`), under what classpath. Example: Databinding generates `*Binding.java` via KAPT; ViewBinding generates via AGP directly; Hilt generates per-module Dagger components via KAPT/KSP; Metro generates via Kotlin compiler plugin with no separate processing stage.
+- **Build hooks** — Gradle plugin id, flags that activate it (`dataBinding = true`, `viewBinding = true`, `kotlin("kapt")`), tasks it registers.
+- **Classpath / scanning behavior** — does it scan annotations across modules (Hilt does; ViewBinding does not), does it require `@AndroidEntryPoint` markers, does it inject at runtime or compile time.
+- **Side effects** — build time impact, generated R-classes, lint integration, IDE plugin requirements, KSP1 vs KSP2 compatibility, AGP version requirements.
+- **Interop facilities** — does the TO technology offer an explicit interop layer with FROM (Metro has Dagger interop; Coroutines have RxJava bridges; Compose has `AndroidView`/`ComposeView`)? This is the foundation for any incremental approach.
+
+Verify each fact against authoritative sources (official docs, the library's GitHub README, `ksrc` for installed dependencies). Do not rely on training-data memory — APIs and build behavior change.
+
+For Android-specific migrations, prefer `android docs search` for official guidance. For Kotlin/JVM libraries, use `ksrc` to read the actual installed source. See `references/approaches.md` for a list of common FROM/TO pairs and where to find their docs.
+
+---
+
+## Phase 2: Discover (scope in the project)
+
+Map every use-site of the FROM technology in the current codebase. Without a complete inventory, Cleanup cannot succeed — leftovers stay hidden.
+
+Produce `./swarm-report/<slug>-discover.md`:
+
+- **Use-site inventory** — files, classes, modules using the FROM technology. Group by horizontal (cuts across modules: DI, async, build plugins) vs vertical (single screen / module / feature).
+- **Dependency graph fragment** — which modules pull in the FROM library directly vs transitively. Note any modules where FROM leaks through `api` configuration.
+- **Generated-code footprint** — which `build/generated/...` directories will need cleanup; which downstream code imports from them.
+- **In scope / out of scope** — explicit list of what this migration will and will not touch. Adjacent migrations that surface during discovery (UI migration uncovers state-holder issues; DI migration uncovers scoping concerns) go into out-of-scope unless the user explicitly extends the contract in Phase 4.
+
+This phase must produce a `Risk of scope explosion` section listing any adjacent technology that *might* need migrating later. The list itself is the protection — it forces an explicit decision instead of drift.
+
+For investigations that touch the entire codebase, delegate to the Explore subagent rather than running grep yourself in the main session. See `~/.claude/rules/orchestration.md`.
+
+---
+
+## Phase 3: Behavior-Fix (three planes)
+
+Fix current behavior across three independent planes. Each plane catches what the others miss. The level of investment per plane is calibrated to the migration risk (see `references/behavior-fix.md` for the calibration matrix).
+
+**Plane A — Code tests.** Characterization tests (Feathers, *Working Effectively with Legacy Code*, ch. 13), contract tests, integration tests, golden snapshots. These run in CI and turn red on regression.
+
+**Plane B — Test cases (`<slug>-test-cases.md`).** Formal test scenarios written in prose — TC-1, TC-2, …, each with steps and expected outcome. This is the document the user reads during Phase 6 Device Verify; it is the source of truth for "what should still work".
+
+**Plane C — Manual scenarios (`<slug>-manual-scenarios.md`).** Exploratory paths that are hard to automate: accessibility (TalkBack/VoiceOver), RTL, dark mode, locale switching, low memory, slow network, configuration changes.
+
+Plane A is the strongest but most expensive. Plane B is the cheapest investment with the highest leverage — write the test cases before deciding how much of Plane A to invest in. Plane C is the safety net against unknown unknowns.
+
+See `references/behavior-fix.md` for templates, the calibration matrix (how much of each plane per migration type), and how to balance the investment against migration risk.
+
+If the FROM stack has zero tests and writing a full Plane A is more expensive than the migration itself — say so, propose dropping Plane A in favor of stronger Planes B and C, and capture the trade-off in Phase 4.
+
+---
+
+## Phase 4: Strategy + USER GATE
+
+This is the only mandatory blocking phase. Until the user confirms the strategy, do not start implementation.
+
+Produce `./swarm-report/<slug>-strategy.md` containing:
+
+1. **Chosen approach** — one of: Branch by Abstraction, Strangler Fig vertical slice, Duplicate-then-delete, Utility refactor. See `references/approaches.md` for the selection matrix.
+2. **Rationale** — why this approach, why not the others, in two sentences.
+3. **Implementation order** — which modules/files/screens go first, second, third. For horizontal migrations: bottom-up by dependency graph. For vertical: simplest screens first to build team confidence.
+4. **Intentional behavioral changes** — explicit list of "behavior X changes from A to B because Y". Anything not on this list must remain identical.
+5. **Bridge / interop layers** — if any (Hilt-Metro bridge, `AndroidView`, `rxSingle { await() }` adapters), each gets a sunset date and a removal criterion.
+6. **Rollback plan** — one paragraph describing how to undo the migration if Phase 6 finds blocking regressions.
+
+Present the strategy to the user, wait for explicit approval. The wait is the gate — phrased once, no nagging. Confirmation can be in any language; match by intent ("yes", "ok", "go", "approved", "looks good", a Russian/German/Spanish equivalent), not by exact phrase.
+
+After approval, the document becomes immutable. Any later change in scope or approach requires returning to Phase 4 explicitly.
+
+---
+
+## Phase 5: Implement
+
+Execute the migration according to the strategy. The four approaches differ in mechanics but share the same hand-off pattern: this skill produces a brief; an engineer agent (`developer-workflow-kotlin:kotlin-engineer` or `developer-workflow-kotlin:compose-developer` depending on layer) writes the code; the main session reviews.
+
+**Branch by Abstraction.** Introduce the abstraction first, route all use-sites through it (system still runs on the old impl), build the new impl, switch incrementally, then remove the old impl. The interface is the boundary; tests cover the boundary.
+
+**Strangler Fig vertical slice.** Migrate one self-contained slice (screen, module, feature) end-to-end on the new stack. Other slices keep using the old stack. Coexistence via interop (ComposeView/AndroidView for UI, Dagger/Metro interop for DI). No long-lived hybrid screens.
+
+**Duplicate-then-delete.** Copy the file/class/module under a new name or in a new package, freeze the original, migrate the copy, switch routing (feature flag, navigation, build variant), then delete the original. The simplest rollback mechanism — delete the copy.
+
+**Utility refactor.** Enable the new technology alongside the old (`viewBinding = true` next to `dataBinding = true`), convert use-sites in batches (manually or via IntelliJ plugin / scripted codemod), then remove the old flag. The compiler is the safety net.
+
+For full mechanics, trade-offs, and "when which" — see `references/approaches.md`.
+
+Delegate the actual implementation work. The main session orchestrates, agents implement. See `~/.claude/rules/orchestration.md` for the routing matrix.
+
+---
+
+## Phase 6: Device Verify
+
+Run the application on a device, emulator, or appropriate test harness (JVM rig for backend / library code). Walk through every TC in `<slug>-test-cases.md` and every scenario in `<slug>-manual-scenarios.md`. Compare actual behavior to FROM behavior recorded in Phase 3.
+
+For UI migrations, ask the user to provide before/after screenshots, or delegate the capture to the `manual-tester` agent.
+
+Produce `./swarm-report/<slug>-device-verify.md`:
+
+- TC-N → pass / fail / N/A, with a one-line note on any deviation.
+- Manual scenarios → same.
+- Discrepancies — for each: is it on the "intentional changes" list from Phase 4? If yes, mark as expected. If no, it is a regression — go back to Phase 5 to fix.
+
+The phase ends only when every TC and scenario is either passing or explicitly accepted as an intentional change.
+
+For Android device automation, the `android` CLI (Google's agent-oriented tool) is the primary mechanism for screen capture, layout dump, and APK deploy. See `~/.claude/rules/android-cli.md`. For exploratory QA against a running app, call the `developer-workflow:manual-tester` agent directly via the Task tool — do not invoke `/acceptance` from this skill.
+
+---
+
+## Phase 7: Cleanup
+
+Remove the FROM technology fully. Until this phase completes, the migration is not done — coexistence is technical debt, not a milestone.
+
+Use the universal checklist in `references/cleanup.md`. Walk it top to bottom for the specific migration:
+
+1. No imports of the FROM technology remain outside explicitly-frozen `:legacy:*` modules.
+2. `libs.versions.toml` no longer references the FROM technology version.
+3. `build.gradle*` plugin declarations removed (`kotlin("kapt")` if no other processors remain, `dataBinding = true`, etc.).
+4. Bridge / adapter / interop layers removed or registered as long-term public API with an ADR.
+5. Generated-code directories no longer populate for FROM.
+6. Lint baseline / Konsist rules for the migration removed or updated.
+7. Documentation (`CLAUDE.md`, ADRs, onboarding) updated.
+8. CI passes without legacy-related warnings.
+9. APK/AAB size reduced (Android only — sanity check that the dependency really left).
+10. Release notes list any intentional behavioral changes from Phase 4.
+
+Cleanup uses an engineer agent for code edits; review the deletions with `developer-workflow-experts:architecture-expert` if the migration was horizontal (DI, async, build) — these have the highest risk of leaving invisible coupling.
+
+---
+
+## Phase 8: Final Audit
+
+Close the loop. The artifacts are now an audit trail; the migration is complete or has a documented partial state.
+
+Produce `./swarm-report/<slug>-migration-report.md` aggregating:
+
+- Strategy (from Phase 4) — what was promised.
+- Implementation summary — what was done, which approach, deviations from the strategy and why.
+- Behavioral parity status — TC pass rate, intentional changes list, any accepted regressions with rationale.
+- Cleanup status — checklist from Phase 7 with pass/fail per item.
+- Outstanding follow-ups — adjacent migrations now visible, bridge layers that survived with sunset dates, technical debt incurred.
+
+Optionally request a `developer-workflow-experts:code-reviewer` pass on the cleanup commit and a `developer-workflow-experts:architecture-expert` pass on the strategy retrospective. These are optional — do not invoke them automatically. The user decides.
+
+---
+
+## Approach selection — quick reference
+
+| Migration class | Default approach | Why |
+|---|---|---|
+| Horizontal: DI, async runtime, build plugin | Branch by Abstraction | Global contract; copies cannot coexist |
+| Vertical: UI screen, feature module | Strangler Fig + Duplicate-then-delete | Self-contained; common abstraction is artificial |
+| Self-contained utility, single class | Duplicate-then-delete | Cheapest rollback, no abstraction overhead |
+| Idiom swap (Databinding → ViewBinding, KAPT → KSP, kotlin-android-extensions removal) | Utility refactor | Compiler enforces parity; full BBA is overkill |
+
+Full decision tree, mechanics, and trade-offs are in `references/approaches.md`. Consult it before locking in Phase 4.
+
+---
+
+## Artifacts checklist
+
+All artifacts live in `./swarm-report/`. None are mandatory beyond `<slug>-strategy.md` (the Phase 4 gate output). Skip what does not apply.
+
+- `<slug>-tech-snapshot.md` — FROM and TO technology study.
+- `<slug>-discover.md` — use-site inventory and scope.
+- `<slug>-behavior-spec.md` — index pointing to the three behavior-fix planes.
+- `<slug>-test-cases.md` — Plane B, formal test cases.
+- `<slug>-manual-scenarios.md` — Plane C, exploratory scenarios.
+- `<slug>-strategy.md` — Phase 4 output (mandatory).
+- `<slug>-device-verify.md` — Phase 6 verification log.
+- `<slug>-cleanup-checklist.md` — Phase 7 status per item.
+- `<slug>-migration-report.md` — Phase 8 final aggregation.
+
+Templates for each are in `references/artifacts.md`.
+
+---
+
+## Delegation routing
+
+The main session orchestrates; specialists implement. See `~/.claude/rules/orchestration.md` for the full matrix. Migration-specific routing:
+
+| Phase | Primary agent | Model |
+|---|---|---|
+| 1 Tech-Study | main session (light reads) + `Explore` for codebase scan | haiku for Explore |
+| 2 Discover | `Explore` for multi-file scan | haiku |
+| 3 Behavior-Fix code tests | `developer-workflow-kotlin:kotlin-engineer` or `compose-developer` | sonnet |
+| 4 Strategy | main session synthesis + optional `developer-workflow-experts:architecture-expert` review | opus for review |
+| 5 Implement | `kotlin-engineer` / `compose-developer` | sonnet |
+| 6 Device Verify | `developer-workflow:manual-tester` (when UI), or main session walking through TCs | sonnet |
+| 7 Cleanup | `kotlin-engineer` for deletions; `architecture-expert` for horizontal-migration review | sonnet / opus |
+| 8 Final Audit | optional `code-reviewer` + `architecture-expert` | sonnet / opus |
+
+This skill does not invoke other skills. The user decides whether to run `/check`, `/finalize`, `/create-pr`, or `/drive-to-merge` afterwards.
+
+---
+
+## Anti-patterns / red flags
+
+Stop and renegotiate (return to Phase 4) when:
+
+- The migration of one slice takes 2–3× the original estimate.
+- A new dependency surfaces ("we also need to migrate X to make Y work").
+- The cycle "old depends on new, new depends on old" appears anywhere in the diff. Loops block cleanup. The dependency direction must always be FROM → TO; never TO → FROM. See `references/anti-orchestrator.md` for the dependency-direction enforcement options (Konsist, Lint baseline).
+- A bridge layer outlives its sunset date once already — it is becoming permanent debt.
+- Phase 3 (Behavior-Fix) was skipped on a non-trivial migration. Without recorded behavior, parity is opinion, not evidence.
+- The skill starts calling `/acceptance`, `/finalize`, `/create-pr`, or any other slash command from inside its own phases. The skill is supposed to produce material, not to orchestrate the whole pipeline. See `references/anti-orchestrator.md`.

--- a/plugins/developer-workflow-kotlin/skills/migration/SKILL.md
+++ b/plugins/developer-workflow-kotlin/skills/migration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: migration
-description: "Use for migrating one technology to another in Android/Kotlin/KMP/JVM projects with behavioral parity — Databinding to ViewBinding, Dagger/Hilt to Metro DI, RxJava to Coroutines, KAPT to KSP, Java to Kotlin, Gson to kotlinx.serialization, and similar tech swaps. Triggers: \"migrate X to Y\", \"replace X with Y\", \"swap X for Y\", \"drop X in favor of Y\", \"move off X\", \"decommission X\". Covers studying FROM/TO technologies and their build artifacts, mapping use-sites, fixing current behavior across three planes (code tests + test cases + manual scenarios), agreeing strategy with the user, implementing via one of four approaches (Branch by Abstraction, Strangler Fig, Duplicate-then-delete, Utility refactor), verifying on a real device, and cleaning up the old stack fully. Do NOT use for: Android XML View to Jetpack Compose (use migrate-to-compose), enabling KMP on an Android project (use kmp-migration), bug fixes (use plan mode), or pure library version bumps without API changes (use maven-mcp:check-deps)."
+description: "Use for migrating one technology to another in Android/Kotlin/KMP/JVM projects with behavioral parity — Databinding to ViewBinding, Dagger/Hilt to Metro DI, RxJava to Coroutines, KAPT to KSP, Java to Kotlin, Gson to kotlinx.serialization, and similar tech swaps. Triggers: \"migrate X to Y\", \"replace X with Y\", \"swap X for Y\", \"drop X in favor of Y\", \"move off X\", \"decommission X\". Covers studying FROM/TO technologies and their build artifacts, mapping use-sites, fixing current behavior across three planes (code tests + test cases + manual scenarios), agreeing strategy with the user, implementing via one of four approaches (Branch by Abstraction, Strangler Fig, Duplicate-then-delete, Utility refactor), verifying on a real device, and cleaning up the old stack fully. Do NOT use for: Android XML View to Jetpack Compose (use migrate-to-compose), enabling KMP on an Android project (use kmp-migration), bug fixes (use plan mode), or pure library version bumps without API changes."
 ---
 
 # Migration
@@ -48,9 +48,9 @@ Produce `./swarm-report/<slug>-tech-snapshot.md` covering both FROM and TO:
 - **Side effects** — build time impact, generated R-classes, lint integration, IDE plugin requirements, KSP1 vs KSP2 compatibility, AGP version requirements.
 - **Interop facilities** — does the TO technology offer an explicit interop layer with FROM (Metro has Dagger interop; Coroutines have RxJava bridges; Compose has `AndroidView`/`ComposeView`)? This is the foundation for any incremental approach.
 
-Verify each fact against authoritative sources (official docs, the library's GitHub README, `ksrc` for installed dependencies). Do not rely on training-data memory — APIs and build behavior change.
+Verify each fact against authoritative sources — official documentation, the library's own GitHub README, the source code of installed dependencies. Do not rely on training-data memory — APIs and build behavior change.
 
-For Android-specific migrations, prefer `android docs search` for official guidance. For Kotlin/JVM libraries, use `ksrc` to read the actual installed source. See `references/approaches.md` for a list of common FROM/TO pairs and where to find their docs.
+If the project ships JVM/Kotlin dependencies in a Gradle cache, a source-reading tool (such as `ksrc` if installed) is preferred over web fetches because it sees the exact installed version. For Android platform migrations, an official Android docs search tool (such as the `android` CLI if installed) gives curated guidance; otherwise fall back to web search against `developer.android.com`. See `references/approaches.md` for a list of common FROM/TO pairs and where to find their docs.
 
 ---
 
@@ -140,7 +140,7 @@ Produce `./swarm-report/<slug>-device-verify.md`:
 
 The phase ends only when every TC and scenario is either passing or explicitly accepted as an intentional change.
 
-For Android device automation, the `android` CLI (Google's agent-oriented tool) is the primary mechanism for screen capture, layout dump, and APK deploy. See `~/.claude/rules/android-cli.md`. For exploratory QA against a running app, call the `developer-workflow:manual-tester` agent directly via the Task tool — do not invoke `/acceptance` from this skill.
+For Android device automation, an agent-oriented Android CLI (such as Google's `android` tool if installed) covers screen capture, layout dump, and APK deploy with one interface; without it, fall back to `adb` directly (`adb shell screencap`, `adb shell uiautomator dump`, `adb install`). For exploratory QA against a running app, call the `developer-workflow:manual-tester` agent directly via the Task tool — do not invoke `/acceptance` from this skill.
 
 ---
 

--- a/plugins/developer-workflow-kotlin/skills/migration/references/anti-orchestrator.md
+++ b/plugins/developer-workflow-kotlin/skills/migration/references/anti-orchestrator.md
@@ -72,18 +72,23 @@ fun `no new code depends on legacy databinding`() {
 
 ### Gradle dependency constraints
 
-For module-level boundaries: prevent any module outside `:legacy:*` from depending on the FROM library directly.
+For module-level boundaries: actively fail the build if a module outside `:legacy:*` depends on the FROM library. A plain Gradle version constraint does not block a dependency — it only narrows version resolution; conflict resolution can still pick whatever the consumer requested. Use one of the mechanisms that actually fails the build instead:
 
 ```kotlin
-// build.gradle.kts of a feature module
-dependencies {
-    constraints {
-        implementation("com.google.dagger:dagger-android:0.0.0") {
-            because("Migrating to Metro. New code must not use Dagger.")
+// build.gradle.kts of a feature module — resolution strategy that hard-fails on the legacy artifact.
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "com.google.dagger") {
+            throw GradleException(
+                "Module ${project.path} must not depend on Dagger directly. " +
+                "Migrating to Metro — see migration plan in swarm-report/."
+            )
         }
     }
 }
 ```
+
+Or, for repository-wide policy that does not need to live in every module, a Konsist or `ArchUnit` test (running in `:test` of a dedicated `:rules` module) is more discoverable and runs in CI.
 
 These are recommendations to the user, not skill-enforced rules. The skill points at them; the user adopts them.
 

--- a/plugins/developer-workflow-kotlin/skills/migration/references/anti-orchestrator.md
+++ b/plugins/developer-workflow-kotlin/skills/migration/references/anti-orchestrator.md
@@ -1,0 +1,103 @@
+# Anti-orchestrator — five criteria
+
+This skill must not become an orchestrator. The deleted `code-migration` skill (v0.14.0) was an orchestrator and was removed because forced pipelines are a worse user experience than plan mode + on-demand tools.
+
+If any of the criteria below is violated in an iteration of this skill, the skill is reverting to the deleted v0.14.0 design. Treat each one as a hard constraint, not a guideline.
+
+## Criterion 1: Each invocation is narrow
+
+This is one skill for one migration at a time. Not a meta-skill that schedules multiple migrations. Not a wrapper that delegates to a sub-skill per migration type.
+
+The deleted v0.14.0 tried to describe "the phenomenon of migration in general" with a state machine that branched on feature-flow vs bugfix-flow. This skill instead describes one phase structure that the user walks through for one migration; the user picks the approach inside Phase 4.
+
+**Test.** If the SKILL.md grows a `feature-flow` / `bugfix-flow` / `<other>-flow` selector at the top, the skill is over-reaching.
+
+## Criterion 2: Phases are checklists, not state transitions
+
+The eight phases are headings in SKILL.md, not nodes in a graph. There is no explicit `state machine`, no enumerated transitions, no `Discovery → Plan → Implement → Acceptance` enforcement.
+
+The single exception is Phase 4 (Strategy + User Gate). It is the only place where the skill explicitly waits for user confirmation before proceeding. Everything else flows naturally — the user can skip a phase, return to a previous one, or run phases out of order if it makes sense.
+
+**Test.** If the SKILL.md text uses words like `cycle`, `cap`, `escalation point`, `state transition`, `PARTIAL`, `FULL`, or describes phase-to-phase routing rules, the skill is becoming a state machine.
+
+## Criterion 3: Any phase except Phase 4 is optional
+
+Tech-Study, Discover, Behavior-Fix, Implement, Device Verify, Cleanup, Final Audit — each can be skipped by the user. The skill describes what each phase produces and why it is useful; the user decides which ones apply.
+
+Phase 4 is the only mandatory gate because the user explicitly asked for it during the design of this skill — they want to confirm the strategy before implementation starts.
+
+**Test.** If the SKILL.md says "this phase is mandatory" or "this phase blocks the next" for any phase other than Phase 4, the skill is wrong.
+
+## Criterion 4: This skill does not invoke other skills
+
+It does not call `/check`, `/finalize`, `/create-pr`, `/drive-to-merge`, `/acceptance`, `/multiexpert-review`, `/write-spec`, or any other slash command from its phases.
+
+The skill delegates to **agents** (kotlin-engineer, compose-developer, code-reviewer, architecture-expert, manual-tester) for implementation work — that is normal subagent delegation. But it does not chain skills.
+
+Reasoning: the user is in control. Plan mode is the orchestrator. After Phase 7 (Cleanup), the user runs `/check` and `/finalize` because they want to, not because this skill schedules them.
+
+**Test.** If `Phase N` in SKILL.md says "run `/check` now" or "invoke `/finalize` at the end", the skill is orchestrating other skills.
+
+## Criterion 5: Artifacts inform; they do not gate
+
+Files in `./swarm-report/` are documents for the user — `<slug>-tech-snapshot.md`, `<slug>-discover.md`, `<slug>-test-cases.md`, etc. They are not lock files. There is no `if file does not exist, refuse to proceed` logic.
+
+The single exception is `<slug>-strategy.md` — Phase 4 produces it and the user confirms it before implementation. Implementation should not start without user confirmation, and the strategy document is the record of what was confirmed.
+
+**Test.** If the SKILL.md text says "do not proceed without `<slug>-X.md`" for any X except `strategy.md`, the skill is using artifacts as gates.
+
+---
+
+## Dependency-direction enforcement (architectural, not skill-level)
+
+A related risk: code-level loops between FROM and TO (new depends on old; old depends on new). These are not orchestrator issues but they are migration killers — they make cleanup impossible.
+
+The skill does not enforce these — they belong in the project's architecture rules. But the skill should *recommend* them in Phase 4:
+
+### Konsist rule example
+
+```kotlin
+@Test
+fun `no new code depends on legacy databinding`() {
+    Konsist.scopeFromProject()
+        .files()
+        .filterNot { it.packageDeclaration?.fullyQualifiedName?.contains(".legacy.") == true }
+        .assertFalse { it.text.contains("import android.databinding") }
+}
+```
+
+### Lint baseline as gate
+
+`lint-baseline.xml` records current Databinding usages. New usages do not appear in the baseline and fail the lint check. Apply on the migration branch from day 1 so growth is blocked while migration progresses.
+
+### Gradle dependency constraints
+
+For module-level boundaries: prevent any module outside `:legacy:*` from depending on the FROM library directly.
+
+```kotlin
+// build.gradle.kts of a feature module
+dependencies {
+    constraints {
+        implementation("com.google.dagger:dagger-android:0.0.0") {
+            because("Migrating to Metro. New code must not use Dagger.")
+        }
+    }
+}
+```
+
+These are recommendations to the user, not skill-enforced rules. The skill points at them; the user adopts them.
+
+---
+
+## How to spot drift
+
+If a future iteration of this skill starts to look like an orchestrator, expect these symptoms:
+
+- The SKILL.md grows beyond 500 lines.
+- A new phase appears that "orchestrates" or "schedules" earlier phases.
+- The skill starts emitting commands to run other skills.
+- Artifacts get prefixed with `state-` (signal of state-machine thinking).
+- A glossary of statuses appears (PARTIAL, FULL, ESCALATE, BLOCKED).
+- The user reports "this feels like a forced pipeline".
+
+The fix in all cases is to strip the orchestration and return to: one skill, eight phases as headings, one gate at Phase 4, everything else informational.

--- a/plugins/developer-workflow-kotlin/skills/migration/references/approaches.md
+++ b/plugins/developer-workflow-kotlin/skills/migration/references/approaches.md
@@ -182,6 +182,6 @@ When studying FROM and TO in Phase 1, prefer authoritative sources. Training-dat
 | AGP major bump with breaking changes | Utility refactor + targeted BBA for breakages | https://developer.android.com/build/agp-upgrade-assistant, release notes for the AGP version |
 
 For each migration, also check:
-- The library's own GitHub release notes for the FROM and TO versions.
-- `maven-mcp:dependency-changes <from> <to>` for an automatic changelog summary.
-- `maven-mcp:check-deps-vulnerabilities` on both versions — a vulnerability in either is a separate decision input.
+- The library's own GitHub release notes for the FROM and TO versions, focusing on breaking changes between them.
+- A dependency-changelog lookup capability, if one is installed, can summarize the diff between two versions automatically; otherwise read the release notes manually.
+- A vulnerability scan on the FROM dependency in the current project — a known CVE in FROM is a separate decision input. If a vulnerability is also publicly known to be fixed in TO, that strengthens the case for the migration. Use whatever dependency-vulnerability scanner is installed (or the ecosystem default: `npm audit`, `pip-audit`, `cargo audit`, the OSV CLI).

--- a/plugins/developer-workflow-kotlin/skills/migration/references/approaches.md
+++ b/plugins/developer-workflow-kotlin/skills/migration/references/approaches.md
@@ -1,0 +1,187 @@
+# Migration Approaches
+
+Four approaches to migrating from one technology to another, with the criteria that select between them and the mechanics of each. Consult this document during Phase 4 (Strategy) — the choice of approach is the most consequential decision of the entire migration.
+
+## Table of contents
+
+- Decision tree
+- Approach 1: Branch by Abstraction
+- Approach 2: Strangler Fig (vertical slice)
+- Approach 3: Duplicate-then-delete
+- Approach 4: Utility refactor
+- Side-by-side comparison
+- Common FROM/TO pairs and where to find authoritative docs
+
+---
+
+## Decision tree
+
+Use this order of questions to pick an approach. Stop at the first match.
+
+1. **Does the technology have a global contract that cuts across the whole module graph?** (DI registry, async runtime, build plugin, logging framework, serialization framework.) → **Branch by Abstraction**. Copies cannot coexist; you need a single contract and two implementations behind it.
+
+2. **Is the migration scoped to a self-contained vertical (one screen, one feature module, one bounded set of files) with no global contract?** → **Strangler Fig**. Migrate the slice end-to-end on the new stack; the rest of the system continues on the old stack via interop (`ComposeView`/`AndroidView`, Dagger/Metro interop, RxJava-Coroutines bridges).
+
+3. **Inside a vertical slice, is introducing a common abstraction artificial?** (For example: an XML screen and a Compose screen do not share a meaningful API contract — they are different paradigms.) → **Duplicate-then-delete**. Copy the file/class/module, freeze the original, migrate the copy, switch routing, then delete the original.
+
+4. **Is the migration an idiom swap where the compiler enforces parity?** (Databinding → ViewBinding, KAPT → KSP for one processor, `kotlin-android-extensions` → ViewBinding, Java → Kotlin file-by-file.) → **Utility refactor**. Enable both side-by-side, convert in batches, remove the old flag.
+
+Edge cases:
+- **Cross-cutting concern over a vertical slice** (e.g., migrating logging on one screen): treat as Utility refactor — the contract is local.
+- **DB schema migration**: this is a different category. Use proper migration tooling (Room/SQLDelight migrations, Flyway, Liquibase). The four approaches here do not apply directly.
+- **`expect/actual` contract change in KMP**: the migration is horizontal across platforms — use Branch by Abstraction, but the `expect` declaration *is* the abstraction.
+
+---
+
+## Approach 1: Branch by Abstraction
+
+**Source.** Fowler, https://martinfowler.com/bliki/BranchByAbstraction.html.
+
+**When.** Horizontal migrations: DI framework (Hilt → Metro, Dagger → Hilt), async runtime (RxJava → Coroutines), serialization (Gson → kotlinx.serialization), logging framework, threading model, build plugin replacement (KAPT → KSP for projects with many processors). Anywhere the technology has a global contract that touches the whole module graph.
+
+**Mechanics.**
+
+1. **Identify.** Find every use-site of the FROM technology. Output of Phase 2 (Discover).
+2. **Introduce abstraction.** Define an interface or abstract type that captures the contract. The existing `OldImpl` implements it; nothing else changes. Convert every use-site to depend on the abstraction. The system still runs on `OldImpl` — behavior is unchanged.
+3. **Build new implementation.** Write `NewImpl` against the abstraction. Wire it up but do not switch yet. Run all contract tests against both implementations in a `@ParameterizedTest impl: [OldImpl, NewImpl]` matrix.
+4. **Switch incrementally.** Feature flag, per-module switch, per-environment toggle. One line of code chooses `OldImpl` or `NewImpl`. Rollback is the inverse.
+5. **Remove old.** After full cutover and a soak period, delete `OldImpl`. If the abstraction was introduced only for the migration and has no other reason to exist, consider removing it as well.
+
+**Trade-offs.**
+
+- (+) System works on every step. No long-lived divergent branches.
+- (+) Rollback is one line.
+- (+) Parallel `OldImpl`/`NewImpl` under one contract enables shadow run and A/B testing.
+- (−) Up-front investment in characterization tests is non-trivial.
+- (−) The abstraction can fossilize and remain after the migration is "done", carrying maintenance cost.
+
+**Phase 3 (Behavior-Fix) emphasis.** Plane A (code tests) is dominant — characterization tests on `OldImpl` become contract tests on the abstraction.
+
+---
+
+## Approach 2: Strangler Fig (vertical slice)
+
+**Source.** Fowler, https://martinfowler.com/bliki/StranglerFigApplication.html.
+
+**When.** Vertical migrations where the unit of migration is a self-contained slice: one screen, one feature module, one bounded set of files. The migration progresses slice by slice; the rest of the system runs on the old stack until its own slice is migrated.
+
+**Mechanics.**
+
+1. **Slice inventory.** List every slice that needs to migrate (Phase 2 output). Order by complexity ascending — simplest first to build team experience.
+2. **Coexistence layer.** Establish how old and new stacks coexist. UI: `ComposeView` and `AndroidView` from Google's official interop (https://developer.android.com/develop/ui/compose/migrate/interoperability-apis). DI: Dagger/Metro interop modules. Async: `rxSingle { }`, `await()`, `asFlow()`, `asObservable()`.
+3. **Migrate one slice.** Pick the first slice. Replace its implementation entirely on the new stack. Wire it back into the system via the coexistence layer. Capture behavior tests against the slice before and after.
+4. **Verify and ship.** Phase 6 on the slice. Ship it (behind a feature flag for the first slice; subsequent slices once the team is confident).
+5. **Repeat.** Move to the next slice.
+6. **Remove coexistence layer.** When the last slice migrates, the bridge is no longer needed. Delete it.
+
+**Trade-offs.**
+
+- (+) Risk is bounded to one slice at a time.
+- (+) Production feedback per slice — issues surface early.
+- (+) Compatible with Duplicate-then-delete inside a slice (combine approaches).
+- (−) Coexistence layer is fragile and must be policed; long-lived hybrid screens are anti-pattern (Getir, Reddit case studies).
+- (−) Some slices are not actually self-contained; what looks like a slice may share state with the rest of the system.
+
+**Phase 3 (Behavior-Fix) emphasis.** Plane B (test cases) and Plane C (manual scenarios) carry most of the weight per slice. Plane A is useful but slice-scoped.
+
+---
+
+## Approach 3: Duplicate-then-delete
+
+**When.** Vertical migrations where introducing a common abstraction (Branch by Abstraction) would be artificial. The classic case: migrating an XML screen to a Compose screen — there is no meaningful API contract shared by `LoginActivity` and `LoginScreen` composable. They are different paradigms.
+
+Also applies to: self-contained utility classes, mappers, pure functions, entire feature modules.
+
+**Mechanics.**
+
+1. **Copy.** Duplicate the file/class/module under a new name or in a new package. Examples: `LoginScreenLegacy.kt` next to `LoginScreen.kt`; `:feature:checkout-legacy` next to `:feature:checkout`; `OldMapper.kt` frozen, `NewMapper.kt` mutable.
+2. **Freeze the original.** Do not modify the original after the copy is made. If a bug surfaces in the original during the migration, decide explicitly: fix in original (and re-copy), fix only in new, or leave both (defer).
+3. **Route.** Build the switch mechanism. Options: feature flag (`if (flag.useNewLogin) NewLoginScreen() else LegacyLoginScreen()`); build variant (`mainDebug` vs `mainRelease`); navigation entry (`composable("login_new")` vs `Fragment("LoginLegacy")`); `productFlavors` for fully separated builds.
+4. **Migrate the copy.** Rewrite the copy on the new stack while the original keeps serving production. Phase 6 device verification runs on the copy.
+5. **Switch routing.** Route all traffic to the new copy. Monitor.
+6. **Delete the original.** After a soak period, delete the original and simplify the routing to single-target.
+
+**Trade-offs.**
+
+- (+) Rollback is trivial: switch routing back, delete the copy.
+- (+) No abstraction overhead; no forcing of artificial contracts.
+- (+) Side-by-side code makes review easier — reviewers see both versions.
+- (−) Code drift: the original may get bugfixes that miss the copy (or vice versa). Mitigation: explicit freeze policy.
+- (−) Double build cost during the transition.
+- (−) Naming and package conflicts: requires explicit naming convention (`*Legacy` suffix, `legacy/` subpackage) or separate modules.
+- (−) Does not work for horizontal migrations (DI, async) — global graphs do not duplicate.
+
+**Phase 3 (Behavior-Fix) emphasis.** Plane B (test cases) and golden snapshots (Plane A subset). Test cases are walked against both copies during Phase 6.
+
+---
+
+## Approach 4: Utility refactor
+
+**When.** The migration is an idiom swap where the compiler and lint enforce parity:
+
+- Databinding → ViewBinding (replaces XML expression evaluation with direct field access; compiler catches type mismatches).
+- KAPT → KSP for a specific annotation processor (Room, Dagger, Hilt — all ship KSP variants with the same generated API).
+- `kotlin-android-extensions` (synthetic properties) → ViewBinding.
+- Java → Kotlin file-by-file (Kotlin compiler enforces null safety, type checks).
+- Gradle Groovy DSL → Kotlin DSL.
+- Older API → newer API on the same library, where the change is mechanical.
+
+**Mechanics.**
+
+1. **Enable side-by-side.** Turn on the new technology while leaving the old enabled. Example: `buildFeatures { viewBinding = true; dataBinding = true }`. Both can coexist during transition.
+2. **Convert in batches.** Use IntelliJ refactoring, an existing plugin (`Flamedek/viewbinding-migration-plugin` for Databinding → ViewBinding), or a scripted codemod. Convert per module or per batch of files. Run the build after each batch.
+3. **Handle non-mechanical leftovers.** Each idiom has corner cases the compiler cannot rewrite for you. For Databinding → ViewBinding: `@BindingAdapter` definitions, two-way binding (`@={}`), `BindingConversion`, `@={ ...}` observable polling. Extract these into extension functions or imperative listener code.
+4. **Snapshot UI sanity check (optional but recommended).** Run Paparazzi/Roborazzi on the screens that used the old idiom — catches null-handling and visibility regressions.
+5. **Remove the old flag.** Once no use-sites remain, drop `dataBinding = true` (or whatever the activation flag was). Delete generated files. Update `libs.versions.toml` if the dependency is no longer needed.
+
+**Trade-offs.**
+
+- (+) Cheapest class of migrations.
+- (+) Compiler is the safety net; runtime regressions are rare.
+- (+) Can be done incrementally on a large codebase without a flag day.
+- (−) The "trivial" idiom swap often hides a non-trivial corner: `@BindingAdapter` removal can be substantial work in itself.
+- (−) Easy to forget the cleanup step — `dataBinding = true` stays in build files even after the last `<layout>` tag is gone, KAPT plugin stays when no processors need it.
+
+**Phase 3 (Behavior-Fix) emphasis.** Plane B (test cases) for sanity; Plane A only on parts the compiler does not catch (custom binding adapters, null handling, two-way binding logic).
+
+---
+
+## Side-by-side comparison
+
+| Dimension | 1. BBA | 2. Strangler | 3. Duplicate-then-delete | 4. Utility refactor |
+|---|---|---|---|---|
+| Effort | L | M per slice | M | S |
+| Blast radius | Whole graph behind one contract | One slice | One file/class | Imports + generated |
+| Rollback | One line (switch impl) | Per-slice route | Delete copy + switch | Revert commit |
+| Behavioral guarantee | Contract tests, optional shadow run | Golden snapshots + behavior-scenarios | Side-by-side QA + golden snapshots | Compiler + lint + snapshot sanity |
+| Cleanup signal | Delete `OldImpl` + interface | Delete coexistence layer | Delete original file/module | Drop old flag, delete generated |
+| Boundary location | Module / Gradle dependency | Composable / Fragment / Screen / Module | File / class / package | Import / package |
+| Horizontal contract (DI, async, build) | Yes | No (slice has no global contract) | No (cannot duplicate global graph) | Yes (compiler enforces) |
+| Vertical slice (UI, screen) | Possible but artificial | Yes | Yes | Possible |
+
+---
+
+## Common FROM/TO pairs and where to find authoritative docs
+
+When studying FROM and TO in Phase 1, prefer authoritative sources. Training-data memory is unreliable for build-time behavior.
+
+| Migration | Approach | Where to verify |
+|---|---|---|
+| Databinding → ViewBinding | Utility refactor | https://developer.android.com/topic/libraries/view-binding/migration |
+| `kotlin-android-extensions` → ViewBinding | Utility refactor | https://developer.android.com/topic/libraries/view-binding/migration |
+| Dagger → Hilt | BBA + Utility (mechanical parts) | https://dagger.dev/hilt/migration-guide.html |
+| Hilt / Dagger → Metro DI | BBA | https://github.com/ZacSweers/metro, https://www.zacsweers.dev/metro-is-stable/ |
+| Anvil → Metro DI | BBA | https://github.com/ZacSweers/metro, square/metro-extensions for compiler-plugin scenarios |
+| RxJava → Coroutines/Flow | BBA | kotlinx-coroutines-rx interop module README on GitHub |
+| Gson/Moshi → kotlinx.serialization | BBA | https://kotlinlang.org/docs/serialization.html |
+| KAPT → KSP (specific processor) | Utility refactor | https://kotlinlang.org/docs/ksp-overview.html, processor's own KSP guide |
+| Java → Kotlin (per file) | Utility refactor | https://kotlinlang.org/docs/mixing-java-kotlin-intellij.html |
+| XML View → Compose (a screen) | Duplicate-then-delete | Use the `migrate-to-compose` skill (this skill defers to it) |
+| Fragment navigation → Compose navigation | Strangler Fig per screen | https://developer.android.com/develop/ui/compose/navigation |
+| Groovy Gradle → Kotlin Gradle | Utility refactor (file by file) | https://docs.gradle.org/current/userguide/migrating_from_groovy_to_kotlin_dsl.html |
+| AGP major bump with breaking changes | Utility refactor + targeted BBA for breakages | https://developer.android.com/build/agp-upgrade-assistant, release notes for the AGP version |
+
+For each migration, also check:
+- The library's own GitHub release notes for the FROM and TO versions.
+- `maven-mcp:dependency-changes <from> <to>` for an automatic changelog summary.
+- `maven-mcp:check-deps-vulnerabilities` on both versions — a vulnerability in either is a separate decision input.

--- a/plugins/developer-workflow-kotlin/skills/migration/references/artifacts.md
+++ b/plugins/developer-workflow-kotlin/skills/migration/references/artifacts.md
@@ -72,7 +72,8 @@ Does TO offer a bridge with FROM?
 
 - Official doc: ...
 - GitHub: ...
-- Verified via: ksrc / android docs / Context7 / WebFetch
+- Verified via: <official docs / installed dependency source / release notes / authoritative web source>
+- Reference source category for this entry: <one of: official documentation, installed dependency source, GitHub release notes, library README, third-party article (rare — name and justify)>
 ```
 
 ---

--- a/plugins/developer-workflow-kotlin/skills/migration/references/artifacts.md
+++ b/plugins/developer-workflow-kotlin/skills/migration/references/artifacts.md
@@ -1,0 +1,378 @@
+# Artifacts — templates
+
+All migration artifacts live in `./swarm-report/<slug>-*.md` where `<slug>` is a kebab-case short identifier for the migration (`databinding-to-viewbinding`, `hilt-to-metro`, `rxjava-to-coroutines`).
+
+None are mandatory beyond `<slug>-strategy.md` (Phase 4 gate output). Skip what does not apply.
+
+## Index
+
+| Phase | Artifact | Mandatory |
+|---|---|---|
+| 1 | `<slug>-tech-snapshot.md` | no |
+| 2 | `<slug>-discover.md` | no |
+| 3 | `<slug>-behavior-spec.md` (index) | no |
+| 3 | `<slug>-test-cases.md` | recommended |
+| 3 | `<slug>-manual-scenarios.md` | recommended |
+| 4 | `<slug>-strategy.md` | **yes** |
+| 6 | `<slug>-device-verify.md` | no |
+| 7 | `<slug>-cleanup-checklist.md` | recommended |
+| 8 | `<slug>-migration-report.md` | recommended |
+
+---
+
+## `<slug>-tech-snapshot.md`
+
+```markdown
+# Tech Snapshot: <FROM> -> <TO>
+
+## FROM: <technology name and version>
+
+### Generated artifacts
+- What it generates: ...
+- Where: ...
+- Via: KAPT / KSP / FIR-IR / AGP plugin / runtime
+
+### Build hooks
+- Gradle plugin id: ...
+- Activation flag: ...
+- Tasks registered: ...
+
+### Classpath / scanning behavior
+- Annotation scanning across modules: yes/no
+- Entry-point markers required: ...
+- Inject time: compile / runtime
+
+### Side effects
+- Build time impact: ...
+- Generated R classes: ...
+- Lint integration: ...
+- IDE plugin: ...
+- KSP1 vs KSP2: ...
+- AGP version constraint: ...
+
+### Known limitations
+- ...
+
+## TO: <technology name and version>
+
+(Same structure as FROM)
+
+## Interop facilities
+
+Does TO offer a bridge with FROM?
+- ...
+
+## Migration-relevant differences
+
+| Aspect | FROM | TO |
+|---|---|---|
+| ... | ... | ... |
+
+## Sources
+
+- Official doc: ...
+- GitHub: ...
+- Verified via: ksrc / android docs / Context7 / WebFetch
+```
+
+---
+
+## `<slug>-discover.md`
+
+```markdown
+# Discover: <slug>
+
+Migration: <FROM> -> <TO>
+Date: <YYYY-MM-DD>
+
+## Use-site inventory
+
+### Horizontal cross-cuts
+- Modules affected: :core:*, :data:*, :domain, :feature:*
+- Total files: N
+
+### Vertical slices (if any)
+- :feature:login (8 files)
+- :feature:checkout (12 files)
+
+## Dependency graph fragment
+
+- :app depends on FROM (transitively via :feature:*)
+- :feature:* depends on FROM directly via `implementation`
+- :data:* does not depend on FROM
+
+## Generated-code footprint
+
+- build/generated/databinding/* in modules: :feature:login, :feature:checkout, :feature:profile
+- Total generated files at last clean build: ~120
+
+## In scope
+- All modules in :feature:*
+- Specifically: replace Databinding with ViewBinding; remove `<layout>` wrapping; convert `@BindingAdapter` to extension functions.
+
+## Out of scope
+- ViewModel state management (LiveData stays as LiveData; no migration to StateFlow)
+- Navigation framework (stays Fragment-based)
+- DI framework (stays Hilt)
+
+## Risk of scope explosion
+
+The following adjacent migrations might surface during work and are explicitly deferred:
+- LiveData -> StateFlow (would simplify Compose adoption later, but not now)
+- Fragment -> Compose Navigation (separate migration)
+- KAPT -> KSP for Hilt (if Hilt eventually migrates to KSP, separate effort)
+```
+
+---
+
+## `<slug>-behavior-spec.md`
+
+Thin index document. See `references/behavior-fix.md` for the full template — the example there is canonical.
+
+---
+
+## `<slug>-test-cases.md`
+
+```markdown
+# Test Cases: <slug>
+
+Migration: <FROM> -> <TO>
+Source: <link to acceptance criteria or behavior recording>
+Last updated: <YYYY-MM-DD>
+
+## TC-1: User logs in with valid credentials
+**Preconditions:** App freshly installed, no user logged in.
+**Priority:** P0
+**Steps:**
+1. Open the app, navigate to Login.
+2. Enter email "test@example.com".
+3. Enter password "correctPassword123".
+4. Tap "Log in".
+**Expected:** Loading spinner appears for ~1s, then user lands on Home screen. Email is shown in the top bar.
+**Verification source:** Plane A `LoginIntegrationTest#logsInWithValidCredentials` + manual.
+
+## TC-2: User sees validation error for empty email
+**Preconditions:** App on Login screen.
+**Priority:** P1
+**Steps:**
+1. Leave email empty.
+2. Enter any password.
+3. Tap "Log in".
+**Expected:** Inline error under email field: "Enter your email." Login button stays disabled until email is non-empty.
+**Verification source:** manual only.
+
+## TC-3: ...
+```
+
+Priority guide:
+- **P0** — crash, data loss, security, payment, auth.
+- **P1** — acceptance criteria from migration scope.
+- **P2** — happy path of each surface.
+- **P3** — edges, boundaries, locale, timezone.
+
+---
+
+## `<slug>-manual-scenarios.md`
+
+```markdown
+# Manual Scenarios: <slug>
+
+## MS-1: Accessibility (TalkBack)
+- Open Login screen.
+- Enable TalkBack.
+- Walk through with swipe-right navigation.
+- Verify: focus order is email -> password -> login button -> forgot password link.
+- Verify: each control announces its label and current state.
+
+## MS-2: RTL
+- Set device language to Arabic.
+- Open Login screen.
+- Verify: form fields right-aligned.
+- Verify: leading/trailing icons flipped.
+
+## MS-3: Dark mode
+- Toggle system dark mode.
+- Verify: backgrounds, text colors, button colors all switch correctly.
+- Verify: no hard-coded #FFFFFF / #000000 leaking.
+
+## MS-4: Configuration change
+- Open Login screen.
+- Type email and password (do not submit).
+- Rotate device.
+- Verify: typed values are preserved.
+
+## MS-5: Process death
+- Open Login screen.
+- Background the app.
+- adb shell am kill <pkg>.
+- Reopen.
+- Verify: app resumes at Login (or appropriate restoration point).
+```
+
+Adapt the scenarios to the surface being migrated. For backend / library migrations without UI, replace MS-1..MS-3 with concurrency, error handling, and resource cleanup scenarios.
+
+---
+
+## `<slug>-strategy.md` (Phase 4 — mandatory gate output)
+
+```markdown
+# Strategy: <slug>
+
+Migration: <FROM> -> <TO>
+Date: <YYYY-MM-DD>
+Author: <Claude / user>
+Status: Draft | Confirmed (with timestamp of confirmation)
+
+## Chosen approach
+
+<one of: Branch by Abstraction | Strangler Fig | Duplicate-then-delete | Utility refactor>
+
+## Rationale
+
+<one or two sentences on why this approach, why not the others>
+
+## Implementation order
+
+1. ...
+2. ...
+3. ...
+
+Rationale for ordering: bottom-up by dependency graph / simplest first / by user-facing risk / ...
+
+## Intentional behavioral changes
+
+Anything that intentionally changes between FROM and TO. Anything not in this list must remain identical.
+
+- ...
+
+## Bridge / interop layers
+
+If any temporary bridge is introduced during Phase 5, list it here with sunset criterion.
+
+| Bridge | Purpose | Sunset criterion | Sunset target date |
+|---|---|---|---|
+| ... | ... | ... | YYYY-MM-DD |
+
+If no bridges are needed, write "None — direct migration".
+
+## Rollback plan
+
+<one paragraph: how do we undo this migration if Phase 6 reveals a blocking regression?>
+
+## User confirmation
+
+- [ ] User has reviewed this strategy and approved.
+
+Confirmation timestamp: <YYYY-MM-DD HH:MM>
+```
+
+---
+
+## `<slug>-device-verify.md`
+
+```markdown
+# Device Verify: <slug>
+
+Migration: <FROM> -> <TO>
+Verification date: <YYYY-MM-DD>
+Device(s): <device + OS version>
+Build under test: <branch / commit / build number>
+
+## Test cases (from <slug>-test-cases.md)
+
+| ID | Title | Status | Notes |
+|---|---|---|---|
+| TC-1 | User logs in with valid credentials | pass | identical to FROM |
+| TC-2 | Validation error for empty email | pass | |
+| TC-3 | ... | fail | error toast color differs from FROM |
+| ... | ... | ... | ... |
+
+## Manual scenarios (from <slug>-manual-scenarios.md)
+
+| ID | Title | Status | Notes |
+|---|---|---|---|
+| MS-1 | Accessibility | pass | |
+| MS-2 | RTL | partial | login button reflows on long Arabic labels |
+| ... | ... | ... | ... |
+
+## Discrepancies
+
+For each non-pass result above, classify:
+
+- TC-3 (error toast color): **regression**, go back to Phase 5 and align color.
+- MS-2 (button reflow): **intentional change** per Phase 4 strategy (longer-text accommodation was explicitly accepted).
+
+## Sign-off
+
+- [ ] All TCs and MSs are either passing or explicitly classified as intentional.
+- [ ] Regressions, if any, are fixed and re-verified.
+
+Verifier: <name>
+Date: <YYYY-MM-DD>
+```
+
+---
+
+## `<slug>-cleanup-checklist.md`
+
+See `references/cleanup.md` — the template at the end is canonical.
+
+---
+
+## `<slug>-migration-report.md` (Phase 8 final aggregation)
+
+```markdown
+# Migration Report: <slug>
+
+Migration: <FROM> -> <TO>
+Started: <YYYY-MM-DD>
+Completed: <YYYY-MM-DD>
+Status: Done | Partial | Blocked
+
+## Strategy (from Phase 4)
+
+<approach + rationale + intentional changes — copy/paste from strategy.md>
+
+## Implementation summary
+
+- Approach used: ...
+- Modules migrated: N
+- Files changed: M
+- Bridges introduced: K (all removed in Cleanup; or list survivors with sunset)
+- Deviations from strategy: <if any, with reasoning>
+
+## Behavioral parity status
+
+- Plane A coverage: <test names + counts>
+- Plane B (test cases): <TC count, P0/P1/P2/P3 breakdown>; pass rate: X%
+- Plane C (manual scenarios): <MS count>; pass rate: X%
+- Intentional changes shipped: <list from strategy>
+- Accepted regressions (with rationale): <if any>
+
+## Cleanup status
+
+<10-item checklist from cleanup.md with per-item status>
+
+## Outstanding follow-ups
+
+- Adjacent migrations now visible: ...
+- Bridge layers that survived with sunset dates: ...
+- Technical debt incurred: ...
+
+## Issues found (out of scope)
+
+Things observed during the migration that were not migrated (bugs, refactor opportunities, missing tests). For each: short description + suggested follow-up tracker entry.
+
+- ...
+
+## Sources
+
+- Tech snapshot: ./swarm-report/<slug>-tech-snapshot.md
+- Discover: ./swarm-report/<slug>-discover.md
+- Behavior spec: ./swarm-report/<slug>-behavior-spec.md
+- Test cases: ./swarm-report/<slug>-test-cases.md
+- Manual scenarios: ./swarm-report/<slug>-manual-scenarios.md
+- Strategy: ./swarm-report/<slug>-strategy.md
+- Device verify: ./swarm-report/<slug>-device-verify.md
+- Cleanup: ./swarm-report/<slug>-cleanup-checklist.md
+```

--- a/plugins/developer-workflow-kotlin/skills/migration/references/behavior-fix.md
+++ b/plugins/developer-workflow-kotlin/skills/migration/references/behavior-fix.md
@@ -1,0 +1,173 @@
+# Behavior-Fix — three planes
+
+Phase 3 fixes current FROM behavior across three independent planes. Each plane catches what the others miss. The investment per plane is calibrated to migration risk — over-investing wastes effort, under-investing lets regressions through.
+
+## Why three planes
+
+A single test pyramid (Plane A) is not enough for migrations:
+
+- Plane A misses anything that depends on the running environment (real device rendering, real network, real OS-level state).
+- A pure manual checklist is not reproducible across iterations and fails as a CI gate.
+- A test plan document is unreadable for a machine but indispensable for human verification.
+
+The three planes work together: Plane A is the regression sentinel in CI, Plane B is the human-readable contract for what should still work, Plane C is the safety net for things you cannot fully automate.
+
+---
+
+## Plane A — Code tests
+
+**Goal.** Reproducible, in-CI verification that catches regressions automatically.
+
+**Sub-types.**
+
+- **Characterization tests** (Feathers, *Working Effectively with Legacy Code*, ch. 13). Run the FROM implementation against typical inputs, record actual outputs, assert against the recording. The test is the specification — it documents what the code *does*, not what it *should* do. Strangenesses (bugs-as-features) become visible as `expected = "weird value"`.
+- **Contract tests.** Tests on an interface that run against both `OldImpl` and `NewImpl` (parameterized matrix). Idiomatic for Branch by Abstraction.
+- **Integration tests.** Wire components and run end-to-end against the test harness (Robolectric, JVM in-memory DB, fake network). Cover DI graph assembly, serialization round-trip, repository → use-case wiring.
+- **Golden snapshots.** UI screenshot tests (Paparazzi, Roborazzi) for visual parity. Stored alongside the test; CI fails on diff.
+- **Property-based tests.** For pure functions and bounded inputs: generate inputs, assert an invariant holds for both implementations. Useful when an exhaustive case list is impractical.
+
+**Investment cost.** Highest. Writing characterization tests for a legacy codebase that has none is itself a significant project.
+
+**When to invest heavily.** Horizontal migrations (DI, async, serialization) — bugs there affect everything downstream. High-traffic critical paths — payments, authentication, data persistence. Anything where regression is hard to detect by eye.
+
+**When to invest minimally.** Single-screen UI migrations where Plane B + manual verification is cheaper and equally effective. Idiom swaps where the compiler enforces parity.
+
+---
+
+## Plane B — Test cases
+
+**Goal.** A human-readable contract for "what should still work after the migration". The source of truth that Phase 6 (Device Verify) walks against.
+
+**Format.** Prose test cases in `<slug>-test-cases.md`, each with steps and expected outcome. Numbered: TC-1, TC-2, … . One test case per behavior, not per UI element.
+
+**Template:**
+
+```markdown
+# Test Cases: <slug>
+
+## TC-1: <short title>
+**Preconditions:** <state before the test>
+**Steps:**
+1. <action>
+2. <action>
+**Expected:** <observable outcome>
+**Priority:** P0 / P1 / P2 / P3 (P0 = release-critical, P3 = edge case)
+**Verification source:** Plane A test name (if any), or "manual only".
+```
+
+**Priority framework** (matches `~/.claude/rules/qa-and-testing.md`):
+
+- **P0** — release-critical. Failure blocks release. Crashes, data loss, security, payment, auth.
+- **P1** — acceptance-criteria driven. Each "given X then Y" from the migration scope maps to one TC.
+- **P2** — happy path. The single most common successful flow per surface.
+- **P3** — edges. Boundary values, empty inputs, locale, timezone, large inputs.
+
+**Investment cost.** Low to medium. Writing 20–40 test cases for one migration takes a few hours; reading and running them takes much less than writing them.
+
+**When to invest heavily.** Every non-trivial migration. Plane B is the cheapest plane with the highest leverage — it forces an explicit answer to "what does this thing actually do?".
+
+**When to skip.** Pure utility refactors where the compiler is the verification (file-by-file Kotlin DSL conversion, IDE-driven `kotlin-android-extensions` cleanup).
+
+---
+
+## Plane C — Manual scenarios
+
+**Goal.** The safety net. Covers paths that Plane A cannot reasonably automate and Plane B does not enumerate.
+
+**Format.** Exploratory paths in `<slug>-manual-scenarios.md`, organized by concern.
+
+**Standard concerns to cover** (mark N/A explicitly when one does not apply):
+
+- **Accessibility** — TalkBack (Android) / VoiceOver (iOS) walk-through, focus order, contrast, content descriptions.
+- **RTL** — layout in `ar-SA` or `iw-IL` locale.
+- **Dark mode** — both light and dark variants of each screen.
+- **Locale switching** — `en` → `de` → `ar` runtime switch; verify formatting (numbers, currencies, dates).
+- **Low memory** — `adb shell am send-trim-memory <pkg> COMPLETE` and recovery.
+- **Slow network** — Charles / Network Conditioner throttling; verify loading states, timeouts, retries.
+- **Configuration change** — rotation, font scaling, dynamic theme, split-screen.
+- **Back stack** — deep navigation, then back; verify state restoration.
+- **Process death** — kill app, return — state restoration.
+- **Permissions** — grant/revoke each runtime permission; verify graceful handling.
+
+**Template:**
+
+```markdown
+# Manual Scenarios: <slug>
+
+## MS-1: Accessibility
+- TalkBack on login screen: focus order should be email → password → login button → forgot password link.
+- Each control announces its label and state.
+- Decorative icons are excluded from focus.
+
+## MS-2: RTL
+- Switch device to Arabic.
+- Login screen: form fields right-aligned, navigation icons flipped.
+- Forgot-password link wraps correctly.
+```
+
+**Investment cost.** Low for the document; the cost is the time spent walking through during Phase 6.
+
+**When to invest heavily.** Any user-facing migration. UI migrations especially benefit from Plane C because Plane A (snapshot tests) is brittle and Plane B describes intent, not edge-case visual behavior.
+
+**When to skip.** Backend/library migrations with no UI surface.
+
+---
+
+## Calibration matrix
+
+| Migration class | Plane A | Plane B | Plane C |
+|---|---|---|---|
+| Horizontal: DI, async, serialization | Heavy (contract tests on abstraction) | Medium | Light |
+| Vertical UI: single screen | Light (golden snapshots) | Heavy | Heavy |
+| Vertical UI: many screens | Medium (snapshot suite) | Heavy | Medium per screen |
+| Utility refactor (idiom swap, compiler-enforced) | Light (sanity snapshots) | Light | Light |
+| Backend/library swap | Heavy (contract + property-based) | Medium | N/A |
+| KMP `expect/actual` change | Medium (parameterized across targets) | Light | Light per platform |
+
+The matrix is a starting point. Adjust based on:
+- **Risk.** Higher cost-of-failure → invest more in Plane A.
+- **Existing coverage.** If Plane A already covers FROM behavior — extend it. If FROM has zero tests — Plane B and Plane C carry the parity contract.
+- **Reversibility.** If the migration uses a feature flag with fast rollback (Duplicate-then-delete, Strangler Fig with flag), Planes B and C can carry more weight.
+
+---
+
+## When Plane A is too expensive
+
+If the FROM stack has no tests and writing characterization tests for it would cost more than the migration itself:
+
+1. Be explicit. State this in the Phase 4 strategy document: "Plane A reduced to TC-mapped sanity snapshots; Planes B and C carry parity."
+2. Strengthen Planes B and C. Add more TCs covering edge cases that Plane A would normally catch. Add more manual scenarios.
+3. Consider shadow run for critical paths only (Branch by Abstraction supports this naturally). Send real production traffic to both `OldImpl` and `NewImpl`, compare outputs off-line.
+4. Use a phased rollout with monitoring. Phase 6 then includes a canary release window with explicit metrics to watch.
+5. Document the trade-off in `<slug>-strategy.md` so it is visible to the user and to future reviewers.
+
+The trade-off is acceptable as long as it is explicit. Silent "we'll skip Plane A" is the failure mode.
+
+---
+
+## Behavior-spec index
+
+`<slug>-behavior-spec.md` is a thin index that lists what was captured and where. Keep it short:
+
+```markdown
+# Behavior spec: <slug>
+
+FROM: <technology + version>
+TO: <technology + version>
+
+## Plane A — Code tests
+- Characterization: `module/src/test/.../OldImplCharacterizationTest.kt` (47 tests)
+- Contract: `module/src/test/.../<Abstraction>ContractTest.kt` (matrix OldImpl × NewImpl)
+- Golden snapshots: `module/src/test/snapshots/<slug>/` (12 baselines)
+
+## Plane B — Test cases
+- `swarm-report/<slug>-test-cases.md` (TC-1..TC-32; P0×4, P1×12, P2×8, P3×8)
+
+## Plane C — Manual scenarios
+- `swarm-report/<slug>-manual-scenarios.md` (MS-1..MS-8 covering a11y, RTL, dark, locale, low memory, rotation, back stack, process death)
+
+## Calibration rationale
+<one paragraph explaining why Planes were weighted this way>
+```
+
+The index makes Phase 6 (Device Verify) trivial to start — one entry point points at everything.

--- a/plugins/developer-workflow-kotlin/skills/migration/references/cleanup.md
+++ b/plugins/developer-workflow-kotlin/skills/migration/references/cleanup.md
@@ -1,0 +1,180 @@
+# Cleanup
+
+The migration is not done until the FROM technology is removed. Parallel stacks accumulate cognitive load, double build cost, doubled onboarding tax, and coupling drift. Cleanup is part of the migration, not a follow-up.
+
+## The ten-item universal checklist
+
+Walk this top to bottom for the specific migration. Each item must end up in one of three states: **done**, **N/A with reason**, or **deferred with sunset date and tracker link**. Nothing else.
+
+### 1. No FROM imports outside frozen legacy modules
+
+**Check.** Search the entire repo for FROM imports.
+
+```bash
+# Example: Databinding cleanup
+grep -rn "import android.databinding" --include="*.kt" --include="*.java" \
+  | grep -v ":legacy:"  # exclude explicitly-frozen modules
+```
+
+**Allowable exceptions.** Modules explicitly named `:legacy:*` or `:*-legacy` with a frozen status and a sunset plan. Anything else is a leftover.
+
+For Compose-specific audits, the `migrate-to-compose` skill defines a more aggressive scan list (`android.view.*`, `android.widget.*`, `androidx.databinding.*`, `androidx.viewbinding.*`, `findViewById`, etc.). Reuse that list when applicable.
+
+### 2. `libs.versions.toml` no longer references FROM
+
+**Check.** Open the version catalog and grep for the FROM artifact coordinates.
+
+```bash
+grep -E "(databinding|com.google.dagger|io.reactivex)" gradle/libs.versions.toml
+```
+
+**Allowable exceptions.** None. If a transitive dependency still pulls FROM, that is a Phase 2 (Discover) miss — track it and resolve.
+
+### 3. `build.gradle*` plugin declarations removed
+
+**Check.** Search Gradle files for activation flags and plugin applications.
+
+```bash
+grep -rn -E "(dataBinding\s*=\s*true|kotlin-kapt|com.google.devtools.ksp|io.reactivex.rxjava3)" \
+  --include="*.gradle*" .
+```
+
+For Databinding → ViewBinding: remove `dataBinding = true`, keep `viewBinding = true`.
+For KAPT → KSP (full): remove `kotlin("kapt")` plugin if no other processors require KAPT.
+For Dagger → Metro: remove dagger-compiler dependency and KAPT/KSP plugin invocations specific to it.
+
+**Allowable exceptions.** If another active migration still needs the same plugin (e.g., other modules have not migrated KAPT yet), leave the plugin and note the cross-migration dependency in `<slug>-cleanup-checklist.md`.
+
+### 4. Bridge / adapter / interop layers removed or registered
+
+**Check.** Locate every bridge introduced during Phase 5.
+
+- DI: Dagger-Metro / Hilt-Metro bridge modules.
+- UI: `AndroidView { ... }` wrappers around legacy custom views.
+- Async: `rxSingle { }`, `asObservable()`, `asFlow()`, `await()` calls.
+- Build: gradle subprojects exposing FROM as `api` to maintain consumers during migration.
+
+**Decision for each bridge:**
+
+- **Delete.** Default action — the bridge was temporary.
+- **Promote to long-term public API.** Requires an ADR. Justification: real cross-paradigm need (e.g., `AndroidView` around a Maps SDK with no Compose equivalent).
+- **Defer with sunset date.** A documented tracker entry with a date and a closure criterion. If a sunset date is missed once, the bridge is becoming permanent debt — escalate.
+
+### 5. Generated-code directories no longer populate for FROM
+
+**Check.** After a clean build, the FROM technology's generated directories should be empty or absent.
+
+```bash
+./gradlew clean
+find . -type d -path "*/build/generated/*" | xargs ls -la 2>/dev/null \
+  | grep -E "(databinding|dagger|hilt|kapt)"
+```
+
+**Allowable exceptions.** Other active processors. Note them and verify they are not for FROM.
+
+### 6. Lint baseline / Konsist rules updated
+
+**Check.** Lint baseline files (`lint-baseline.xml`) and Konsist tests for migration-specific rules.
+
+If the migration used `LintBaseline` to gate growth: regenerate from current state (should be empty for migration-related issues) or delete the file if it was migration-specific.
+
+If Konsist tests enforced direction rules (`no new imports of FROM in package X`): keep them if they remain valuable invariants (preventing accidental reintroduction), or delete them if FROM is fully gone and the rule is no longer enforceable.
+
+See `references/anti-orchestrator.md` for the dependency-direction Konsist patterns.
+
+### 7. Documentation updated
+
+**Check.** Each of these mentions FROM by name:
+
+- `CLAUDE.md` (project root and any per-module files) — onboarding notes, conventions.
+- Architecture decision records (`docs/adr/`, `docs/architecture/`) — if FROM was a documented decision, write an ADR superseding it.
+- Onboarding guides, READMEs, contributor docs.
+- Internal wiki / Notion / Confluence pages — out of scope for this skill but should be flagged to the user.
+
+Update or mark as historical with date and link to the migration report.
+
+### 8. CI passes without legacy-related warnings
+
+**Check.** Trigger a CI run on the cleanup branch. Watch for:
+
+- Deprecation warnings related to FROM.
+- "Unused dependency" warnings (if a build-scan plugin is configured).
+- Lint warnings that were previously suppressed in the baseline.
+
+**Allowable exceptions.** Warnings unrelated to the migration. If a CI step was disabled to unblock the migration ("we'll re-enable lint after"), re-enable it now.
+
+### 9. APK / AAB size reduced (Android-only)
+
+**Check.** Compare before/after.
+
+```bash
+./gradlew :app:bundleRelease
+# Compare app/build/outputs/bundle/release/*.aab sizes
+```
+
+A meaningful reduction is sanity check that the FROM library actually left. If size is unchanged, suspect a transitive dependency or a wrong scope in the version catalog.
+
+**Allowable exceptions.** Library-only or KMP-only migrations with no APK build. Mark as N/A.
+
+### 10. Release notes list intentional behavioral changes
+
+**Check.** The list of "intentional behavioral changes" agreed in Phase 4 (Strategy) appears in:
+
+- Release notes for the next user-facing release.
+- The migration report (`<slug>-migration-report.md`).
+- Any "behavior change" announcement channel the team uses (Slack, dev mailing list, in-app notice if user-visible).
+
+If the list is empty (truly invisible migration), state so explicitly in the release notes — "DI framework migrated from Hilt to Metro; no user-visible changes."
+
+---
+
+## When cleanup gets stuck
+
+If one or more items cannot be completed, the migration is not done. Be explicit about the partial state:
+
+1. Mark each blocked item with the blocker and the owner.
+2. Open a tracker entry (issue, ticket, ADR-style note) for each item.
+3. Update `<slug>-migration-report.md` Status field: **Done** / **Partial** / **Blocked**.
+4. Do not claim "migration complete" in release notes. Use "phase 1 complete; cleanup in progress" with the link to the tracker.
+
+The worst outcome is a migration that is 90% done and called complete — the remaining 10% sits forever, paralleling the FROM stack indefinitely.
+
+---
+
+## Cleanup audit (optional, for horizontal migrations)
+
+For horizontal migrations (DI, async, serialization), invite a `developer-workflow-experts:architecture-expert` review after Cleanup completes. The reviewer checks:
+
+- Dependency direction (FROM → TO only, never TO → FROM).
+- No surviving FROM imports outside frozen modules.
+- Generated-code footprint matches expectations.
+- Bridge layers either gone or registered with ADRs.
+
+This is optional and user-initiated. The skill does not invoke it automatically.
+
+---
+
+## Cleanup checklist template
+
+Save the per-migration status to `<slug>-cleanup-checklist.md`:
+
+```markdown
+# Cleanup Checklist: <slug>
+
+Migration: <FROM> -> <TO>
+Date: <YYYY-MM-DD>
+Status: Done | Partial | Blocked
+
+| # | Item | Status | Notes |
+|---|---|---|---|
+| 1 | No FROM imports outside :legacy:* | done | grep clean |
+| 2 | libs.versions.toml no FROM | done | removed androidx.databinding entries |
+| 3 | build.gradle* plugin declarations removed | done | removed `dataBinding = true` in 14 modules |
+| 4 | Bridge layers removed or registered | done | no bridges in this migration |
+| 5 | Generated-code directories clean | done | no databinding/* in build/generated |
+| 6 | Lint baseline / Konsist updated | done | removed databinding-related lint baselines |
+| 7 | Documentation updated | done | CLAUDE.md updated; ADR-0023 supersedes ADR-0007 |
+| 8 | CI passes without warnings | done | green |
+| 9 | APK/AAB size reduced | done | -180 KB |
+| 10 | Release notes list intentional changes | done | "no user-visible changes" |
+```

--- a/plugins/developer-workflow-kotlin/skills/migration/references/cleanup.md
+++ b/plugins/developer-workflow-kotlin/skills/migration/references/cleanup.md
@@ -11,8 +11,10 @@ Walk this top to bottom for the specific migration. Each item must end up in one
 **Check.** Search the entire repo for FROM imports.
 
 ```bash
-# Example: Databinding cleanup
-grep -rn "import android.databinding" --include="*.kt" --include="*.java" \
+# Example: Databinding cleanup (matches both pre-AndroidX and AndroidX packages).
+# The trailing `.` is the search root — omitting it leaves grep reading from stdin and hanging.
+grep -rn -E "import (android\.databinding|androidx\.databinding)" \
+  --include="*.kt" --include="*.java" . \
   | grep -v ":legacy:"  # exclude explicitly-frozen modules
 ```
 
@@ -32,16 +34,24 @@ grep -E "(databinding|com.google.dagger|io.reactivex)" gradle/libs.versions.toml
 
 ### 3. `build.gradle*` plugin declarations removed
 
-**Check.** Search Gradle files for activation flags and plugin applications.
+**Check.** Search Gradle files for the FROM activation flags and plugin applications specifically — not for the TO plugin (the TO plugin is supposed to stay).
+
+Substitute the regex for the actual FROM technology of the current migration:
 
 ```bash
-grep -rn -E "(dataBinding\s*=\s*true|kotlin-kapt|com.google.devtools.ksp|io.reactivex.rxjava3)" \
-  --include="*.gradle*" .
+# Databinding -> ViewBinding: look for the FROM activation flag.
+grep -rn -E "dataBinding\s*=\s*true" --include="*.gradle*" .
+
+# KAPT -> KSP (when no other processors need KAPT): look for the FROM plugin.
+grep -rn -E "kotlin\(\"kapt\"\)|kotlin-kapt" --include="*.gradle*" .
+
+# RxJava -> Coroutines: look for the FROM dependency coordinates.
+grep -rn -E "io\.reactivex\.rxjava3" --include="*.gradle*" .
 ```
 
 For Databinding → ViewBinding: remove `dataBinding = true`, keep `viewBinding = true`.
-For KAPT → KSP (full): remove `kotlin("kapt")` plugin if no other processors require KAPT.
-For Dagger → Metro: remove dagger-compiler dependency and KAPT/KSP plugin invocations specific to it.
+For KAPT → KSP (full): remove `kotlin("kapt")` plugin if no other processors require KAPT. The KSP plugin (`com.google.devtools.ksp`) is the TO and must remain.
+For Dagger → Metro: remove dagger-compiler dependency and the KAPT (or KSP) invocations that exist solely for Dagger; keep KAPT/KSP if other processors still need them.
 
 **Allowable exceptions.** If another active migration still needs the same plugin (e.g., other modules have not migrated KAPT yet), leave the plugin and note the cross-migration dependency in `<slug>-cleanup-checklist.md`.
 


### PR DESCRIPTION
## Summary

Adds a new `migration` skill to `developer-workflow-kotlin` covering migrations between technologies in Android/Kotlin/KMP/JVM projects with behavioral parity. Examples: Databinding to ViewBinding, Hilt to Metro DI, RxJava to Coroutines, KAPT to KSP.

## What it is

A guided 8-phase methodology — **not** an orchestrator. The user drives; plan mode orchestrates; this skill supplies structure and material.

Phases:
1. Tech-Study (FROM and TO + their build artifacts)
2. Discover (use-sites and scope)
3. Behavior-Fix (three planes: code tests + test cases + manual scenarios)
4. **Strategy + USER GATE** — the only mandatory blocking phase
5. Implement (via one of four approaches)
6. Device Verify
7. Cleanup
8. Final Audit

Four approaches with explicit selection criteria:
- Branch by Abstraction (horizontal: DI, async, build plugins)
- Strangler Fig (vertical slices)
- Duplicate-then-delete (parallel copies, simplest rollback)
- Utility refactor (compiler-enforced idiom swaps)

## Anti-orchestrator design

Designed explicitly to avoid the forced-pipeline failure mode of the deleted `code-migration` orchestrator (v0.14.0). Five concrete criteria codified in `references/anti-orchestrator.md`:
1. Each invocation is narrow (one migration, not many).
2. Phases are checklists, not state-machine transitions.
3. All phases except Phase 4 are optional.
4. The skill never invokes other skills.
5. Artifacts inform but do not gate (except `strategy.md`).

## Files

- `plugins/developer-workflow-kotlin/skills/migration/SKILL.md` (244 lines, description 1013 chars)
- `plugins/developer-workflow-kotlin/skills/migration/references/approaches.md` — 4 approaches with decision tree and FROM/TO authoritative-doc table
- `plugins/developer-workflow-kotlin/skills/migration/references/behavior-fix.md` — three planes, calibration matrix
- `plugins/developer-workflow-kotlin/skills/migration/references/cleanup.md` — 10-item universal checklist
- `plugins/developer-workflow-kotlin/skills/migration/references/anti-orchestrator.md` — 5 criteria + Konsist/Lint enforcement
- `plugins/developer-workflow-kotlin/skills/migration/references/artifacts.md` — templates for the 9 swarm-report artifacts

## Side fix

`marketplace.json` description for `developer-workflow-kotlin` still referenced the deleted `code-migration` skill — updated to the current skill list (added `migration` and `snapshot`).

## Validation

- `bash scripts/validate.sh` — green, zero errors.
- `plugin-dev:plugin-validator` on `developer-workflow-kotlin` — PASS, no Critical / Major / Minor findings.

## Test plan

- [ ] Manual: trigger by prompts like "migrate this Databinding usage to ViewBinding" and verify the skill activates appropriately, and does NOT trigger for plain XML View to Compose migrations (those go to `migrate-to-compose`).
- [ ] Manual: walk a small real migration end-to-end through the 8 phases on a sample project; confirm Phase 4 actually blocks until user confirms.
- [ ] Manual: confirm the skill does not invoke `/check`, `/finalize`, `/create-pr`, `/acceptance`, or other slash commands from inside its phases.
- [ ] Validator: `plugin-dev:plugin-validator` PASS on the four other plugins remains unchanged (no cross-plugin regressions).

## Research

Underlying research and methodology trade-offs: `swarm-report/migration-methodology-research.md` (not part of this PR — local artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)