### PR TITLE
Simplify migration skill: cross-link to canonical sources

### DIFF
--- a/plugins/developer-workflow-kotlin/skills/migration/SKILL.md
+++ b/plugins/developer-workflow-kotlin/skills/migration/SKILL.md
@@ -112,15 +112,13 @@ After approval, the document becomes immutable. Any later change in scope or app
 
 Execute the migration according to the strategy. The four approaches differ in mechanics but share the same hand-off pattern: this skill produces a brief; an engineer agent (`developer-workflow-kotlin:kotlin-engineer` or `developer-workflow-kotlin:compose-developer` depending on layer) writes the code; the main session reviews.
 
-**Branch by Abstraction.** Introduce the abstraction first, route all use-sites through it (system still runs on the old impl), build the new impl, switch incrementally, then remove the old impl. The interface is the boundary; tests cover the boundary.
+**Branch by Abstraction.** Introduce a shared interface, route all use-sites through it, build the new implementation behind it, then switch and remove the old. See `references/approaches.md` for mechanics, trade-offs, and ordering.
 
-**Strangler Fig vertical slice.** Migrate one self-contained slice (screen, module, feature) end-to-end on the new stack. Other slices keep using the old stack. Coexistence via interop (ComposeView/AndroidView for UI, Dagger/Metro interop for DI). No long-lived hybrid screens.
+**Strangler Fig vertical slice.** Migrate one self-contained slice end-to-end on the new stack while the rest of the system continues on the old stack via interop. See `references/approaches.md` for mechanics, trade-offs, and ordering.
 
-**Duplicate-then-delete.** Copy the file/class/module under a new name or in a new package, freeze the original, migrate the copy, switch routing (feature flag, navigation, build variant), then delete the original. The simplest rollback mechanism — delete the copy.
+**Duplicate-then-delete.** Copy the file/class/module, freeze the original, migrate the copy, switch routing, then delete the original. See `references/approaches.md` for mechanics, trade-offs, and ordering.
 
-**Utility refactor.** Enable the new technology alongside the old (`viewBinding = true` next to `dataBinding = true`), convert use-sites in batches (manually or via IntelliJ plugin / scripted codemod), then remove the old flag. The compiler is the safety net.
-
-For full mechanics, trade-offs, and "when which" — see `references/approaches.md`.
+**Utility refactor.** Enable the new technology alongside the old, convert use-sites in batches, then remove the old flag — the compiler is the safety net. See `references/approaches.md` for mechanics, trade-offs, and ordering.
 
 Delegate the actual implementation work. The main session orchestrates, agents implement. See `~/.claude/rules/orchestration.md` for the routing matrix.
 
@@ -148,18 +146,7 @@ For Android device automation, an agent-oriented Android CLI (such as Google's `
 
 Remove the FROM technology fully. Until this phase completes, the migration is not done — coexistence is technical debt, not a milestone.
 
-Use the universal checklist in `references/cleanup.md`. Walk it top to bottom for the specific migration:
-
-1. No imports of the FROM technology remain outside explicitly-frozen `:legacy:*` modules.
-2. `libs.versions.toml` no longer references the FROM technology version.
-3. `build.gradle*` plugin declarations removed (`kotlin("kapt")` if no other processors remain, `dataBinding = true`, etc.).
-4. Bridge / adapter / interop layers removed or registered as long-term public API with an ADR.
-5. Generated-code directories no longer populate for FROM.
-6. Lint baseline / Konsist rules for the migration removed or updated.
-7. Documentation (`CLAUDE.md`, ADRs, onboarding) updated.
-8. CI passes without legacy-related warnings.
-9. APK/AAB size reduced (Android only — sanity check that the dependency really left).
-10. Release notes list any intentional behavioral changes from Phase 4.
+Walk the ten-item checklist in `references/cleanup.md` top to bottom; each item ends in done / N/A with reason / deferred with sunset date.
 
 Cleanup uses an engineer agent for code edits; review the deletions with `developer-workflow-experts:architecture-expert` if the migration was horizontal (DI, async, build) — these have the highest risk of leaving invisible coupling.
 
@@ -181,16 +168,7 @@ Optionally request a `developer-workflow-experts:code-reviewer` pass on the clea
 
 ---
 
-## Approach selection — quick reference
-
-| Migration class | Default approach | Why |
-|---|---|---|
-| Horizontal: DI, async runtime, build plugin | Branch by Abstraction | Global contract; copies cannot coexist |
-| Vertical: UI screen, feature module | Strangler Fig + Duplicate-then-delete | Self-contained; common abstraction is artificial |
-| Self-contained utility, single class | Duplicate-then-delete | Cheapest rollback, no abstraction overhead |
-| Idiom swap (Databinding → ViewBinding, KAPT → KSP, kotlin-android-extensions removal) | Utility refactor | Compiler enforces parity; full BBA is overkill |
-
-Full decision tree, mechanics, and trade-offs are in `references/approaches.md`. Consult it before locking in Phase 4.
+See `references/approaches.md` for the decision tree.
 
 ---
 

--- a/plugins/developer-workflow-kotlin/skills/migration/SKILL.md
+++ b/plugins/developer-workflow-kotlin/skills/migration/SKILL.md
@@ -146,7 +146,7 @@ For Android device automation, an agent-oriented Android CLI (such as Google's `
 
 Remove the FROM technology fully. Until this phase completes, the migration is not done — coexistence is technical debt, not a milestone.
 
-Walk the ten-item checklist in `references/cleanup.md` top to bottom; each item ends in done / N/A with reason / deferred with sunset date.
+Walk the ten-item checklist in `references/cleanup.md` top to bottom; each item ends in done / N/A with reason / deferred with sunset date and tracker link.
 
 Cleanup uses an engineer agent for code edits; review the deletions with `developer-workflow-experts:architecture-expert` if the migration was horizontal (DI, async, build) — these have the highest risk of leaving invisible coupling.
 

--- a/plugins/developer-workflow-kotlin/skills/migration/references/approaches.md
+++ b/plugins/developer-workflow-kotlin/skills/migration/references/approaches.md
@@ -2,18 +2,6 @@
 
 Four approaches to migrating from one technology to another, with the criteria that select between them and the mechanics of each. Consult this document during Phase 4 (Strategy) — the choice of approach is the most consequential decision of the entire migration.
 
-## Table of contents
-
-- Decision tree
-- Approach 1: Branch by Abstraction
-- Approach 2: Strangler Fig (vertical slice)
-- Approach 3: Duplicate-then-delete
-- Approach 4: Utility refactor
-- Side-by-side comparison
-- Common FROM/TO pairs and where to find authoritative docs
-
----
-
 ## Decision tree
 
 Use this order of questions to pick an approach. Stop at the first match.

--- a/plugins/developer-workflow-kotlin/skills/migration/references/artifacts.md
+++ b/plugins/developer-workflow-kotlin/skills/migration/references/artifacts.md
@@ -316,7 +316,13 @@ Date: <YYYY-MM-DD>
 
 ## `<slug>-cleanup-checklist.md`
 
-See `references/cleanup.md` — the template at the end is canonical.
+The cleanup checklist template is in `references/cleanup.md`. The Status column uses three states only: **done**, **n/a** (with reason in Notes), or **deferred: YYYY-MM-DD** (with tracker link in Notes). Example rows:
+
+```markdown
+| 1 | No FROM imports outside :legacy:* | done | grep clean |
+| 9 | APK/AAB size reduced | n/a | library-only migration, no APK build |
+| 6 | Lint baseline / Konsist updated | deferred: 2026-08-01 | lint rules shared with another active migration — JIRA-4521 |
+```
 
 ---
 

--- a/plugins/developer-workflow-kotlin/skills/migration/references/artifacts.md
+++ b/plugins/developer-workflow-kotlin/skills/migration/references/artifacts.md
@@ -316,11 +316,11 @@ Date: <YYYY-MM-DD>
 
 ## `<slug>-cleanup-checklist.md`
 
-The cleanup checklist template is in `references/cleanup.md`. The Status column uses three states only: **done**, **n/a** (with reason in Notes), or **deferred: YYYY-MM-DD** (with tracker link in Notes). Example rows:
+The cleanup checklist template is in `references/cleanup.md`. The Status column uses three states only: **done**, **N/A** (with reason in Notes), or **deferred: YYYY-MM-DD** (with tracker link in Notes). Example rows:
 
 ```markdown
 | 1 | No FROM imports outside :legacy:* | done | grep clean |
-| 9 | APK/AAB size reduced | n/a | library-only migration, no APK build |
+| 9 | APK/AAB size reduced | N/A | library-only migration, no APK build |
 | 6 | Lint baseline / Konsist updated | deferred: 2026-08-01 | lint rules shared with another active migration — JIRA-4521 |
 ```
 

--- a/plugins/developer-workflow-kotlin/skills/migration/references/behavior-fix.md
+++ b/plugins/developer-workflow-kotlin/skills/migration/references/behavior-fix.md
@@ -1,7 +1,5 @@
 # Behavior-Fix — three planes
 
-Phase 3 fixes current FROM behavior across three independent planes. Each plane catches what the others miss. The investment per plane is calibrated to migration risk — over-investing wastes effort, under-investing lets regressions through.
-
 ## Why three planes
 
 A single test pyramid (Plane A) is not enough for migrations:
@@ -20,7 +18,7 @@ The three planes work together: Plane A is the regression sentinel in CI, Plane 
 
 **Sub-types.**
 
-- **Characterization tests** (Feathers, *Working Effectively with Legacy Code*, ch. 13). Run the FROM implementation against typical inputs, record actual outputs, assert against the recording. The test is the specification — it documents what the code *does*, not what it *should* do. Strangenesses (bugs-as-features) become visible as `expected = "weird value"`.
+- **Characterization tests.** Record what the FROM implementation actually does, then assert against that recording — bugs-as-features included. See `developer-workflow-kotlin:snapshot` for the canonical characterization-test methodology; apply it here to the FROM-stack targets.
 - **Contract tests.** Tests on an interface that run against both `OldImpl` and `NewImpl` (parameterized matrix). Idiomatic for Branch by Abstraction.
 - **Integration tests.** Wire components and run end-to-end against the test harness (Robolectric, JVM in-memory DB, fake network). Cover DI graph assembly, serialization round-trip, repository → use-case wiring.
 - **Golden snapshots.** UI screenshot tests (Paparazzi, Roborazzi) for visual parity. Stored alongside the test; CI fails on diff.
@@ -40,27 +38,19 @@ The three planes work together: Plane A is the regression sentinel in CI, Plane 
 
 **Format.** Prose test cases in `<slug>-test-cases.md`, each with steps and expected outcome. Numbered: TC-1, TC-2, … . One test case per behavior, not per UI element.
 
-**Template:**
+**Template fields:**
 
 ```markdown
-# Test Cases: <slug>
-
-## TC-1: <short title>
-**Preconditions:** <state before the test>
-**Steps:**
-1. <action>
-2. <action>
-**Expected:** <observable outcome>
-**Priority:** P0 / P1 / P2 / P3 (P0 = release-critical, P3 = edge case)
+**Preconditions:** ...
+**Priority:** P0 / P1 / P2 / P3
+**Steps:** ...
+**Expected:** ...
 **Verification source:** Plane A test name (if any), or "manual only".
 ```
 
-**Priority framework** (matches `~/.claude/rules/qa-and-testing.md`):
+See `references/artifacts.md` for a fill-in template with worked examples.
 
-- **P0** — release-critical. Failure blocks release. Crashes, data loss, security, payment, auth.
-- **P1** — acceptance-criteria driven. Each "given X then Y" from the migration scope maps to one TC.
-- **P2** — happy path. The single most common successful flow per surface.
-- **P3** — edges. Boundary values, empty inputs, locale, timezone, large inputs.
+**Priority framework:** P0–P3 as defined in `~/.claude/rules/qa-and-testing.md § 2`. Do not redefine here.
 
 **Investment cost.** Low to medium. Writing 20–40 test cases for one migration takes a few hours; reading and running them takes much less than writing them.
 
@@ -89,21 +79,7 @@ The three planes work together: Plane A is the regression sentinel in CI, Plane 
 - **Process death** — kill app, return — state restoration.
 - **Permissions** — grant/revoke each runtime permission; verify graceful handling.
 
-**Template:**
-
-```markdown
-# Manual Scenarios: <slug>
-
-## MS-1: Accessibility
-- TalkBack on login screen: focus order should be email → password → login button → forgot password link.
-- Each control announces its label and state.
-- Decorative icons are excluded from focus.
-
-## MS-2: RTL
-- Switch device to Arabic.
-- Login screen: form fields right-aligned, navigation icons flipped.
-- Forgot-password link wraps correctly.
-```
+See `references/artifacts.md` for the Manual Scenarios template (MS-1..MS-5 worked examples).
 
 **Investment cost.** Low for the document; the cost is the time spent walking through during Phase 6.
 


### PR DESCRIPTION
## Summary
Follow-up to #207 — removes duplication and over-explanation in the new `migration` skill markdown. Findings from `/simplify` over the merged content (3 parallel reviewers: reuse, quality, efficiency).

- **SKILL.md (hot path)**: Phase 5 collapses 4 expanded approach paragraphs + redundant quick-ref table to one-liners pointing to `references/approaches.md`; Phase 7 inline 10-item checklist replaced by single link to `references/cleanup.md`.
- **behavior-fix.md**: drops opening meta-paragraph; P0–P3 definition replaced by reference to `~/.claude/rules/qa-and-testing.md § 2`; characterization-tests paragraph cross-links to `developer-workflow-kotlin:snapshot`; TC / MS templates trimmed to minimal structure with cross-link to `references/artifacts.md` (canonical).
- **approaches.md**: redundant 6-item ToC removed (markdown rendering handles navigation).
- **artifacts.md**: cleanup-checklist template Status column now demonstrates the three-state vocabulary (`done` / `n/a` / `deferred: YYYY-MM-DD`) consistent with prose in `cleanup.md`.

Net: 22 insertions, 74 deletions across 4 files. No behavior change, no version bump, no manifest changes.

## Test plan
- [x] `bash scripts/validate.sh` green
- [x] SKILL.md description ≤ 1024 chars (986 unchanged)
- [ ] CI green
- [ ] Copilot review

🤖 Generated with [Claude Code](https://claude.com/claude-code)