### PR TITLE
Release v0.19.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.18.0",
+      "version": "0.19.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/maven-mcp/plugin"
@@ -23,7 +23,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.18.0",
+      "version": "0.19.0",
       "category": "security",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/sensitive-guard"
@@ -34,7 +34,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.18.0",
+      "version": "0.19.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow"
@@ -45,7 +45,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.18.0",
+      "version": "0.19.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-experts"
@@ -56,7 +56,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.18.0",
+      "version": "0.19.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-kotlin"
@@ -67,7 +67,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.18.0",
+      "version": "0.19.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-swift"

--- a/plugins/developer-workflow-experts/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-experts/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-experts",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Reusable expert agents for code review, architecture, security, performance, UX, build, DevOps, business analysis, and debugging. Safe to install standalone \u2014 no skills, no hooks, no MCP servers.",
   "author": {
     "name": "kirich1409"

--- a/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-kotlin",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Kotlin, Android, and KMP specialist agents and migration skills \u2014 kotlin-engineer, compose-developer, migration, kmp-migration, migrate-to-compose, snapshot, databinding-to-viewbinding. Extends developer-workflow for Kotlin/Android projects.",
   "author": {
     "name": "kirich1409"
@@ -18,11 +18,11 @@
   "dependencies": [
     {
       "name": "developer-workflow",
-      "version": "^0.18.0"
+      "version": "^0.19.0"
     },
     {
       "name": "developer-workflow-experts",
-      "version": "^0.18.0"
+      "version": "^0.19.0"
     }
   ]
 }

--- a/plugins/developer-workflow-swift/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-swift/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-swift",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Swift, iOS, and macOS specialist agents \u2014 swift-engineer and swiftui-developer, with references covering Swift concurrency, testing, and SwiftUI patterns/state/performance. Extends developer-workflow for Apple platforms.",
   "author": {
     "name": "kirich1409"
@@ -17,11 +17,11 @@
   "dependencies": [
     {
       "name": "developer-workflow",
-      "version": "^0.18.0"
+      "version": "^0.19.0"
     },
     {
       "name": "developer-workflow-experts",
-      "version": "^0.18.0"
+      "version": "^0.19.0"
     }
   ]
 }

--- a/plugins/developer-workflow/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Developer workflow toolbox \u2014 on-demand skills for research, specification (write-spec, reverse-spec), multiexpert review, retroactive tests, code-quality finalize, mechanical /check, QA (test plans, acceptance), PR creation, and autonomous drive-to-merge (CI monitor, review handler, re-request, poll). Exploratory QA without a spec is performed by calling the manual-tester agent directly. Platform-neutral; platform-specific engineers live in developer-workflow-kotlin and developer-workflow-swift.",
   "author": {
     "name": "kirich1409"
@@ -18,7 +18,7 @@
   "dependencies": [
     {
       "name": "developer-workflow-experts",
-      "version": "^0.18.0"
+      "version": "^0.19.0"
     }
   ]
 }

--- a/plugins/maven-mcp/package-lock.json
+++ b/plugins/maven-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@krozov/maven-central-mcp",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/plugins/maven-mcp/package.json
+++ b/plugins/maven-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "MCP server for Maven Central dependency intelligence",
   "main": "./dist/index.js",
   "type": "module",

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maven-mcp",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps, /check-deps-vulnerabilities, /latest-version, and /dependency-changes skills",
   "author": {
     "name": "kirich1409"
@@ -19,7 +19,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@krozov/maven-central-mcp@^0.18.0"
+        "@krozov/maven-central-mcp@^0.19.0"
       ]
     }
   }

--- a/plugins/sensitive-guard/.claude-plugin/plugin.json
+++ b/plugins/sensitive-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sensitive-guard",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Prevents sensitive data (secrets, PII) from reaching AI servers by scanning files before they are read into conversation",
   "author": {
     "name": "kirich1409"


### PR DESCRIPTION
## What changed

Unified version bump across all six plugins: `0.18.0` → `0.19.0`. No behavior changes — pure release commit on top of the three additive PRs that landed in `main` since `v0.18.0`.

- All 6 plugins (`maven-mcp`, `sensitive-guard`, `developer-workflow`, `developer-workflow-experts`, `developer-workflow-kotlin`, `developer-workflow-swift`) bumped to `0.19.0` in `plugin.json` and `marketplace.json`.
- Family `dependencies` semver ranges extended `^0.18.0` → `^0.19.0` (pre-1.0 caret is patch-only, so the bump is required): 1 ref in `developer-workflow`, 2 refs each in `-kotlin` and `-swift`.
- `maven-mcp` npx pin (`@krozov/maven-central-mcp`) bumped to `^0.19.0` so the plugin installs the matching MCP server build.
- `plugins/maven-mcp/package-lock.json` synced (root `version` + `packages[\"\"].version`) to keep release-CI version parity.

## Why

Three additive changes landed in `main` after `v0.18.0`:

- #207 — Added `migration` skill to `developer-workflow-kotlin` (8-phase methodology for migrating between technologies in Android/Kotlin/KMP/JVM projects).
- #208 — Simplified the `migration` skill via cross-links to canonical sources.
- #209 — Added `databinding-to-viewbinding` skill to `developer-workflow-kotlin`.

All three are additive, no breaking changes → semver-minor bump to `0.19.0`.

## Release Notes

### Added

- **developer-workflow-kotlin**: `migration` skill — guided 8-phase methodology for migrating between technologies in Android / Kotlin / KMP / JVM projects with behavioral parity. Four implementation approaches (Branch by Abstraction, Strangler Fig, Duplicate-then-delete, Utility refactor). (#207)
- **developer-workflow-kotlin**: `databinding-to-viewbinding` skill — manual-only skill for migrating Android DataBinding layouts to ViewBinding, with discovery flow, property-map spec, 5 adapter-cleanup options. (#209)

### Changed

- **developer-workflow-kotlin**: `migration` skill simplified via cross-links to canonical sources; removed duplicated content. (#208)
- **all plugins**: version `0.18.0` → `0.19.0`. Family `dependencies` semver ranges widened to `^0.19.0`. `maven-mcp` npx pin bumped to `@krozov/maven-central-mcp@^0.19.0`.

## How to test

Pre-flight (already passed locally):

- [x] `bash scripts/validate.sh` — green.
- [x] `plugin-dev:plugin-validator` agent on each of the 6 plugins — PASS or Minor-only, no Critical/Major findings.
- [x] `git grep -n '0\\.18\\.0' -- plugins .claude-plugin` returns zero matches.
- [x] `git grep -n '\"version\": \"0\\.19\\.0\"' -- plugins .claude-plugin` returns 13 entries (7 plugin.json + 1 package.json + 6 in marketplace.json — 14 if counting the maven-mcp version line in plugin manifest).

CI on this PR runs the release workflow's preconditions: lint, tests, build.

## Status

| Stage | Result |
|---|---|
| validate.sh | PASS |
| plugin-validator × 6 | PASS / Minor-only |
| Local commit | PASS |
| Push | PASS |
| CI checks | pending |

## Release path

After this PR is merged to `main`:

1. `git tag v0.19.0 && git push origin v0.19.0`
2. `.github/workflows/release.yml` triggers on the `v*` tag — verifies all versions match, runs lint/tests/build, publishes `@krozov/maven-central-mcp@0.19.0` to npm, creates per-plugin tags `{plugin}--v0.19.0` for each of the 6 plugins in `marketplace.json` (used by Claude Code to resolve `dependencies` semver ranges).