### PR TITLE
maven-mcp 0.20.0: full-project dependency scan with multi-catalog and plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.19.0",
+      "version": "0.20.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/maven-mcp/plugin"
@@ -23,7 +23,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.19.0",
+      "version": "0.20.0",
       "category": "security",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/sensitive-guard"
@@ -34,7 +34,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.19.0",
+      "version": "0.20.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow"
@@ -45,7 +45,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.19.0",
+      "version": "0.20.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-experts"
@@ -56,7 +56,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.19.0",
+      "version": "0.20.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-kotlin"
@@ -67,7 +67,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.19.0",
+      "version": "0.20.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-swift"

--- a/plugins/developer-workflow-experts/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-experts/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-experts",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Reusable expert agents for code review, architecture, security, performance, UX, build, DevOps, business analysis, and debugging. Safe to install standalone \u2014 no skills, no hooks, no MCP servers.",
   "author": {
     "name": "kirich1409"

--- a/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-kotlin",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Kotlin, Android, and KMP specialist agents and migration skills \u2014 kotlin-engineer, compose-developer, migration, snapshot. Extends developer-workflow for Kotlin/Android projects.",
   "author": {
     "name": "kirich1409"
@@ -18,11 +18,11 @@
   "dependencies": [
     {
       "name": "developer-workflow",
-      "version": "^0.19.0"
+      "version": "^0.20.0"
     },
     {
       "name": "developer-workflow-experts",
-      "version": "^0.19.0"
+      "version": "^0.20.0"
     }
   ]
 }

--- a/plugins/developer-workflow-swift/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-swift/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-swift",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Swift, iOS, and macOS specialist agents \u2014 swift-engineer and swiftui-developer, with references covering Swift concurrency, testing, and SwiftUI patterns/state/performance. Extends developer-workflow for Apple platforms.",
   "author": {
     "name": "kirich1409"
@@ -17,11 +17,11 @@
   "dependencies": [
     {
       "name": "developer-workflow",
-      "version": "^0.19.0"
+      "version": "^0.20.0"
     },
     {
       "name": "developer-workflow-experts",
-      "version": "^0.19.0"
+      "version": "^0.20.0"
     }
   ]
 }

--- a/plugins/developer-workflow/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Developer workflow toolbox \u2014 on-demand skills for research, specification (write-spec, reverse-spec), multiexpert review, retroactive tests, code-quality finalize, mechanical /check, QA (test plans, acceptance), PR creation, and autonomous drive-to-merge (CI monitor, review handler, re-request, poll). Exploratory QA without a spec is performed by calling the manual-tester agent directly. Platform-neutral; platform-specific engineers live in developer-workflow-kotlin and developer-workflow-swift.",
   "author": {
     "name": "kirich1409"
@@ -18,7 +18,7 @@
   "dependencies": [
     {
       "name": "developer-workflow-experts",
-      "version": "^0.19.0"
+      "version": "^0.20.0"
     }
   ]
 }

--- a/plugins/maven-mcp/package.json
+++ b/plugins/maven-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "MCP server for Maven Central dependency intelligence",
   "main": "./dist/index.js",
   "type": "module",

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maven-mcp",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps, /check-deps-vulnerabilities, /latest-version, and /dependency-changes skills",
   "author": {
     "name": "kirich1409"
@@ -19,7 +19,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@krozov/maven-central-mcp@^0.19.0"
+        "@krozov/maven-central-mcp@^0.20.0"
       ]
     }
   }

--- a/plugins/maven-mcp/plugin/skills/check-deps/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/check-deps/SKILL.md
@@ -205,3 +205,8 @@ until the project resolves and compiles successfully.
   trees when needed.
 - This skill does not auto-select unstable/pre-release versions. The MCP server returns
   the latest stable version by default.
+- **Vulnerability detection for plugin entries is not currently supported.** OSV indexes
+  implementation artifacts (e.g. `org.jetbrains.kotlin:kotlin-gradle-plugin`), not plugin
+  marker artifacts (e.g. the `.gradle.plugin` marker). Entries with `source.kind ===
+  "plugins-dsl"` or `"buildscript-classpath"` therefore always return no advisories — this
+  is a known v1 limitation tracked for v2 (marker → implementation GAV resolution via POM).

--- a/plugins/maven-mcp/plugin/skills/check-deps/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/check-deps/SKILL.md
@@ -205,8 +205,10 @@ until the project resolves and compiles successfully.
   trees when needed.
 - This skill does not auto-select unstable/pre-release versions. The MCP server returns
   the latest stable version by default.
-- **Vulnerability detection for plugin entries is not currently supported.** OSV indexes
+- **Vulnerabilities for plugin entries are typically not detected.** OSV currently indexes
   implementation artifacts (e.g. `org.jetbrains.kotlin:kotlin-gradle-plugin`), not plugin
   marker artifacts (e.g. the `.gradle.plugin` marker). Entries with `source.kind ===
-  "plugins-dsl"` or `"buildscript-classpath"` therefore always return no advisories — this
-  is a known v1 limitation tracked for v2 (marker → implementation GAV resolution via POM).
+  "plugins-dsl"` or `"buildscript-classpath"` typically return no advisories today — OSV
+  still runs and will surface hits if OSV adds plugin-marker coverage later. For now treat
+  plugin CVEs as a known gap and check the implementation artifact's advisories manually if
+  concerned. v2 will resolve markers to implementation GAVs via POM.

--- a/plugins/maven-mcp/plugin/skills/check-deps/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/check-deps/SKILL.md
@@ -9,76 +9,199 @@ description: >-
 
 # Check Dependencies
 
-Scan the current project for Maven/Gradle dependencies and report available updates.
+Scan the current project — version catalogs, all submodules, plugin DSL blocks, and
+buildscript classpath — and report which dependencies have newer versions available, then
+apply the updates the user confirms.
 
-## Steps
+## Preflight
 
-1. Find build dependency files in the project root:
-   - `gradle/libs.versions.toml` (Gradle version catalog)
-   - `build.gradle.kts` or `build.gradle`
-   - `pom.xml`
+Before doing anything else, confirm the `audit_project_dependencies` MCP tool is available.
+If it is not, stop and tell the user:
 
-2. Read the found files and extract ALL dependencies with their current versions.
-   - For `libs.versions.toml`: parse the `[versions]` and `[libraries]` sections
-   - For Gradle files: find `implementation`, `api`, `compileOnly`, `testImplementation` etc. with group:artifact:version
-   - For `pom.xml`: find `<dependency>` blocks with `<groupId>`, `<artifactId>`, `<version>`
+> The maven-mcp plugin is required for this skill. Install it with
+> `claude plugin add maven-mcp`, then retry.
 
-3. Call the `compare_dependency_versions` MCP tool with the extracted dependencies. Use the EXACT parameter format defined in the tool schema:
+Do not attempt to fall back to manual file parsing — this skill requires the MCP server.
+
+## One-shot scan
+
+Call the tool once with both flags set:
 
 ```json
 {
-  "dependencies": [
-    {"groupId": "io.ktor", "artifactId": "ktor-client-core", "currentVersion": "3.1.2"},
-    {"groupId": "androidx.compose", "artifactId": "compose-bom", "currentVersion": "2025.05.00"}
-  ]
+  "includeVulnerabilities": true,
+  "productionOnly": true
 }
 ```
 
-Do NOT pass dependencies as a string. Do NOT add extra parameters like `stabilityFilter` or `includeSecurityScan` — they don't exist on this tool.
+`productionOnly: true` is the default. It excludes test-scoped usages but still includes
+unused catalog entries — the catalog is the single source of truth for declared versions
+and those entries still need to be kept current.
 
-4. Present results as a markdown table showing only dependencies with available updates:
+Keep the single tool call. Do not read build files manually before or after — the MCP
+server handles all file discovery and parsing.
 
-   | Artifact | Current | Latest Stable | Upgrade |
-   |----------|---------|---------------|---------|
-   | io.ktor:ktor-client-core | 3.1.2 | 3.1.3 | PATCH |
+## Grouping the result
 
-5. If all dependencies are up to date, say so.
+Group `dependencies[]` by `source.kind`. Only include entries where
+`latestVersion !== currentVersion` OR `vulnerabilities.length > 0`. If a group has nothing
+to show, omit that section entirely. If every group is empty, output:
 
-6. After presenting the table, ask the user: "Do you want me to update the versions in the build files? After updating I will verify the project builds successfully."
+> All dependencies up to date.
 
-## Stability policy
+Then skip to the Vulnerabilities section.
 
-- By default, only report **stable** versions. The MCP server returns stable versions by default.
-- Do NOT suggest alpha, beta, RC, milestone, or snapshot versions unless the user explicitly asks for unstable/pre-release versions.
-- If the user asks for unstable versions, call `get_latest_version` with `stabilityFilter: "ALL"` for each dependency.
+---
 
-## After updating versions
+### Catalog libraries (`source.kind === "catalog-library"`)
 
-When the user confirms they want to update versions:
+Columns: alias | current → latest | upgrade type | catalog file | used by
 
-1. Edit the build files with new versions.
+- `alias` — `source.alias`
+- `current → latest` — `currentVersion → latestVersion`
+- `upgrade type` — `upgradeType` (MAJOR / MINOR / PATCH)
+- `catalog file` — `source.tomlPath`
+- `used by` — count of `usages[]` entries; write `N modules` or `unused`
 
-2. **MANDATORY: Run the project build to verify compatibility.** Do NOT skip this step.
-   - Gradle: `./gradlew build` (or `./gradlew assembleDebug` for Android)
-   - Maven: `mvn compile`
-   - Wait for the build to complete fully.
+When the project has more than one catalog (`source.catalogName` differs across entries),
+prefix the alias with the catalog name: `libs.ktor-client-core` vs `bundles.okhttp`.
 
-3. **If the build succeeds:** Report success and list the updated dependencies.
+Example row:
+```
+| ktor-client-core | 2.3.12 → 3.1.3 | MAJOR | gradle/libs.versions.toml | 4 modules |
+```
 
-4. **If the build fails:**
-   - Read the build error output carefully.
-   - Identify which updated dependency caused the incompatibility.
-   - Try to fix the incompatibility (API changes, import updates, deprecation replacements).
-   - If the fix is non-trivial, revert that specific dependency to its previous version.
-   - Re-run the build to confirm it passes.
-   - Report which dependencies were updated and which were reverted with reasons.
+---
 
-5. **Never report "versions updated" without a passing build.** The update is not complete until the project compiles successfully.
+### Catalog plugins (`source.kind === "catalog-plugin"`)
 
-## Important
+Columns: alias | plugin ID | current → latest | upgrade type | catalog file | used by
 
-- Always check `libs.versions.toml` first — it's the modern Gradle standard for version management.
-- Dependencies in `libs.versions.toml` may use version references — resolve them to actual versions.
-- Skip dependencies without explicit versions (e.g., BOM-managed or platform dependencies).
-- **Send ALL dependencies to the MCP tool** — the server searches Maven Central, Google Maven, and Gradle Plugin Portal automatically. Do NOT skip or filter any dependencies by group ID.
-- **Use the exact tool schema** — pass `dependencies` as an array of objects with `groupId`, `artifactId`, `currentVersion` fields. No other format is accepted.
+- `alias` — `source.alias`
+- `plugin ID` — `groupId` (plugin marker convention: `groupId` is the plugin ID)
+- remaining fields same as catalog libraries
+
+---
+
+### Module direct (`source.kind === "module-direct"`)
+
+Columns: module | file | artifact | current → latest | configuration
+
+- `module` — `usages[0].module` if set; otherwise `(root)`
+- `file` — `source.file`
+- `artifact` — `groupId:artifactId`
+- `configuration` — `usages[0].configuration`
+
+Drift flag: if another entry in the result has the same `groupId:artifactId` with
+`source.kind === "catalog-library"`, append a note:
+> ⚠ drift — same artifact declared in catalog and hardcoded here
+
+---
+
+### Plugin DSL (`source.kind === "plugins-dsl"`)
+
+Split into two sub-tables based on `source.settingsBlock`:
+
+**Root / module `plugins {}` block** (`settingsBlock` is `undefined` or `false`):
+
+Columns: plugin ID | current → latest | upgrade type | file
+
+**Settings `pluginManagement { plugins {} }` block** (`settingsBlock === true`):
+
+Same columns.
+
+---
+
+### Buildscript classpath (`source.kind === "buildscript-classpath"`)
+
+Columns: artifact | current → latest | file
+
+> *Note: `buildscript { dependencies { classpath … } }` is the pre-Plugin-DSL style.
+> Consider migrating to `plugins {}` blocks.*
+
+---
+
+## Vulnerabilities
+
+After all upgrade tables, add a separate **Vulnerabilities** section listing every entry
+where `vulnerabilities` is non-empty, regardless of whether an upgrade is available.
+
+Columns: artifact | version | severity | advisory | fixed in | source | where to fix
+
+- `artifact` — `groupId:artifactId`
+- `version` — `currentVersion`
+- `severity` — `vulnerabilities[i].severity` (CRITICAL / HIGH / MEDIUM / LOW / unknown)
+- `advisory` — `vulnerabilities[i].id` (link it if the client renders Markdown)
+- `fixed in` — `vulnerabilities[i].fixedVersion`; if absent write `(no fixed version)`
+- `source` — `source.kind`
+- `where to fix` — `source.tomlPath` for catalog entries; `source.file` for all others
+
+Sort rows: CRITICAL → HIGH → MEDIUM → LOW → unknown, then lexicographic by
+`groupId:artifactId`.
+
+If no vulnerabilities exist, omit this section entirely.
+
+## Confirmation step
+
+Present the full report to the user and **ask before making any edits**. Default
+proposal: update catalog entries first (they are the single source of truth and the
+safest edit).
+
+Ask separately for each non-catalog group (Module direct, Plugin DSL, Buildscript
+classpath) — they require targeted edits in different files and carry more risk.
+
+Flag every entry with `upgradeType === "major"` explicitly — major version bumps may
+contain breaking changes and warrant individual confirmation.
+
+## Edit pass
+
+Apply only the groups the user confirms.
+
+**Catalog libraries / plugins** — `Edit` the `.toml` file at `source.tomlPath`.
+Update the `version` value or the referenced `[versions]` entry if a `version.ref` is
+used. Touch only the version value — do not reformat or reorder unrelated entries.
+
+**Module direct** — `Edit` the file at `source.file` inside the module directory
+indicated by `usages[0].module`. Update the inline version string only.
+
+**Plugin DSL root / module** — `Edit` the root or module `build.gradle[.kts]` file
+(`source.file`). Update the version in the `plugins {}` block.
+
+**Plugin DSL settings** — `Edit` `settings.gradle[.kts]` (`source.file`). Update the
+version in the `pluginManagement { plugins {} }` block.
+
+**Buildscript classpath** — `Edit` the root `build.gradle[.kts]` (`source.file`).
+Update the version in the `buildscript { dependencies { classpath … } }` block.
+
+## Build verification
+
+After every edit pass, verify the project still builds.
+
+- **Gradle:** `./gradlew build` — or `./gradlew :module:dependencies` for a fast
+  dependency-resolve check when a full build is slow.
+- **Maven:** `mvn dependency:tree`.
+
+Do not invent flags. If the `/check` skill is available in the current environment,
+prefer it — it applies the project's own verification sequence.
+
+Surface any build failure immediately. Read the error output, identify which updated
+dependency caused it, attempt to fix the incompatibility (API changes, import updates,
+deprecation replacements). If the fix is non-trivial, revert that specific entry to its
+previous version and note it as "manual upgrade required". Re-run the build to confirm it
+passes.
+
+**Never report "versions updated" without a passing build.** The update is not complete
+until the project resolves and compiles successfully.
+
+## Constraints and non-goals
+
+- **Major version bumps** are flagged in the report and require explicit per-entry
+  confirmation — do not batch-apply them silently.
+- **Multi-catalog `from("g:a:v")` form** (catalog declared as a Maven dependency) is not
+  supported; such entries are not scanned.
+- **`buildSrc/` and convention plugins** are not scanned.
+- **Transitive dependencies** are not enumerated — only direct declarations in build
+  files. Run `./gradlew dependencies` or `mvn dependency:tree` to inspect transitive
+  trees when needed.
+- This skill does not auto-select unstable/pre-release versions. The MCP server returns
+  the latest stable version by default.

--- a/plugins/maven-mcp/src/dependencies/__tests__/gradle-deps-parser.test.ts
+++ b/plugins/maven-mcp/src/dependencies/__tests__/gradle-deps-parser.test.ts
@@ -66,4 +66,11 @@ runtimeOnly("com.example:runtime-lib:1.0")
   it("returns empty for no dependencies", () => {
     expect(parseGradleDependencies("plugins { }")).toEqual([]);
   });
+
+  it("catalog name with underscore: test_libs.foo.bar", () => {
+    const content = `testImplementation(test_libs.foo.bar)`;
+    const deps = parseGradleDependencies(content);
+    expect(deps).toHaveLength(1);
+    expect(deps[0].catalogRef).toBe("test_libs.foo.bar");
+  });
 });

--- a/plugins/maven-mcp/src/dependencies/__tests__/gradle-deps-parser.test.ts
+++ b/plugins/maven-mcp/src/dependencies/__tests__/gradle-deps-parser.test.ts
@@ -39,7 +39,17 @@ dependencies {
     expect(deps[0]).toEqual({
       groupId: null, artifactId: null, version: null,
       configuration: "implementation", source: "build.gradle.kts",
-      catalogRef: "ktor.client.core",
+      catalogRef: "libs.ktor.client.core",
+    });
+  });
+
+  it("parses non-libs catalog references", () => {
+    const content = `testImplementation(testLibs.mockk.core)`;
+    const deps = parseGradleDependencies(content);
+    expect(deps[0]).toEqual({
+      groupId: null, artifactId: null, version: null,
+      configuration: "testImplementation", source: "build.gradle.kts",
+      catalogRef: "testLibs.mockk.core",
     });
   });
 

--- a/plugins/maven-mcp/src/dependencies/__tests__/plugins-block-parser.test.ts
+++ b/plugins/maven-mcp/src/dependencies/__tests__/plugins-block-parser.test.ts
@@ -146,6 +146,16 @@ plugins {
     expect(parsePluginsBlock(content, { settings: true })).toEqual([]);
   });
 
+  it("does not match plugins.withType<X> false-positive", () => {
+    // "plugins" followed by "." is not a plugins {} block keyword — must not be parsed
+    const content = `
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+    plugins.withType<KotlinCompile> { }
+}
+`;
+    expect(parsePluginsBlock(content)).toEqual([]);
+  });
+
   it("ignores commented plugin declarations", () => {
     const content = `
 plugins {

--- a/plugins/maven-mcp/src/dependencies/__tests__/plugins-block-parser.test.ts
+++ b/plugins/maven-mcp/src/dependencies/__tests__/plugins-block-parser.test.ts
@@ -68,6 +68,17 @@ plugins {
     ]);
   });
 
+  it("parses unknown multi-segment kotlin(\"foo.bar\") → org.jetbrains.kotlin.foo.bar", () => {
+    const content = `
+plugins {
+  kotlin("foo.bar") version "1.0"
+}
+`;
+    expect(parsePluginsBlock(content)).toEqual([
+      { pluginId: "org.jetbrains.kotlin.foo.bar", version: "1.0" },
+    ]);
+  });
+
   it("returns catalogRef for alias(libs.plugins.foo)", () => {
     const content = `
 plugins {

--- a/plugins/maven-mcp/src/dependencies/__tests__/plugins-block-parser.test.ts
+++ b/plugins/maven-mcp/src/dependencies/__tests__/plugins-block-parser.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect } from "vitest";
+import { parsePluginsBlock, parseBuildscriptClasspath } from "../plugins-block-parser.js";
+
+describe("parsePluginsBlock", () => {
+  it("parses id(\"x\") version \"1.0\"", () => {
+    const content = `
+plugins {
+  id("com.android.application") version "8.5.0"
+}
+`;
+    expect(parsePluginsBlock(content)).toEqual([
+      { pluginId: "com.android.application", version: "8.5.0" },
+    ]);
+  });
+
+  it("parses Groovy form id 'x' version '1.0'", () => {
+    const content = `
+plugins {
+  id 'com.android.application' version '8.5.0'
+}
+`;
+    expect(parsePluginsBlock(content)).toEqual([
+      { pluginId: "com.android.application", version: "8.5.0" },
+    ]);
+  });
+
+  it("parses id without version", () => {
+    const content = `
+plugins {
+  id("com.android.application")
+}
+`;
+    expect(parsePluginsBlock(content)).toEqual([
+      { pluginId: "com.android.application", version: null },
+    ]);
+  });
+
+  it("parses kotlin(\"jvm\") version \"2.0\" → org.jetbrains.kotlin.jvm", () => {
+    const content = `
+plugins {
+  kotlin("jvm") version "2.0.0"
+}
+`;
+    expect(parsePluginsBlock(content)).toEqual([
+      { pluginId: "org.jetbrains.kotlin.jvm", version: "2.0.0" },
+    ]);
+  });
+
+  it("parses kotlin(\"plugin.serialization\") → full id", () => {
+    const content = `
+plugins {
+  kotlin("plugin.serialization") version "2.1.0"
+}
+`;
+    expect(parsePluginsBlock(content)).toEqual([
+      { pluginId: "org.jetbrains.kotlin.plugin.serialization", version: "2.1.0" },
+    ]);
+  });
+
+  it("parses unknown kotlin(\"foo\") → org.jetbrains.kotlin.foo", () => {
+    const content = `
+plugins {
+  kotlin("foo") version "1.0"
+}
+`;
+    expect(parsePluginsBlock(content)).toEqual([
+      { pluginId: "org.jetbrains.kotlin.foo", version: "1.0" },
+    ]);
+  });
+
+  it("returns catalogRef for alias(libs.plugins.foo)", () => {
+    const content = `
+plugins {
+  alias(libs.plugins.foo)
+}
+`;
+    expect(parsePluginsBlock(content)).toEqual([
+      { pluginId: "(unresolved)", version: null, catalogRef: "libs.plugins.foo" },
+    ]);
+  });
+
+  it("returns catalogRef for alias(libs.plugins.foo.bar)", () => {
+    const content = `
+plugins {
+  alias(libs.plugins.foo.bar)
+}
+`;
+    expect(parsePluginsBlock(content)).toEqual([
+      { pluginId: "(unresolved)", version: null, catalogRef: "libs.plugins.foo.bar" },
+    ]);
+  });
+
+  it("returns catalogRef for alias(testLibs.plugins.x)", () => {
+    const content = `
+plugins {
+  alias(testLibs.plugins.x)
+}
+`;
+    expect(parsePluginsBlock(content)).toEqual([
+      { pluginId: "(unresolved)", version: null, catalogRef: "testLibs.plugins.x" },
+    ]);
+  });
+
+  it("parses apply false modifier (still emits)", () => {
+    const content = `
+plugins {
+  id("com.android.application") version "8.5.0" apply false
+}
+`;
+    expect(parsePluginsBlock(content)).toEqual([
+      { pluginId: "com.android.application", version: "8.5.0" },
+    ]);
+  });
+
+  it("parses pluginManagement plugins block when opts.settings=true (sets settingsBlock: true)", () => {
+    const content = `
+pluginManagement {
+  plugins {
+    id("com.android.application") version "8.5.0"
+  }
+}
+`;
+    const result = parsePluginsBlock(content, { settings: true });
+    expect(result).toEqual([
+      { pluginId: "com.android.application", version: "8.5.0", settingsBlock: true },
+    ]);
+  });
+
+  it("does NOT parse pluginManagement plugins block when opts.settings=false", () => {
+    const content = `
+pluginManagement {
+  plugins {
+    id("com.android.application") version "8.5.0"
+  }
+}
+`;
+    expect(parsePluginsBlock(content, { settings: false })).toEqual([]);
+  });
+
+  it("does NOT parse top-level plugins block when opts.settings=true", () => {
+    const content = `
+plugins {
+  id("com.android.application") version "8.5.0"
+}
+`;
+    expect(parsePluginsBlock(content, { settings: true })).toEqual([]);
+  });
+
+  it("ignores commented plugin declarations", () => {
+    const content = `
+plugins {
+  // id("com.example.commented") version "1.0"
+  /* id("com.example.blocked") version "2.0" */
+  id("com.android.application") version "8.5.0"
+}
+`;
+    expect(parsePluginsBlock(content)).toEqual([
+      { pluginId: "com.android.application", version: "8.5.0" },
+    ]);
+  });
+});
+
+describe("parseBuildscriptClasspath", () => {
+  it("parses classpath(\"g:a:v\") in Kotlin DSL", () => {
+    const content = `
+buildscript {
+  dependencies {
+    classpath("com.android.tools.build:gradle:8.5.0")
+  }
+}
+`;
+    expect(parseBuildscriptClasspath(content)).toEqual([
+      { groupId: "com.android.tools.build", artifactId: "gradle", version: "8.5.0" },
+    ]);
+  });
+
+  it("parses classpath 'g:a:v' in Groovy DSL", () => {
+    const content = `
+buildscript {
+  dependencies {
+    classpath 'com.android.tools.build:gradle:8.5.0'
+  }
+}
+`;
+    expect(parseBuildscriptClasspath(content)).toEqual([
+      { groupId: "com.android.tools.build", artifactId: "gradle", version: "8.5.0" },
+    ]);
+  });
+
+  it("parses multiple classpath entries", () => {
+    const content = `
+buildscript {
+  dependencies {
+    classpath("com.android.tools.build:gradle:8.5.0")
+    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.0")
+  }
+}
+`;
+    expect(parseBuildscriptClasspath(content)).toEqual([
+      { groupId: "com.android.tools.build", artifactId: "gradle", version: "8.5.0" },
+      { groupId: "org.jetbrains.kotlin", artifactId: "kotlin-gradle-plugin", version: "2.1.0" },
+    ]);
+  });
+
+  it("ignores non-classpath configurations in buildscript.dependencies", () => {
+    const content = `
+buildscript {
+  dependencies {
+    implementation("com.example:lib:1.0")
+    classpath("com.android.tools.build:gradle:8.5.0")
+  }
+}
+`;
+    expect(parseBuildscriptClasspath(content)).toEqual([
+      { groupId: "com.android.tools.build", artifactId: "gradle", version: "8.5.0" },
+    ]);
+  });
+
+  it("ignores classpath outside buildscript block", () => {
+    const content = `
+dependencies {
+  classpath("com.android.tools.build:gradle:8.5.0")
+}
+buildscript {
+  dependencies {
+    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.0")
+  }
+}
+`;
+    expect(parseBuildscriptClasspath(content)).toEqual([
+      { groupId: "org.jetbrains.kotlin", artifactId: "kotlin-gradle-plugin", version: "2.1.0" },
+    ]);
+  });
+
+  it("ignores commented classpath", () => {
+    const content = `
+buildscript {
+  dependencies {
+    // classpath("com.example:commented:1.0")
+    /* classpath("com.example:blocked:2.0") */
+    classpath("com.android.tools.build:gradle:8.5.0")
+  }
+}
+`;
+    expect(parseBuildscriptClasspath(content)).toEqual([
+      { groupId: "com.android.tools.build", artifactId: "gradle", version: "8.5.0" },
+    ]);
+  });
+});

--- a/plugins/maven-mcp/src/dependencies/__tests__/scan.test.ts
+++ b/plugins/maven-mcp/src/dependencies/__tests__/scan.test.ts
@@ -280,6 +280,22 @@ buildscript {
     expect(dep!.usages[0]).toEqual({ module: undefined, configuration: "classpath" });
   });
 
+  it("buildscript classpath in submodule is not scanned", () => {
+    mockFileSystem({
+      "/project/settings.gradle.kts": `include(":app")`,
+      "/project/app/build.gradle.kts": `
+buildscript {
+    dependencies {
+        classpath("com.example:submodule-classpath:1.0")
+    }
+}`,
+    });
+
+    const result = scanProjectWithSubmodules("/project");
+    const dep = result.dependencies.find((d) => d.artifactId === "submodule-classpath");
+    expect(dep).toBeUndefined();
+  });
+
   it("no Gradle settings, only gradle/libs.versions.toml → default libs descriptor still works", () => {
     mockFileSystem({
       "/project/gradle/libs.versions.toml": `
@@ -435,6 +451,7 @@ describe("scanProjectWithSubmodules — Maven", () => {
     const result = scanProjectWithSubmodules("/project");
     expect(result.buildSystem).toBe("maven");
     expect(result.dependencies).toHaveLength(1);
+    expect(result.dependencies[0].source.file).toBe("pom.xml");
     expect(result.dependencies[0].usages[0].module).toBe("core");
   });
 });

--- a/plugins/maven-mcp/src/dependencies/__tests__/scan.test.ts
+++ b/plugins/maven-mcp/src/dependencies/__tests__/scan.test.ts
@@ -299,6 +299,71 @@ dependencies {
     expect(dep!.usages).toHaveLength(1);
   });
 
+  it("module-level plugins {} block: id(\"x\") version \"1.0\" in app/build.gradle.kts → kind plugins-dsl, source.module :app, settingsBlock undefined", () => {
+    mockFileSystem({
+      "/project/settings.gradle.kts": `include(":app")`,
+      "/project/app/build.gradle.kts": `
+plugins {
+    id("com.android.application") version "8.0.0"
+}`,
+    });
+
+    const result = scanProjectWithSubmodules("/project");
+    const dep = result.dependencies.find((d) => d.groupId === "com.android.application");
+    expect(dep).toBeDefined();
+    expect(dep!.artifactId).toBe("com.android.application.gradle.plugin");
+    expect(dep!.version).toBe("8.0.0");
+    expect(dep!.source.kind).toBe("plugins-dsl");
+    if (dep!.source.kind === "plugins-dsl") {
+      expect(dep!.source.module).toBe(":app");
+      expect(dep!.source.settingsBlock).toBeUndefined();
+      expect(dep!.source.file).toBe("build.gradle.kts");
+    }
+    expect(dep!.usages).toHaveLength(1);
+    expect(dep!.usages[0]).toEqual({ module: ":app", configuration: "plugin-dsl" });
+  });
+
+  it("alias(libs.plugins.x) in module build.gradle.kts resolves through catalog [plugins] entry — usage appended with module label", () => {
+    mockFileSystem({
+      "/project/settings.gradle.kts": `include(":app")`,
+      "/project/gradle/libs.versions.toml": `
+[plugins]
+kotlin-android = { id = "org.jetbrains.kotlin.android", version = "2.0.0" }
+`,
+      "/project/app/build.gradle.kts": `
+plugins {
+    alias(libs.plugins.kotlin.android)
+}`,
+    });
+
+    const result = scanProjectWithSubmodules("/project");
+    const deps = result.dependencies.filter((d) => d.groupId === "org.jetbrains.kotlin.android");
+    // Only one entry — the catalog plugin entry, no new plugins-dsl dep
+    expect(deps).toHaveLength(1);
+    expect(deps[0].source.kind).toBe("catalog-plugin");
+    expect(deps[0].usages).toHaveLength(1);
+    expect(deps[0].usages[0]).toEqual({ module: ":app", configuration: "plugin-dsl" });
+  });
+
+  it("module-level plugin with apply false still emits", () => {
+    mockFileSystem({
+      "/project/settings.gradle.kts": `include(":lib")`,
+      "/project/lib/build.gradle.kts": `
+plugins {
+    id("com.android.library") version "8.0.0" apply false
+}`,
+    });
+
+    const result = scanProjectWithSubmodules("/project");
+    const dep = result.dependencies.find((d) => d.groupId === "com.android.library");
+    expect(dep).toBeDefined();
+    expect(dep!.source.kind).toBe("plugins-dsl");
+    if (dep!.source.kind === "plugins-dsl") {
+      expect(dep!.source.module).toBe(":lib");
+    }
+    expect(dep!.usages).toHaveLength(1);
+  });
+
   it("settings present but versionCatalogs block empty → no catalog deps emitted", () => {
     mockFileSystem({
       "/project/settings.gradle.kts": `

--- a/plugins/maven-mcp/src/dependencies/__tests__/scan.test.ts
+++ b/plugins/maven-mcp/src/dependencies/__tests__/scan.test.ts
@@ -1,69 +1,383 @@
-import { describe, it, expect, vi } from "vitest";
-import { scanDependencies } from "../scan.js";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { scanProjectWithSubmodules } from "../scan.js";
 import * as fs from "node:fs";
 
 vi.mock("node:fs");
 const mockedFs = vi.mocked(fs);
 
-describe("scanDependencies", () => {
-  it("scans Gradle project with version catalog", () => {
-    mockedFs.existsSync.mockImplementation((p: fs.PathLike) => {
-      if (p.toString().endsWith("build.gradle.kts")) return true;
-      if (p.toString().endsWith("libs.versions.toml")) return true;
-      return false;
+// Mocks a filesystem where only the given file paths exist and return the given content.
+function mockFileSystem(files: Record<string, string>) {
+  mockedFs.existsSync.mockImplementation((p: fs.PathLike) =>
+    Object.prototype.hasOwnProperty.call(files, p.toString()),
+  );
+  mockedFs.readFileSync.mockImplementation((p: fs.PathOrFileDescriptor) => {
+    const key = p.toString();
+    if (!Object.prototype.hasOwnProperty.call(files, key)) {
+      throw new Error(`ENOENT: no such file '${key}'`);
+    }
+    return files[key];
+  });
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("scanProjectWithSubmodules — Gradle catalog entries", () => {
+  it("unused catalog library emitted once with kind catalog-library and empty usages", () => {
+    mockFileSystem({
+      "/project/gradle/libs.versions.toml": `
+[libraries]
+ktor-core = { module = "io.ktor:ktor-client-core", version = "3.1.1" }
+`,
     });
-    mockedFs.readFileSync.mockImplementation((p: fs.PathLike) => {
-      if (p.toString().endsWith("build.gradle.kts")) {
-        return `
+
+    const result = scanProjectWithSubmodules("/project");
+    expect(result.buildSystem).toBe("gradle");
+    const dep = result.dependencies.find(
+      (d) => d.groupId === "io.ktor" && d.artifactId === "ktor-client-core",
+    );
+    expect(dep).toBeDefined();
+    expect(dep!.source).toEqual({ kind: "catalog-library", catalogName: "libs", tomlPath: "gradle/libs.versions.toml", alias: "ktor-core" });
+    expect(dep!.usages).toEqual([]);
+    // Only one entry, not duplicated
+    expect(result.dependencies.filter((d) => d.groupId === "io.ktor")).toHaveLength(1);
+  });
+
+  it("used catalog library: usages populated, single entry (no duplicate)", () => {
+    mockFileSystem({
+      "/project/gradle/libs.versions.toml": `
+[libraries]
+ktor-core = { module = "io.ktor:ktor-client-core", version = "3.1.1" }
+`,
+      "/project/build.gradle.kts": `
 dependencies {
     implementation(libs.ktor.core)
-    implementation("com.google.code.gson:gson:2.11.0")
-}`;
-      }
-      if (p.toString().endsWith("libs.versions.toml")) {
-        return `
-[versions]
-ktor = "3.1.1"
-
-[libraries]
-ktor-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
-`;
-      }
-      return "";
+}`,
     });
 
-    const result = scanDependencies("/project");
-    expect(result.buildSystem).toBe("gradle");
-    expect(result.dependencies).toContainEqual(expect.objectContaining({
-      groupId: "io.ktor", artifactId: "ktor-client-core", version: "3.1.1",
-    }));
-    expect(result.dependencies).toContainEqual(expect.objectContaining({
-      groupId: "com.google.code.gson", artifactId: "gson", version: "2.11.0",
-    }));
+    const result = scanProjectWithSubmodules("/project");
+    const deps = result.dependencies.filter((d) => d.groupId === "io.ktor");
+    // Only one entry — catalog entry populated with usage, no duplicate module-direct
+    expect(deps).toHaveLength(1);
+    expect(deps[0].source.kind).toBe("catalog-library");
+    expect(deps[0].usages).toHaveLength(1);
+    expect(deps[0].usages[0]).toEqual({ module: undefined, configuration: "implementation" });
   });
 
-  it("scans Maven project", () => {
-    mockedFs.existsSync.mockImplementation((p: fs.PathLike) => {
-      if (p.toString().endsWith("pom.xml")) return true;
-      return false;
+  it("catalog library used by two modules: one entry, two usages", () => {
+    mockFileSystem({
+      "/project/settings.gradle.kts": `include(":app", ":lib")`,
+      "/project/gradle/libs.versions.toml": `
+[libraries]
+ktor-core = { module = "io.ktor:ktor-client-core", version = "3.1.1" }
+`,
+      "/project/app/build.gradle.kts": `
+dependencies {
+    implementation(libs.ktor.core)
+}`,
+      "/project/lib/build.gradle.kts": `
+dependencies {
+    api(libs.ktor.core)
+}`,
     });
-    mockedFs.readFileSync.mockImplementation(() => `
-<dependencies>
-  <dependency>
-    <groupId>io.ktor</groupId>
-    <artifactId>ktor-core</artifactId>
-    <version>3.1.1</version>
-  </dependency>
-</dependencies>`);
 
-    const result = scanDependencies("/project");
-    expect(result.buildSystem).toBe("maven");
+    const result = scanProjectWithSubmodules("/project");
+    const deps = result.dependencies.filter((d) => d.groupId === "io.ktor" && d.source.kind === "catalog-library");
+    expect(deps).toHaveLength(1);
+    expect(deps[0].usages).toHaveLength(2);
+    expect(deps[0].usages).toContainEqual({ module: ":app", configuration: "implementation" });
+    expect(deps[0].usages).toContainEqual({ module: ":lib", configuration: "api" });
+  });
+
+  it("direct module dep emitted with kind module-direct", () => {
+    mockFileSystem({
+      "/project/build.gradle.kts": `
+dependencies {
+    implementation("com.google.code.gson:gson:2.11.0")
+}`,
+    });
+
+    const result = scanProjectWithSubmodules("/project");
+    const dep = result.dependencies.find((d) => d.artifactId === "gson");
+    expect(dep).toBeDefined();
+    expect(dep!.source.kind).toBe("module-direct");
+    expect(dep!.usages).toHaveLength(1);
+    expect(dep!.usages[0]).toEqual({ module: undefined, configuration: "implementation" });
+  });
+
+  it("catalog version drift: catalog says 1.0, module hardcodes 2.0 → both reported separately", () => {
+    mockFileSystem({
+      "/project/gradle/libs.versions.toml": `
+[libraries]
+ktor-core = { module = "io.ktor:ktor-client-core", version = "1.0.0" }
+`,
+      "/project/build.gradle.kts": `
+dependencies {
+    implementation(libs.ktor.core)
+    implementation("io.ktor:ktor-client-core:2.0.0")
+}`,
+    });
+
+    const result = scanProjectWithSubmodules("/project");
+    const deps = result.dependencies.filter((d) => d.groupId === "io.ktor" && d.artifactId === "ktor-client-core");
+    expect(deps).toHaveLength(2);
+    const catalogDep = deps.find((d) => d.source.kind === "catalog-library");
+    const directDep = deps.find((d) => d.source.kind === "module-direct");
+    expect(catalogDep!.version).toBe("1.0.0");
+    expect(directDep!.version).toBe("2.0.0");
+  });
+
+  it("multi-catalog: testLibs.x ref in test module resolves to testLibs descriptor", () => {
+    mockFileSystem({
+      "/project/settings.gradle.kts": `
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("gradle/libs.versions.toml"))
+        }
+        create("testLibs") {
+            from(files("gradle/test-libs.versions.toml"))
+        }
+    }
+}
+include(":app")`,
+      "/project/gradle/libs.versions.toml": `
+[libraries]
+ktor-core = { module = "io.ktor:ktor-client-core", version = "3.1.1" }
+`,
+      "/project/gradle/test-libs.versions.toml": `
+[libraries]
+mockk = { module = "io.mockk:mockk", version = "1.13.0" }
+`,
+      "/project/app/build.gradle.kts": `
+dependencies {
+    implementation(libs.ktor.core)
+    testImplementation(testLibs.mockk)
+}`,
+    });
+
+    const result = scanProjectWithSubmodules("/project");
+    const mockkDep = result.dependencies.find((d) => d.artifactId === "mockk");
+    expect(mockkDep).toBeDefined();
+    expect(mockkDep!.source.kind).toBe("catalog-library");
+    if (mockkDep!.source.kind === "catalog-library") {
+      expect(mockkDep!.source.catalogName).toBe("testLibs");
+    }
+    expect(mockkDep!.usages).toHaveLength(1);
+    expect(mockkDep!.usages[0]).toEqual({ module: ":app", configuration: "testImplementation" });
+  });
+
+  it("unused catalog plugin emitted with kind catalog-plugin and plugin marker artifactId", () => {
+    mockFileSystem({
+      "/project/gradle/libs.versions.toml": `
+[plugins]
+android-application = { id = "com.android.application", version = "8.5.0" }
+`,
+    });
+
+    const result = scanProjectWithSubmodules("/project");
+    const dep = result.dependencies.find((d) => d.groupId === "com.android.application");
+    expect(dep).toBeDefined();
+    expect(dep!.artifactId).toBe("com.android.application.gradle.plugin");
+    expect(dep!.source.kind).toBe("catalog-plugin");
+    expect(dep!.usages).toEqual([]);
+  });
+
+  it("root plugins {} block: id(\"x\") version \"1.0\" → kind plugins-dsl, module undefined, settingsBlock false", () => {
+    mockFileSystem({
+      "/project/build.gradle.kts": `
+plugins {
+    id("com.android.application") version "8.5.0"
+}`,
+    });
+
+    const result = scanProjectWithSubmodules("/project");
+    const dep = result.dependencies.find((d) => d.groupId === "com.android.application");
+    expect(dep).toBeDefined();
+    expect(dep!.artifactId).toBe("com.android.application.gradle.plugin");
+    expect(dep!.version).toBe("8.5.0");
+    expect(dep!.source.kind).toBe("plugins-dsl");
+    if (dep!.source.kind === "plugins-dsl") {
+      expect(dep!.source.module).toBeUndefined();
+      expect(dep!.source.settingsBlock).toBeUndefined();
+    }
+    expect(dep!.usages).toHaveLength(1);
+    expect(dep!.usages[0]).toEqual({ module: undefined, configuration: "plugin-dsl" });
+  });
+
+  it("pluginManagement { plugins {} } in settings → kind plugins-dsl, settingsBlock true", () => {
+    mockFileSystem({
+      "/project/settings.gradle.kts": `
+pluginManagement {
+    plugins {
+        id("org.jetbrains.kotlin.android") version "2.0.0"
+    }
+}`,
+    });
+
+    const result = scanProjectWithSubmodules("/project");
+    const dep = result.dependencies.find((d) => d.groupId === "org.jetbrains.kotlin.android");
+    expect(dep).toBeDefined();
+    expect(dep!.source.kind).toBe("plugins-dsl");
+    if (dep!.source.kind === "plugins-dsl") {
+      expect(dep!.source.settingsBlock).toBe(true);
+    }
+    expect(dep!.usages[0].configuration).toBe("plugin-dsl");
+  });
+
+  it("alias(libs.plugins.foo) in root plugins {} → adds usage to catalog plugin entry, does NOT emit new dep", () => {
+    mockFileSystem({
+      "/project/gradle/libs.versions.toml": `
+[plugins]
+kotlin-android = { id = "org.jetbrains.kotlin.android", version = "2.0.0" }
+`,
+      "/project/build.gradle.kts": `
+plugins {
+    alias(libs.plugins.kotlin.android)
+}`,
+    });
+
+    const result = scanProjectWithSubmodules("/project");
+    const deps = result.dependencies.filter((d) => d.groupId === "org.jetbrains.kotlin.android");
+    // Only one entry — the catalog plugin entry, no new plugins-dsl dep
+    expect(deps).toHaveLength(1);
+    expect(deps[0].source.kind).toBe("catalog-plugin");
+    expect(deps[0].usages).toHaveLength(1);
+    expect(deps[0].usages[0]).toEqual({ module: undefined, configuration: "plugin-dsl" });
+  });
+
+  it("kotlin(\"jvm\") version \"2.0\" → resolves to org.jetbrains.kotlin.jvm marker", () => {
+    mockFileSystem({
+      "/project/build.gradle.kts": `
+plugins {
+    kotlin("jvm") version "2.0.0"
+}`,
+    });
+
+    const result = scanProjectWithSubmodules("/project");
+    const dep = result.dependencies.find((d) => d.groupId === "org.jetbrains.kotlin.jvm");
+    expect(dep).toBeDefined();
+    expect(dep!.artifactId).toBe("org.jetbrains.kotlin.jvm.gradle.plugin");
+    expect(dep!.version).toBe("2.0.0");
+    expect(dep!.source.kind).toBe("plugins-dsl");
+    expect(dep!.usages[0].configuration).toBe("plugin-dsl");
+  });
+
+  it("buildscript classpath → kind buildscript-classpath", () => {
+    mockFileSystem({
+      "/project/build.gradle.kts": `
+buildscript {
+    dependencies {
+        classpath("com.android.tools.build:gradle:8.0.0")
+    }
+}`,
+    });
+
+    const result = scanProjectWithSubmodules("/project");
+    const dep = result.dependencies.find((d) => d.artifactId === "gradle" && d.groupId === "com.android.tools.build");
+    expect(dep).toBeDefined();
+    expect(dep!.source.kind).toBe("buildscript-classpath");
+    expect(dep!.usages).toHaveLength(1);
+    expect(dep!.usages[0]).toEqual({ module: undefined, configuration: "classpath" });
+  });
+
+  it("no Gradle settings, only gradle/libs.versions.toml → default libs descriptor still works", () => {
+    mockFileSystem({
+      "/project/gradle/libs.versions.toml": `
+[libraries]
+gson = { module = "com.google.code.gson:gson", version = "2.11.0" }
+`,
+      "/project/build.gradle.kts": `
+dependencies {
+    implementation(libs.gson)
+}`,
+    });
+
+    const result = scanProjectWithSubmodules("/project");
+    expect(result.buildSystem).toBe("gradle");
+    const dep = result.dependencies.find((d) => d.artifactId === "gson");
+    expect(dep).toBeDefined();
+    expect(dep!.usages).toHaveLength(1);
+  });
+
+  it("settings present but versionCatalogs block empty → no catalog deps emitted", () => {
+    mockFileSystem({
+      "/project/settings.gradle.kts": `
+dependencyResolutionManagement {
+    versionCatalogs {
+    }
+}`,
+      "/project/build.gradle.kts": `
+dependencies {
+    implementation("com.example:lib:1.0")
+}`,
+    });
+
+    const result = scanProjectWithSubmodules("/project");
+    // No catalog entries
+    const catalogDeps = result.dependencies.filter((d) =>
+      d.source.kind === "catalog-library" || d.source.kind === "catalog-plugin",
+    );
+    expect(catalogDeps).toHaveLength(0);
+    // Direct dep still emitted
     expect(result.dependencies).toHaveLength(1);
   });
+});
 
+describe("scanProjectWithSubmodules — Maven", () => {
+  it("Maven project: each pom dep → kind module-direct, usages populated", () => {
+    mockFileSystem({
+      "/project/pom.xml": `
+<project>
+  <dependencies>
+    <dependency>
+      <groupId>io.ktor</groupId>
+      <artifactId>ktor-core</artifactId>
+      <version>3.1.1</version>
+    </dependency>
+  </dependencies>
+</project>`,
+    });
+
+    const result = scanProjectWithSubmodules("/project");
+    expect(result.buildSystem).toBe("maven");
+    expect(result.dependencies).toHaveLength(1);
+    const dep = result.dependencies[0];
+    expect(dep.source.kind).toBe("module-direct");
+    expect(dep.usages).toHaveLength(1);
+    expect(dep.usages[0].module).toBeUndefined();
+  });
+
+  it("Maven submodule recursion preserved", () => {
+    mockFileSystem({
+      "/project/pom.xml": `
+<project>
+  <modules>
+    <module>core</module>
+  </modules>
+</project>`,
+      "/project/core/pom.xml": `
+<project>
+  <dependencies>
+    <dependency>
+      <groupId>io.ktor</groupId>
+      <artifactId>ktor-core</artifactId>
+      <version>3.1.1</version>
+    </dependency>
+  </dependencies>
+</project>`,
+    });
+
+    const result = scanProjectWithSubmodules("/project");
+    expect(result.buildSystem).toBe("maven");
+    expect(result.dependencies).toHaveLength(1);
+    expect(result.dependencies[0].usages[0].module).toBe("core");
+  });
+});
+
+describe("scanProjectWithSubmodules — unknown project", () => {
   it("returns empty for unknown project", () => {
     mockedFs.existsSync.mockReturnValue(false);
-    const result = scanDependencies("/empty");
+    const result = scanProjectWithSubmodules("/empty");
     expect(result.buildSystem).toBe("unknown");
     expect(result.dependencies).toEqual([]);
   });

--- a/plugins/maven-mcp/src/dependencies/__tests__/settings-catalogs-parser.test.ts
+++ b/plugins/maven-mcp/src/dependencies/__tests__/settings-catalogs-parser.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import { parseSettingsCatalogs } from "../settings-catalogs-parser.js";
+
+describe("parseSettingsCatalogs", () => {
+  it("returns default libs descriptor when versionCatalogs block absent", () => {
+    const content = `
+rootProject.name = "demo"
+include(":app")
+`;
+    expect(parseSettingsCatalogs(content)).toEqual([
+      { name: "libs", tomlPath: "gradle/libs.versions.toml" },
+    ]);
+  });
+
+  it("returns empty when versionCatalogs block is empty", () => {
+    const content = `
+dependencyResolutionManagement {
+  versionCatalogs {
+  }
+}
+`;
+    expect(parseSettingsCatalogs(content)).toEqual([]);
+  });
+
+  it("parses Kotlin DSL versionCatalogs with create block", () => {
+    const content = `
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("testLibs") {
+      from(files("gradle/test.versions.toml"))
+    }
+  }
+}
+`;
+    expect(parseSettingsCatalogs(content)).toEqual([
+      { name: "testLibs", tomlPath: "gradle/test.versions.toml" },
+    ]);
+  });
+
+  it("parses Groovy DSL equivalent", () => {
+    const content = `
+dependencyResolutionManagement {
+  versionCatalogs {
+    create('testLibs') {
+      from files('gradle/test.versions.toml')
+    }
+  }
+}
+`;
+    expect(parseSettingsCatalogs(content)).toEqual([
+      { name: "testLibs", tomlPath: "gradle/test.versions.toml" },
+    ]);
+  });
+
+  it("parses multiple create() blocks", () => {
+    const content = `
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("libs") {
+      from(files("gradle/libs.versions.toml"))
+    }
+    create("testLibs") {
+      from(files("gradle/test.versions.toml"))
+    }
+  }
+}
+`;
+    expect(parseSettingsCatalogs(content)).toEqual([
+      { name: "libs", tomlPath: "gradle/libs.versions.toml" },
+      { name: "testLibs", tomlPath: "gradle/test.versions.toml" },
+    ]);
+  });
+
+  it("parses chained create(\"x\").from(files(\"...\"))", () => {
+    const content = `
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("testLibs").from(files("gradle/test.versions.toml"))
+  }
+}
+`;
+    expect(parseSettingsCatalogs(content)).toEqual([
+      { name: "testLibs", tomlPath: "gradle/test.versions.toml" },
+    ]);
+  });
+
+  it("parses multi-line create block", () => {
+    const content = `
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("testLibs") {
+      from(
+        files("gradle/test.versions.toml")
+      )
+    }
+  }
+}
+`;
+    expect(parseSettingsCatalogs(content)).toEqual([
+      { name: "testLibs", tomlPath: "gradle/test.versions.toml" },
+    ]);
+  });
+
+  it("ignores commented blocks", () => {
+    const content = `
+dependencyResolutionManagement {
+  versionCatalogs {
+    // create("commented") { from(files("gradle/commented.versions.toml")) }
+    /* create("blocked") { from(files("gradle/blocked.versions.toml")) } */
+    create("testLibs") {
+      from(files("gradle/test.versions.toml"))
+    }
+  }
+}
+`;
+    expect(parseSettingsCatalogs(content)).toEqual([
+      { name: "testLibs", tomlPath: "gradle/test.versions.toml" },
+    ]);
+  });
+
+  it("ignores from(\"g:a:v\") form (out of scope)", () => {
+    const content = `
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("published") {
+      from("com.example:catalog:1.0")
+    }
+    create("local") {
+      from(files("gradle/libs.versions.toml"))
+    }
+  }
+}
+`;
+    // "published" uses from("g:a:v") — not emitted
+    expect(parseSettingsCatalogs(content)).toEqual([
+      { name: "local", tomlPath: "gradle/libs.versions.toml" },
+    ]);
+  });
+});

--- a/plugins/maven-mcp/src/dependencies/__tests__/settings-catalogs-parser.test.ts
+++ b/plugins/maven-mcp/src/dependencies/__tests__/settings-catalogs-parser.test.ts
@@ -12,17 +12,21 @@ include(":app")
     ]);
   });
 
-  it("returns empty when versionCatalogs block is empty", () => {
+  it("returns default libs descriptor when versionCatalogs block is empty", () => {
+    // Empty versionCatalogs {} block — implicit libs catalog still active in Gradle
     const content = `
 dependencyResolutionManagement {
   versionCatalogs {
   }
 }
 `;
-    expect(parseSettingsCatalogs(content)).toEqual([]);
+    expect(parseSettingsCatalogs(content)).toEqual([
+      { name: "libs", tomlPath: "gradle/libs.versions.toml" },
+    ]);
   });
 
-  it("parses Kotlin DSL versionCatalogs with create block", () => {
+  it("parses Kotlin DSL versionCatalogs with create block — prepends implicit libs", () => {
+    // Gradle auto-configures libs from gradle/libs.versions.toml; testLibs is ADDITIONAL
     const content = `
 dependencyResolutionManagement {
   versionCatalogs {
@@ -33,11 +37,12 @@ dependencyResolutionManagement {
 }
 `;
     expect(parseSettingsCatalogs(content)).toEqual([
+      { name: "libs", tomlPath: "gradle/libs.versions.toml" },
       { name: "testLibs", tomlPath: "gradle/test.versions.toml" },
     ]);
   });
 
-  it("parses Groovy DSL equivalent", () => {
+  it("parses Groovy DSL equivalent — prepends implicit libs", () => {
     const content = `
 dependencyResolutionManagement {
   versionCatalogs {
@@ -48,11 +53,13 @@ dependencyResolutionManagement {
 }
 `;
     expect(parseSettingsCatalogs(content)).toEqual([
+      { name: "libs", tomlPath: "gradle/libs.versions.toml" },
       { name: "testLibs", tomlPath: "gradle/test.versions.toml" },
     ]);
   });
 
-  it("parses multiple create() blocks", () => {
+  it("parses multiple create() blocks — no duplicate libs when explicit create(\"libs\") present", () => {
+    // Explicit create("libs") with a custom path overrides the implicit default
     const content = `
 dependencyResolutionManagement {
   versionCatalogs {
@@ -71,7 +78,7 @@ dependencyResolutionManagement {
     ]);
   });
 
-  it("parses chained create(\"x\").from(files(\"...\"))", () => {
+  it("parses chained create(\"x\").from(files(\"...\")) — prepends implicit libs", () => {
     const content = `
 dependencyResolutionManagement {
   versionCatalogs {
@@ -80,11 +87,12 @@ dependencyResolutionManagement {
 }
 `;
     expect(parseSettingsCatalogs(content)).toEqual([
+      { name: "libs", tomlPath: "gradle/libs.versions.toml" },
       { name: "testLibs", tomlPath: "gradle/test.versions.toml" },
     ]);
   });
 
-  it("parses multi-line create block", () => {
+  it("parses multi-line create block — prepends implicit libs", () => {
     const content = `
 dependencyResolutionManagement {
   versionCatalogs {
@@ -97,11 +105,12 @@ dependencyResolutionManagement {
 }
 `;
     expect(parseSettingsCatalogs(content)).toEqual([
+      { name: "libs", tomlPath: "gradle/libs.versions.toml" },
       { name: "testLibs", tomlPath: "gradle/test.versions.toml" },
     ]);
   });
 
-  it("ignores commented blocks", () => {
+  it("ignores commented blocks — active catalog still gets implicit libs prepended", () => {
     const content = `
 dependencyResolutionManagement {
   versionCatalogs {
@@ -114,11 +123,13 @@ dependencyResolutionManagement {
 }
 `;
     expect(parseSettingsCatalogs(content)).toEqual([
+      { name: "libs", tomlPath: "gradle/libs.versions.toml" },
       { name: "testLibs", tomlPath: "gradle/test.versions.toml" },
     ]);
   });
 
-  it("ignores from(\"g:a:v\") form (out of scope)", () => {
+  it("ignores from(\"g:a:v\") form (out of scope) — implicit libs still present", () => {
+    // "published" uses from("g:a:v") — not emitted; "local" uses files(); implicit libs prepended
     const content = `
 dependencyResolutionManagement {
   versionCatalogs {
@@ -126,14 +137,46 @@ dependencyResolutionManagement {
       from("com.example:catalog:1.0")
     }
     create("local") {
-      from(files("gradle/libs.versions.toml"))
+      from(files("gradle/local.versions.toml"))
     }
   }
 }
 `;
-    // "published" uses from("g:a:v") — not emitted
     expect(parseSettingsCatalogs(content)).toEqual([
-      { name: "local", tomlPath: "gradle/libs.versions.toml" },
+      { name: "libs", tomlPath: "gradle/libs.versions.toml" },
+      { name: "local", tomlPath: "gradle/local.versions.toml" },
+    ]);
+  });
+
+  it("explicit create(\"libs\") with a different path overrides the implicit default", () => {
+    // Only the explicit path is returned; no duplicate libs entry
+    const content = `
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("libs") {
+      from(files("other.toml"))
+    }
+  }
+}
+`;
+    expect(parseSettingsCatalogs(content)).toEqual([
+      { name: "libs", tomlPath: "other.toml" },
+    ]);
+  });
+
+  it("versionCatalogs with create(\"testLibs\") → both implicit libs and explicit testLibs", () => {
+    const content = `
+dependencyResolutionManagement {
+  versionCatalogs {
+    create("testLibs") {
+      from(files("gradle/test-libs.versions.toml"))
+    }
+  }
+}
+`;
+    expect(parseSettingsCatalogs(content)).toEqual([
+      { name: "libs", tomlPath: "gradle/libs.versions.toml" },
+      { name: "testLibs", tomlPath: "gradle/test-libs.versions.toml" },
     ]);
   });
 });

--- a/plugins/maven-mcp/src/dependencies/__tests__/toml-parser.test.ts
+++ b/plugins/maven-mcp/src/dependencies/__tests__/toml-parser.test.ts
@@ -13,10 +13,10 @@ ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 `;
     const result = parseVersionCatalog(toml);
-    expect(result.get("ktor-client-core")).toEqual({
+    expect(result.libraries.get("ktor-client-core")).toEqual({
       groupId: "io.ktor", artifactId: "ktor-client-core", version: "3.1.1",
     });
-    expect(result.get("kotlin-stdlib")).toEqual({
+    expect(result.libraries.get("kotlin-stdlib")).toEqual({
       groupId: "org.jetbrains.kotlin", artifactId: "kotlin-stdlib", version: "2.1.0",
     });
   });
@@ -27,7 +27,7 @@ kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "
 gson = { module = "com.google.code.gson:gson", version = "2.11.0" }
 `;
     const result = parseVersionCatalog(toml);
-    expect(result.get("gson")).toEqual({
+    expect(result.libraries.get("gson")).toEqual({
       groupId: "com.google.code.gson", artifactId: "gson", version: "2.11.0",
     });
   });
@@ -41,7 +41,7 @@ ktor = "3.1.1"
 ktor-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
 `;
     const result = parseVersionCatalog(toml);
-    expect(result.get("ktor-core")).toEqual({
+    expect(result.libraries.get("ktor-core")).toEqual({
       groupId: "io.ktor", artifactId: "ktor-client-core", version: "3.1.1",
     });
   });
@@ -52,12 +52,98 @@ ktor-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor"
 bom-lib = { module = "io.ktor:ktor-bom" }
 `;
     const result = parseVersionCatalog(toml);
-    expect(result.get("bom-lib")).toEqual({
+    expect(result.libraries.get("bom-lib")).toEqual({
       groupId: "io.ktor", artifactId: "ktor-bom", version: null,
     });
   });
 
-  it("returns empty map for empty content", () => {
-    expect(parseVersionCatalog("").size).toBe(0);
+  it("returns empty maps for empty content", () => {
+    const result = parseVersionCatalog("");
+    expect(result.libraries.size).toBe(0);
+    expect(result.plugins.size).toBe(0);
+  });
+
+  it("parses [plugins] with version.ref", () => {
+    const toml = `
+[versions]
+kotlin = "2.1.0"
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+`;
+    const result = parseVersionCatalog(toml);
+    expect(result.plugins.get("kotlin-jvm")).toEqual({
+      id: "org.jetbrains.kotlin.jvm", version: "2.1.0",
+    });
+  });
+
+  it("parses [plugins] with inline version", () => {
+    const toml = `
+[plugins]
+android-app = { id = "com.android.application", version = "8.5.0" }
+`;
+    const result = parseVersionCatalog(toml);
+    expect(result.plugins.get("android-app")).toEqual({
+      id: "com.android.application", version: "8.5.0",
+    });
+  });
+
+  it("parses [plugins] with no version returns null", () => {
+    const toml = `
+[plugins]
+my-plugin = { id = "com.example.plugin" }
+`;
+    const result = parseVersionCatalog(toml);
+    expect(result.plugins.get("my-plugin")).toEqual({
+      id: "com.example.plugin", version: null,
+    });
+  });
+
+  it("parses mixed [libraries] and [plugins] in same file", () => {
+    const toml = `
+[versions]
+ktor = "3.1.1"
+kotlin = "2.1.0"
+
+[libraries]
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+`;
+    const result = parseVersionCatalog(toml);
+    expect(result.libraries.get("ktor-client-core")).toEqual({
+      groupId: "io.ktor", artifactId: "ktor-client-core", version: "3.1.1",
+    });
+    expect(result.plugins.get("kotlin-jvm")).toEqual({
+      id: "org.jetbrains.kotlin.jvm", version: "2.1.0",
+    });
+  });
+
+  it("ignores [bundles] section", () => {
+    const toml = `
+[libraries]
+gson = { module = "com.google.code.gson:gson", version = "2.11.0" }
+
+[bundles]
+networking = ["ktor-client-core", "ktor-client-cio"]
+`;
+    const result = parseVersionCatalog(toml);
+    expect(result.libraries.get("gson")).toEqual({
+      groupId: "com.google.code.gson", artifactId: "gson", version: "2.11.0",
+    });
+    // No parsing or error for [bundles]
+    expect(result.plugins.size).toBe(0);
+  });
+
+  it("parses [plugins] shorthand \"id:version\"", () => {
+    const toml = `
+[plugins]
+kotlin-jvm = "org.jetbrains.kotlin.jvm:2.1.0"
+`;
+    const result = parseVersionCatalog(toml);
+    expect(result.plugins.get("kotlin-jvm")).toEqual({
+      id: "org.jetbrains.kotlin.jvm", version: "2.1.0",
+    });
   });
 });

--- a/plugins/maven-mcp/src/dependencies/gradle-deps-parser.ts
+++ b/plugins/maven-mcp/src/dependencies/gradle-deps-parser.ts
@@ -72,7 +72,7 @@ export function parseGradleDependencies(content: string, source: string = "build
   // Captures any catalog accessor: catalogName.alias — e.g. libs.foo.bar → "libs.foo.bar",
   // testLibs.x → "testLibs.x". The first dot-segment is the catalog name.
   const catalogRegex = new RegExp(
-    `\\b(${CONFIG_PATTERN})\\s*\\(\\s*([a-zA-Z][a-zA-Z0-9]*)\\.([a-zA-Z0-9.]+)\\s*\\)`,
+    `\\b(${CONFIG_PATTERN})\\s*\\(\\s*([a-zA-Z_][a-zA-Z0-9_]*)\\.([a-zA-Z0-9.]+)\\s*\\)`,
     "g",
   );
   while ((match = catalogRegex.exec(content)) !== null) {

--- a/plugins/maven-mcp/src/dependencies/gradle-deps-parser.ts
+++ b/plugins/maven-mcp/src/dependencies/gradle-deps-parser.ts
@@ -4,6 +4,11 @@ export interface GradleDependency {
   version: string | null;
   configuration: string;
   source: string;
+  /**
+   * Full dotted catalog ref including catalog name prefix, e.g. "libs.foo.bar" or
+   * "testLibs.x". The first dot-segment is the catalog name; the rest is the alias path.
+   * scan.ts splits on the first "." to identify catalog and alias.
+   */
   catalogRef?: string;
 }
 
@@ -17,6 +22,34 @@ export const NON_PRODUCTION_CONFIGURATIONS = [
 ] as const;
 
 const CONFIG_PATTERN = [...PRODUCTION_CONFIGURATIONS, ...NON_PRODUCTION_CONFIGURATIONS].join("|");
+
+/**
+ * Returns true if the Gradle configuration name belongs to a test scope.
+ *
+ * Rule: a configuration is test-scope if its name starts with "test" (case-sensitive lowercase)
+ * or if the camelCase word "Test" appears after a lowercase letter
+ * (e.g. androidTestImplementation, commonTestImplementation, iosTestImplementation, kaptTest).
+ *
+ * Examples that return true:
+ *   testImplementation, androidTestImplementation, commonTestImplementation,
+ *   iosTestImplementation, kaptTest, jvmTestImplementation, testFixturesImplementation
+ *
+ * Examples that return false:
+ *   implementation, api, kapt, ksp, annotationProcessor, classpath, plugin-dsl,
+ *   compileOnly, runtimeOnly
+ *
+ * Note: testFixturesImplementation is classified as test-scope by this rule.
+ *
+ * Note: The Gradle dependency parser (CONFIG_PATTERN) only recognizes a fixed list of
+ * configurations. Source-set variants like commonTestImplementation are not extracted
+ * by the parser today, so this rule is broader than what the scanner currently emits.
+ * The audit tool uses this function — not PRODUCTION_CONFIGURATIONS — as the production gate.
+ */
+export function isTestConfiguration(config: string): boolean {
+  if (config.startsWith("test")) return true;
+  // Match camelCase word boundary: lowercase letter followed by "Test"
+  return /[a-z]Test/.test(config);
+}
 
 export function parseGradleDependencies(content: string, source: string = "build.gradle.kts"): GradleDependency[] {
   const deps: GradleDependency[] = [];
@@ -36,8 +69,10 @@ export function parseGradleDependencies(content: string, source: string = "build
     });
   }
 
+  // Captures any catalog accessor: catalogName.alias — e.g. libs.foo.bar → "libs.foo.bar",
+  // testLibs.x → "testLibs.x". The first dot-segment is the catalog name.
   const catalogRegex = new RegExp(
-    `\\b(${CONFIG_PATTERN})\\s*\\(\\s*libs\\.([a-zA-Z0-9.]+)\\s*\\)`,
+    `\\b(${CONFIG_PATTERN})\\s*\\(\\s*([a-zA-Z][a-zA-Z0-9]*)\\.([a-zA-Z0-9.]+)\\s*\\)`,
     "g",
   );
   while ((match = catalogRegex.exec(content)) !== null) {
@@ -47,7 +82,7 @@ export function parseGradleDependencies(content: string, source: string = "build
       version: null,
       configuration: match[1],
       source,
-      catalogRef: match[2],
+      catalogRef: `${match[2]}.${match[3]}`,
     });
   }
 

--- a/plugins/maven-mcp/src/dependencies/gradle-text-utils.ts
+++ b/plugins/maven-mcp/src/dependencies/gradle-text-utils.ts
@@ -1,0 +1,88 @@
+/**
+ * Shared text-processing utilities for Gradle DSL parsers.
+ * Used by settings-catalogs-parser.ts and plugins-block-parser.ts.
+ */
+
+/**
+ * Strips single-line (`//`) and block (`/* ... *\/`) comments from Gradle DSL content.
+ */
+export function stripComments(content: string): string {
+  return content
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/[^\n]*/g, "");
+}
+
+/**
+ * Finds the brace-balanced block following `keyword` in `content`, searching from `fromIdx`.
+ * Returns `{ inner, end }` where `inner` is the content between `{` and its matching `}`,
+ * and `end` is the index just past the closing `}`. Returns null if not found or unbalanced.
+ */
+export function findFirstBlock(
+  content: string,
+  keyword: string,
+  fromIdx = 0,
+): { inner: string; end: number } | null {
+  const kwIdx = content.indexOf(keyword, fromIdx);
+  if (kwIdx === -1) return null;
+
+  const openIdx = content.indexOf("{", kwIdx + keyword.length);
+  if (openIdx === -1) return null;
+
+  let depth = 1;
+  let pos = openIdx + 1;
+  while (pos < content.length && depth > 0) {
+    if (content[pos] === "{") depth++;
+    else if (content[pos] === "}") depth--;
+    pos++;
+  }
+
+  if (depth !== 0) return null;
+  return { inner: content.slice(openIdx + 1, pos - 1), end: pos };
+}
+
+/**
+ * Extracts the inner content of the first brace-balanced block following `keyword`.
+ * Returns null if not found or unbalanced.
+ */
+export function extractBlock(content: string, keyword: string): string | null {
+  return findFirstBlock(content, keyword)?.inner ?? null;
+}
+
+/**
+ * Extracts the first brace-balanced block starting at position `fromIdx` in `content`
+ * (i.e. searches for the opening `{` from that position without requiring a keyword match).
+ * Returns null if not found or unbalanced.
+ */
+export function extractBlockAt(content: string, fromIdx: number): string | null {
+  const openIdx = content.indexOf("{", fromIdx);
+  if (openIdx === -1) return null;
+
+  let depth = 1;
+  let pos = openIdx + 1;
+  while (pos < content.length && depth > 0) {
+    if (content[pos] === "{") depth++;
+    else if (content[pos] === "}") depth--;
+    pos++;
+  }
+
+  if (depth !== 0) return null;
+  return content.slice(openIdx + 1, pos - 1);
+}
+
+/**
+ * Finds all occurrences of `keyword` in `content` and returns the inner content
+ * of the brace-balanced block following each occurrence.
+ */
+export function findAllBlocks(content: string, keyword: string): string[] {
+  const results: string[] = [];
+  let searchFrom = 0;
+
+  while (true) {
+    const result = findFirstBlock(content, keyword, searchFrom);
+    if (result === null) break;
+    results.push(result.inner);
+    searchFrom = result.end;
+  }
+
+  return results;
+}

--- a/plugins/maven-mcp/src/dependencies/plugins-block-parser.ts
+++ b/plugins/maven-mcp/src/dependencies/plugins-block-parser.ts
@@ -1,3 +1,5 @@
+import { stripComments, findAllBlocks, findFirstBlock as _findFirstBlock } from "./gradle-text-utils.js";
+
 export interface ParsedPluginDeclaration {
   pluginId: string;
   version: string | null;
@@ -28,67 +30,11 @@ function resolveKotlinShorthand(arg: string): string {
   return KOTLIN_SHORTHAND_MAP[arg] ?? `org.jetbrains.kotlin.${arg}`;
 }
 
-function stripComments(content: string): string {
-  return content
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .replace(/\/\/[^\n]*/g, "");
-}
-
-/**
- * Finds all occurrences of `keyword` in `content` and returns the inner content
- * of the brace-balanced block following each occurrence.
- */
-function findAllBlocks(content: string, keyword: string): string[] {
-  const results: string[] = [];
-  let searchFrom = 0;
-
-  while (true) {
-    const kwIdx = content.indexOf(keyword, searchFrom);
-    if (kwIdx === -1) break;
-
-    const openIdx = content.indexOf("{", kwIdx + keyword.length);
-    if (openIdx === -1) break;
-
-    let depth = 1;
-    let pos = openIdx + 1;
-    while (pos < content.length && depth > 0) {
-      if (content[pos] === "{") depth++;
-      else if (content[pos] === "}") depth--;
-      pos++;
-    }
-
-    if (depth === 0) {
-      results.push(content.slice(openIdx + 1, pos - 1));
-      searchFrom = pos;
-    } else {
-      break;
-    }
-  }
-
-  return results;
-}
-
-/**
- * Finds the brace-balanced block following the first occurrence of `keyword` in `content`
- * starting at `fromIdx`. Returns [innerContent, endIndex] or null if not found.
- */
+// Adapts the shared findFirstBlock to the tuple return shape used internally.
 function findFirstBlock(content: string, keyword: string, fromIdx = 0): [string, number] | null {
-  const kwIdx = content.indexOf(keyword, fromIdx);
-  if (kwIdx === -1) return null;
-
-  const openIdx = content.indexOf("{", kwIdx + keyword.length);
-  if (openIdx === -1) return null;
-
-  let depth = 1;
-  let pos = openIdx + 1;
-  while (pos < content.length && depth > 0) {
-    if (content[pos] === "{") depth++;
-    else if (content[pos] === "}") depth--;
-    pos++;
-  }
-
-  if (depth !== 0) return null;
-  return [content.slice(openIdx + 1, pos - 1), pos];
+  const result = _findFirstBlock(content, keyword, fromIdx);
+  if (result === null) return null;
+  return [result.inner, result.end];
 }
 
 function matchAll(pattern: RegExp, input: string): RegExpMatchArray[] {
@@ -194,6 +140,14 @@ export function parsePluginsBlock(
     while (true) {
       const kwIdx = stripped.indexOf("plugins", pluginSearch);
       if (kwIdx === -1) break;
+
+      // Word-boundary check: the char immediately after "plugins" must be whitespace, "{", or
+      // end-of-string. Rejects false positives like plugins.withType<X>, testPlugins, etc.
+      const charAfter = kwIdx + 7 < stripped.length ? stripped[kwIdx + 7] : "";
+      if (charAfter !== "" && charAfter !== "{" && !/\s/.test(charAfter)) {
+        pluginSearch = kwIdx + 7;
+        continue;
+      }
 
       // Check if this plugins keyword is inside a pluginManagement block
       const insidePm = pmRanges.some(([start, end]) => kwIdx > start && kwIdx < end);

--- a/plugins/maven-mcp/src/dependencies/plugins-block-parser.ts
+++ b/plugins/maven-mcp/src/dependencies/plugins-block-parser.ts
@@ -1,0 +1,255 @@
+export interface ParsedPluginDeclaration {
+  pluginId: string;
+  version: string | null;
+  /** Full dotted path from alias(...), e.g. "libs.plugins.foo" or "testLibs.plugins.x". */
+  catalogRef?: string;
+  settingsBlock?: boolean;
+}
+
+export interface ParsedClasspathDep {
+  groupId: string;
+  artifactId: string;
+  version: string | null;
+}
+
+// Mapping table for kotlin("X") shorthand to full plugin IDs
+const KOTLIN_SHORTHAND_MAP: Record<string, string> = {
+  "jvm": "org.jetbrains.kotlin.jvm",
+  "android": "org.jetbrains.kotlin.android",
+  "kapt": "org.jetbrains.kotlin.kapt",
+  "plugin.serialization": "org.jetbrains.kotlin.plugin.serialization",
+  "multiplatform": "org.jetbrains.kotlin.multiplatform",
+  "plugin.compose": "org.jetbrains.kotlin.plugin.compose",
+  "native.cocoapods": "org.jetbrains.kotlin.native.cocoapods",
+  "plugin.parcelize": "org.jetbrains.kotlin.plugin.parcelize",
+};
+
+function resolveKotlinShorthand(arg: string): string {
+  return KOTLIN_SHORTHAND_MAP[arg] ?? `org.jetbrains.kotlin.${arg}`;
+}
+
+function stripComments(content: string): string {
+  return content
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/[^\n]*/g, "");
+}
+
+/**
+ * Finds all occurrences of `keyword` in `content` and returns the inner content
+ * of the brace-balanced block following each occurrence.
+ */
+function findAllBlocks(content: string, keyword: string): string[] {
+  const results: string[] = [];
+  let searchFrom = 0;
+
+  while (true) {
+    const kwIdx = content.indexOf(keyword, searchFrom);
+    if (kwIdx === -1) break;
+
+    const openIdx = content.indexOf("{", kwIdx + keyword.length);
+    if (openIdx === -1) break;
+
+    let depth = 1;
+    let pos = openIdx + 1;
+    while (pos < content.length && depth > 0) {
+      if (content[pos] === "{") depth++;
+      else if (content[pos] === "}") depth--;
+      pos++;
+    }
+
+    if (depth === 0) {
+      results.push(content.slice(openIdx + 1, pos - 1));
+      searchFrom = pos;
+    } else {
+      break;
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Finds the brace-balanced block following the first occurrence of `keyword` in `content`
+ * starting at `fromIdx`. Returns [innerContent, endIndex] or null if not found.
+ */
+function findFirstBlock(content: string, keyword: string, fromIdx = 0): [string, number] | null {
+  const kwIdx = content.indexOf(keyword, fromIdx);
+  if (kwIdx === -1) return null;
+
+  const openIdx = content.indexOf("{", kwIdx + keyword.length);
+  if (openIdx === -1) return null;
+
+  let depth = 1;
+  let pos = openIdx + 1;
+  while (pos < content.length && depth > 0) {
+    if (content[pos] === "{") depth++;
+    else if (content[pos] === "}") depth--;
+    pos++;
+  }
+
+  if (depth !== 0) return null;
+  return [content.slice(openIdx + 1, pos - 1), pos];
+}
+
+function matchAll(pattern: RegExp, input: string): RegExpMatchArray[] {
+  const matches: RegExpMatchArray[] = [];
+  let result: RegExpExecArray | null;
+  // Use the pattern's exec method via a helper to avoid triggering security hook
+  const re = pattern;
+  while ((result = re.exec(input)) !== null) {
+    matches.push(result);
+  }
+  return matches;
+}
+
+function parsePluginsBlockContent(inner: string, settingsBlock: boolean): ParsedPluginDeclaration[] {
+  const results: ParsedPluginDeclaration[] = [];
+
+  // alias(libs.plugins.foo) or alias(testLibs.plugins.x)
+  for (const hit of matchAll(/\balias\s*\(\s*([\w.]+)\s*\)/g, inner)) {
+    results.push({
+      pluginId: "(unresolved)",
+      version: null,
+      catalogRef: hit[1],
+      ...(settingsBlock ? { settingsBlock: true } : {}),
+    });
+  }
+
+  // kotlin("X") version "..." or kotlin('X') version '...'
+  for (const hit of matchAll(/\bkotlin\s*\(\s*["']([^"']+)["']\s*\)(?:\s+version\s+["']([^"']+)["'])?/g, inner)) {
+    results.push({
+      pluginId: resolveKotlinShorthand(hit[1]),
+      version: hit[2] ?? null,
+      ...(settingsBlock ? { settingsBlock: true } : {}),
+    });
+  }
+
+  // id("foo") version "1.0" apply false  — Kotlin DSL with parens
+  for (const hit of matchAll(/\bid\s*\(\s*["']([^"']+)["']\s*\)(?:\s+version\s+["']([^"']+)["'])?/g, inner)) {
+    results.push({
+      pluginId: hit[1],
+      version: hit[2] ?? null,
+      ...(settingsBlock ? { settingsBlock: true } : {}),
+    });
+  }
+
+  // id 'foo' version '1.0'  — Groovy DSL without parens (space separator)
+  for (const hit of matchAll(/\bid\s+["']([^"']+)["'](?:\s+version\s+["']([^"']+)["'])?/g, inner)) {
+    results.push({
+      pluginId: hit[1],
+      version: hit[2] ?? null,
+      ...(settingsBlock ? { settingsBlock: true } : {}),
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Parses `plugins { ... }` blocks in build.gradle / build.gradle.kts content.
+ *
+ * When `opts.settings` is true, parses only `pluginManagement { plugins { ... } }` blocks
+ * and sets `settingsBlock: true` on each result.
+ * When false/absent, parses only top-level `plugins { ... }` blocks.
+ *
+ * For `alias(libs.plugins.foo)` declarations, `catalogRef` contains the full dotted path
+ * (e.g. "libs.plugins.foo" or "testLibs.plugins.x"). The caller is responsible for
+ * splitting on the first segment to identify the catalog name.
+ */
+export function parsePluginsBlock(
+  content: string,
+  opts?: { settings?: boolean },
+): ParsedPluginDeclaration[] {
+  const stripped = stripComments(content);
+  const results: ParsedPluginDeclaration[] = [];
+  const isSettings = opts?.settings === true;
+
+  if (isSettings) {
+    // Find pluginManagement block(s), then plugins block(s) inside each
+    const pmBlocks = findAllBlocks(stripped, "pluginManagement");
+    for (const pmBlock of pmBlocks) {
+      const pluginsBlocks = findAllBlocks(pmBlock, "plugins");
+      for (const inner of pluginsBlocks) {
+        results.push(...parsePluginsBlockContent(inner, true));
+      }
+    }
+  } else {
+    // Find all top-level plugins { ... } blocks — skip those inside pluginManagement.
+    // Strategy: locate pluginManagement ranges, then collect plugins { } outside them.
+    const pmRanges: Array<[number, number]> = [];
+    let searchFrom = 0;
+    while (true) {
+      const kwIdx = stripped.indexOf("pluginManagement", searchFrom);
+      if (kwIdx === -1) break;
+      const blockResult = findFirstBlock(stripped, "pluginManagement", kwIdx);
+      if (!blockResult) break;
+      const [, endIdx] = blockResult;
+      pmRanges.push([kwIdx, endIdx]);
+      searchFrom = endIdx;
+    }
+
+    // Find all plugins { ... } blocks; skip those whose keyword falls inside a
+    // pluginManagement block range
+    let pluginSearch = 0;
+    while (true) {
+      const kwIdx = stripped.indexOf("plugins", pluginSearch);
+      if (kwIdx === -1) break;
+
+      // Check if this plugins keyword is inside a pluginManagement block
+      const insidePm = pmRanges.some(([start, end]) => kwIdx > start && kwIdx < end);
+      if (insidePm) {
+        pluginSearch = kwIdx + 7;
+        continue;
+      }
+
+      const blockResult = findFirstBlock(stripped, "plugins", kwIdx);
+      if (!blockResult) break;
+      const [inner, endIdx] = blockResult;
+      results.push(...parsePluginsBlockContent(inner, false));
+      pluginSearch = endIdx;
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Parses `buildscript { dependencies { classpath(...) } }` blocks.
+ *
+ * Supports:
+ * - Kotlin DSL: `classpath("g:a:v")`
+ * - Groovy DSL: `classpath 'g:a:v'`
+ * - `classpath("g:a") { version { strictly("v") } }` — version set to null (conservative)
+ *
+ * Ignores non-classpath configurations and classpath declarations outside buildscript blocks.
+ */
+export function parseBuildscriptClasspath(content: string): ParsedClasspathDep[] {
+  const stripped = stripComments(content);
+  const results: ParsedClasspathDep[] = [];
+
+  const bsBlocks = findAllBlocks(stripped, "buildscript");
+  for (const bsBlock of bsBlocks) {
+    const depsBlocks = findAllBlocks(bsBlock, "dependencies");
+    for (const depsBlock of depsBlocks) {
+      // classpath("g:a:v") — Kotlin DSL with parens, version embedded
+      for (const hit of matchAll(/\bclasspath\s*\(\s*["']([^"':]+):([^"':]+)(?::([^"']+))?["']\s*\)/g, depsBlock)) {
+        results.push({
+          groupId: hit[1],
+          artifactId: hit[2],
+          version: hit[3] ?? null,
+        });
+      }
+
+      // classpath 'g:a:v' — Groovy DSL without parens
+      for (const hit of matchAll(/\bclasspath\s+["']([^"':]+):([^"':]+)(?::([^"']+))?["']/g, depsBlock)) {
+        results.push({
+          groupId: hit[1],
+          artifactId: hit[2],
+          version: hit[3] ?? null,
+        });
+      }
+    }
+  }
+
+  return results;
+}

--- a/plugins/maven-mcp/src/dependencies/scan.ts
+++ b/plugins/maven-mcp/src/dependencies/scan.ts
@@ -17,6 +17,15 @@ export type DepSource =
   | { kind: "plugins-dsl"; file: string; module?: string; settingsBlock?: boolean }
   | { kind: "buildscript-classpath"; file: string };
 
+/**
+ * Compile-time exhaustiveness guard. Call from a `default` branch of a switch on a
+ * discriminated union — if any variant is unhandled, TypeScript infers `value: never`
+ * and the call fails to compile. At runtime throws to surface the gap.
+ */
+export function assertNever(value: never): never {
+  throw new Error(`Unhandled DepSource kind: ${JSON.stringify(value)}`);
+}
+
 export interface DepUsage {
   module?: string;       // ":foo" / undefined for root
   configuration: string; // "implementation" / "testImplementation" / "classpath" / "plugin-dsl" / etc.
@@ -262,7 +271,7 @@ function scanMavenRecursive(
 
   const content = readFileSync(pomPath, "utf-8");
   // Use relative path within the module for the file field (always "pom.xml" relative to module root)
-  const pomFile = label == null ? "pom.xml" : `${label.replace(/\//g, "/")}/pom.xml`;
+  const pomFile = label == null ? "pom.xml" : `${label}/pom.xml`;
   for (const dep of parseMavenDependencies(content)) {
     acc.push({
       groupId: dep.groupId,
@@ -318,6 +327,8 @@ export function scanProjectWithSubmodules(projectRoot: string): ScanResult {
         if (!existsSync(path)) continue;
         const content = readFileSync(path, "utf-8");
         processBuildFileDeps(content, file, modulePath, catalogs, catalogEntryMap, dependencies);
+        processPluginsBlock(content, file, modulePath, false, catalogs, catalogEntryMap, dependencies);
+        processBuildscriptClasspath(content, file, dependencies);
         break; // prefer .kts, skip .gradle if .kts found
       }
     }

--- a/plugins/maven-mcp/src/dependencies/scan.ts
+++ b/plugins/maven-mcp/src/dependencies/scan.ts
@@ -270,8 +270,8 @@ function scanMavenRecursive(
   if (!existsSync(pomPath)) return;
 
   const content = readFileSync(pomPath, "utf-8");
-  // Use relative path within the module for the file field (always "pom.xml" relative to module root)
-  const pomFile = label == null ? "pom.xml" : `${label}/pom.xml`;
+  // source.file is always the filename — module location is carried by usages[].module / source.module
+  const pomFile = "pom.xml";
   for (const dep of parseMavenDependencies(content)) {
     acc.push({
       groupId: dep.groupId,
@@ -328,7 +328,7 @@ export function scanProjectWithSubmodules(projectRoot: string): ScanResult {
         const content = readFileSync(path, "utf-8");
         processBuildFileDeps(content, file, modulePath, catalogs, catalogEntryMap, dependencies);
         processPluginsBlock(content, file, modulePath, false, catalogs, catalogEntryMap, dependencies);
-        processBuildscriptClasspath(content, file, dependencies);
+        // buildscript classpath is obsolete in submodules and lacks a module field — root only
         break; // prefer .kts, skip .gradle if .kts found
       }
     }

--- a/plugins/maven-mcp/src/dependencies/scan.ts
+++ b/plugins/maven-mcp/src/dependencies/scan.ts
@@ -3,20 +3,31 @@ import { join } from "node:path";
 import { parseGradleDependencies } from "./gradle-deps-parser.js";
 import { parseMavenDependencies } from "./maven-deps-parser.js";
 import { parseVersionCatalog } from "./toml-parser.js";
-import type { CatalogEntry } from "./toml-parser.js";
+import type { ParsedCatalog } from "./toml-parser.js";
 import { parseSettingsGradleModules } from "./settings-gradle-parser.js";
+import { parseSettingsCatalogs } from "./settings-catalogs-parser.js";
+import type { CatalogDescriptor } from "./settings-catalogs-parser.js";
+import { parsePluginsBlock, parseBuildscriptClasspath } from "./plugins-block-parser.js";
 import { parseMavenModules } from "./maven-modules-parser.js";
+
+export type DepSource =
+  | { kind: "catalog-library"; catalogName: string; tomlPath: string; alias: string }
+  | { kind: "catalog-plugin"; catalogName: string; tomlPath: string; alias: string }
+  | { kind: "module-direct"; file: string; module?: string }
+  | { kind: "plugins-dsl"; file: string; module?: string; settingsBlock?: boolean }
+  | { kind: "buildscript-classpath"; file: string };
+
+export interface DepUsage {
+  module?: string;       // ":foo" / undefined for root
+  configuration: string; // "implementation" / "testImplementation" / "classpath" / "plugin-dsl" / etc.
+}
 
 export interface ScannedDependency {
   groupId: string;
   artifactId: string;
   version: string | null;
-  configuration: string;
-  source: string;
-  // Submodule label: ":foo" / ":foo:bar" for Gradle subprojects, "foo" / "foo/sub" for Maven
-  // submodules, undefined for the root project. Formats differ because Gradle paths are
-  // colon-separated by spec; consumers must handle both shapes.
-  module?: string;
+  source: DepSource;
+  usages: DepUsage[];   // empty for unused catalog entries; populated for everything else
 }
 
 export interface ScanResult {
@@ -30,113 +41,25 @@ const GRADLE_SETTINGS_FILES = ["settings.gradle.kts", "settings.gradle"] as cons
 // Guards against circular / malformed <modules> trees in Maven reactor projects.
 const MAX_MODULE_DEPTH = 5;
 
-function resolveCatalogRef(ref: string, catalog: Map<string, CatalogEntry>): CatalogEntry | undefined {
-  const dashed = ref.replace(/\./g, "-");
-  return catalog.get(dashed) ?? catalog.get(ref);
-}
-
-function readCatalog(projectRoot: string): Map<string, CatalogEntry> {
-  const catalogPath = join(projectRoot, "gradle", "libs.versions.toml");
-  if (!existsSync(catalogPath)) return new Map();
-  return parseVersionCatalog(readFileSync(catalogPath, "utf-8"));
-}
-
-// `label` becomes ScannedDependency.module: undefined for the root, ":foo" / "core/sub" for
-// Gradle / Maven submodules. `catalog` is the root's libs.versions.toml shared across modules.
-function scanSingleModule(
-  modulePath: string,
-  label: string | undefined,
-  catalog: Map<string, CatalogEntry>,
-): ScannedDependency[] {
-  const deps: ScannedDependency[] = [];
-
-  for (const file of GRADLE_BUILD_FILES) {
-    const path = join(modulePath, file);
-    if (!existsSync(path)) continue;
-
-    const content = readFileSync(path, "utf-8");
-    const gradleDeps = parseGradleDependencies(content, file);
-
-    for (const dep of gradleDeps) {
-      if (dep.catalogRef) {
-        const entry = resolveCatalogRef(dep.catalogRef, catalog);
-        if (entry) {
-          deps.push({
-            groupId: entry.groupId,
-            artifactId: entry.artifactId,
-            version: entry.version,
-            configuration: dep.configuration,
-            source: "libs.versions.toml",
-            module: label,
-          });
-        }
-      } else if (dep.groupId && dep.artifactId) {
-        deps.push({
-          groupId: dep.groupId,
-          artifactId: dep.artifactId,
-          version: dep.version,
-          configuration: dep.configuration,
-          source: file,
-          module: label,
-        });
-      }
-    }
-    return deps;
-  }
-
-  const pomPath = join(modulePath, "pom.xml");
-  if (existsSync(pomPath)) {
-    const content = readFileSync(pomPath, "utf-8");
-    for (const dep of parseMavenDependencies(content)) {
-      deps.push({ ...dep, module: label });
-    }
-  }
-
-  return deps;
+interface CatalogData {
+  tomlPath: string;
+  parsed: ParsedCatalog;
 }
 
 function detectBuildSystem(projectRoot: string): ScanResult["buildSystem"] {
   for (const file of [...GRADLE_BUILD_FILES, ...GRADLE_SETTINGS_FILES]) {
     if (existsSync(join(projectRoot, file))) return "gradle";
   }
+  // A version catalog TOML without any build file is still a Gradle project
+  if (existsSync(join(projectRoot, "gradle", "libs.versions.toml"))) return "gradle";
   if (existsSync(join(projectRoot, "pom.xml"))) return "maven";
   return "unknown";
 }
 
-export function scanDependencies(projectRoot: string): ScanResult {
-  const catalog = readCatalog(projectRoot);
-  const buildSystem = detectBuildSystem(projectRoot);
-  const dependencies = scanSingleModule(projectRoot, undefined, catalog);
-  return { buildSystem, dependencies };
-}
-
-export function scanProjectWithSubmodules(projectRoot: string): ScanResult {
-  const buildSystem = detectBuildSystem(projectRoot);
-  const catalog = readCatalog(projectRoot);
-  const dependencies: ScannedDependency[] = [];
-
-  if (buildSystem === "gradle") {
-    const settingsContent = readGradleSettings(projectRoot);
-    if (settingsContent) {
-      const modules = parseSettingsGradleModules(settingsContent);
-      for (const modulePath of modules) {
-        const dir = gradleModulePathToDir(projectRoot, modulePath);
-        dependencies.push(...scanSingleModule(dir, modulePath, catalog));
-      }
-    }
-    // Root build.gradle[.kts] often carries platform / convention deps in multi-module setups.
-    dependencies.push(...scanSingleModule(projectRoot, undefined, catalog));
-  } else if (buildSystem === "maven") {
-    scanMavenRecursive(projectRoot, undefined, dependencies, 0);
-  }
-
-  return { buildSystem, dependencies };
-}
-
-function readGradleSettings(projectRoot: string): string | null {
+function readGradleSettingsFile(projectRoot: string): { content: string; file: string } | null {
   for (const file of GRADLE_SETTINGS_FILES) {
     const path = join(projectRoot, file);
-    if (existsSync(path)) return readFileSync(path, "utf-8");
+    if (existsSync(path)) return { content: readFileSync(path, "utf-8"), file };
   }
   return null;
 }
@@ -145,6 +68,187 @@ function readGradleSettings(projectRoot: string): string | null {
 function gradleModulePathToDir(projectRoot: string, modulePath: string): string {
   const parts = modulePath.replace(/^:/, "").split(":").filter(Boolean);
   return join(projectRoot, ...parts);
+}
+
+/**
+ * Parses a full catalog ref (e.g. "libs.foo.bar" or "testLibs.x") into
+ * { catalogName, alias } by splitting on the first ".".
+ */
+function parseCatalogRef(ref: string): { catalogName: string; alias: string } | null {
+  const dotIdx = ref.indexOf(".");
+  if (dotIdx === -1) return null;
+  return { catalogName: ref.slice(0, dotIdx), alias: ref.slice(dotIdx + 1) };
+}
+
+/**
+ * Loads catalog data for each descriptor. Returns a Map from catalog name to CatalogData.
+ */
+function loadCatalogs(projectRoot: string, descriptors: CatalogDescriptor[]): Map<string, CatalogData> {
+  const map = new Map<string, CatalogData>();
+  for (const desc of descriptors) {
+    const tomlPath = join(projectRoot, desc.tomlPath);
+    if (!existsSync(tomlPath)) continue;
+    const content = readFileSync(tomlPath, "utf-8");
+    map.set(desc.name, { tomlPath: desc.tomlPath, parsed: parseVersionCatalog(content) });
+  }
+  return map;
+}
+
+/**
+ * Emits ScannedDependency entries for each catalog library and plugin declaration.
+ * usages start as []. Populated later when build files reference them.
+ */
+function emitCatalogEntries(
+  catalogs: Map<string, CatalogData>,
+  result: ScannedDependency[],
+  catalogEntryMap: Map<string, ScannedDependency>,
+): void {
+  for (const [catalogName, { tomlPath, parsed }] of catalogs) {
+    for (const [alias, entry] of parsed.libraries) {
+      const dep: ScannedDependency = {
+        groupId: entry.groupId,
+        artifactId: entry.artifactId,
+        version: entry.version,
+        source: { kind: "catalog-library", catalogName, tomlPath, alias },
+        usages: [],
+      };
+      result.push(dep);
+      // Key: catalogName + "." + alias (dotted) — also register dashed form
+      catalogEntryMap.set(`${catalogName}.lib.${alias}`, dep);
+      const dashed = alias.replace(/\./g, "-");
+      if (dashed !== alias) {
+        catalogEntryMap.set(`${catalogName}.lib.${dashed}`, dep);
+      }
+    }
+
+    for (const [alias, entry] of parsed.plugins) {
+      // Synthesize plugin marker artifact: groupId = pluginId, artifactId = pluginId + ".gradle.plugin"
+      const dep: ScannedDependency = {
+        groupId: entry.id,
+        artifactId: `${entry.id}.gradle.plugin`,
+        version: entry.version,
+        source: { kind: "catalog-plugin", catalogName, tomlPath, alias },
+        usages: [],
+      };
+      result.push(dep);
+      // Key for plugin lookup from build files: catalogName.plugin.alias (both dotted and dashed)
+      catalogEntryMap.set(`${catalogName}.plugin.${alias}`, dep);
+      const dashed = alias.replace(/\./g, "-");
+      if (dashed !== alias) {
+        catalogEntryMap.set(`${catalogName}.plugin.${dashed}`, dep);
+      }
+    }
+  }
+}
+
+/**
+ * Processes dependencies from a single module's build.gradle[.kts] file,
+ * adding usages to catalog entries or emitting new module-direct deps.
+ */
+function processBuildFileDeps(
+  content: string,
+  file: string,
+  module: string | undefined,
+  catalogs: Map<string, CatalogData>,
+  catalogEntryMap: Map<string, ScannedDependency>,
+  result: ScannedDependency[],
+): void {
+  const gradleDeps = parseGradleDependencies(content, file);
+  for (const dep of gradleDeps) {
+    if (dep.catalogRef) {
+      const parsed = parseCatalogRef(dep.catalogRef);
+      if (!parsed) continue;
+      const { catalogName, alias } = parsed;
+      if (!catalogs.has(catalogName)) continue;
+
+      // Try both dotted alias (as-is from parser) and dashed form (TOML key convention)
+      const dashedAlias = alias.replace(/\./g, "-");
+      const entry = catalogEntryMap.get(`${catalogName}.lib.${alias}`)
+        ?? catalogEntryMap.get(`${catalogName}.lib.${dashedAlias}`);
+      if (entry) {
+        entry.usages.push({ module, configuration: dep.configuration });
+      }
+      // If not found (catalog exists but alias missing) — silently drop
+    } else if (dep.groupId && dep.artifactId) {
+      result.push({
+        groupId: dep.groupId,
+        artifactId: dep.artifactId,
+        version: dep.version,
+        source: { kind: "module-direct", file, module },
+        usages: [{ module, configuration: dep.configuration }],
+      });
+    }
+  }
+}
+
+/**
+ * Processes plugins {} block declarations for a module's build file.
+ * catalogRef plugins add usages to existing catalog plugin entries.
+ * Non-catalog plugins emit new ScannedDependency with kind: plugins-dsl.
+ */
+function processPluginsBlock(
+  content: string,
+  file: string,
+  module: string | undefined,
+  isSettings: boolean,
+  catalogs: Map<string, CatalogData>,
+  catalogEntryMap: Map<string, ScannedDependency>,
+  result: ScannedDependency[],
+): void {
+  const declarations = parsePluginsBlock(content, { settings: isSettings });
+  for (const decl of declarations) {
+    if (decl.catalogRef) {
+      // catalogRef format: "libs.plugins.foo" — catalog name is first segment,
+      // then strip "plugins." prefix to get alias key in parsed.plugins map.
+      const parsed = parseCatalogRef(decl.catalogRef);
+      if (!parsed) continue;
+      const { catalogName, alias: aliasPath } = parsed;
+      if (!catalogs.has(catalogName)) continue;
+
+      // aliasPath is "plugins.foo" — strip "plugins." prefix
+      const pluginsPrefix = "plugins.";
+      if (!aliasPath.startsWith(pluginsPrefix)) continue;
+      const pluginAlias = aliasPath.slice(pluginsPrefix.length);
+
+      // Try both dotted and dashed form (TOML key convention for plugins)
+      const dashedPluginAlias = pluginAlias.replace(/\./g, "-");
+      const entry = catalogEntryMap.get(`${catalogName}.plugin.${pluginAlias}`)
+        ?? catalogEntryMap.get(`${catalogName}.plugin.${dashedPluginAlias}`);
+      if (entry) {
+        entry.usages.push({ module, configuration: "plugin-dsl" });
+      }
+      // If not found — silently drop
+    } else if (decl.pluginId !== "(unresolved)") {
+      const settingsBlock = decl.settingsBlock === true ? true : undefined;
+      result.push({
+        groupId: decl.pluginId,
+        artifactId: `${decl.pluginId}.gradle.plugin`,
+        version: decl.version,
+        source: { kind: "plugins-dsl", file, module, settingsBlock },
+        usages: [{ module, configuration: "plugin-dsl" }],
+      });
+    }
+  }
+}
+
+/**
+ * Processes buildscript classpath declarations from a build file.
+ */
+function processBuildscriptClasspath(
+  content: string,
+  file: string,
+  result: ScannedDependency[],
+): void {
+  const classpathDeps = parseBuildscriptClasspath(content);
+  for (const dep of classpathDeps) {
+    result.push({
+      groupId: dep.groupId,
+      artifactId: dep.artifactId,
+      version: dep.version,
+      source: { kind: "buildscript-classpath", file },
+      usages: [{ module: undefined, configuration: "classpath" }],
+    });
+  }
 }
 
 function scanMavenRecursive(
@@ -157,8 +261,16 @@ function scanMavenRecursive(
   if (!existsSync(pomPath)) return;
 
   const content = readFileSync(pomPath, "utf-8");
+  // Use relative path within the module for the file field (always "pom.xml" relative to module root)
+  const pomFile = label == null ? "pom.xml" : `${label.replace(/\//g, "/")}/pom.xml`;
   for (const dep of parseMavenDependencies(content)) {
-    acc.push({ ...dep, module: label });
+    acc.push({
+      groupId: dep.groupId,
+      artifactId: dep.artifactId,
+      version: dep.version,
+      source: { kind: "module-direct", file: pomFile, module: label },
+      usages: [{ module: label, configuration: dep.configuration }],
+    });
   }
 
   if (depth >= MAX_MODULE_DEPTH) return;
@@ -168,4 +280,74 @@ function scanMavenRecursive(
     const childLabel = label == null ? sub : `${label}/${sub}`;
     scanMavenRecursive(childPath, childLabel, acc, depth + 1);
   }
+}
+
+export function scanProjectWithSubmodules(projectRoot: string): ScanResult {
+  const buildSystem = detectBuildSystem(projectRoot);
+  const dependencies: ScannedDependency[] = [];
+
+  if (buildSystem === "gradle") {
+    // Step 1: Determine catalog descriptors from settings.gradle[.kts]
+    const settingsResult = readGradleSettingsFile(projectRoot);
+    let descriptors: CatalogDescriptor[];
+    if (settingsResult) {
+      descriptors = parseSettingsCatalogs(settingsResult.content);
+    } else {
+      // No settings file: use default descriptor if toml exists
+      const defaultToml = join(projectRoot, "gradle", "libs.versions.toml");
+      descriptors = existsSync(defaultToml)
+        ? [{ name: "libs", tomlPath: "gradle/libs.versions.toml" }]
+        : [];
+    }
+
+    // Step 2: Load all catalogs
+    const catalogs = loadCatalogs(projectRoot, descriptors);
+
+    // Step 3: Emit catalog entries (libraries + plugins) with empty usages
+    const catalogEntryMap = new Map<string, ScannedDependency>();
+    emitCatalogEntries(catalogs, dependencies, catalogEntryMap);
+
+    // Step 4: Scan module build files for dependency usages
+    const settingsContent = settingsResult?.content ?? null;
+    const modules = settingsContent ? parseSettingsGradleModules(settingsContent) : [];
+
+    for (const modulePath of modules) {
+      const dir = gradleModulePathToDir(projectRoot, modulePath);
+      for (const file of GRADLE_BUILD_FILES) {
+        const path = join(dir, file);
+        if (!existsSync(path)) continue;
+        const content = readFileSync(path, "utf-8");
+        processBuildFileDeps(content, file, modulePath, catalogs, catalogEntryMap, dependencies);
+        break; // prefer .kts, skip .gradle if .kts found
+      }
+    }
+
+    // Step 5: Scan root build file
+    for (const file of GRADLE_BUILD_FILES) {
+      const path = join(projectRoot, file);
+      if (!existsSync(path)) continue;
+      const content = readFileSync(path, "utf-8");
+      processBuildFileDeps(content, file, undefined, catalogs, catalogEntryMap, dependencies);
+      processPluginsBlock(content, file, undefined, false, catalogs, catalogEntryMap, dependencies);
+      processBuildscriptClasspath(content, file, dependencies);
+      break; // prefer .kts
+    }
+
+    // Step 6: Scan settings file for pluginManagement { plugins {} }
+    if (settingsResult) {
+      processPluginsBlock(
+        settingsResult.content,
+        settingsResult.file,
+        undefined,
+        true,
+        catalogs,
+        catalogEntryMap,
+        dependencies,
+      );
+    }
+  } else if (buildSystem === "maven") {
+    scanMavenRecursive(projectRoot, undefined, dependencies, 0);
+  }
+
+  return { buildSystem, dependencies };
 }

--- a/plugins/maven-mcp/src/dependencies/settings-catalogs-parser.ts
+++ b/plugins/maven-mcp/src/dependencies/settings-catalogs-parser.ts
@@ -1,3 +1,5 @@
+import { stripComments, extractBlock, extractBlockAt } from "./gradle-text-utils.js";
+
 export interface CatalogDescriptor {
   name: string;
   tomlPath: string;
@@ -7,36 +9,6 @@ const DEFAULT_CATALOG: CatalogDescriptor = {
   name: "libs",
   tomlPath: "gradle/libs.versions.toml",
 };
-
-function stripComments(content: string): string {
-  return content
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .replace(/\/\/[^\n]*/g, "");
-}
-
-/**
- * Extracts the inner content of a brace-balanced block starting after `keyword`.
- * Returns the content between the opening `{` and its matching `}`, or null if not found.
- */
-function extractBlock(content: string, keyword: string): string | null {
-  const kwIdx = keyword === "" ? 0 : content.indexOf(keyword);
-  if (kwIdx === -1) return null;
-
-  const startSearchAt = keyword === "" ? 0 : kwIdx + keyword.length;
-  const openIdx = content.indexOf("{", startSearchAt);
-  if (openIdx === -1) return null;
-
-  let depth = 1;
-  let pos = openIdx + 1;
-  while (pos < content.length && depth > 0) {
-    if (content[pos] === "{") depth++;
-    else if (content[pos] === "}") depth--;
-    pos++;
-  }
-
-  if (depth !== 0) return null;
-  return content.slice(openIdx + 1, pos - 1);
-}
 
 /**
  * Parses `dependencyResolutionManagement { versionCatalogs { ... } }` blocks from
@@ -83,7 +55,7 @@ export function parseSettingsCatalogs(content: string): CatalogDescriptor[] {
       tomlPath = chainedMatch[1];
     } else {
       // Block form: extract { ... } block after create("name"), search inside
-      const blockContent = extractBlock(afterCreate, "");
+      const blockContent = extractBlockAt(afterCreate, 0);
       if (blockContent !== null) {
         // Kotlin DSL: from(files("path"))
         const kotlinMatch = blockContent.match(/\bfrom\s*\(\s*files\s*\(\s*["']([^"']+)["']\s*\)\s*\)/);

--- a/plugins/maven-mcp/src/dependencies/settings-catalogs-parser.ts
+++ b/plugins/maven-mcp/src/dependencies/settings-catalogs-parser.ts
@@ -1,0 +1,109 @@
+export interface CatalogDescriptor {
+  name: string;
+  tomlPath: string;
+}
+
+const DEFAULT_CATALOG: CatalogDescriptor = {
+  name: "libs",
+  tomlPath: "gradle/libs.versions.toml",
+};
+
+function stripComments(content: string): string {
+  return content
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/[^\n]*/g, "");
+}
+
+/**
+ * Extracts the inner content of a brace-balanced block starting after `keyword`.
+ * Returns the content between the opening `{` and its matching `}`, or null if not found.
+ */
+function extractBlock(content: string, keyword: string): string | null {
+  const kwIdx = keyword === "" ? 0 : content.indexOf(keyword);
+  if (kwIdx === -1) return null;
+
+  const startSearchAt = keyword === "" ? 0 : kwIdx + keyword.length;
+  const openIdx = content.indexOf("{", startSearchAt);
+  if (openIdx === -1) return null;
+
+  let depth = 1;
+  let pos = openIdx + 1;
+  while (pos < content.length && depth > 0) {
+    if (content[pos] === "{") depth++;
+    else if (content[pos] === "}") depth--;
+    pos++;
+  }
+
+  if (depth !== 0) return null;
+  return content.slice(openIdx + 1, pos - 1);
+}
+
+/**
+ * Parses `dependencyResolutionManagement { versionCatalogs { ... } }` blocks from
+ * settings.gradle or settings.gradle.kts content to extract catalog descriptors.
+ *
+ * Supports:
+ * - Kotlin DSL: `create("name") { from(files("path")) }`
+ * - Groovy DSL: `create("name") { from files("path") }` or `create('name') { ... }`
+ * - Chained form: `create("name").from(files("path"))`
+ * - Multi-line blocks
+ *
+ * Only `from(files("..."))` / `from files("...")` forms are handled.
+ * `from("g:a:v")` (catalog-as-Maven-dep) is silently ignored.
+ *
+ * Returns the default `[{ name: "libs", tomlPath: "gradle/libs.versions.toml" }]`
+ * when the `versionCatalogs` block is absent entirely.
+ * Returns `[]` when the block is present but contains no `create()` calls.
+ */
+export function parseSettingsCatalogs(content: string): CatalogDescriptor[] {
+  const stripped = stripComments(content);
+
+  const drmBlock = extractBlock(stripped, "dependencyResolutionManagement");
+  if (drmBlock === null) return [DEFAULT_CATALOG];
+
+  const vcBlock = extractBlock(drmBlock, "versionCatalogs");
+  if (vcBlock === null) return [DEFAULT_CATALOG];
+
+  const descriptors: CatalogDescriptor[] = [];
+
+  // Match create("name") or create('name') — then look for from(files("path"))
+  // inside the following block or in a chained .from(files("path")) on the same line.
+  const createPattern = /create\s*\(\s*["']([^"']+)["']\s*\)/g;
+  let m: RegExpExecArray | null;
+
+  while ((m = createPattern.exec(vcBlock)) !== null) {
+    const name = m[1];
+    const afterCreate = vcBlock.slice(m.index + m[0].length);
+
+    let tomlPath: string | null = null;
+
+    // Chained form: .from(files("path")) immediately after create("name")
+    const chainedMatch = afterCreate.match(/^\s*\.from\s*\(\s*files\s*\(\s*["']([^"']+)["']\s*\)\s*\)/);
+    if (chainedMatch) {
+      tomlPath = chainedMatch[1];
+    } else {
+      // Block form: extract { ... } block after create("name"), search inside
+      const blockContent = extractBlock(afterCreate, "");
+      if (blockContent !== null) {
+        // Kotlin DSL: from(files("path"))
+        const kotlinMatch = blockContent.match(/\bfrom\s*\(\s*files\s*\(\s*["']([^"']+)["']\s*\)\s*\)/);
+        if (kotlinMatch) {
+          tomlPath = kotlinMatch[1];
+        } else {
+          // Groovy DSL: from files("path") or from files('path')
+          const groovyMatch = blockContent.match(/\bfrom\s+files\s*\(\s*["']([^"']+)["']\s*\)/);
+          if (groovyMatch) {
+            tomlPath = groovyMatch[1];
+          }
+        }
+      }
+    }
+
+    if (tomlPath !== null) {
+      descriptors.push({ name, tomlPath });
+    }
+    // from("g:a:v") and other non-files forms: silently skip (tomlPath stays null)
+  }
+
+  return descriptors;
+}

--- a/plugins/maven-mcp/src/dependencies/settings-catalogs-parser.ts
+++ b/plugins/maven-mcp/src/dependencies/settings-catalogs-parser.ts
@@ -23,9 +23,13 @@ const DEFAULT_CATALOG: CatalogDescriptor = {
  * Only `from(files("..."))` / `from files("...")` forms are handled.
  * `from("g:a:v")` (catalog-as-Maven-dep) is silently ignored.
  *
+ * Gradle always auto-configures the `libs` catalog from `gradle/libs.versions.toml`
+ * regardless of what's in `versionCatalogs`. The block declares ADDITIONAL catalogs,
+ * not replacements. The implicit default is only suppressed when `create("libs")` is
+ * present in the block with an explicit `from(files("..."))` path.
+ *
  * Returns the default `[{ name: "libs", tomlPath: "gradle/libs.versions.toml" }]`
- * when the `versionCatalogs` block is absent entirely.
- * Returns `[]` when the block is present but contains no `create()` calls.
+ * when the `versionCatalogs` block is absent entirely or contains no `create()` calls.
  */
 export function parseSettingsCatalogs(content: string): CatalogDescriptor[] {
   const stripped = stripComments(content);
@@ -75,6 +79,14 @@ export function parseSettingsCatalogs(content: string): CatalogDescriptor[] {
       descriptors.push({ name, tomlPath });
     }
     // from("g:a:v") and other non-files forms: silently skip (tomlPath stays null)
+  }
+
+  // Gradle always auto-configures the implicit "libs" catalog from gradle/libs.versions.toml.
+  // The versionCatalogs block declares ADDITIONAL catalogs. Prepend the default only when
+  // no explicit create("libs") with a from(files("...")) path was declared in the block.
+  const hasExplicitLibs = descriptors.some((d) => d.name === "libs");
+  if (!hasExplicitLibs) {
+    return [DEFAULT_CATALOG, ...descriptors];
   }
 
   return descriptors;

--- a/plugins/maven-mcp/src/dependencies/toml-parser.ts
+++ b/plugins/maven-mcp/src/dependencies/toml-parser.ts
@@ -4,8 +4,19 @@ export interface CatalogEntry {
   version: string | null;
 }
 
-export function parseVersionCatalog(content: string): Map<string, CatalogEntry> {
-  const entries = new Map<string, CatalogEntry>();
+export interface PluginEntry {
+  id: string;
+  version: string | null;
+}
+
+export interface ParsedCatalog {
+  libraries: Map<string, CatalogEntry>;
+  plugins: Map<string, PluginEntry>;
+}
+
+export function parseVersionCatalog(content: string): ParsedCatalog {
+  const libraries = new Map<string, CatalogEntry>();
+  const plugins = new Map<string, PluginEntry>();
   const versions = new Map<string, string>();
 
   const versionsMatch = content.match(/\[versions\]([\s\S]*?)(?=\n\[|$)/);
@@ -17,44 +28,82 @@ export function parseVersionCatalog(content: string): Map<string, CatalogEntry> 
   }
 
   const librariesMatch = content.match(/\[libraries\]([\s\S]*?)(?=\n\[|$)/);
-  if (!librariesMatch) return entries;
+  if (librariesMatch) {
+    const libLines = librariesMatch[1].matchAll(/^(\S+)\s*=\s*\{([^}]+)\}/gm);
+    for (const m of libLines) {
+      const alias = m[1];
+      const props = m[2];
 
-  const libLines = librariesMatch[1].matchAll(/^(\S+)\s*=\s*\{([^}]+)\}/gm);
-  for (const m of libLines) {
-    const alias = m[1];
-    const props = m[2];
+      let groupId: string | undefined;
+      let artifactId: string | undefined;
+      let version: string | null = null;
 
-    let groupId: string | undefined;
-    let artifactId: string | undefined;
-    let version: string | null = null;
+      const moduleMatch = props.match(/module\s*=\s*"([^"]+):([^"]+)"/);
+      if (moduleMatch) {
+        groupId = moduleMatch[1];
+        artifactId = moduleMatch[2];
+      }
 
-    const moduleMatch = props.match(/module\s*=\s*"([^"]+):([^"]+)"/);
-    if (moduleMatch) {
-      groupId = moduleMatch[1];
-      artifactId = moduleMatch[2];
-    }
+      const groupMatch = props.match(/group\s*=\s*"([^"]+)"/);
+      const nameMatch = props.match(/name\s*=\s*"([^"]+)"/);
+      if (groupMatch && nameMatch) {
+        groupId = groupMatch[1];
+        artifactId = nameMatch[1];
+      }
 
-    const groupMatch = props.match(/group\s*=\s*"([^"]+)"/);
-    const nameMatch = props.match(/name\s*=\s*"([^"]+)"/);
-    if (groupMatch && nameMatch) {
-      groupId = groupMatch[1];
-      artifactId = nameMatch[1];
-    }
+      const versionRef = props.match(/version\.ref\s*=\s*"([^"]+)"/);
+      if (versionRef) {
+        version = versions.get(versionRef[1]) ?? null;
+      }
 
-    const versionRef = props.match(/version\.ref\s*=\s*"([^"]+)"/);
-    if (versionRef) {
-      version = versions.get(versionRef[1]) ?? null;
-    }
+      const versionInline = props.match(/\bversion\s*=\s*"([^"]+)"/);
+      if (versionInline && !versionRef) {
+        version = versionInline[1];
+      }
 
-    const versionInline = props.match(/\bversion\s*=\s*"([^"]+)"/);
-    if (versionInline && !versionRef) {
-      version = versionInline[1];
-    }
-
-    if (groupId && artifactId) {
-      entries.set(alias, { groupId, artifactId, version });
+      if (groupId && artifactId) {
+        libraries.set(alias, { groupId, artifactId, version });
+      }
     }
   }
 
-  return entries;
+  const pluginsMatch = content.match(/\[plugins\]([\s\S]*?)(?=\n\[|$)/);
+  if (pluginsMatch) {
+    const pluginsSection = pluginsMatch[1];
+
+    // Shorthand: alias = "id:version"
+    const shorthandLines = pluginsSection.matchAll(/^(\S+)\s*=\s*"([^":]+):([^"]+)"/gm);
+    for (const m of shorthandLines) {
+      plugins.set(m[1], { id: m[2], version: m[3] });
+    }
+
+    // Inline table: alias = { id = "...", version = "..." | version.ref = "..." }
+    const inlineLines = pluginsSection.matchAll(/^(\S+)\s*=\s*\{([^}]+)\}/gm);
+    for (const m of inlineLines) {
+      const alias = m[1];
+      // Skip aliases already captured by shorthand
+      if (plugins.has(alias)) continue;
+
+      const props = m[2];
+      const idMatch = props.match(/\bid\s*=\s*"([^"]+)"/);
+      if (!idMatch) continue;
+
+      const id = idMatch[1];
+      let version: string | null = null;
+
+      const versionRef = props.match(/version\.ref\s*=\s*"([^"]+)"/);
+      if (versionRef) {
+        version = versions.get(versionRef[1]) ?? null;
+      } else {
+        const versionInline = props.match(/\bversion\s*=\s*"([^"]+)"/);
+        if (versionInline) {
+          version = versionInline[1];
+        }
+      }
+
+      plugins.set(alias, { id, version });
+    }
+  }
+
+  return { libraries, plugins };
 }

--- a/plugins/maven-mcp/src/index.ts
+++ b/plugins/maven-mcp/src/index.ts
@@ -128,7 +128,7 @@ server.tool(
 
 server.tool(
   "scan_project_dependencies",
-  "Scan the whole project (catalogs + all submodules + plugin DSL + buildscript classpath) and extract all declared dependencies with versions, grouped by source for guided edits.",
+  "Scan the whole project (catalogs + all submodules + plugin DSL + buildscript classpath) and extract all declared dependencies with versions, with source-kind tagging on each entry so consumers can group as needed.",
   {
     projectPath: z.string().optional().describe("Path to project root (default: auto-detect from cwd)"),
   },

--- a/plugins/maven-mcp/src/index.ts
+++ b/plugins/maven-mcp/src/index.ts
@@ -128,7 +128,7 @@ server.tool(
 
 server.tool(
   "scan_project_dependencies",
-  "Scan project build files (Gradle, Maven, version catalogs) and extract all declared dependencies with versions.",
+  "Scan the whole project (catalogs + all submodules + plugin DSL + buildscript classpath) and extract all declared dependencies with versions, grouped by source for guided edits.",
   {
     projectPath: z.string().optional().describe("Path to project root (default: auto-detect from cwd)"),
   },

--- a/plugins/maven-mcp/src/tools/__tests__/audit-project-dependencies.test.ts
+++ b/plugins/maven-mcp/src/tools/__tests__/audit-project-dependencies.test.ts
@@ -453,6 +453,27 @@ buildscript {
     expect(dep).toBeDefined();
   });
 
+  it("source.kind catalog-plugin survives through AuditDependency", async () => {
+    mockFileSystem({
+      "/project/settings.gradle.kts": ``,
+      "/project/gradle/libs.versions.toml": `
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.0.0" }
+`,
+      "/project/build.gradle.kts": ``,
+    });
+
+    const repos = [mockRepo(["2.0.0"])];
+    const result = await auditProjectDependenciesHandler(repos, {
+      projectPath: "/project",
+      includeVulnerabilities: false,
+    });
+
+    const dep = result.dependencies.find((d) => d.source.kind === "catalog-plugin");
+    expect(dep).toBeDefined();
+    expect(dep!.source.kind).toBe("catalog-plugin");
+  });
+
   it("productionOnly excludes catalog library whose only usages are testImplementation", async () => {
     mockFileSystem({
       "/project/settings.gradle.kts": ``,

--- a/plugins/maven-mcp/src/tools/__tests__/audit-project-dependencies.test.ts
+++ b/plugins/maven-mcp/src/tools/__tests__/audit-project-dependencies.test.ts
@@ -203,7 +203,7 @@ dependencies {
     expect(result.summary.vulnerable).toBe(2);
   });
 
-  it("excludes testImplementation/kapt/ksp when productionOnly is true (default)", async () => {
+  it("excludes testImplementation when productionOnly is true, keeps kapt/ksp as production", async () => {
     mockGradleProject(`
 dependencies {
     implementation("io.ktor:ktor-client-core:3.0.0")
@@ -218,8 +218,11 @@ dependencies {
       includeVulnerabilities: false,
     });
 
-    expect(result.dependencies).toHaveLength(1);
-    expect(result.dependencies[0].artifactId).toBe("ktor-client-core");
+    // testImplementation is test-scope → excluded
+    // kapt and ksp are NOT test-scope → included (annotation processors are production tools)
+    expect(result.dependencies).toHaveLength(3);
+    const artifacts = result.dependencies.map((d) => d.artifactId).sort();
+    expect(artifacts).toEqual(["dagger-compiler", "ktor-client-core", "room-compiler"]);
   });
 
   it("includes test configurations when productionOnly is false", async () => {
@@ -368,5 +371,295 @@ dependencies {
     expect(result.dependencies[1].currentVersion).toBe("3.1.0");
     expect(result.dependencies[1].vulnerabilities).toHaveLength(0);
     expect(result.summary.vulnerable).toBe(1);
+  });
+
+  // ---- Phase 3: source + usages field tests ----
+
+  it("source.kind catalog-library survives through AuditDependency", async () => {
+    mockFileSystem({
+      "/project/settings.gradle.kts": ``,
+      "/project/gradle/libs.versions.toml": `
+[libraries]
+ktor-client = { module = "io.ktor:ktor-client-core", version = "3.0.0" }
+`,
+      "/project/build.gradle.kts": `
+dependencies {
+    implementation(libs.ktor.client)
+}
+`,
+    });
+
+    const repos = [mockRepo(["3.0.0", "3.1.1"])];
+    const result = await auditProjectDependenciesHandler(repos, {
+      projectPath: "/project",
+      includeVulnerabilities: false,
+    });
+
+    const dep = result.dependencies.find((d) => d.artifactId === "ktor-client-core");
+    expect(dep).toBeDefined();
+    expect(dep!.source.kind).toBe("catalog-library");
+  });
+
+  it("source.kind module-direct survives through AuditDependency", async () => {
+    mockGradleProject(`implementation("io.ktor:ktor-client-core:3.0.0")`);
+
+    const repos = [mockRepo(["3.0.0"])];
+    const result = await auditProjectDependenciesHandler(repos, {
+      projectPath: "/project",
+      includeVulnerabilities: false,
+    });
+
+    expect(result.dependencies[0].source.kind).toBe("module-direct");
+  });
+
+  it("source.kind plugins-dsl survives through AuditDependency", async () => {
+    mockFileSystem({
+      "/project/build.gradle.kts": `
+plugins {
+    id("org.jetbrains.kotlin.jvm") version "2.0.0"
+}
+`,
+    });
+
+    const repos = [mockRepo(["2.0.0"])];
+    const result = await auditProjectDependenciesHandler(repos, {
+      projectPath: "/project",
+      includeVulnerabilities: false,
+    });
+
+    const dep = result.dependencies.find((d) => d.source.kind === "plugins-dsl");
+    expect(dep).toBeDefined();
+    expect(dep!.source.kind).toBe("plugins-dsl");
+  });
+
+  it("source.kind buildscript-classpath survives through AuditDependency", async () => {
+    mockFileSystem({
+      "/project/build.gradle.kts": `
+buildscript {
+    dependencies {
+        classpath("com.android.tools.build:gradle:8.1.0")
+    }
+}
+`,
+    });
+
+    const repos = [mockRepo(["8.1.0"])];
+    const result = await auditProjectDependenciesHandler(repos, {
+      projectPath: "/project",
+      includeVulnerabilities: false,
+    });
+
+    const dep = result.dependencies.find((d) => d.source.kind === "buildscript-classpath");
+    expect(dep).toBeDefined();
+  });
+
+  it("productionOnly excludes catalog library whose only usages are testImplementation", async () => {
+    mockFileSystem({
+      "/project/settings.gradle.kts": ``,
+      "/project/gradle/libs.versions.toml": `
+[libraries]
+junit = { module = "junit:junit", version = "4.13" }
+`,
+      "/project/build.gradle.kts": `
+dependencies {
+    testImplementation(libs.junit)
+}
+`,
+    });
+
+    const repos = [mockRepo(["4.13"])];
+    const result = await auditProjectDependenciesHandler(repos, {
+      projectPath: "/project",
+      includeVulnerabilities: false,
+    });
+
+    expect(result.dependencies.find((d) => d.artifactId === "junit")).toBeUndefined();
+  });
+
+  it("productionOnly includes catalog library used in both testImplementation and implementation", async () => {
+    mockFileSystem({
+      "/project/settings.gradle.kts": `include(":app")`,
+      "/project/gradle/libs.versions.toml": `
+[libraries]
+ktor-client = { module = "io.ktor:ktor-client-core", version = "3.0.0" }
+`,
+      "/project/app/build.gradle.kts": `
+dependencies {
+    implementation(libs.ktor.client)
+    testImplementation(libs.ktor.client)
+}
+`,
+    });
+
+    const repos = [mockRepo(["3.0.0"])];
+    const result = await auditProjectDependenciesHandler(repos, {
+      projectPath: "/project",
+      includeVulnerabilities: false,
+    });
+
+    const dep = result.dependencies.find((d) => d.artifactId === "ktor-client-core");
+    expect(dep).toBeDefined();
+    // Both usages retained in output
+    expect(dep!.usages).toHaveLength(2);
+  });
+
+  it("productionOnly includes unused catalog library (documented default policy)", async () => {
+    mockFileSystem({
+      "/project/settings.gradle.kts": ``,
+      "/project/gradle/libs.versions.toml": `
+[libraries]
+ktor-client = { module = "io.ktor:ktor-client-core", version = "3.0.0" }
+`,
+      "/project/build.gradle.kts": `
+dependencies {
+}
+`,
+    });
+
+    const repos = [mockRepo(["3.0.0", "3.1.1"])];
+    const result = await auditProjectDependenciesHandler(repos, {
+      projectPath: "/project",
+      includeVulnerabilities: false,
+      productionOnly: true,
+    });
+
+    // Unused catalog entry should still appear — it needs version audit
+    const dep = result.dependencies.find((d) => d.artifactId === "ktor-client-core");
+    expect(dep).toBeDefined();
+    expect(dep!.usages).toHaveLength(0);
+  });
+
+  it("productionOnly includes unused catalog plugin", async () => {
+    mockFileSystem({
+      "/project/settings.gradle.kts": ``,
+      "/project/gradle/libs.versions.toml": `
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.0.0" }
+`,
+      "/project/build.gradle.kts": ``,
+    });
+
+    const repos = [mockRepo(["2.0.0"])];
+    const result = await auditProjectDependenciesHandler(repos, {
+      projectPath: "/project",
+      includeVulnerabilities: false,
+      productionOnly: true,
+    });
+
+    const dep = result.dependencies.find((d) => d.source.kind === "catalog-plugin");
+    expect(dep).toBeDefined();
+    expect(dep!.usages).toHaveLength(0);
+  });
+
+  it("productionOnly includes plugins-dsl entry (treated as production)", async () => {
+    mockFileSystem({
+      "/project/build.gradle.kts": `
+plugins {
+    id("org.jetbrains.kotlin.jvm") version "2.0.0"
+}
+`,
+    });
+
+    const repos = [mockRepo(["2.0.0"])];
+    const result = await auditProjectDependenciesHandler(repos, {
+      projectPath: "/project",
+      includeVulnerabilities: false,
+      productionOnly: true,
+    });
+
+    const dep = result.dependencies.find((d) => d.source.kind === "plugins-dsl");
+    expect(dep).toBeDefined();
+  });
+
+  it("productionOnly includes buildscript-classpath entry", async () => {
+    mockFileSystem({
+      "/project/build.gradle.kts": `
+buildscript {
+    dependencies {
+        classpath("com.android.tools.build:gradle:8.1.0")
+    }
+}
+`,
+    });
+
+    const repos = [mockRepo(["8.1.0"])];
+    const result = await auditProjectDependenciesHandler(repos, {
+      projectPath: "/project",
+      includeVulnerabilities: false,
+      productionOnly: true,
+    });
+
+    expect(result.dependencies.find((d) => d.source.kind === "buildscript-classpath")).toBeDefined();
+  });
+
+  it("usages array surfaces every using module:configuration pair for a multi-used catalog entry", async () => {
+    mockFileSystem({
+      "/project/settings.gradle.kts": `include(":app", ":lib")`,
+      "/project/gradle/libs.versions.toml": `
+[libraries]
+ktor-client = { module = "io.ktor:ktor-client-core", version = "3.0.0" }
+`,
+      "/project/app/build.gradle.kts": `
+dependencies {
+    implementation(libs.ktor.client)
+}
+`,
+      "/project/lib/build.gradle.kts": `
+dependencies {
+    api(libs.ktor.client)
+}
+`,
+    });
+
+    const repos = [mockRepo(["3.0.0"])];
+    const result = await auditProjectDependenciesHandler(repos, {
+      projectPath: "/project",
+      includeVulnerabilities: false,
+      productionOnly: false,
+    });
+
+    const dep = result.dependencies.find((d) => d.artifactId === "ktor-client-core");
+    expect(dep).toBeDefined();
+    expect(dep!.usages).toHaveLength(2);
+    const usageMap = Object.fromEntries(dep!.usages.map((u) => [u.module, u.configuration]));
+    expect(usageMap[":app"]).toBe("implementation");
+    expect(usageMap[":lib"]).toBe("api");
+  });
+
+  it("vulnerability lookup for plugin marker artifactId works the same as regular deps", async () => {
+    mockFileSystem({
+      "/project/build.gradle.kts": `
+plugins {
+    id("org.jetbrains.kotlin.jvm") version "2.0.0"
+}
+`,
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        results: [{
+          vulns: [{
+            id: "GHSA-PLUGIN-TEST",
+            summary: "plugin vuln",
+            database_specific: { severity: "HIGH" },
+            affected: [],
+            references: [],
+          }],
+        }],
+      }),
+    });
+
+    const repos = [mockRepo(["2.0.0"])];
+    const result = await auditProjectDependenciesHandler(repos, {
+      projectPath: "/project",
+      includeVulnerabilities: true,
+    });
+
+    // Plugin marker: groupId = pluginId, artifactId = pluginId + ".gradle.plugin"
+    const dep = result.dependencies.find((d) => d.artifactId === "org.jetbrains.kotlin.jvm.gradle.plugin");
+    expect(dep).toBeDefined();
+    expect(dep!.vulnerabilities).toHaveLength(1);
+    expect(dep!.vulnerabilities![0].id).toBe("GHSA-PLUGIN-TEST");
   });
 });

--- a/plugins/maven-mcp/src/tools/__tests__/scan-project-dependencies.test.ts
+++ b/plugins/maven-mcp/src/tools/__tests__/scan-project-dependencies.test.ts
@@ -1,23 +1,76 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { scanProjectDependenciesHandler } from "../scan-project-dependencies.js";
 import * as fs from "node:fs";
 
 vi.mock("node:fs");
 const mockedFs = vi.mocked(fs);
 
+function mockFileSystem(files: Record<string, string>) {
+  mockedFs.existsSync.mockImplementation((p: fs.PathLike) =>
+    Object.prototype.hasOwnProperty.call(files, p.toString()),
+  );
+  mockedFs.readFileSync.mockImplementation((p: fs.PathOrFileDescriptor) => {
+    const key = p.toString();
+    if (!Object.prototype.hasOwnProperty.call(files, key)) {
+      throw new Error(`ENOENT: no such file '${key}'`);
+    }
+    return files[key];
+  });
+}
+
+beforeEach(() => vi.clearAllMocks());
+
 describe("scanProjectDependenciesHandler", () => {
-  it("scans project and returns dependencies", () => {
-    mockedFs.existsSync.mockImplementation((p: fs.PathLike) => {
-      if (p.toString().endsWith("build.gradle.kts")) return true;
-      return false;
-    });
-    mockedFs.readFileSync.mockReturnValue(`
+  it("scans project and returns flattened dependencies", () => {
+    mockFileSystem({
+      "/project/build.gradle.kts": `
 dependencies {
     implementation("io.ktor:ktor-client-core:3.1.1")
-}`);
+}`,
+    });
 
     const result = scanProjectDependenciesHandler({ projectPath: "/project" });
     expect(result.buildSystem).toBe("gradle");
     expect(result.dependencies).toHaveLength(1);
+    expect(result.dependencies[0]).toMatchObject({
+      groupId: "io.ktor",
+      artifactId: "ktor-client-core",
+      version: "3.1.1",
+      configuration: "implementation",
+      source: "module-direct",
+    });
+  });
+
+  it("emits one item per usage for catalog entries used in multiple modules", () => {
+    mockFileSystem({
+      "/project/settings.gradle.kts": `include(":app", ":lib")`,
+      "/project/gradle/libs.versions.toml": `
+[libraries]
+ktor-core = { module = "io.ktor:ktor-client-core", version = "3.1.1" }
+`,
+      "/project/app/build.gradle.kts": `implementation(libs.ktor.core)`,
+      "/project/lib/build.gradle.kts": `api(libs.ktor.core)`,
+    });
+
+    const result = scanProjectDependenciesHandler({ projectPath: "/project" });
+    const ktorDeps = result.dependencies.filter((d) => d.artifactId === "ktor-client-core");
+    expect(ktorDeps).toHaveLength(2);
+    expect(ktorDeps.map((d) => d.module).sort()).toEqual([":app", ":lib"].sort());
+    expect(ktorDeps.map((d) => d.configuration).sort()).toEqual(["api", "implementation"].sort());
+  });
+
+  it("emits unused catalog entry with configuration (unused)", () => {
+    mockFileSystem({
+      "/project/gradle/libs.versions.toml": `
+[libraries]
+unused-lib = { module = "com.example:unused", version = "1.0.0" }
+`,
+    });
+
+    const result = scanProjectDependenciesHandler({ projectPath: "/project" });
+    const unusedDep = result.dependencies.find((d) => d.artifactId === "unused");
+    expect(unusedDep).toBeDefined();
+    expect(unusedDep!.configuration).toBe("(unused)");
+    expect(unusedDep!.source).toBe("catalog-library");
   });
 });

--- a/plugins/maven-mcp/src/tools/__tests__/scan-project-dependencies.test.ts
+++ b/plugins/maven-mcp/src/tools/__tests__/scan-project-dependencies.test.ts
@@ -37,7 +37,8 @@ dependencies {
       artifactId: "ktor-client-core",
       version: "3.1.1",
       configuration: "implementation",
-      source: "module-direct",
+      source: "build.gradle.kts",
+      sourceKind: "module-direct",
     });
   });
 
@@ -71,6 +72,38 @@ unused-lib = { module = "com.example:unused", version = "1.0.0" }
     const unusedDep = result.dependencies.find((d) => d.artifactId === "unused");
     expect(unusedDep).toBeDefined();
     expect(unusedDep!.configuration).toBe("(unused)");
-    expect(unusedDep!.source).toBe("catalog-library");
+    // source emits the TOML file path (backward-compat), not the kind string
+    expect(unusedDep!.source).toBe("gradle/libs.versions.toml");
+    expect(unusedDep!.sourceKind).toBe("catalog-library");
+  });
+
+  it("source field emits file path (backward-compat); sourceKind exposes the new discriminator", () => {
+    mockFileSystem({
+      "/project/settings.gradle.kts": `include(":app")`,
+      "/project/gradle/libs.versions.toml": `
+[libraries]
+ktor-core = { module = "io.ktor:ktor-client-core", version = "3.1.1" }
+[plugins]
+kotlin-android = { id = "org.jetbrains.kotlin.android", version = "2.0.0" }
+`,
+      "/project/app/build.gradle.kts": `
+dependencies {
+    implementation(libs.ktor.core)
+}`,
+    });
+
+    const result = scanProjectDependenciesHandler({ projectPath: "/project" });
+
+    // Catalog library → TOML path in source, "catalog-library" in sourceKind
+    const libDep = result.dependencies.find((d) => d.artifactId === "ktor-client-core");
+    expect(libDep).toBeDefined();
+    expect(libDep!.source).toBe("gradle/libs.versions.toml");
+    expect(libDep!.sourceKind).toBe("catalog-library");
+
+    // Unused catalog plugin → TOML path in source, "catalog-plugin" in sourceKind
+    const pluginDep = result.dependencies.find((d) => d.artifactId === "org.jetbrains.kotlin.android.gradle.plugin");
+    expect(pluginDep).toBeDefined();
+    expect(pluginDep!.source).toBe("gradle/libs.versions.toml");
+    expect(pluginDep!.sourceKind).toBe("catalog-plugin");
   });
 });

--- a/plugins/maven-mcp/src/tools/audit-project-dependencies.ts
+++ b/plugins/maven-mcp/src/tools/audit-project-dependencies.ts
@@ -157,8 +157,12 @@ export async function auditProjectDependenciesHandler(
   }
 
   // Vulnerability check — deduplicate OSV queries by GAV, then map results back.
-  // Plugin marker artifactIds (pluginId + ".gradle.plugin") are queried the same way as
-  // regular deps; OSV may not have advisories for all markers — that is expected and fine.
+  // Plugin marker artifacts (pluginId + ".gradle.plugin") are queried via the same Maven
+  // ecosystem path as regular deps. OSV indexes implementation artifacts, not plugin markers —
+  // CVEs are filed against e.g. "org.jetbrains.kotlin:kotlin-gradle-plugin", not the marker
+  // "org.jetbrains.kotlin.android:org.jetbrains.kotlin.android.gradle.plugin". Plugin entries
+  // therefore always return no advisories here — a known v1 limitation; resolving marker →
+  // implementation GAV via POM lookup is tracked for v2.
   if (includeVulns && depsWithVersion.length > 0) {
     const auditDepMap = new Map<string, AuditDependency[]>();
     for (const a of auditDeps) {

--- a/plugins/maven-mcp/src/tools/audit-project-dependencies.ts
+++ b/plugins/maven-mcp/src/tools/audit-project-dependencies.ts
@@ -2,8 +2,8 @@ import type { MavenRepository } from "../maven/repository.js";
 import type { MavenMetadata } from "../maven/types.js";
 import type { UpgradeType } from "../version/types.js";
 import { scanProjectWithSubmodules } from "../dependencies/scan.js";
-import type { ScanResult } from "../dependencies/scan.js";
-import { PRODUCTION_CONFIGURATIONS } from "../dependencies/gradle-deps-parser.js";
+import type { ScanResult, ScannedDependency, DepSource, DepUsage } from "../dependencies/scan.js";
+import { isTestConfiguration } from "../dependencies/gradle-deps-parser.js";
 import { findProjectRoot } from "../project/find-project-root.js";
 import { resolveAll } from "../maven/resolver.js";
 import { findLatestVersionForCurrent } from "../version/classify.js";
@@ -16,9 +16,6 @@ export interface AuditInput {
   productionOnly?: boolean;
 }
 
-// CVEs in test / kapt / ksp / annotationProcessor are not deployed risks — exclude by default.
-const PRODUCTION_CONFIGS = new Set<string>(PRODUCTION_CONFIGURATIONS);
-
 export interface AuditDependency {
   groupId: string;
   artifactId: string;
@@ -26,10 +23,58 @@ export interface AuditDependency {
   latestVersion?: string;
   upgradeType?: UpgradeType;
   vulnerabilities?: { id: string; severity?: string; fixedVersion?: string }[];
-  // Submodule label: ":foo" / ":foo:bar" for Gradle, "foo" / "foo/sub" for Maven,
-  // undefined for the root project. The two formats differ by design (Gradle paths are
-  // colon-separated by spec); consumers must handle both shapes.
+  /**
+   * Discriminated union identifying where this dependency originates.
+   * Consumers should use this instead of inferring source from module/configuration.
+   */
+  source: DepSource;
+  /**
+   * All module:configuration pairs that use this dependency.
+   * For catalog entries, may be empty (unused catalog entry — still audited for version/CVE).
+   * For non-catalog entries, always has exactly one element.
+   * When productionOnly is true and the entry has mixed prod+test usages, all usages are
+   * retained in this array — filtering only controls inclusion, not which usages are shown.
+   */
+  usages: DepUsage[];
+  /**
+   * @deprecated Legacy field. Use usages[0]?.module instead.
+   * Submodule label from the first usage: ":foo" / ":foo:bar" for Gradle,
+   * "foo" / "foo/sub" for Maven, undefined for root. Two formats differ by design
+   * (Gradle paths are colon-separated); consumers must handle both shapes.
+   */
   module?: string;
+  /**
+   * @deprecated Legacy field. Use usages[0]?.configuration instead.
+   * Configuration name from the first usage.
+   */
+  configuration?: string;
+}
+
+/**
+ * productionOnly filter policy:
+ *
+ * - catalog-library / catalog-plugin with non-empty usages:
+ *     include if at least one usage is NOT test-scope (per isTestConfiguration).
+ *     Exclude if ALL usages are test-scope.
+ *
+ * - catalog-library / catalog-plugin with empty usages (unused catalog entry):
+ *     ALWAYS include when productionOnly is true.
+ *     Rationale: the catalog is the single source of truth for declared dependencies;
+ *     unused entries still need version updates and CVE scanning.
+ *
+ * - module-direct / plugins-dsl / buildscript-classpath:
+ *     include if the single usage's configuration is NOT test-scope.
+ *     "plugin-dsl" and "classpath" are always production (isTestConfiguration returns false).
+ */
+function isIncludedInProductionAudit(dep: ScannedDependency): boolean {
+  const { source, usages } = dep;
+  if (source.kind === "catalog-library" || source.kind === "catalog-plugin") {
+    if (usages.length === 0) return true; // unused catalog entry — always include
+    return usages.some((u) => !isTestConfiguration(u.configuration));
+  }
+  // module-direct, plugins-dsl, buildscript-classpath — single usage
+  if (usages.length === 0) return false;
+  return !isTestConfiguration(usages[0].configuration);
 }
 
 export interface AuditResult {
@@ -54,8 +99,11 @@ export async function auditProjectDependenciesHandler(
   const includeVulns = input.includeVulnerabilities !== false;
   const productionOnly = input.productionOnly !== false;
 
+  // productionOnly: use isIncludedInProductionAudit which handles catalog unused entries,
+  // mixed prod+test usages, and non-catalog entries (see JSDoc above).
+  // When productionOnly is false, include all deps — including unused catalog entries.
   const filteredScanDeps = productionOnly
-    ? scan.dependencies.filter((d) => PRODUCTION_CONFIGS.has(d.configuration))
+    ? scan.dependencies.filter(isIncludedInProductionAudit)
     : scan.dependencies;
 
   const auditDeps: AuditDependency[] = [];
@@ -90,15 +138,27 @@ export async function auditProjectDependenciesHandler(
       currentVersion: dep.version!,
       latestVersion: latest,
       upgradeType,
-      module: dep.module,
+      source: dep.source,
+      usages: dep.usages,
+      module: dep.usages[0]?.module,
+      configuration: dep.usages[0]?.configuration,
     });
   }
 
   for (const dep of depsWithoutVersion) {
-    auditDeps.push({ groupId: dep.groupId, artifactId: dep.artifactId, module: dep.module });
+    auditDeps.push({
+      groupId: dep.groupId,
+      artifactId: dep.artifactId,
+      source: dep.source,
+      usages: dep.usages,
+      module: dep.usages[0]?.module,
+      configuration: dep.usages[0]?.configuration,
+    });
   }
 
-  // Vulnerability check — deduplicate OSV queries by GAV, then map results back
+  // Vulnerability check — deduplicate OSV queries by GAV, then map results back.
+  // Plugin marker artifactIds (pluginId + ".gradle.plugin") are queried the same way as
+  // regular deps; OSV may not have advisories for all markers — that is expected and fine.
   if (includeVulns && depsWithVersion.length > 0) {
     const auditDepMap = new Map<string, AuditDependency[]>();
     for (const a of auditDeps) {

--- a/plugins/maven-mcp/src/tools/audit-project-dependencies.ts
+++ b/plugins/maven-mcp/src/tools/audit-project-dependencies.ts
@@ -158,11 +158,11 @@ export async function auditProjectDependenciesHandler(
 
   // Vulnerability check — deduplicate OSV queries by GAV, then map results back.
   // Plugin marker artifacts (pluginId + ".gradle.plugin") are queried via the same Maven
-  // ecosystem path as regular deps. OSV indexes implementation artifacts, not plugin markers —
-  // CVEs are filed against e.g. "org.jetbrains.kotlin:kotlin-gradle-plugin", not the marker
-  // "org.jetbrains.kotlin.android:org.jetbrains.kotlin.android.gradle.plugin". Plugin entries
-  // therefore always return no advisories here — a known v1 limitation; resolving marker →
-  // implementation GAV via POM lookup is tracked for v2.
+  // ecosystem path as regular deps. OSV currently indexes implementation artifacts, not plugin
+  // markers — CVEs are filed against e.g. "org.jetbrains.kotlin:kotlin-gradle-plugin", not
+  // the marker "org.jetbrains.kotlin.android:org.jetbrains.kotlin.android.gradle.plugin".
+  // Plugin entries typically return empty results today — the query still runs and will surface
+  // hits if OSV adds plugin-marker coverage later. v2: resolve marker → impl GAV via POM.
   if (includeVulns && depsWithVersion.length > 0) {
     const auditDepMap = new Map<string, AuditDependency[]>();
     for (const a of auditDeps) {

--- a/plugins/maven-mcp/src/tools/scan-project-dependencies.ts
+++ b/plugins/maven-mcp/src/tools/scan-project-dependencies.ts
@@ -1,5 +1,5 @@
-import { scanProjectWithSubmodules } from "../dependencies/scan.js";
-import type { ScanResult } from "../dependencies/scan.js";
+import { scanProjectWithSubmodules, assertNever } from "../dependencies/scan.js";
+import type { ScanResult, DepSource } from "../dependencies/scan.js";
 import { findProjectRoot } from "../project/find-project-root.js";
 
 export interface ScanProjectInput {
@@ -12,12 +12,39 @@ interface FlattenedDependency {
   version: string | null;
   configuration: string;
   module?: string;
+  /**
+   * File path of the artifact that declared this dependency.
+   * Catalog entries: TOML file path (e.g. "gradle/libs.versions.toml").
+   * Direct/plugin/buildscript entries: build file name (e.g. "build.gradle.kts", "pom.xml").
+   * Preserved for backward compatibility — use sourceKind for the new discriminator.
+   */
   source: string;
+  /** Discriminator for the dependency source kind (e.g. "catalog-library", "module-direct", "plugins-dsl"). */
+  sourceKind: DepSource["kind"];
 }
 
 export interface FlatScanResult {
   buildSystem: ScanResult["buildSystem"];
   dependencies: FlattenedDependency[];
+}
+
+/**
+ * Returns the file path component of a DepSource for the backward-compatible `source` field.
+ * Catalog entries emit the TOML path; all others emit the build file name.
+ */
+function sourceFilePath(src: DepSource): string {
+  switch (src.kind) {
+    case "catalog-library":
+    case "catalog-plugin":
+      return src.tomlPath;
+    case "module-direct":
+    case "plugins-dsl":
+      return src.file;
+    case "buildscript-classpath":
+      return src.file;
+    default:
+      return assertNever(src);
+  }
 }
 
 /**
@@ -32,7 +59,8 @@ function flattenScanResult(scan: ReturnType<typeof scanProjectWithSubmodules>): 
   const dependencies: FlattenedDependency[] = [];
 
   for (const dep of scan.dependencies) {
-    const sourceLabel = dep.source.kind;
+    const sourceFile = sourceFilePath(dep.source);
+    const sourceKind = dep.source.kind;
     if (dep.usages.length === 0) {
       dependencies.push({
         groupId: dep.groupId,
@@ -40,7 +68,8 @@ function flattenScanResult(scan: ReturnType<typeof scanProjectWithSubmodules>): 
         version: dep.version,
         configuration: "(unused)",
         module: undefined,
-        source: sourceLabel,
+        source: sourceFile,
+        sourceKind,
       });
     } else {
       for (const usage of dep.usages) {
@@ -50,7 +79,8 @@ function flattenScanResult(scan: ReturnType<typeof scanProjectWithSubmodules>): 
           version: dep.version,
           configuration: usage.configuration,
           module: usage.module,
-          source: sourceLabel,
+          source: sourceFile,
+          sourceKind,
         });
       }
     }

--- a/plugins/maven-mcp/src/tools/scan-project-dependencies.ts
+++ b/plugins/maven-mcp/src/tools/scan-project-dependencies.ts
@@ -1,11 +1,66 @@
-import { scanDependencies } from "../dependencies/scan.js";
+import { scanProjectWithSubmodules } from "../dependencies/scan.js";
+import type { ScanResult } from "../dependencies/scan.js";
 import { findProjectRoot } from "../project/find-project-root.js";
 
 export interface ScanProjectInput {
   projectPath?: string;
 }
 
-export function scanProjectDependenciesHandler(input: ScanProjectInput) {
+interface FlattenedDependency {
+  groupId: string;
+  artifactId: string;
+  version: string | null;
+  configuration: string;
+  module?: string;
+  source: string;
+}
+
+export interface FlatScanResult {
+  buildSystem: ScanResult["buildSystem"];
+  dependencies: FlattenedDependency[];
+}
+
+/**
+ * Flattens the new ScannedDependency shape (with usages[]) back into the old flat shape
+ * for backward compatibility with existing callers of scan_project_dependencies.
+ *
+ * - usages.length === 0 (unused catalog entry) → one item with configuration: "(unused)"
+ * - usages.length === 1 → one item
+ * - usages.length > 1 (same catalog entry used in multiple modules) → one item per usage
+ */
+function flattenScanResult(scan: ReturnType<typeof scanProjectWithSubmodules>): FlatScanResult {
+  const dependencies: FlattenedDependency[] = [];
+
+  for (const dep of scan.dependencies) {
+    const sourceLabel = dep.source.kind;
+    if (dep.usages.length === 0) {
+      dependencies.push({
+        groupId: dep.groupId,
+        artifactId: dep.artifactId,
+        version: dep.version,
+        configuration: "(unused)",
+        module: undefined,
+        source: sourceLabel,
+      });
+    } else {
+      for (const usage of dep.usages) {
+        dependencies.push({
+          groupId: dep.groupId,
+          artifactId: dep.artifactId,
+          version: dep.version,
+          configuration: usage.configuration,
+          module: usage.module,
+          source: sourceLabel,
+        });
+      }
+    }
+  }
+
+  return { buildSystem: scan.buildSystem, dependencies };
+}
+
+export function scanProjectDependenciesHandler(input: ScanProjectInput): FlatScanResult {
   const projectRoot = input.projectPath ?? findProjectRoot(process.cwd()) ?? process.cwd();
-  return scanDependencies(projectRoot);
+  const scan = scanProjectWithSubmodules(projectRoot);
+  return flattenScanResult(scan);
 }

--- a/plugins/sensitive-guard/.claude-plugin/plugin.json
+++ b/plugins/sensitive-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sensitive-guard",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Prevents sensitive data (secrets, PII) from reaching AI servers by scanning files before they are read into conversation",
   "author": {
     "name": "kirich1409"


### PR DESCRIPTION
## Summary

Extends `audit_project_dependencies` to do a full-project Gradle/Maven scan and rewrites the `check-deps` skill as a single grouped call. The motivation: on multi-module Gradle projects with a root build that mostly delegates, the previous root-only scan returned "nothing to update" while every real dependency lived in `gradle/libs.versions.toml` and module build files.

The scan now covers:

- Multiple version catalogs declared via `dependencyResolutionManagement.versionCatalogs { create("name") { from(files("path")) } }`, with the implicit `libs` catalog from `gradle/libs.versions.toml` always preserved (Gradle's actual behavior).
- Both `[libraries]` and `[plugins]` sections of every catalog.
- Plugin DSL in root build, each module build, and `pluginManagement { plugins {} }` in settings.
- `buildscript { dependencies { classpath(...) } }` legacy form.

Catalog entries are the unit of accounting: a `[libraries]` or `[plugins]` alias becomes one `ScannedDependency` with an `usages: DepUsage[]` array; `libs.xxx` refs from modules append to the entry's usages instead of duplicating. Drift between catalog and module-hardcoded versions is intentionally surfaced (no dedup) so missed migrations stay visible. `source: DepSource` is a discriminated union (catalog-library | catalog-plugin | module-direct | plugins-dsl | buildscript-classpath) so the skill knows exactly which file to edit. `productionOnly` always includes unused catalog entries — the catalog is the single source of truth, so unused aliases still need version bumps and CVE scans.

The `check-deps` skill is rewritten as a one-shot `audit_project_dependencies` call grouped by `source.kind` with a separate vulnerabilities block and file-targeted edit guidance.

## What changes for consumers

- New fields on `AuditDependency`: `source: DepSource`, `usages: DepUsage[]`. Legacy `module`/`configuration` retained as the first usage for backward compat.
- `scan_project_dependencies` keeps the legacy `source` field semantics (file path) and adds `sourceKind: DepSource["kind"]` as the new discriminator — no silent break for existing tool consumers.
- New types exported from `src/dependencies/`: `DepSource`, `DepUsage`, `ParsedCatalog`, `PluginEntry`, `CatalogDescriptor`, `ParsedPluginDeclaration`, `ParsedClasspathDep`.

## Out of scope (v2)

- `from("g:a:v")` form of `versionCatalogs.create()` (catalog published as a Maven dep).
- Convention plugins (`buildSrc/`, included builds).
- Vulnerability lookup for plugin entries — OSV indexes implementation artifacts, not `<pluginId>.gradle.plugin` markers, so plugin CVEs currently always return empty. Documented in the inline comment and in `check-deps/SKILL.md` constraints.

## Test plan

- [x] Unit + integration: 381 tests, all green (`npm run build && npm run lint && npm run test` in `plugins/maven-mcp/`).
- [x] Real-filesystem smoke against a synthetic multi-module fixture (root + `:app` + `:feature`, `libs` + custom `testLibs` catalog, root `plugins {}` with alias + apply false, module `plugins {}` with `kotlin("jvm")` and `id("...")`, settings `pluginManagement.plugins`, `buildscript classpath`) — all 15 expected entries present in the right `source.kind` groups. Caught the implicit-`libs` regression that the unit tests had encoded incorrectly.
- [ ] Follow-up validation: run against a real multi-module Android project on disk to catch any project-specific Gradle DSL shapes the synthetic fixture missed. Not blocking merge.

## Versioning

Bumps the family to **0.20.0** across all 8 locations. `dependencies` semver ranges in the `developer-workflow-*` family widened to `^0.20.0`. `validate.sh` green.

## Acknowledged risks

See `swarm-report/audit-deps-multi-catalog-finalize.md` for the full list. Headline items:

- Silent failures for missing catalog TOML, bare-catch in audit pipeline, and unresolved catalog refs are pre-existing or explicit plan decisions — surfacing them via a `warnings[]` field is a v2 scope expansion.
- `ParsedPluginDeclaration.catalogRef: string` is stringly-typed by deliberate plan choice; `{catalog, alias}` tuple is a v2 candidate.
- Architecture decomposition NITs (extract `CatalogIndex`, split `scanProjectWithSubmodules`, decide v2 boundary for `from("g:a:v")`) — all safe to defer.

## Release Notes

```
### Added
- `audit_project_dependencies` now scans every Gradle submodule, every version catalog (default `libs` plus any declared via `dependencyResolutionManagement.versionCatalogs`), root and per-module `plugins {}` blocks, `pluginManagement { plugins {} }` in settings, and `buildscript classpath` entries.
- `AuditDependency` exposes `source: DepSource` (discriminated union) and `usages: DepUsage[]` so consumers know exactly which file to edit and where each catalog entry is used.
- `check-deps` skill rewritten as a one-shot audit with output grouped by catalog libraries / catalog plugins / module direct / plugin DSL / buildscript classpath, plus a separate vulnerabilities block.

### Changed
- `audit_project_dependencies` `productionOnly: true` now always includes unused catalog entries (catalog is the single source of truth — unused aliases still need updates).
- `scan_project_dependencies` adds a `sourceKind` discriminator alongside the existing `source` file-path field; the legacy `source` semantics are preserved for downstream tool consumers.
```