### PR TITLE
drive-to-merge: ground review handling in the full branch diff

### DIFF
--- a/plugins/developer-workflow/skills/drive-to-merge/SKILL.md
+++ b/plugins/developer-workflow/skills/drive-to-merge/SKILL.md
@@ -11,9 +11,9 @@ description: >
 # Drive to Merge
 
 Autonomous end-to-end PR driver. Takes the currently open PR/MR from its present state
-and loops — diagnose CI, categorize review comments, propose fixes, delegate, push,
-re-request review, wait for new activity — until the PR is merged or a true blocker
-requires the user.
+and loops — diagnose CI, categorize review comments against the full branch diff, propose
+fixes, delegate, push, re-request review, wait for new activity — until the PR is merged
+or a true blocker requires the user.
 
 **Core principle:** keep the PR moving. Every obstacle (CI failure, review comment,
 stalled reviewer) is a loop iteration, not a stop. The skill stops only for: the final
@@ -51,7 +51,7 @@ stays the stable orchestration contract.
 |---|---|
 | [`references/setup.md`](references/setup.md) | Phase 1: platform detect, metadata fetch, preconditions, state-file schema, mode precedence on resume |
 | [`references/ci.md`](references/ci.md) | Phase 2.2: run-id extraction from `statusCheckRollup`, log download, classification, CI failure table, infra-flake retry, failure-loop guard |
-| [`references/reviews.md`](references/reviews.md) | Phase 2.3 + 2.4: fetch, categorize, verify, pattern-match, group, propose; decision-table format and gate behaviour |
+| [`references/reviews.md`](references/reviews.md) | Phase 2.3 + 2.4: build/refresh the branch-change model (full diff, then delta), fetch, categorize against the whole branch, verify, pattern-match, group, propose; decision-table format (diff-grounded plan) and gate behaviour |
 | [`references/delegation.md`](references/delegation.md) | Phase 3: edit / delegate / ask-in-thread / dismiss; reply-delivery safety rules; commit + push; re-request review (humans + Copilot) |
 | [`references/polling.md`](references/polling.md) | Phase 4: ScheduleWakeup schedule, delaySeconds matrix, cache-window tuning, poll-cap blocker |
 | [`references/merge.md`](references/merge.md) | Phase 5: pre-merge checks, confirmation UX, final re-check, merge commands; Phase 2.6 rebase companion |
@@ -100,10 +100,12 @@ Investigate failing checks, retry infra flakes, hand code-fix rows to Phase 3. P
 
 ### 2.3 Review handling
 
-Fetch comments, filter already-owned threads, categorize (BLOCKING / IMPORTANT /
-SUGGESTION / NIT / QUESTION / PRAISE / OUT_OF_SCOPE) crossed with actionability (FIXABLE
-/ NEEDS_CLARIFICATION / DISCUSSION / NO_ACTION), verify suggestions against the diff,
-pattern-match, group, and generate a concrete proposal per item. Full procedure in
+Build or refresh the branch-change model first (full branch diff on first entry, delta
+on later rounds), then fetch comments, filter already-owned threads, categorize (BLOCKING
+/ IMPORTANT / SUGGESTION / NIT / QUESTION / PRAISE / OUT_OF_SCOPE) crossed with
+actionability (FIXABLE / NEEDS_CLARIFICATION / DISCUSSION / NO_ACTION). Reason about each
+leftover comment against the whole branch diff — verify suggestions, pattern-match across
+all changed files, group, and generate a concrete proposal per item. Full procedure in
 [`references/reviews.md`](references/reviews.md).
 
 ### 2.4 Decision table (the gate)
@@ -220,6 +222,8 @@ The skill decides these without asking, in any mode:
 **Respect the reviewer.** Push back on wrong suggestions (record as DISCUSSION, draft a counter-reply); do not dress a broken suggestion up as FIXABLE and ship the broken fix.
 
 **Pattern completeness.** Fixing one reported instance while identical problems remain elsewhere in the diff gets the thread reopened. Pattern-match at analysis time, fix at apply time.
+
+**Plan grounded in the full branch diff.** Build a model of the whole change set before responding, and reason about every leftover comment against it — not just its line. A reviewer's comment is often a symptom whose cause or correct fix lives elsewhere in the branch. The decision table is that plan.
 
 **Fail loudly, not silently.** Three CI failures on the same signature, an integrity mismatch, a rebase with logic conflicts — stop and surface, do not retry forever.
 

--- a/plugins/developer-workflow/skills/drive-to-merge/evals/evals.json
+++ b/plugins/developer-workflow/skills/drive-to-merge/evals/evals.json
@@ -168,6 +168,32 @@
           "type": "safety"
         }
       ]
+    },
+    {
+      "id": 7,
+      "name": "eval-7-branch-diff-grounded-rootcause",
+      "prompt": "Drive PR #112 to merge in --dry-run mode. A reviewer flags a symptom at one site, but the root cause is a change this same branch introduced in a different file.\n\nFixture:\n```json\n{\n  \"number\": 112,\n  \"state\": \"OPEN\",\n  \"isDraft\": false,\n  \"mergeable\": \"MERGEABLE\",\n  \"mergeStateStatus\": \"BLOCKED\",\n  \"reviewDecision\": \"CHANGES_REQUESTED\",\n  \"statusCheckRollup\": [{\"name\": \"build\", \"conclusion\": \"SUCCESS\"}],\n  \"reviews\": [\n    {\"author\": {\"login\": \"grace\"}, \"state\": \"CHANGES_REQUESTED\", \"body\": \"The receipt now shows a raw timestamp like 2026-05-26T10:00:00Z instead of a friendly date. Please fix the receipt screen.\", \"path\": \"ui/src/main/kotlin/Receipt.kt\", \"line\": 55}\n  ]\n}\n```\n\nFull branch diff (`git diff origin/main...HEAD`) — this branch refactors date formatting:\n```kotlin\n// util/src/main/kotlin/Format.kt (changed by THIS branch)\n-fun formatDate(d: Instant): String = d.toLocaleString()   // old: friendly locale date\n+fun formatDate(d: Instant): String = d.toString()         // new: raw ISO-8601\n\n// ui/src/main/kotlin/Receipt.kt:55 (unchanged by this branch — calls the shared helper)\n  val label = formatDate(receipt.createdAt)\n```",
+      "expected_output": "Decision table opens with a `Branch context:` line summarizing that the branch refactors date formatting in util/Format.kt. Grounded in the full branch diff, the skill traces Grace's symptom at Receipt.kt:55 to its root cause — the formatDate() change in util/Format.kt introduced by this same branch — rather than proposing a local-only patch at Receipt.kt:55. The proposal names both sites and targets the shared helper (or explains the relationship). In --dry-run no edit is applied, nothing posted, no merge.",
+      "principle": "Plan grounded in the full branch diff — trace a flagged symptom to a root cause the branch introduced elsewhere, not just the commented line",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Decision table includes a `Branch context:` line summarizing what the branch does (date-formatting refactor in util/Format.kt)",
+          "type": "structural"
+        },
+        {
+          "text": "Skill traces Grace's symptom at Receipt.kt:55 to the root-cause change in util/Format.kt (formatDate) introduced by this branch, not a local-only fix at Receipt.kt:55",
+          "type": "diff-grounding"
+        },
+        {
+          "text": "Proposal names both sites and targets the shared helper (or explicitly explains the cross-file relationship)",
+          "type": "coverage"
+        },
+        {
+          "text": "No edit is applied, nothing posted, no merge — --dry-run is respected",
+          "type": "safety"
+        }
+      ]
     }
   ]
 }

--- a/plugins/developer-workflow/skills/drive-to-merge/references/reviews.md
+++ b/plugins/developer-workflow/skills/drive-to-merge/references/reviews.md
@@ -1,6 +1,26 @@
 # drive-to-merge — Phase 2.3 Review Handling + 2.4 Decision Table
 
-Fetch review activity, categorize, verify suggestions, propose a concrete action per item, and render the gate.
+Build (or refresh) the branch-change model, fetch review activity, categorize each leftover comment against the whole branch diff, verify suggestions, propose a concrete action per item, and render the gate as a diff-grounded plan.
+
+## 2.3.0 Build (or refresh) the branch-change model
+
+Before touching individual comments, understand what the whole branch does. Every leftover comment is reasoned against this model, not just its own line — a reviewer often flags a symptom whose cause or correct fix lives elsewhere in the branch diff.
+
+First entry this session — build the full model from the complete branch diff:
+
+```bash
+git diff "origin/$BASE"...HEAD
+```
+
+From it, write a short structured understanding (a few lines, not a transcript): what the branch does, which files/areas it touches, and the key behaviors, invariants, and contracts it introduces or changes. Record `analyzed_through_sha` = current `HEAD`.
+
+Subsequent rounds — refresh with the **delta** only, do not re-read the full diff:
+
+```bash
+git diff "<analyzed_through_sha>"...HEAD   # new commits since last analysis
+```
+
+Reconcile the delta into the cached model and advance `analyzed_through_sha` to the new `HEAD`. Persist the compact model summary and `analyzed_through_sha` to the state file (see [`setup.md`](setup.md) `Branch change model`) so the model survives context compaction; on resume, reuse the cached model and re-read only the delta since the stored sha.
 
 ## 2.3.1 Fetch
 
@@ -23,11 +43,7 @@ gh api "repos/$OWNER/$REPO_NAME/issues/$PR_NUMBER/comments" \
 
 For GitLab use `glab api "/projects/$PROJECT/merge_requests/$MR_IID/discussions"` which returns resolution state inline.
 
-Fetch diff:
-
-```bash
-git diff "origin/$BASE"...HEAD
-```
+The branch diff is already loaded into the branch-change model (2.3.0) — do not re-fetch it here.
 
 ## 2.3.2 Filter before categorizing
 
@@ -66,20 +82,21 @@ Priority (derived, used for ordering in the decision table):
 - `P3` = NIT + FIXABLE, SUGGESTION + DISCUSSION
 - `P4` = PRAISE, OUT_OF_SCOPE, NO_ACTION
 
-## 2.3.4 Verify the suggestion against the diff
+## 2.3.4 Verify the suggestion against the branch-change model
 
-For every BLOCKING / IMPORTANT + FIXABLE item:
+For every BLOCKING / IMPORTANT + FIXABLE item, reason about it against the whole branch (the 2.3.0 model), not just the commented line:
 
 1. Is the suggestion correct for this codebase's patterns?
 2. Would it break tests that currently pass?
 3. Is there a comment / ADR / commit message explaining why the current form exists?
 4. Does it apply to all platforms/versions this PR targets?
+5. Does the fix conflict with — or duplicate — something the branch introduces elsewhere, and is the flagged symptom actually caused by a change in another part of the diff? If so, the real fix may live at that other site.
 
 If any check fails → keep the category but change actionability to `DISCUSSION`, record a short note explaining what's wrong with the suggestion.
 
-## 2.3.5 Pattern match across the diff
+## 2.3.5 Pattern match across the branch-change model
 
-For every concrete code pattern mentioned (missing null check, deprecated API, hardcoded string, etc.) — search the rest of the diff for the same shape. Additional locations become part of the same item, not separate ones.
+For every concrete code pattern mentioned (missing null check, deprecated API, hardcoded string, etc.) — search the whole branch diff (all changed files in the 2.3.0 model) for the same shape, not just the local hunk. Additional locations become part of the same item, not separate ones.
 
 ## 2.3.6 Group and dedup
 
@@ -98,10 +115,12 @@ Never output only a category without a proposal. The value of this skill is the 
 
 ## 2.4 Decision table (the gate)
 
-Render in session as a **prioritized list**, not a table. One section per priority bucket present in the round, ordered most critical first. Each item is one short paragraph: bold headline = the gist; then prose with author, location, brief context, and the action — no bullet labels, no `→` arrows, no `Reviewer:` / `Action:` / `Verdict:` fields. Reads like a human issue note, not a form.
+Render in session as a **prioritized list**, not a table — a plan grounded in the whole branch, not a per-line checklist. Open with a one-line **branch context** drawn from the 2.3.0 model so the plan visibly accounts for the entire change set. Then one section per priority bucket present in the round, ordered most critical first. Each item is one short paragraph: bold headline = the gist; then prose with author, location, brief context, and the action — no bullet labels, no `→` arrows, no `Reviewer:` / `Action:` / `Verdict:` fields. Reads like a human issue note, not a form. Where a fix touches related changes elsewhere in the branch, name those sites in the item.
 
 ```
 Round N — review proposals
+
+Branch context: adds nullable userId to the auth flow; touches api/User.kt, api/Repo.kt, ui/Screen.kt.
 
 ## P0 — Blocking
 
@@ -146,6 +165,8 @@ none.
 
 ### Format rules
 
+- One `Branch context:` line right under the title, drawn from the 2.3.0 model — one sentence on what the branch does plus the areas it touches. This frames the plan as diff-grounded; keep it to a single line.
+- When an item's fix touches related changes elsewhere in the branch, name those sites inline (e.g. "same contract at api/Repo.kt:120") so the plan reads as a whole, not a per-line list.
 - Sections in order P0 → P1 → P2 → P3 → P4. Skip empty buckets.
 - Numbering is **continuous** across sections (1, 2, 3 …) — gate commands (`approve`, `skip 1,4`, `stop`) reference these numbers.
 - Each item: `**Bold headline.**` (one sentence on the gist) + `@author, file:line.` + 1–2 sentences of context and action. Snippet inline indented when relevant (≤15 lines).

--- a/plugins/developer-workflow/skills/drive-to-merge/references/reviews.md
+++ b/plugins/developer-workflow/skills/drive-to-merge/references/reviews.md
@@ -14,13 +14,15 @@ git diff "origin/$BASE"...HEAD
 
 From it, write a short structured understanding (a few lines, not a transcript): what the branch does, which files/areas it touches, and the key behaviors, invariants, and contracts it introduces or changes. Record `analyzed_through_sha` = current `HEAD`.
 
-Subsequent rounds — refresh with the **delta** only, do not re-read the full diff:
+Subsequent rounds — refresh with the **delta** only, do not re-read the full diff. First guard: if `analyzed_through_sha` is non-empty **and** `git merge-base --is-ancestor "<analyzed_through_sha>" HEAD` succeeds, use the delta:
 
 ```bash
 git diff "<analyzed_through_sha>"...HEAD   # new commits since last analysis
 ```
 
-Reconcile the delta into the cached model and advance `analyzed_through_sha` to the new `HEAD`. Persist the compact model summary and `analyzed_through_sha` to the state file (see [`setup.md`](setup.md) `Branch change model`) so the model survives context compaction; on resume, reuse the cached model and re-read only the delta since the stored sha.
+Otherwise (sha empty, or rebase rewrote history so the sha is no longer an ancestor), rebuild from the full diff (`git diff "origin/$BASE"...HEAD`) and reset `analyzed_through_sha` to the current `HEAD`.
+
+Reconcile the result into the cached model and advance `analyzed_through_sha` to the new `HEAD`. Persist the compact model summary and `analyzed_through_sha` to the state file (see [`setup.md`](setup.md) `Branch change model`) so the model survives context compaction; on resume, reuse the cached model and re-read only the delta since the stored sha (same guard applies).
 
 ## 2.3.1 Fetch
 

--- a/plugins/developer-workflow/skills/drive-to-merge/references/setup.md
+++ b/plugins/developer-workflow/skills/drive-to-merge/references/setup.md
@@ -100,7 +100,7 @@ analyzed_through_sha: <abbreviated sha the model is current as of, or empty befo
 <empty | list of items the skill surfaced to the user>
 ```
 
-On every resume (new session after context compaction) — re-read this file first; do not re-run analysis that already lives in a "Commitments" row unless the reviewer posted new activity. Reuse the stored `Branch change model` rather than rebuilding it from the full diff: re-read only the delta since `analyzed_through_sha` (`git diff <analyzed_through_sha>...HEAD`), reconcile it into the model, and advance the sha.
+On every resume (new session after context compaction) — re-read this file first; do not re-run analysis that already lives in a "Commitments" row unless the reviewer posted new activity. Reuse the stored `Branch change model` rather than rebuilding it from the full diff: re-read only the delta since `analyzed_through_sha` — but only if `analyzed_through_sha` is non-empty **and** `git merge-base --is-ancestor "<analyzed_through_sha>" HEAD` succeeds (i.e. the sha is still an ancestor after any rebase). If the sha is empty or the ancestry check fails, rebuild from the full diff (`git diff "origin/$BASE"...HEAD`) and reset `analyzed_through_sha` to the current `HEAD`.
 
 ### Mode precedence on resume
 

--- a/plugins/developer-workflow/skills/drive-to-merge/references/setup.md
+++ b/plugins/developer-workflow/skills/drive-to-merge/references/setup.md
@@ -81,6 +81,11 @@ Copilot node id: <graphql node id of copilot-pull-request-reviewer or `unavailab
 Started: <ISO8601>
 Status: running | waiting-for-user | merged | blocked
 
+## Branch change model
+analyzed_through_sha: <abbreviated sha the model is current as of, or empty before first build>
+
+<compact prose summary of what the branch does: areas/files touched, key behaviors, invariants, and contracts introduced — a few lines, refreshed by delta each round>
+
 ## Rounds
 | # | Started | Trigger | CI | New comments | Actions | Outcome |
 |---|---------|---------|----|--------------|---------|---------|
@@ -95,7 +100,7 @@ Status: running | waiting-for-user | merged | blocked
 <empty | list of items the skill surfaced to the user>
 ```
 
-On every resume (new session after context compaction) — re-read this file first; do not re-run analysis that already lives in a "Commitments" row unless the reviewer posted new activity.
+On every resume (new session after context compaction) — re-read this file first; do not re-run analysis that already lives in a "Commitments" row unless the reviewer posted new activity. Reuse the stored `Branch change model` rather than rebuilding it from the full diff: re-read only the delta since `analyzed_through_sha` (`git diff <analyzed_through_sha>...HEAD`), reconcile it into the model, and advance the sha.
 
 ### Mode precedence on resume
 


### PR DESCRIPTION
## Summary

Reworks the `drive-to-merge` skill so it collects review feedback and responds with planning that is grounded in **all** the changes in the PR/MR branch — not just the line a comment is attached to. The decision table is reframed as a diff-grounded plan.

- **New step `2.3.0 Build (or refresh) the branch-change model`** (`references/reviews.md`): before categorizing comments, understand what the whole branch does. Full diff on first entry; **delta only** on later rounds (`git diff <analyzed_through_sha>...HEAD`). Persisted to the state file so it survives context compaction.
- **`2.3.4` verify and `2.3.5` pattern-match** reason about each leftover comment against the whole branch — including whether the flagged symptom's cause/fix lives elsewhere in the diff.
- **`2.4` decision table** becomes a diff-grounded plan: a one-line `Branch context:` header and cross-references to related changes elsewhere in the branch.
- **`SKILL.md`**: updated 2.3 summary, reference table, core description, and a new principle *"Plan grounded in the full branch diff."*
- **`setup.md`**: state-file schema gains a `Branch change model` section (`analyzed_through_sha` + compact summary) and a resume rule to reuse the model and re-read only the delta.
- **`evals/evals.json`**: adds `eval-7` — trace a flagged symptom to a root cause the branch introduced in a different file.

Scope: review comments only (CI handling, polling, merge, delegation unchanged). No separate upfront planning phase; the proven one-skill-one-loop architecture is preserved.

## Test plan

- [x] `bash scripts/validate.sh` — green
- [x] `evals.json` is valid JSON
- [ ] `plugin-dev:plugin-validator` on `developer-workflow` — PASS or Minor only
- [ ] Manual read-through of SKILL.md + reviews.md + setup.md for loop coherence

https://claude.ai/code/session_013RgEHRczGjmC7TvsNKf8dZ

---
_Generated by [Claude Code](https://claude.ai/code/session_013RgEHRczGjmC7TvsNKf8dZ)_