### PR TITLE
Add library evaluation before adopting a new dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,8 +19,8 @@ Monorepo for Claude Code plugins by krozov. Contains six plugins:
 |--------|-----------|-------------|
 | maven-mcp | `plugins/maven-mcp/` | MCP server for Maven dependency intelligence |
 | sensitive-guard | `plugins/sensitive-guard/` | Scans files for secrets and PII before they reach AI servers |
-| developer-workflow | `plugins/developer-workflow/` | Toolbox of on-demand skills — research, write-spec, reverse-spec, multiexpert review, write-tests, check, finalize, generate-test-plan, acceptance, create-pr, drive-to-merge (exploratory QA: call manual-tester agent directly) |
-| developer-workflow-experts | `plugins/developer-workflow-experts/` | 9 reusable review/consult agents (code-reviewer, architecture-expert, security-expert, …) — safe standalone |
+| developer-workflow | `plugins/developer-workflow/` | Toolbox of on-demand skills — research, write-spec, reverse-spec, multiexpert review, evaluate-dependency, write-tests, check, finalize, generate-test-plan, acceptance, create-pr, drive-to-merge (exploratory QA: call manual-tester agent directly) |
+| developer-workflow-experts | `plugins/developer-workflow-experts/` | 10 reusable review/consult agents (code-reviewer, architecture-expert, security-expert, dependency-evaluator, …) — safe standalone |
 | developer-workflow-kotlin | `plugins/developer-workflow-kotlin/` | Kotlin/Android/KMP specialists and migration skills |
 | developer-workflow-swift | `plugins/developer-workflow-swift/` | Swift/iOS/macOS specialists and Swift/SwiftUI references |
 
@@ -31,7 +31,7 @@ plugins/
   maven-mcp/                    # TypeScript, npm package @krozov/maven-central-mcp
   sensitive-guard/              # Shell-based Claude Code plugin
   developer-workflow/           # Toolbox skills + manual-tester agent
-  developer-workflow-experts/   # 9 reusable expert agents (library)
+  developer-workflow-experts/   # 10 reusable expert agents (library)
   developer-workflow-kotlin/    # Kotlin/Android/KMP specialists and migrations
   developer-workflow-swift/     # Swift/iOS specialists and references
 ```

--- a/plugins/developer-workflow-experts/README.md
+++ b/plugins/developer-workflow-experts/README.md
@@ -15,6 +15,7 @@ Reusable expert agents extracted from `developer-workflow` for standalone consum
 | `devops-expert` | CI/CD pipelines, deployment automation, dependency scanning, release workflows | CI/CD work |
 | `business-analyst` | Product and business value evaluation — requirements, scope, MVP, trade-offs | Research review, scope analysis |
 | `debugging-expert` | Read-only root cause analysis before any fix is attempted | Bug investigation |
+| `dependency-evaluator` | Whether a new library is worth adopting — maintenance, activity, reputation, adoption, publisher, license, CVEs | Before adding a new dependency |
 
 ## Standalone use
 

--- a/plugins/developer-workflow-experts/agents/dependency-evaluator.md
+++ b/plugins/developer-workflow-experts/agents/dependency-evaluator.md
@@ -1,0 +1,108 @@
+---
+name: "dependency-evaluator"
+description: "Use this agent to decide whether a new library/dependency is worth adopting BEFORE it is added to a build file. It judges maintenance, activity (release cadence + issue dynamics), reputation & web sentiment, adoption, publisher/maintainer reputation, transparency (open vs closed source), security (CVEs), license, maturity, and fit, then returns a verdict: ADOPT / ADOPT WITH CAUTION / AVOID. Optimised for the JVM/Maven ecosystem and degrades gracefully for others. Examples: user asks 'should we use library X for Y?' — launch dependency-evaluator to vet it. A plan proposes pulling in a new dependency — launch dependency-evaluator before committing to it. user asks 'is this library still maintained / any good?' — launch dependency-evaluator. Do NOT use for: resolving version conflicts or BOM alignment (use build-engineer), deep security audit of code (use security-expert), or comparing already-adopted in-tree modules (use architecture-expert)."
+model: opus
+tools: Read, Glob, Grep, WebSearch, WebFetch
+color: cyan
+memory: project
+maxTurns: 30
+---
+
+You are a dependency adoption analyst. Your job is to answer one question before a library
+enters the codebase: **is this dependency worth taking on?** You weigh long-term cost — who
+maintains it, how alive it is, how the community regards it, what it locks the project into —
+not just whether it compiles today. You are skeptical by default but fair: a small library can
+be a fine choice, and a popular one can still be a trap.
+
+**Language:** Match the user's working language. Technical terms, coordinates, and code
+identifiers stay in their original form.
+
+**Communication style:** Neutral and evidence-driven. Lead with the verdict, then justify it.
+No filler. Every claim ties to a concrete signal (a metric, a date, a source).
+
+## Inputs
+
+You may be launched with pre-gathered signals (latest version, stability, known CVEs, and a
+health report with GitHub activity, issue dynamics, license, owner type). **If a Maven
+dependency-intelligence tool or such data is available to you, use it** for the objective
+metrics; **otherwise gather what you can from the web and explicitly note the gap.** Never
+fabricate metrics — an unknown is reported as unknown.
+
+## Evaluation Axes
+
+Assess each axis as good / concern / blocker. Not every axis applies to every library; skip
+with a one-line reason rather than padding.
+
+1. **Maintenance** — recency of commits and releases; archived/deprecated status; whether the
+   project explicitly seeks new maintainers or is in maintenance-only mode.
+2. **Activity** — release cadence (median gap between releases) and **issue dynamics**: open vs
+   closed counts, close ratio, median time-to-close, whether maintainers respond. A large,
+   growing backlog with a low close ratio is a concern even when stars are high.
+3. **Reputation & sentiment** — search the web for how the library is regarded: queries like
+   "<lib> review", "<lib> problems", "<lib> deprecated", "<lib> abandoned", "<lib> vs
+   <alternative>". Check Reddit/Hacker News/Stack Overflow discussions, blog posts, and any
+   history of security incidents or malware/supply-chain events.
+4. **Adoption** — is it actually used? Stars/forks, download/popularity signals, presence in
+   well-known projects. An explicit red flag if almost nobody uses it or it looks abandoned.
+5. **Publisher / maintainer reputation** — who publishes it: owner type (organisation vs single
+   user) and the groupId namespace (known vendors such as `org.jetbrains.*`, `com.google.*`,
+   `com.squareup.*`, `org.apache.*` vs an anonymous individual); account scale and age;
+   bus-factor (a single maintainer is a continuity risk). This adjusts the weight of the verdict
+   when other signals are close.
+6. **Transparency** — is the source open and is there a public repository? Closed source / no
+   public repo is an explicit risk (harder to audit, fork, or patch) but not an automatic AVOID —
+   weigh it against publisher reputation and the Maven/web signals.
+7. **Security** — known CVEs for the candidate version; whether fixed versions exist.
+8. **License** — is a license declared, and is it compatible with the project's distribution
+   model? Flag missing, copyleft, or unusual licenses for the user to confirm.
+9. **Maturity** — has a stable (non-alpha/beta/snapshot) release; project age; API churn signals.
+10. **Fit** — does it match the project's constraints (e.g. KMP targets, platform, runtime)?
+
+## How You Work
+
+1. **Identify the candidate** precisely: groupId:artifactId (or package name) and the version
+   under consideration. If ambiguous, state your assumption.
+2. **Use provided/available objective signals first**, then fill reputation, sentiment, and
+   adoption from the web. Cross-check: a metric that contradicts the web narrative is worth
+   calling out.
+3. **Weigh, don't tally.** A single blocker (active CVE with no fix, archived repo, no license)
+   can sink an otherwise healthy library. Conversely, minor concerns on a JetBrains/Google
+   library rarely justify AVOID.
+4. **Suggest alternatives** when the verdict is AVOID or CAUTION and a credible, healthier option
+   exists — one line each, not a research report.
+
+## Output Format
+
+1. **Verdict** — one of `ADOPT` / `ADOPT WITH CAUTION` / `AVOID`, with a one-sentence rationale.
+2. **Signal table** — the axes that applied, each marked good / concern / blocker with the
+   evidence (metric or source) in a few words.
+3. **Risks** — each with severity (critical / major / minor) and, where relevant, a mitigation.
+4. **Alternatives** — only if verdict is CAUTION or AVOID and a better option exists.
+5. **Sources** — URLs and coordinates backing the non-obvious claims; mark anything you could not
+   verify as "unknown".
+
+## Anti-Patterns to Avoid
+
+- Treating star count as a proxy for health — a popular library can be unmaintained.
+- AVOID purely because a library is small or new, when the publisher is reputable and it fits.
+- Ignoring transitive cost — a tiny convenience wrapper that drags in a heavy tree is a concern.
+- Verdict without evidence, or padding every axis when only a few are decisive.
+- Inventing metrics when the data is unavailable — say "unknown" instead.
+
+## Escalation
+
+- Version conflicts, BOM alignment, transitive resolution → recommend **build-engineer**.
+- Deep security analysis beyond CVE lookup (supply-chain threat modelling) → **security-expert**.
+- How the dependency reshapes module boundaries / layering → **architecture-expert**.
+- Build/CI impact of adopting it (scanning, SBOM, update automation) → **devops-expert**.
+
+## Agent Memory
+
+**Update your agent memory** as you evaluate dependencies for this project.
+
+Examples of what to record:
+- Verdicts reached for specific libraries and the key reason (so re-evaluations are consistent).
+- The project's distribution/licensing constraints once learned (e.g. "ships closed-source app —
+  copyleft is a blocker").
+- Preferred libraries the project already standardised on (so you can suggest them as alternatives).
+- Recurring constraints (KMP targets, min SDK, runtime) that affect fit judgements.

--- a/plugins/developer-workflow/CLAUDE.md
+++ b/plugins/developer-workflow/CLAUDE.md
@@ -11,7 +11,7 @@ Rules that are not open for discussion. Violating these is an error, not a judgm
 ## Structure
 
 ```
-skills/<name>/SKILL.md    # 11 on-demand skills, each a directory with YAML frontmatter
+skills/<name>/SKILL.md    # 12 on-demand skills, each a directory with YAML frontmatter
 agents/manual-tester.md   # only agent in core (QA executor; covers exploratory mode)
 evals/                    # eval-harness fixtures (gitignored iterations + tracked README)
 ```
@@ -22,7 +22,7 @@ This plugin is part of a split family. Depending on the task, Claude Code will h
 
 | Plugin | Contributes |
 |---|---|
-| `developer-workflow` (this) | 11 on-demand skills + `manual-tester` |
+| `developer-workflow` (this) | 12 on-demand skills + `manual-tester` |
 | `developer-workflow-experts` | `code-reviewer`, `architecture-expert`, `security-expert`, `performance-expert`, `ux-expert`, `build-engineer`, `devops-expert`, `business-analyst`, `debugging-expert` — required, auto-installed as a dependency |
 | `developer-workflow-kotlin` | `kotlin-engineer`, `compose-developer`; skills `migration`, `snapshot` — install for Kotlin/Android/KMP work |
 | `developer-workflow-swift` | `swift-engineer`, `swiftui-developer` — install for Swift/iOS/macOS work |
@@ -43,9 +43,9 @@ Skills in this plugin delegate to engineer agents (kotlin-engineer / compose-dev
 - Skills use YAML frontmatter: `name`, `description` (≤ 1024 chars), optionally `disable-model-invocation`.
 - `code-reviewer` (in `developer-workflow-experts`) is read-only — no Edit, Write, NotebookEdit, or Bash tools.
 
-## Skills roster (11)
+## Skills roster (12)
 
-- Planning / research: `research`, `write-spec`, `reverse-spec`, `multiexpert-review`
+- Planning / research: `research`, `write-spec`, `reverse-spec`, `multiexpert-review`, `evaluate-dependency`
 - Implementation: `check`, `finalize`, `write-tests`
 - QA: `generate-test-plan`, `acceptance`
 - PR: `create-pr`, `drive-to-merge`

--- a/plugins/developer-workflow/README.md
+++ b/plugins/developer-workflow/README.md
@@ -6,7 +6,7 @@ This plugin is the **core** of the `developer-workflow` family:
 
 ```
                  developer-workflow-experts
-                 (9 review/consult agents)
+                 (10 review/consult agents)
                           ▲
                           │ depends on
                           │
@@ -22,7 +22,7 @@ developer-workflow-kotlin          developer-workflow-swift
 
 Installing this plugin automatically pulls `developer-workflow-experts`. Installing `-kotlin` or `-swift` additionally pulls this plugin.
 
-## Skills (11)
+## Skills (12)
 
 Skills are independent on-demand tools — invoke them when the task calls for the capability. They do not orchestrate each other; the model drives sequencing through plan mode.
 
@@ -33,6 +33,7 @@ Skills are independent on-demand tools — invoke them when the task calls for t
 | `/write-spec` | Specification-Driven Development — multi-round interview producing an exhaustive spec |
 | `/reverse-spec` | Reverse-engineer an existing feature from code into a tech-agnostic spec |
 | `/multiexpert-review` | Panel of LLM evaluators (PoLL) review of a plan, spec, or test-plan via the appropriate profile |
+| `/evaluate-dependency` | Vet a new library before adding it — gathers health signals (via maven-mcp when available) + web reputation, delegates to `dependency-evaluator` for an adopt/avoid verdict |
 
 ### Implementation
 | Skill | Purpose |
@@ -62,7 +63,7 @@ For undirected exploratory QA without a spec — call the `manual-tester` agent 
 | `manual-tester` | this plugin | Real-device QA via mobile/browser MCP (disallowed Edit/Write/NotebookEdit) |
 
 Agents from sibling plugins invoked by skills in this plugin:
-- From [`developer-workflow-experts`](../developer-workflow-experts/): `code-reviewer`, `architecture-expert`, `security-expert`, `performance-expert`, `ux-expert`, `build-engineer`, `devops-expert`, `business-analyst`, `debugging-expert`
+- From [`developer-workflow-experts`](../developer-workflow-experts/): `code-reviewer`, `architecture-expert`, `security-expert`, `performance-expert`, `ux-expert`, `build-engineer`, `devops-expert`, `business-analyst`, `debugging-expert`, `dependency-evaluator`
 - From [`developer-workflow-kotlin`](../developer-workflow-kotlin/): `kotlin-engineer`, `compose-developer`
 - From [`developer-workflow-swift`](../developer-workflow-swift/): `swift-engineer`, `swiftui-developer`
 

--- a/plugins/developer-workflow/skills/evaluate-dependency/SKILL.md
+++ b/plugins/developer-workflow/skills/evaluate-dependency/SKILL.md
@@ -44,7 +44,8 @@ Collect what is knowable without judgement:
 - **JVM/Maven (preferred path):** if a Maven dependency-intelligence capability is available,
   request latest version + stability, known CVEs for the candidate version, and the library's
   health signals — maintenance (last commit/release, archived), activity (release cadence,
-  open/closed issue counts, close ratio, time-to-close), license, owner type, repository.
+  open/closed issue counts, close ratio, time-to-close), license, owner type, publisher scale
+  (public-repo count, account age), repository.
 - **No such capability / other ecosystems:** gather the equivalents from the web — the project's
   repository, release history, issue tracker, and registry page.
 

--- a/plugins/developer-workflow/skills/evaluate-dependency/SKILL.md
+++ b/plugins/developer-workflow/skills/evaluate-dependency/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: evaluate-dependency
+description: "Evaluate whether a new library/dependency is worth adopting BEFORE adding it to a build file. Gathers objective signals (latest version, stability, known CVEs, GitHub activity, issue dynamics, license, owner) — via a Maven dependency-intelligence tool when available — plus web reputation/sentiment and adoption, then delegates to the dependency-evaluator agent for a verdict (ADOPT / ADOPT WITH CAUTION / AVOID) and asks how to proceed. Optimised for JVM/Maven; degrades to web-only for other ecosystems. Use when: about to add a new dependency, \"should we use X\", \"is this library worth adding\", \"vet/evaluate this library\", \"is X still maintained\". Do NOT use for: bumping an already-used dependency's version (use a version/changelog lookup tool), resolving version conflicts or BOM alignment (build-engineer), or deep code security audits (security-expert)."
+---
+
+# Evaluate Dependency
+
+Vet a candidate library before it enters the build. The skill collects objective signals,
+hands them to the `dependency-evaluator` agent for a verdict, and brings the
+adopt/avoid decision back to you in chat — so a dependency is a deliberate choice, not a
+side effect of writing code.
+
+**When this fires.** Trigger it the moment a *new* dependency is about to be introduced —
+whether the user asks "should we use X?" or you are about to edit `build.gradle[.kts]`,
+`gradle/libs.versions.toml`, or `pom.xml` to add a coordinate that is not already present.
+Upgrading an already-used dependency is out of scope (that is a version/changelog lookup).
+
+**Graceful degradation — non-negotiable.** This skill must run without any MCP server. When a
+Maven dependency-intelligence capability is available, use it for the deep objective metrics;
+when it is not, fall back to web evidence and say so. Describe the data you need (latest
+version, stability, CVEs, maintenance/activity/license signals) — do not depend on a specific
+tool name.
+
+---
+
+## Phase 1: Identify the candidate(s)
+
+Pin down what is being evaluated:
+- **Coordinate / package** — `groupId:artifactId` for JVM/Maven, or the package name otherwise.
+- **Version** — the one under consideration, or "latest" if unspecified.
+- **Purpose** — what the user wants it for (feeds the "fit" judgement and alternative search).
+
+If several libraries are proposed at once, evaluate them as a batch. If the coordinate is
+ambiguous (e.g. only a feature is named), ask via `AskUserQuestion` or state the assumed
+candidate before proceeding.
+
+If the dependency is **already declared** in the project, stop — this skill is for *new*
+adoptions. Redirect to a version/changelog lookup instead.
+
+## Phase 2: Gather objective signals
+
+Collect what is knowable without judgement:
+
+- **JVM/Maven (preferred path):** if a Maven dependency-intelligence capability is available,
+  request latest version + stability, known CVEs for the candidate version, and the library's
+  health signals — maintenance (last commit/release, archived), activity (release cadence,
+  open/closed issue counts, close ratio, time-to-close), license, owner type, repository.
+- **No such capability / other ecosystems:** gather the equivalents from the web — the project's
+  repository, release history, issue tracker, and registry page.
+
+Record signals as facts; do not interpret them yet. Mark anything unavailable as unknown rather
+than guessing.
+
+## Phase 3: Judge
+
+Launch the `dependency-evaluator` agent via the Task tool, passing the candidate, its purpose,
+and every signal gathered in Phase 2. Let the agent add web reputation/sentiment and adoption
+checks and return the verdict — **ADOPT / ADOPT WITH CAUTION / AVOID** — with a signal table,
+risks (with severity), and any alternatives.
+
+Do not second-guess the agent's verdict; if it is missing a signal you can cheaply provide,
+fetch it and re-run rather than overriding.
+
+## Phase 4: Decide (dialogue)
+
+Present a compact summary in chat — verdict, the 2–4 signals that drove it, and the top risk —
+then use `AskUserQuestion` to let the user choose how to proceed. Offer options aligned to the
+verdict, e.g.:
+- **Adopt** — proceed to add the dependency.
+- **Adopt with caution** — proceed, noting the mitigation(s).
+- **Evaluate an alternative** — re-run this skill on the suggested alternative.
+- **Don't adopt** — abandon this dependency.
+
+The decision lives in chat, never parked in a file. Only after the user chooses "adopt" do you
+edit the build file.
+
+## Phase 5: Optional artifact
+
+For a non-trivial evaluation worth keeping (e.g. a decision the team will revisit), save the
+verdict and signal table to `./swarm-report/evaluate-dependency-<slug>.md`. Skip this for a
+quick yes/no check — the chat summary is enough.
+
+---
+
+## Red Flags / STOP Conditions
+
+- **Coordinate cannot be resolved anywhere** (not in Maven, not on the web) — report it; a
+  package that cannot be found is itself a strong AVOID signal.
+- **Active CVE with no fixed version** — surface as a critical risk before anything else.
+- **Closed source / no public repository** — not an automatic AVOID, but call it out explicitly
+  so the user weighs the reduced auditability.
+- **User is mid-implementation and adding the dep is blocking them** — keep the evaluation tight;
+  lead with the verdict so they can move.

--- a/plugins/maven-mcp/CLAUDE.md
+++ b/plugins/maven-mcp/CLAUDE.md
@@ -85,6 +85,7 @@ src/
 - `scan_project_dependencies` -> local only (no network), delegates to `dependencies/scan.ts`
 - `search_artifacts` -> Maven Central Solr Search API (no repo resolution)
 - `get_dependency_vulnerabilities` -> OSV batch API (`api.osv.dev/v1/querybatch`)
+- `get_dependency_health` -> `resolveAll` (versions/stability/lastUpdated) + POM fetch (SCM URL, license) → GitHub repo discovery → GitHub REST (`fetchRepo`) + releases (cadence) + Search API (`fetchIssueStats`: open/closed counts, close ratio, median time-to-close). Returns raw signals only — verdict is the caller's job. Degrades to `github: null` + `healthError` when no public GitHub repo / rate-limited
 - `audit_project_dependencies` -> `scanDependencies` + `resolveAll` (memoized per GA) + `queryOsvBatch` (deduplicated per GAV)
 
 **Deduplication responsibility:** Parsers return raw results; `discoverRepositories()` in `discover.ts` handles URL deduplication.
@@ -93,7 +94,7 @@ src/
 
 ## Environment
 
-- `GITHUB_TOKEN` — optional, enables higher GitHub API rate limits (5000 req/h vs 60) for `get_dependency_changes` tool
+- `GITHUB_TOKEN` — optional, enables higher GitHub API rate limits (5000 req/h vs 60) for `get_dependency_changes` and `get_dependency_health` tools (the health tool also uses the rate-limited Search API for issue stats)
 - Persistent cache: `~/.cache/maven-central-mcp/` — SCM mappings (permanent), releases/changelog (24h TTL)
 
 ## Conventions

--- a/plugins/maven-mcp/CLAUDE.md
+++ b/plugins/maven-mcp/CLAUDE.md
@@ -85,7 +85,7 @@ src/
 - `scan_project_dependencies` -> local only (no network), delegates to `dependencies/scan.ts`
 - `search_artifacts` -> Maven Central Solr Search API (no repo resolution)
 - `get_dependency_vulnerabilities` -> OSV batch API (`api.osv.dev/v1/querybatch`)
-- `get_dependency_health` -> `resolveAll` (versions/stability/lastUpdated) + POM fetch (SCM URL, license) → GitHub repo discovery → GitHub REST (`fetchRepo`) + releases (cadence) + Search API (`fetchIssueStats`: open/closed counts, close ratio, median time-to-close). Returns raw signals only — verdict is the caller's job. Degrades to `github: null` + `healthError` when no public GitHub repo / rate-limited
+- `get_dependency_health` -> `resolveAll` (versions/stability/lastUpdated) + POM fetch (SCM URL, license) → GitHub repo discovery → GitHub REST (`fetchRepo`) + releases (cadence) + Search API (`fetchIssueStats`: open/closed counts, close ratio, median time-to-close) + owner lookup (`fetchUser`: publisher public-repo count and account age). Returns raw signals only — verdict is the caller's job. Degrades to `github: null` + `healthError` when no public GitHub repo / rate-limited; the owner lookup is non-fatal and yields `null` publisher fields on failure
 - `audit_project_dependencies` -> `scanDependencies` + `resolveAll` (memoized per GA) + `queryOsvBatch` (deduplicated per GAV)
 
 **Deduplication responsibility:** Parsers return raw results; `discoverRepositories()` in `discover.ts` handles URL deduplication.

--- a/plugins/maven-mcp/README.md
+++ b/plugins/maven-mcp/README.md
@@ -17,6 +17,7 @@ An MCP server registers tools that Claude can call during a conversation. The se
 | `get_dependency_changes` | Show changes between versions from GitHub changelogs |
 | `scan_project_dependencies` | Scan Gradle/Maven build files and Gradle version catalogs (`gradle/libs.versions.toml`) for dependencies |
 | `get_dependency_vulnerabilities` | Check for known CVEs via OSV.dev |
+| `get_dependency_health` | Assess adoption-worthiness: version/stability, GitHub activity, issue dynamics, license, owner — raw signals for a verdict |
 | `search_artifacts` | Search Maven Central |
 | `audit_project_dependencies` | Full audit: scan + version compare + vulnerability check |
 
@@ -41,7 +42,7 @@ Custom repositories are auto-discovered from Gradle `settings.gradle(.kts)`/`bui
 
 - **Node.js** 18+ (required)
 - **jq** (required when hooks are enabled) — used by the PostToolUse hook script (`plugin/hooks/post-edit-deps.sh`) to parse JSON input
-- **GITHUB_TOKEN** (optional) — set this environment variable to raise GitHub API rate limits from 60 to 5000 requests/hour, used by the `get_dependency_changes` tool to fetch changelogs and release notes
+- **GITHUB_TOKEN** (optional) — set this environment variable to raise GitHub API rate limits from 60 to 5000 requests/hour, used by the `get_dependency_changes` and `get_dependency_health` tools to fetch changelogs, release notes, repository metadata, and issue statistics
 
 ## Installation
 

--- a/plugins/maven-mcp/package-lock.json
+++ b/plugins/maven-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@krozov/maven-central-mcp",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/plugins/maven-mcp/src/github/github-client.ts
+++ b/plugins/maven-mcp/src/github/github-client.ts
@@ -29,6 +29,11 @@ export interface IssueStats {
   medianDaysToClose: number | null;
 }
 
+export interface GitHubUser {
+  public_repos: number | null;
+  created_at: string | null;
+}
+
 const GITHUB_API = "https://api.github.com";
 const ACCEPT_HEADER = "application/vnd.github.v3+json";
 
@@ -109,6 +114,24 @@ export class GitHubClient {
       );
       if (!response.ok) return null;
       return (await response.json()) as GitHubRepoMeta;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Publisher/owner account signals: public-repo count and account creation
+   * date, used to gauge maintainer scale and account age. null on failure
+   * (non-fatal — repo metrics still stand without it).
+   */
+  async fetchUser(login: string): Promise<GitHubUser | null> {
+    try {
+      const response = await fetchWithRetry(`${GITHUB_API}/users/${login}`, {
+        headers: this.headers,
+        timeoutMs: 10_000,
+      });
+      if (!response.ok) return null;
+      return (await response.json()) as GitHubUser;
     } catch {
       return null;
     }

--- a/plugins/maven-mcp/src/github/github-client.ts
+++ b/plugins/maven-mcp/src/github/github-client.ts
@@ -4,6 +4,29 @@ export interface GitHubRelease {
   tag_name: string;
   body: string;
   html_url: string;
+  published_at?: string | null;
+  draft?: boolean;
+  prerelease?: boolean;
+}
+
+export interface GitHubRepoMeta {
+  stargazers_count: number;
+  forks_count: number;
+  archived: boolean;
+  pushed_at: string | null;
+  open_issues_count: number;
+  created_at: string | null;
+  license: { spdx_id: string | null; name: string | null } | null;
+  owner: { login: string; type: string };
+}
+
+export interface IssueStats {
+  open: number;
+  closed: number;
+  /** closed / (open + closed); null when either count is unavailable. */
+  closeRatio: number | null;
+  /** Median days-to-close over recent closed issues; null when unavailable. */
+  medianDaysToClose: number | null;
 }
 
 const GITHUB_API = "https://api.github.com";
@@ -74,6 +97,83 @@ export class GitHubClient {
       return response.ok;
     } catch {
       return false;
+    }
+  }
+
+  /** Fetch repository metadata (stars, activity, license, owner). null on failure. */
+  async fetchRepo(owner: string, repo: string): Promise<GitHubRepoMeta | null> {
+    try {
+      const response = await fetchWithRetry(
+        `${GITHUB_API}/repos/${owner}/${repo}`,
+        { headers: this.headers, timeoutMs: 10_000 },
+      );
+      if (!response.ok) return null;
+      return (await response.json()) as GitHubRepoMeta;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Issue dynamics via the GitHub Search API: open vs closed counts, close
+   * ratio, and median days-to-close over recent closed issues. Returns null
+   * when both counts are unavailable (Search API is rate-limited more strictly
+   * than the core API). PRs are excluded via `type:issue`.
+   */
+  async fetchIssueStats(owner: string, repo: string): Promise<IssueStats | null> {
+    const open = await this.searchIssueCount(owner, repo, "open");
+    const closed = await this.searchIssueCount(owner, repo, "closed");
+    if (open === null && closed === null) return null;
+
+    const medianDaysToClose = await this.medianDaysToCloseRecent(owner, repo);
+    const total = (open ?? 0) + (closed ?? 0);
+    const closeRatio =
+      open !== null && closed !== null && total > 0 ? closed / total : null;
+
+    return { open: open ?? 0, closed: closed ?? 0, closeRatio, medianDaysToClose };
+  }
+
+  private async searchIssueCount(
+    owner: string,
+    repo: string,
+    state: "open" | "closed",
+  ): Promise<number | null> {
+    try {
+      const q = `repo:${owner}/${repo} type:issue state:${state}`;
+      const url = `${GITHUB_API}/search/issues?q=${encodeURIComponent(q)}&per_page=1`;
+      const response = await fetchWithRetry(url, { headers: this.headers, timeoutMs: 10_000 });
+      if (!response.ok) return null;
+      const data = (await response.json()) as { total_count?: number };
+      return typeof data.total_count === "number" ? data.total_count : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private async medianDaysToCloseRecent(owner: string, repo: string): Promise<number | null> {
+    try {
+      const q = `repo:${owner}/${repo} type:issue state:closed`;
+      const url = `${GITHUB_API}/search/issues?q=${encodeURIComponent(q)}&sort=updated&order=desc&per_page=30`;
+      const response = await fetchWithRetry(url, { headers: this.headers, timeoutMs: 10_000 });
+      if (!response.ok) return null;
+      const data = (await response.json()) as {
+        items?: { created_at?: string; closed_at?: string }[];
+      };
+      const durations = (data.items ?? [])
+        .map((i) =>
+          i.created_at && i.closed_at
+            ? Date.parse(i.closed_at) - Date.parse(i.created_at)
+            : null,
+        )
+        .filter((d): d is number => d !== null && Number.isFinite(d) && d >= 0)
+        .sort((a, b) => a - b);
+      if (durations.length === 0) return null;
+      const mid = Math.floor(durations.length / 2);
+      const medianMs =
+        durations.length % 2 ? durations[mid] : (durations[mid - 1] + durations[mid]) / 2;
+      return Math.round(medianMs / 86_400_000);
+    } catch {
+      return null;
     }
   }
 

--- a/plugins/maven-mcp/src/github/github-client.ts
+++ b/plugins/maven-mcp/src/github/github-client.ts
@@ -21,8 +21,10 @@ export interface GitHubRepoMeta {
 }
 
 export interface IssueStats {
-  open: number;
-  closed: number;
+  /** null when the Search API call failed (rate-limited or network error). */
+  open: number | null;
+  /** null when the Search API call failed (rate-limited or network error). */
+  closed: number | null;
   /** closed / (open + closed); null when either count is unavailable. */
   closeRatio: number | null;
   /** Median days-to-close over recent closed issues; null when unavailable. */
@@ -153,7 +155,7 @@ export class GitHubClient {
     const closeRatio =
       open !== null && closed !== null && total > 0 ? closed / total : null;
 
-    return { open: open ?? 0, closed: closed ?? 0, closeRatio, medianDaysToClose };
+    return { open, closed, closeRatio, medianDaysToClose };
   }
 
   private async searchIssueCount(

--- a/plugins/maven-mcp/src/github/pom-scm.ts
+++ b/plugins/maven-mcp/src/github/pom-scm.ts
@@ -32,6 +32,22 @@ function parseGitHubUrl(url: string): GitHubRepo | null {
 }
 
 /**
+ * Strips XML comments so a commented-out element cannot poison a match
+ * (e.g. `<!-- <url>https://github.com/wrong/repo</url> -->`). Loops to handle
+ * smuggled forms like `<!<!----->-- evil -->` where a fresh `<!--` only
+ * surfaces after the inner comment is stripped.
+ */
+function stripXmlComments(pomXml: string): string {
+  let xml = pomXml;
+  let prev: string;
+  do {
+    prev = xml;
+    xml = xml.replace(/<!--[\s\S]*?-->/g, "");
+  } while (xml !== prev);
+  return xml;
+}
+
+/**
  * Extracts GitHub owner/repo from POM XML using regex-based parsing.
  *
  * Priority:
@@ -41,16 +57,7 @@ function parseGitHubUrl(url: string): GitHubRepo | null {
  * 4. Root <url> (outside <scm>)
  */
 export function extractGitHubRepo(pomXml: string): GitHubRepo | null {
-  // Strip XML comments first so a commented-out <scm>/<url> cannot poison
-  // the match (e.g. `<!-- <url>https://github.com/wrong/repo</url> -->`).
-  // Loop to handle smuggled forms like `<!<!----->-- evil -->` where a fresh
-  // `<!--` only surfaces after the inner comment is stripped.
-  let xml = pomXml;
-  let prev: string;
-  do {
-    prev = xml;
-    xml = xml.replace(/<!--[\s\S]*?-->/g, "");
-  } while (xml !== prev);
+  const xml = stripXmlComments(pomXml);
 
   // Extract <scm> block
   const scmMatch = xml.match(/<scm>([\s\S]*?)<\/scm>/);
@@ -91,4 +98,62 @@ export function extractGitHubRepo(pomXml: string): GitHubRepo | null {
   }
 
   return null;
+}
+
+// Maven SCM connection strings are prefixed like `scm:git:https://…` or
+// `scm:git:git://…`. Strip the leading `scm:<provider>:` so the bare URL
+// remains for host classification.
+function cleanScmConnection(value: string): string {
+  return value.replace(/^scm:[a-z]+:/i, "");
+}
+
+/**
+ * Extracts the raw SCM URL from POM XML (any host, not only GitHub). Used to
+ * report where the source lives even when GitHub-specific metrics are
+ * unavailable (GitLab/Bitbucket/self-hosted/closed source).
+ *
+ * Priority mirrors extractGitHubRepo: <scm><url> → <connection> →
+ * <developerConnection> → root <url>.
+ */
+export function extractScmUrl(pomXml: string): string | null {
+  const xml = stripXmlComments(pomXml);
+
+  const scmMatch = xml.match(/<scm>([\s\S]*?)<\/scm>/);
+  if (scmMatch) {
+    const scmBlock = scmMatch[1];
+
+    const scmUrl = scmBlock.match(/<url>\s*(.*?)\s*<\/url>/);
+    if (scmUrl && scmUrl[1]) return scmUrl[1].trim();
+
+    const conn = scmBlock.match(/<connection>\s*(.*?)\s*<\/connection>/);
+    if (conn && conn[1]) return cleanScmConnection(conn[1].trim());
+
+    const devConn = scmBlock.match(/<developerConnection>\s*(.*?)\s*<\/developerConnection>/);
+    if (devConn && devConn[1]) return cleanScmConnection(devConn[1].trim());
+  }
+
+  const withoutScm = xml.replace(/<scm>[\s\S]*?<\/scm>/, "");
+  const rootUrl = withoutScm.match(/<url>\s*(.*?)\s*<\/url>/);
+  if (rootUrl && rootUrl[1]) return rootUrl[1].trim();
+
+  return null;
+}
+
+/**
+ * Extracts declared license names from POM XML (<licenses><license><name>).
+ * Regex-based to honour the "no XML parser dependency" non-negotiable.
+ */
+export function extractLicenses(pomXml: string): string[] {
+  const xml = stripXmlComments(pomXml);
+  const block = xml.match(/<licenses>([\s\S]*?)<\/licenses>/);
+  if (!block) return [];
+
+  const names: string[] = [];
+  const licenseRe = /<license>([\s\S]*?)<\/license>/g;
+  let match: RegExpExecArray | null;
+  while ((match = licenseRe.exec(block[1])) !== null) {
+    const nameMatch = match[1].match(/<name>\s*(.*?)\s*<\/name>/);
+    if (nameMatch && nameMatch[1]) names.push(nameMatch[1].trim());
+  }
+  return names;
 }

--- a/plugins/maven-mcp/src/index.ts
+++ b/plugins/maven-mcp/src/index.ts
@@ -13,6 +13,7 @@ import { compareDependencyVersionsHandler } from "./tools/compare-dependency-ver
 import { getDependencyChangesHandler } from "./tools/get-dependency-changes.js";
 import { scanProjectDependenciesHandler } from "./tools/scan-project-dependencies.js";
 import { getDependencyVulnerabilitiesHandler } from "./tools/get-dependency-vulnerabilities.js";
+import { getDependencyHealthHandler } from "./tools/get-dependency-health.js";
 import { searchArtifactsHandler } from "./tools/search-artifacts.js";
 import { auditProjectDependenciesHandler } from "./tools/audit-project-dependencies.js";
 import { PACKAGE_VERSION } from "./version.js";
@@ -150,6 +151,22 @@ server.tool(
   },
   async (params) => {
     const result = await getDependencyVulnerabilitiesHandler(params);
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  },
+);
+
+server.tool(
+  "get_dependency_health",
+  "Assess the health of Maven dependencies before adopting them: latest version & stability, GitHub activity (stars, last commit, release cadence), issue dynamics (open/closed counts, close ratio, median time-to-close), license, owner type, and archived status. Returns raw maintenance/activity/reputation signals — let the caller (or a dependency-evaluator agent) judge whether to adopt. Degrades gracefully when no public GitHub repo exists (closed source / non-GitHub forge).",
+  {
+    dependencies: z.array(z.object({
+      groupId: z.string().describe("Maven group ID"),
+      artifactId: z.string().describe("Maven artifact ID"),
+      version: z.string().optional().describe("Specific version to assess (default: latest)"),
+    })).describe("Dependencies to assess for health"),
+  },
+  async (params) => {
+    const result = await getDependencyHealthHandler(getRepositories(), params);
     return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
   },
 );

--- a/plugins/maven-mcp/src/tools/__tests__/get-dependency-health.test.ts
+++ b/plugins/maven-mcp/src/tools/__tests__/get-dependency-health.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { getDependencyHealthHandler } from "../get-dependency-health.js";
+import { getDependencyHealthHandler, scmHost } from "../get-dependency-health.js";
 import type { MavenRepository } from "../../maven/repository.js";
 
 function mockRepo(versions: string[]): MavenRepository {
@@ -184,5 +184,43 @@ describe("getDependencyHealthHandler", () => {
     });
     expect(r.github).toBeNull();
     expect(r.healthError).toContain("metadata unavailable");
+  });
+});
+
+describe("scmHost", () => {
+  it("detects github from https URL", () => {
+    expect(scmHost("https://github.com/owner/repo")).toBe("github");
+  });
+
+  it("detects github from git:// URL", () => {
+    expect(scmHost("git://github.com/owner/repo")).toBe("github");
+  });
+
+  it("detects github from scp-like SSH URL", () => {
+    expect(scmHost("git@github.com:owner/repo.git")).toBe("github");
+  });
+
+  it("detects gitlab from https URL", () => {
+    expect(scmHost("https://gitlab.com/owner/repo")).toBe("gitlab");
+  });
+
+  it("detects bitbucket from https URL", () => {
+    expect(scmHost("https://bitbucket.org/owner/repo")).toBe("bitbucket");
+  });
+
+  it("returns other for a self-hosted gitlab subdomain", () => {
+    expect(scmHost("https://gitlab.example.com/owner/repo")).toBe("other");
+  });
+
+  it("returns other for an attacker URL containing github.com as a substring", () => {
+    expect(scmHost("https://evil-github.com.attacker.io/x")).toBe("other");
+  });
+
+  it("returns other for an empty string", () => {
+    expect(scmHost("")).toBe("other");
+  });
+
+  it("returns other for a malformed URL", () => {
+    expect(scmHost("not a url at all")).toBe("other");
   });
 });

--- a/plugins/maven-mcp/src/tools/__tests__/get-dependency-health.test.ts
+++ b/plugins/maven-mcp/src/tools/__tests__/get-dependency-health.test.ts
@@ -34,6 +34,26 @@ const POM_WITHOUT_SCM = `<?xml version="1.0" encoding="UTF-8"?>
   <version>1.0.0</version>
 </project>`;
 
+const POM_WITH_GITLAB_SCM = `<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>com.example</groupId>
+  <artifactId>gitlab-lib</artifactId>
+  <version>1.0.0</version>
+  <scm>
+    <url>https://gitlab.com/somegroup/gitlab-lib</url>
+  </scm>
+</project>`;
+
+const POM_WITH_BITBUCKET_SCM = `<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>com.example</groupId>
+  <artifactId>bitbucket-lib</artifactId>
+  <version>1.0.0</version>
+  <scm>
+    <url>https://bitbucket.org/somegroup/bitbucket-lib</url>
+  </scm>
+</project>`;
+
 const RECENT = new Date(Date.now() - 5 * 86_400_000).toISOString();
 const OLD = new Date(Date.now() - 760 * 86_400_000).toISOString(); // ~25 months ago
 
@@ -163,6 +183,60 @@ describe("getDependencyHealthHandler", () => {
     expect(r.signals).toContain("no public GitHub repository found");
     expect(r.signals).toContain("no license declared");
     expect(r.healthError).toContain("not found");
+  });
+
+  it("emits non-alarming SCM signal (not healthError) when SCM is on GitLab", async () => {
+    const repo = mockRepo(["1.0.0", "1.1.0"]);
+    (repo.fetchMetadata as ReturnType<typeof vi.fn>).mockResolvedValue({
+      groupId: "com.example",
+      artifactId: "gitlab-lib",
+      versions: ["1.0.0", "1.1.0"],
+      latest: "1.1.0",
+      release: "1.1.0",
+      lastUpdated: "20240101000000",
+    });
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(new Response(POM_WITH_GITLAB_SCM, { status: 200 })) as typeof fetch;
+
+    const { results } = await getDependencyHealthHandler([repo], {
+      dependencies: [{ groupId: "com.example", artifactId: "gitlab-lib" }],
+    });
+
+    const r = results[0];
+    expect(r.github).toBeNull();
+    expect(r.repository).toBeNull();
+    expect(r.scm).toEqual({ url: "https://gitlab.com/somegroup/gitlab-lib", host: "gitlab" });
+    // Non-alarming informational signal — not a transparency red flag
+    expect(r.signals).toContain("SCM hosted on gitlab; GitHub metrics unavailable");
+    // Must NOT be treated as a missing-repo error
+    expect(r.signals).not.toContain("no public GitHub repository found");
+    expect(r.healthError).toBeUndefined();
+  });
+
+  it("emits non-alarming SCM signal (not healthError) when SCM is on Bitbucket", async () => {
+    const repo = mockRepo(["2.0.0"]);
+    (repo.fetchMetadata as ReturnType<typeof vi.fn>).mockResolvedValue({
+      groupId: "com.example",
+      artifactId: "bitbucket-lib",
+      versions: ["2.0.0"],
+      latest: "2.0.0",
+      release: "2.0.0",
+      lastUpdated: "20240101000000",
+    });
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(new Response(POM_WITH_BITBUCKET_SCM, { status: 200 })) as typeof fetch;
+
+    const { results } = await getDependencyHealthHandler([repo], {
+      dependencies: [{ groupId: "com.example", artifactId: "bitbucket-lib" }],
+    });
+
+    const r = results[0];
+    expect(r.scm).toEqual({ url: "https://bitbucket.org/somegroup/bitbucket-lib", host: "bitbucket" });
+    expect(r.signals).toContain("SCM hosted on bitbucket; GitHub metrics unavailable");
+    expect(r.signals).not.toContain("no public GitHub repository found");
+    expect(r.healthError).toBeUndefined();
   });
 
   it("sets healthError when GitHub metadata is unavailable (rate limit)", async () => {

--- a/plugins/maven-mcp/src/tools/__tests__/get-dependency-health.test.ts
+++ b/plugins/maven-mcp/src/tools/__tests__/get-dependency-health.test.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getDependencyHealthHandler } from "../get-dependency-health.js";
+import type { MavenRepository } from "../../maven/repository.js";
+
+function mockRepo(versions: string[]): MavenRepository {
+  return {
+    name: "central",
+    url: "https://repo1.maven.org/maven2",
+    fetchMetadata: vi.fn().mockResolvedValue({
+      groupId: "io.ktor",
+      artifactId: "ktor-core",
+      versions,
+      latest: versions[versions.length - 1],
+      release: versions[versions.length - 1],
+      lastUpdated: "20240101000000",
+    }),
+  };
+}
+
+const POM_WITH_SCM = `<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>io.ktor</groupId>
+  <artifactId>ktor-core</artifactId>
+  <version>1.2.0</version>
+  <scm>
+    <url>https://github.com/ktorio/ktor</url>
+  </scm>
+</project>`;
+
+const POM_WITHOUT_SCM = `<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>com.example</groupId>
+  <artifactId>no-scm</artifactId>
+  <version>1.0.0</version>
+</project>`;
+
+const RECENT = new Date(Date.now() - 5 * 86_400_000).toISOString();
+const OLD = new Date(Date.now() - 760 * 86_400_000).toISOString(); // ~25 months ago
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+describe("getDependencyHealthHandler", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("reports healthy signals for an active, well-maintained library", async () => {
+    const repo = mockRepo(["1.0.0", "1.1.0", "1.2.0"]);
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(new Response(POM_WITH_SCM, { status: 200 }))
+      .mockResolvedValueOnce(json({
+        stargazers_count: 5000,
+        forks_count: 500,
+        archived: false,
+        pushed_at: RECENT,
+        open_issues_count: 80,
+        created_at: "2018-01-01T00:00:00Z",
+        license: { spdx_id: "Apache-2.0", name: "Apache License 2.0" },
+        owner: { login: "ktorio", type: "Organization" },
+      }))
+      .mockResolvedValueOnce(json([
+        { tag_name: "1.2.0", body: "", html_url: "", published_at: RECENT },
+        { tag_name: "1.1.0", body: "", html_url: "", published_at: new Date(Date.now() - 40 * 86_400_000).toISOString() },
+      ]))
+      .mockResolvedValueOnce(json({ total_count: 80 }))   // open issues
+      .mockResolvedValueOnce(json({ total_count: 920 }))  // closed issues
+      .mockResolvedValueOnce(json({ items: [             // recent closed issues
+        { created_at: "2024-01-01T00:00:00Z", closed_at: "2024-01-03T00:00:00Z" },
+        { created_at: "2024-02-01T00:00:00Z", closed_at: "2024-02-04T00:00:00Z" },
+      ] })) as typeof fetch;
+
+    const { results } = await getDependencyHealthHandler([repo], {
+      dependencies: [{ groupId: "io.ktor", artifactId: "ktor-core" }],
+    });
+
+    expect(results).toHaveLength(1);
+    const r = results[0];
+    expect(r.latestVersion).toBe("1.2.0");
+    expect(r.stability).toBe("stable");
+    expect(r.repository).toEqual({
+      owner: "ktorio",
+      repo: "ktor",
+      url: "https://github.com/ktorio/ktor",
+    });
+    expect(r.scm).toEqual({ url: "https://github.com/ktorio/ktor", host: "github" });
+    expect(r.github?.stars).toBe(5000);
+    expect(r.github?.ownerType).toBe("Organization");
+    expect(r.github?.license).toBe("Apache-2.0");
+    expect(r.github?.archived).toBe(false);
+    expect(r.github?.issues?.closeRatio).toBeCloseTo(0.92, 2);
+    expect(r.signals).toHaveLength(0);
+    expect(r.healthError).toBeUndefined();
+  });
+
+  it("flags archived, stale, and unresponsive repositories", async () => {
+    const repo = mockRepo(["1.0.0", "1.1.0"]);
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(new Response(POM_WITH_SCM, { status: 200 }))
+      .mockResolvedValueOnce(json({
+        stargazers_count: 12,
+        forks_count: 2,
+        archived: true,
+        pushed_at: OLD,
+        open_issues_count: 200,
+        created_at: "2015-01-01T00:00:00Z",
+        license: null,
+        owner: { login: "old", type: "User" },
+      }))
+      .mockResolvedValueOnce(json([
+        { tag_name: "1.1.0", body: "", html_url: "", published_at: OLD },
+      ]))
+      .mockResolvedValueOnce(json({ total_count: 200 }))  // open
+      .mockResolvedValueOnce(json({ total_count: 100 }))  // closed
+      .mockResolvedValueOnce(json({ items: [
+        { created_at: "2022-01-01T00:00:00Z", closed_at: "2023-02-05T00:00:00Z" }, // ~400 days
+      ] })) as typeof fetch;
+
+    const { results } = await getDependencyHealthHandler([repo], {
+      dependencies: [{ groupId: "io.ktor", artifactId: "ktor-core" }],
+    });
+
+    const r = results[0];
+    expect(r.github?.archived).toBe(true);
+    expect(r.github?.ownerType).toBe("User");
+    expect(r.signals).toContain("repository archived");
+    expect(r.signals).toContain("no license declared");
+    expect(r.signals).toContain("high open-issue backlog, low close ratio");
+    expect(r.signals.some((s) => s.startsWith("no commits in"))).toBe(true);
+    expect(r.signals.some((s) => s.startsWith("no release in"))).toBe(true);
+    expect(r.signals.some((s) => s.startsWith("slow issue response"))).toBe(true);
+  });
+
+  it("degrades gracefully when there is no public GitHub repository", async () => {
+    const repo = mockRepo(["1.0.0", "1.1.0"]);
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(new Response(POM_WITHOUT_SCM, { status: 200 })) as typeof fetch;
+
+    const { results } = await getDependencyHealthHandler([repo], {
+      dependencies: [{ groupId: "com.example", artifactId: "no-scm" }],
+    });
+
+    const r = results[0];
+    expect(r.github).toBeNull();
+    expect(r.repository).toBeNull();
+    expect(r.signals).toContain("no public GitHub repository found");
+    expect(r.signals).toContain("no license declared");
+    expect(r.healthError).toContain("not found");
+  });
+
+  it("sets healthError when GitHub metadata is unavailable (rate limit)", async () => {
+    const repo = mockRepo(["1.0.0", "1.1.0", "1.2.0"]);
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(new Response(POM_WITH_SCM, { status: 200 }))
+      .mockResolvedValueOnce(new Response("rate limited", { status: 403 })) as typeof fetch;
+
+    const { results } = await getDependencyHealthHandler([repo], {
+      dependencies: [{ groupId: "io.ktor", artifactId: "ktor-core" }],
+    });
+
+    const r = results[0];
+    expect(r.repository).toEqual({
+      owner: "ktorio",
+      repo: "ktor",
+      url: "https://github.com/ktorio/ktor",
+    });
+    expect(r.github).toBeNull();
+    expect(r.healthError).toContain("metadata unavailable");
+  });
+});

--- a/plugins/maven-mcp/src/tools/__tests__/get-dependency-health.test.ts
+++ b/plugins/maven-mcp/src/tools/__tests__/get-dependency-health.test.ts
@@ -77,7 +77,8 @@ describe("getDependencyHealthHandler", () => {
       .mockResolvedValueOnce(json({ items: [             // recent closed issues
         { created_at: "2024-01-01T00:00:00Z", closed_at: "2024-01-03T00:00:00Z" },
         { created_at: "2024-02-01T00:00:00Z", closed_at: "2024-02-04T00:00:00Z" },
-      ] })) as typeof fetch;
+      ] }))
+      .mockResolvedValueOnce(json({ public_repos: 120, created_at: "2011-05-01T00:00:00Z" })) as typeof fetch;
 
     const { results } = await getDependencyHealthHandler([repo], {
       dependencies: [{ groupId: "io.ktor", artifactId: "ktor-core" }],
@@ -95,6 +96,8 @@ describe("getDependencyHealthHandler", () => {
     expect(r.scm).toEqual({ url: "https://github.com/ktorio/ktor", host: "github" });
     expect(r.github?.stars).toBe(5000);
     expect(r.github?.ownerType).toBe("Organization");
+    expect(r.github?.ownerPublicRepos).toBe(120);
+    expect(r.github?.ownerAccountCreatedAt).toBe("2011-05-01T00:00:00Z");
     expect(r.github?.license).toBe("Apache-2.0");
     expect(r.github?.archived).toBe(false);
     expect(r.github?.issues?.closeRatio).toBeCloseTo(0.92, 2);
@@ -124,7 +127,8 @@ describe("getDependencyHealthHandler", () => {
       .mockResolvedValueOnce(json({ total_count: 100 }))  // closed
       .mockResolvedValueOnce(json({ items: [
         { created_at: "2022-01-01T00:00:00Z", closed_at: "2023-02-05T00:00:00Z" }, // ~400 days
-      ] })) as typeof fetch;
+      ] }))
+      .mockResolvedValueOnce(new Response("not found", { status: 404 })) as typeof fetch; // user lookup fails → null
 
     const { results } = await getDependencyHealthHandler([repo], {
       dependencies: [{ groupId: "io.ktor", artifactId: "ktor-core" }],
@@ -133,6 +137,8 @@ describe("getDependencyHealthHandler", () => {
     const r = results[0];
     expect(r.github?.archived).toBe(true);
     expect(r.github?.ownerType).toBe("User");
+    expect(r.github?.ownerPublicRepos).toBeNull();
+    expect(r.github?.ownerAccountCreatedAt).toBeNull();
     expect(r.signals).toContain("repository archived");
     expect(r.signals).toContain("no license declared");
     expect(r.signals).toContain("high open-issue backlog, low close ratio");

--- a/plugins/maven-mcp/src/tools/__tests__/get-dependency-health.test.ts
+++ b/plugins/maven-mcp/src/tools/__tests__/get-dependency-health.test.ts
@@ -185,6 +185,131 @@ describe("getDependencyHealthHandler", () => {
     expect(r.github).toBeNull();
     expect(r.healthError).toContain("metadata unavailable");
   });
+
+  // Comment #1 fix: latestVersion always reflects real latest even when a specific version is requested
+  it("reports real latestVersion when a specific (older) version is requested", async () => {
+    const repo = mockRepo(["1.0.0", "1.1.0", "1.2.0"]);
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(new Response(POM_WITH_SCM, { status: 200 }))
+      .mockResolvedValueOnce(json({
+        stargazers_count: 100,
+        forks_count: 10,
+        archived: false,
+        pushed_at: RECENT,
+        open_issues_count: 5,
+        created_at: "2020-01-01T00:00:00Z",
+        license: { spdx_id: "MIT", name: "MIT License" },
+        owner: { login: "ktorio", type: "Organization" },
+      }))
+      .mockResolvedValueOnce(json([
+        { tag_name: "1.2.0", body: "", html_url: "", published_at: RECENT },
+      ]))
+      .mockResolvedValueOnce(json({ total_count: 5 }))
+      .mockResolvedValueOnce(json({ total_count: 50 }))
+      .mockResolvedValueOnce(json({ items: [] }))
+      .mockResolvedValueOnce(json({ public_repos: 10, created_at: "2015-01-01T00:00:00Z" })) as typeof fetch;
+
+    const { results } = await getDependencyHealthHandler([repo], {
+      dependencies: [{ groupId: "io.ktor", artifactId: "ktor-core", version: "1.0.0" }],
+    });
+
+    const r = results[0];
+    // latestVersion must be 1.2.0 (real latest), not 1.0.0 (requested version)
+    expect(r.latestVersion).toBe("1.2.0");
+    expect(r.stability).toBe("stable");
+  });
+
+  // Comment #2 fix: issue stats should preserve null when one Search API call fails
+  it("returns null for issue counts when Search API calls fail", async () => {
+    const repo = mockRepo(["1.0.0", "1.1.0", "1.2.0"]);
+
+    globalThis.fetch = vi.fn()
+      .mockResolvedValueOnce(new Response(POM_WITH_SCM, { status: 200 }))
+      .mockResolvedValueOnce(json({
+        stargazers_count: 100,
+        forks_count: 10,
+        archived: false,
+        pushed_at: RECENT,
+        open_issues_count: 5,
+        created_at: "2020-01-01T00:00:00Z",
+        license: { spdx_id: "MIT", name: "MIT License" },
+        owner: { login: "ktorio", type: "Organization" },
+      }))
+      .mockResolvedValueOnce(json([]))  // releases
+      .mockResolvedValueOnce(json({ total_count: 200 }))              // open issues — success
+      .mockResolvedValueOnce(new Response("forbidden", { status: 403 }))  // closed issues — fail
+      .mockResolvedValueOnce(new Response("forbidden", { status: 403 }))  // median — fail
+      .mockResolvedValueOnce(json({ public_repos: 10, created_at: "2015-01-01T00:00:00Z" })) as typeof fetch;
+
+    const { results } = await getDependencyHealthHandler([repo], {
+      dependencies: [{ groupId: "io.ktor", artifactId: "ktor-core" }],
+    });
+
+    const r = results[0];
+    expect(r.github?.issues).not.toBeNull();
+    expect(r.github?.issues?.open).toBe(200);
+    // closed should be null (failed), not 0 (which would be misleading)
+    expect(r.github?.issues?.closed).toBeNull();
+    // closeRatio requires both counts — must be null when one is missing
+    expect(r.github?.issues?.closeRatio).toBeNull();
+  });
+
+  // Comment #3 fix: guess path should call fetchRepo only once (not repoExists + fetchRepo)
+  it("calls fetchRepo only once when guessing the GitHub repo", async () => {
+    const POM_NO_SCM_GITHUB_GROUP = `<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <groupId>io.github.someowner</groupId>
+  <artifactId>some-lib</artifactId>
+  <version>1.0.0</version>
+</project>`;
+
+    const repoWithGithubGroup = mockRepo(["1.0.0"]);
+    (repoWithGithubGroup.fetchMetadata as ReturnType<typeof vi.fn>).mockResolvedValue({
+      groupId: "io.github.someowner",
+      artifactId: "some-lib",
+      versions: ["1.0.0"],
+      latest: "1.0.0",
+      release: "1.0.0",
+      lastUpdated: "20240101000000",
+    });
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(POM_NO_SCM_GITHUB_GROUP, { status: 200 }))
+      // Single fetchRepo call for the guessed repo (owner=someowner, repo=some-lib)
+      .mockResolvedValueOnce(json({
+        stargazers_count: 50,
+        forks_count: 5,
+        archived: false,
+        pushed_at: RECENT,
+        open_issues_count: 2,
+        created_at: "2021-01-01T00:00:00Z",
+        license: { spdx_id: "MIT", name: "MIT License" },
+        owner: { login: "someowner", type: "User" },
+      }))
+      .mockResolvedValueOnce(json([]))  // releases
+      .mockResolvedValueOnce(json({ total_count: 2 }))    // open issues
+      .mockResolvedValueOnce(json({ total_count: 10 }))   // closed issues
+      .mockResolvedValueOnce(json({ items: [] }))         // median
+      .mockResolvedValueOnce(json({ public_repos: 5, created_at: "2018-01-01T00:00:00Z" })) as typeof fetch;
+
+    globalThis.fetch = fetchMock;
+
+    const { results } = await getDependencyHealthHandler([repoWithGithubGroup], {
+      dependencies: [{ groupId: "io.github.someowner", artifactId: "some-lib" }],
+    });
+
+    const r = results[0];
+    expect(r.repository?.owner).toBe("someowner");
+    expect(r.github).not.toBeNull();
+    // Verify fetchRepo was called exactly once for the guessed repo — no prior repoExists call.
+    // Use a regex that matches /repos/owner/repo exactly (no trailing path) to avoid
+    // matching /repos/owner/repo/releases or similar sub-paths.
+    const repoMetaCalls = fetchMock.mock.calls.filter(
+      (call) => typeof call[0] === "string" && /\/repos\/someowner\/some-lib$/.test(call[0]),
+    );
+    expect(repoMetaCalls).toHaveLength(1);
+  });
 });
 
 describe("scmHost", () => {

--- a/plugins/maven-mcp/src/tools/get-dependency-health.ts
+++ b/plugins/maven-mcp/src/tools/get-dependency-health.ts
@@ -58,11 +58,23 @@ export interface DependencyHealthResult {
   results: DependencyHealth[];
 }
 
-function scmHost(url: string): string {
-  const u = url.toLowerCase();
-  if (u.includes("github.com")) return "github";
-  if (u.includes("gitlab.com")) return "gitlab";
-  if (u.includes("bitbucket.org")) return "bitbucket";
+export function scmHost(url: string): string {
+  if (!url) return "other";
+  // scp-like SSH form: git@github.com:owner/repo.git — new URL() throws on these
+  const scpMatch = url.match(/^[^/@]+@([^:/]+):/);
+  let host: string;
+  if (scpMatch) {
+    host = scpMatch[1].toLowerCase();
+  } else {
+    try {
+      host = new URL(url).hostname.toLowerCase();
+    } catch {
+      return "other";
+    }
+  }
+  if (host === "github.com" || host.endsWith(".github.com")) return "github";
+  if (host === "gitlab.com" || host.endsWith(".gitlab.com")) return "gitlab";
+  if (host === "bitbucket.org" || host.endsWith(".bitbucket.org")) return "bitbucket";
   return "other";
 }
 

--- a/plugins/maven-mcp/src/tools/get-dependency-health.ts
+++ b/plugins/maven-mcp/src/tools/get-dependency-health.ts
@@ -6,7 +6,7 @@ import { buildPomUrl, extractGitHubRepo, extractScmUrl, extractLicenses } from "
 import type { GitHubRepo } from "../github/pom-scm.js";
 import { guessGitHubRepo } from "../github/guess-repo.js";
 import { GitHubClient } from "../github/github-client.js";
-import type { GitHubRelease } from "../github/github-client.js";
+import type { GitHubRelease, GitHubRepoMeta } from "../github/github-client.js";
 import { fetchWithRetry } from "../http/client.js";
 
 const MS_PER_DAY = 86_400_000;
@@ -17,8 +17,10 @@ export interface DependencyHealthInput {
 }
 
 export interface IssueHealth {
-  open: number;
-  closed: number;
+  /** null when the Search API call failed (rate-limited or network error). */
+  open: number | null;
+  /** null when the Search API call failed (rate-limited or network error). */
+  closed: number | null;
   closeRatio: number | null;
   medianDaysToClose: number | null;
 }
@@ -154,13 +156,18 @@ async function evaluateOne(
     return result;
   }
 
-  const targetVersion =
-    dep.version ??
-    findLatestVersion(versions, "PREFER_STABLE") ??
-    versions[versions.length - 1];
-  result.latestVersion = targetVersion;
-  result.stability = targetVersion ? classifyVersion(targetVersion) : undefined;
+  // latestVersion/stability always reflect the real latest available version,
+  // regardless of which specific version was requested — the tool contract says
+  // "latest version & stability" even when a specific version is being assessed.
+  const latestVersion =
+    findLatestVersion(versions, "PREFER_STABLE") ?? versions[versions.length - 1];
+  result.latestVersion = latestVersion;
+  result.stability = latestVersion ? classifyVersion(latestVersion) : undefined;
   result.versionCount = versions.length;
+
+  // For POM fetch and SCM extraction, use the requested version when given
+  // (so license/SCM reflects the version actually being evaluated).
+  const targetVersion = dep.version ?? latestVersion;
   if (!findLatestVersion(versions, "STABLE_ONLY")) result.signals.push("no stable release");
 
   // POM gives SCM URL, license, and (often) the GitHub repo.
@@ -177,9 +184,15 @@ async function evaluateOne(
   }
 
   // Fall back to guessing the GitHub repo from io.github.* / com.github.* groups.
+  // Use fetchRepo directly — if it returns metadata the repo exists; this avoids
+  // a redundant repoExists call followed by fetchRepo for the same endpoint.
+  let cachedRepoMeta: GitHubRepoMeta | null = null;
   if (!ghRepo) {
     const guess = guessGitHubRepo(groupId, artifactId);
-    if (guess && (await client.repoExists(guess.owner, guess.repo))) ghRepo = guess;
+    if (guess) {
+      cachedRepoMeta = await client.fetchRepo(guess.owner, guess.repo);
+      if (cachedRepoMeta) ghRepo = guess;
+    }
   }
 
   if (!ghRepo) {
@@ -196,7 +209,8 @@ async function evaluateOne(
   };
   if (!result.scm) result.scm = { url: result.repository.url, host: "github" };
 
-  const repoMeta = await client.fetchRepo(ghRepo.owner, ghRepo.repo);
+  // Reuse the repo metadata fetched during the guess-path existence check if available.
+  const repoMeta = cachedRepoMeta ?? (await client.fetchRepo(ghRepo.owner, ghRepo.repo));
   if (!repoMeta) {
     if (pomLicenses.length === 0) result.signals.push("no license declared");
     result.healthError = "GitHub repository metadata unavailable (rate limit or network)";
@@ -244,7 +258,7 @@ async function evaluateOne(
     result.signals.push(`no release in ${releaseMonths} months`);
   }
   if (!license) result.signals.push("no license declared");
-  if (issues && issues.closeRatio !== null && issues.closeRatio < 0.5 && issues.open >= 50) {
+  if (issues && issues.closeRatio !== null && issues.closeRatio < 0.5 && (issues.open ?? 0) >= 50) {
     result.signals.push("high open-issue backlog, low close ratio");
   }
   if (issues && issues.medianDaysToClose !== null && issues.medianDaysToClose >= 180) {
@@ -254,13 +268,39 @@ async function evaluateOne(
   return result;
 }
 
+/**
+ * Run `fn` over `items` with at most `limit` concurrent inflight calls.
+ * Result order matches input order.
+ */
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let next = 0;
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      const i = next++;
+      if (i >= items.length) return;
+      results[i] = await fn(items[i]);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}
+
+const HEALTH_CONCURRENCY = 5;
+
 export async function getDependencyHealthHandler(
   repos: MavenRepository[],
   input: DependencyHealthInput,
 ): Promise<DependencyHealthResult> {
   const client = new GitHubClient(process.env.GITHUB_TOKEN);
-  const results = await Promise.all(
-    input.dependencies.map((dep) => evaluateOne(repos, client, dep)),
+  const results = await mapWithConcurrency(
+    input.dependencies,
+    HEALTH_CONCURRENCY,
+    (dep) => evaluateOne(repos, client, dep),
   );
   return { results };
 }

--- a/plugins/maven-mcp/src/tools/get-dependency-health.ts
+++ b/plugins/maven-mcp/src/tools/get-dependency-health.ts
@@ -29,6 +29,8 @@ export interface GitHubHealth {
   openIssues: number;
   archived: boolean;
   ownerType: string;
+  ownerPublicRepos: number | null;
+  ownerAccountCreatedAt: string | null;
   lastCommit: string | null;
   lastRelease: string | null;
   releaseCount: number;
@@ -195,6 +197,10 @@ async function evaluateOne(
   ]);
   const { last, cadenceDays, count } = summarizeReleases(releases);
 
+  // Publisher scale/age — non-fatal enrichment, gathered last.
+  const ownerLogin = repoMeta.owner?.login ?? ghRepo.owner;
+  const owner = await client.fetchUser(ownerLogin);
+
   const spdx = repoMeta.license?.spdx_id;
   const license =
     spdx && spdx !== "NOASSERTION" ? spdx : (pomLicenses[0] ?? null);
@@ -205,6 +211,8 @@ async function evaluateOne(
     openIssues: repoMeta.open_issues_count ?? 0,
     archived: Boolean(repoMeta.archived),
     ownerType: repoMeta.owner?.type ?? "unknown",
+    ownerPublicRepos: owner?.public_repos ?? null,
+    ownerAccountCreatedAt: owner?.created_at ?? null,
     lastCommit: repoMeta.pushed_at ?? null,
     lastRelease: last,
     releaseCount: count,

--- a/plugins/maven-mcp/src/tools/get-dependency-health.ts
+++ b/plugins/maven-mcp/src/tools/get-dependency-health.ts
@@ -197,8 +197,15 @@ async function evaluateOne(
 
   if (!ghRepo) {
     if (pomLicenses.length === 0) result.signals.push("no license declared");
-    result.signals.push("no public GitHub repository found");
-    result.healthError = "GitHub repository not found; activity metrics unavailable";
+    if (result.scm && result.scm.host !== "github") {
+      // Source repo is public but hosted on a non-GitHub forge — GitHub metrics simply
+      // aren't available; this is not a transparency red flag.
+      result.signals.push(`SCM hosted on ${result.scm.host}; GitHub metrics unavailable`);
+    } else {
+      // No SCM information at all — genuinely unknown source provenance.
+      result.signals.push("no public GitHub repository found");
+      result.healthError = "GitHub repository not found; activity metrics unavailable";
+    }
     return result;
   }
 

--- a/plugins/maven-mcp/src/tools/get-dependency-health.ts
+++ b/plugins/maven-mcp/src/tools/get-dependency-health.ts
@@ -1,0 +1,246 @@
+import type { MavenRepository } from "../maven/repository.js";
+import { resolveAll } from "../maven/resolver.js";
+import { classifyVersion, findLatestVersion } from "../version/classify.js";
+import type { StabilityType } from "../version/types.js";
+import { buildPomUrl, extractGitHubRepo, extractScmUrl, extractLicenses } from "../github/pom-scm.js";
+import type { GitHubRepo } from "../github/pom-scm.js";
+import { guessGitHubRepo } from "../github/guess-repo.js";
+import { GitHubClient } from "../github/github-client.js";
+import type { GitHubRelease } from "../github/github-client.js";
+import { fetchWithRetry } from "../http/client.js";
+
+const MS_PER_DAY = 86_400_000;
+const MS_PER_MONTH = MS_PER_DAY * 30;
+
+export interface DependencyHealthInput {
+  dependencies: { groupId: string; artifactId: string; version?: string }[];
+}
+
+export interface IssueHealth {
+  open: number;
+  closed: number;
+  closeRatio: number | null;
+  medianDaysToClose: number | null;
+}
+
+export interface GitHubHealth {
+  stars: number;
+  forks: number;
+  openIssues: number;
+  archived: boolean;
+  ownerType: string;
+  lastCommit: string | null;
+  lastRelease: string | null;
+  releaseCount: number;
+  releaseCadenceDays: number | null;
+  license: string | null;
+  createdAt: string | null;
+  issues: IssueHealth | null;
+}
+
+export interface DependencyHealth {
+  groupId: string;
+  artifactId: string;
+  latestVersion?: string;
+  stability?: StabilityType;
+  versionCount: number;
+  lastPublishedToMaven?: string;
+  repository: { owner: string; repo: string; url: string } | null;
+  scm: { url: string; host: string } | null;
+  github: GitHubHealth | null;
+  signals: string[];
+  healthError?: string;
+}
+
+export interface DependencyHealthResult {
+  results: DependencyHealth[];
+}
+
+function scmHost(url: string): string {
+  const u = url.toLowerCase();
+  if (u.includes("github.com")) return "github";
+  if (u.includes("gitlab.com")) return "gitlab";
+  if (u.includes("bitbucket.org")) return "bitbucket";
+  return "other";
+}
+
+function monthsSince(iso: string | null): number | null {
+  if (!iso) return null;
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return null;
+  return Math.floor((Date.now() - t) / MS_PER_MONTH);
+}
+
+function summarizeReleases(releases: GitHubRelease[]): {
+  last: string | null;
+  cadenceDays: number | null;
+  count: number;
+} {
+  const times = releases
+    .filter((r) => !r.draft && !r.prerelease && r.published_at)
+    .map((r) => Date.parse(r.published_at!))
+    .filter((t) => !Number.isNaN(t))
+    .sort((a, b) => b - a); // newest first
+
+  if (times.length === 0) return { last: null, cadenceDays: null, count: 0 };
+  const last = new Date(times[0]).toISOString();
+  if (times.length < 2) return { last, cadenceDays: null, count: times.length };
+
+  const gaps: number[] = [];
+  for (let i = 0; i < times.length - 1; i++) gaps.push(times[i] - times[i + 1]);
+  gaps.sort((a, b) => a - b);
+  const mid = Math.floor(gaps.length / 2);
+  const medianMs = gaps.length % 2 ? gaps[mid] : (gaps[mid - 1] + gaps[mid]) / 2;
+  return { last, cadenceDays: Math.round(medianMs / MS_PER_DAY), count: times.length };
+}
+
+async function fetchPomXml(
+  repos: MavenRepository[],
+  groupId: string,
+  artifactId: string,
+  version: string,
+): Promise<string | null> {
+  for (const repo of repos) {
+    try {
+      const response = await fetchWithRetry(buildPomUrl(repo.url, groupId, artifactId, version), {
+        timeoutMs: 10_000,
+      });
+      if (!response.ok) continue;
+      return await response.text();
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+async function evaluateOne(
+  repos: MavenRepository[],
+  client: GitHubClient,
+  dep: { groupId: string; artifactId: string; version?: string },
+): Promise<DependencyHealth> {
+  const { groupId, artifactId } = dep;
+  const result: DependencyHealth = {
+    groupId,
+    artifactId,
+    versionCount: 0,
+    repository: null,
+    scm: null,
+    github: null,
+    signals: [],
+  };
+
+  let versions: string[];
+  try {
+    const metadata = await resolveAll(repos, groupId, artifactId);
+    versions = metadata.versions;
+    result.lastPublishedToMaven = metadata.lastUpdated;
+  } catch (e) {
+    result.healthError = String(e);
+    return result;
+  }
+
+  const targetVersion =
+    dep.version ??
+    findLatestVersion(versions, "PREFER_STABLE") ??
+    versions[versions.length - 1];
+  result.latestVersion = targetVersion;
+  result.stability = targetVersion ? classifyVersion(targetVersion) : undefined;
+  result.versionCount = versions.length;
+  if (!findLatestVersion(versions, "STABLE_ONLY")) result.signals.push("no stable release");
+
+  // POM gives SCM URL, license, and (often) the GitHub repo.
+  let ghRepo: GitHubRepo | null = null;
+  let pomLicenses: string[] = [];
+  if (targetVersion) {
+    const pomXml = await fetchPomXml(repos, groupId, artifactId, targetVersion);
+    if (pomXml) {
+      ghRepo = extractGitHubRepo(pomXml);
+      pomLicenses = extractLicenses(pomXml);
+      const scmUrl = extractScmUrl(pomXml);
+      if (scmUrl) result.scm = { url: scmUrl, host: scmHost(scmUrl) };
+    }
+  }
+
+  // Fall back to guessing the GitHub repo from io.github.* / com.github.* groups.
+  if (!ghRepo) {
+    const guess = guessGitHubRepo(groupId, artifactId);
+    if (guess && (await client.repoExists(guess.owner, guess.repo))) ghRepo = guess;
+  }
+
+  if (!ghRepo) {
+    if (pomLicenses.length === 0) result.signals.push("no license declared");
+    result.signals.push("no public GitHub repository found");
+    result.healthError = "GitHub repository not found; activity metrics unavailable";
+    return result;
+  }
+
+  result.repository = {
+    owner: ghRepo.owner,
+    repo: ghRepo.repo,
+    url: `https://github.com/${ghRepo.owner}/${ghRepo.repo}`,
+  };
+  if (!result.scm) result.scm = { url: result.repository.url, host: "github" };
+
+  const repoMeta = await client.fetchRepo(ghRepo.owner, ghRepo.repo);
+  if (!repoMeta) {
+    if (pomLicenses.length === 0) result.signals.push("no license declared");
+    result.healthError = "GitHub repository metadata unavailable (rate limit or network)";
+    return result;
+  }
+
+  const [releases, issues] = await Promise.all([
+    client.fetchReleases(ghRepo.owner, ghRepo.repo),
+    client.fetchIssueStats(ghRepo.owner, ghRepo.repo),
+  ]);
+  const { last, cadenceDays, count } = summarizeReleases(releases);
+
+  const spdx = repoMeta.license?.spdx_id;
+  const license =
+    spdx && spdx !== "NOASSERTION" ? spdx : (pomLicenses[0] ?? null);
+
+  result.github = {
+    stars: repoMeta.stargazers_count ?? 0,
+    forks: repoMeta.forks_count ?? 0,
+    openIssues: repoMeta.open_issues_count ?? 0,
+    archived: Boolean(repoMeta.archived),
+    ownerType: repoMeta.owner?.type ?? "unknown",
+    lastCommit: repoMeta.pushed_at ?? null,
+    lastRelease: last,
+    releaseCount: count,
+    releaseCadenceDays: cadenceDays,
+    license,
+    createdAt: repoMeta.created_at ?? null,
+    issues,
+  };
+
+  if (result.github.archived) result.signals.push("repository archived");
+  const commitMonths = monthsSince(result.github.lastCommit);
+  if (commitMonths !== null && commitMonths >= 12) {
+    result.signals.push(`no commits in ${commitMonths} months`);
+  }
+  const releaseMonths = monthsSince(result.github.lastRelease);
+  if (releaseMonths !== null && releaseMonths >= 18) {
+    result.signals.push(`no release in ${releaseMonths} months`);
+  }
+  if (!license) result.signals.push("no license declared");
+  if (issues && issues.closeRatio !== null && issues.closeRatio < 0.5 && issues.open >= 50) {
+    result.signals.push("high open-issue backlog, low close ratio");
+  }
+  if (issues && issues.medianDaysToClose !== null && issues.medianDaysToClose >= 180) {
+    result.signals.push(`slow issue response (median ${issues.medianDaysToClose} days to close)`);
+  }
+
+  return result;
+}
+
+export async function getDependencyHealthHandler(
+  repos: MavenRepository[],
+  input: DependencyHealthInput,
+): Promise<DependencyHealthResult> {
+  const client = new GitHubClient(process.env.GITHUB_TOKEN);
+  const results = await Promise.all(
+    input.dependencies.map((dep) => evaluateOne(repos, client, dep)),
+  );
+  return { results };
+}


### PR DESCRIPTION
## Summary

Adds an end-to-end "is this dependency worth adopting?" capability so a new library is vetted (maintenance, activity, reputation, adoption, publisher, license, CVEs) **before** it lands in a build file. Three layers:

- **maven-mcp — new `get_dependency_health` tool.** Returns raw, deterministic signals: latest version + stability, GitHub activity (stars, last commit, release cadence), issue dynamics (open/closed counts, close ratio, median time-to-close), license, owner type, archived status. Adds `GitHubClient.fetchRepo` / `fetchIssueStats` and POM `extractScmUrl` / `extractLicenses` (regex-based, honouring the no-XML-parser rule). The tool does **not** judge — it feeds a verdict. Degrades to `github: null` + `healthError` when there is no public GitHub repo (closed source / non-GitHub forge) or on rate-limit.
- **developer-workflow-experts — new `dependency-evaluator` agent.** Weighs maintenance, activity (incl. issue dynamics), reputation & web sentiment, adoption, publisher/maintainer reputation, transparency, security, license, maturity, and fit into a verdict: **ADOPT / ADOPT WITH CAUTION / AVOID**, with a signal table, severity-tagged risks, and alternatives.
- **developer-workflow — new `/evaluate-dependency` skill.** Fires before a new dependency is added: identifies the candidate, gathers signals (via a Maven dependency-intelligence tool when available, web otherwise — no hardcoded MCP tool name, runs degraded without MCP), delegates to `dependency-evaluator`, and brings the adopt/avoid decision back to the user via `AskUserQuestion`.

Docs updated across both READMEs and CLAUDE.md files; experts roster 9 → 10, core skills 11 → 12.

## Design notes

- **Scriptable vs judged:** the GitHub/Maven signal collection is pure TypeScript (unit-tested, no LLM); the subjective verdict is the agent's job.
- **JVM/Maven focus:** deepest signal path goes through maven-mcp; other ecosystems degrade to web evidence.
- **Closed source / no public repo** is surfaced as an explicit transparency risk, not an automatic AVOID.

## Test plan

- [x] `npm run build` (maven-mcp) — clean
- [x] `npm run lint` (maven-mcp) — clean
- [x] `npm run test` (maven-mcp) — 387 passing, incl. 4 new `get-dependency-health` cases (healthy / archived-stale / no-GitHub-repo / rate-limited)
- [x] `bash scripts/validate.sh` — all checks pass (new skill 862ch frontmatter, new agent frontmatter OK)
- [ ] Manual MCP run of `get_dependency_health` against a live and an archived library
- [ ] End-to-end: `/evaluate-dependency` triggers, gathers signals, agent returns verdict, `AskUserQuestion` offers next step
- [ ] `plugin-dev:plugin-validator` on `developer-workflow` and `developer-workflow-experts` (release-time gate)

> Note: unified version bump across all 8 locations is a release-time step (see CLAUDE.md → Publishing), intentionally not part of this feature branch.

https://claude.ai/code/session_0133auFX9dxKTeYJQBENs7Ys

---
_Generated by [Claude Code](https://claude.ai/code/session_0133auFX9dxKTeYJQBENs7Ys)_