### PR TITLE
Allow model to auto-invoke the acceptance skill

### DIFF
--- a/plugins/developer-workflow/skills/acceptance/SKILL.md
+++ b/plugins/developer-workflow/skills/acceptance/SKILL.md
@@ -7,7 +7,6 @@ description: >
   "QA the implementation", "run the test plan", "validate acceptance criteria",
   "verify the PR", "verify the fix", "confirm bug is gone", "acceptance",
   "verify this", "test this".
-disable-model-invocation: true
 ---
 
 # Acceptance


### PR DESCRIPTION
## Summary
- Removed `disable-model-invocation: true` from the `acceptance` skill frontmatter (`plugins/developer-workflow/skills/acceptance/SKILL.md`) so Claude can trigger it automatically from natural-language requests like "verify against spec" / "QA the implementation".
- The skill's `description` already carries auto-invoke trigger phrases; the flag was the only thing blocking model-driven discovery.
- Aligns acceptance with the rest of the developer-workflow skills, which are auto-discoverable (same convention adopted for `multiexpert-review`).

## Test plan
- [x] `bash scripts/validate.sh` passes (acceptance frontmatter validated, 436ch)
- [ ] Confirm Claude auto-invokes `/acceptance` on a verification request without an explicit slash command

https://claude.ai/code/session_01KCDGGtZo2MaMPEEjhj8N1o

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCDGGtZo2MaMPEEjhj8N1o)_