### PR TITLE
docs(developer-workflow): clarify research / plan-mode / write-spec boundary

### DIFF
--- a/plugins/developer-workflow/CLAUDE.md
+++ b/plugins/developer-workflow/CLAUDE.md
@@ -61,9 +61,8 @@ investigation first) but answer different questions. Pick by the question, not t
 | **`research`** | "What are the options / is this feasible / which approach?" — needs ≥2 of codebase·web·docs·dependencies·architecture | Durable comparative report in `swarm-report/research/` |
 | **`/write-spec`** | "Specify this *already-decided* feature as an implementation contract" — interview-heavy | Permanent spec in `docs/specs/` |
 
-`research` deliberately yields to plan mode for codebase-only topics: its min-2-tracks rule
-redirects a single-track investigation to a plain Explore agent instead of running the
-consortium. `research` and `write-spec` each run a parallel expert consortium; their
+`research` deliberately steps aside for codebase-only topics: its min-2-tracks rule redirects
+a single-track investigation to a plain inline Explore agent instead of running the consortium. `research` and `write-spec` each run a parallel expert consortium; their
 Codebase / Architecture / Web prompt templates overlap **intentionally** (write-spec's are an
 enriched superset) and are kept as separate per-skill files on purpose — do not collapse them
 into a shared file (same "duplicate + note" idiom as the `acceptance` ↔ `multiexpert-review`

--- a/plugins/developer-workflow/CLAUDE.md
+++ b/plugins/developer-workflow/CLAUDE.md
@@ -50,4 +50,23 @@ Skills in this plugin delegate to engineer agents (kotlin-engineer / compose-dev
 - QA: `generate-test-plan`, `acceptance`
 - PR: `create-pr`, `drive-to-merge`
 
+### Planning: which tool to reach for
+
+`research`, `/write-spec`, and built-in **plan mode** look similar (all do read-only
+investigation first) but answer different questions. Pick by the question, not the surface:
+
+| Reach for | When the question is | Output |
+|---|---|---|
+| **plan mode** (built-in) | "How do I build this *already-decided* change?" — investigation stays inside the codebase | Ephemeral plan, then implement |
+| **`research`** | "What are the options / is this feasible / which approach?" — needs ≥2 of codebase·web·docs·dependencies·architecture | Durable comparative report in `swarm-report/research/` |
+| **`/write-spec`** | "Specify this *already-decided* feature as an implementation contract" — interview-heavy | Permanent spec in `docs/specs/` |
+
+`research` deliberately yields to plan mode for codebase-only topics: its min-2-tracks rule
+redirects a single-track investigation to a plain Explore agent instead of running the
+consortium. `research` and `write-spec` each run a parallel expert consortium; their
+Codebase / Architecture / Web prompt templates overlap **intentionally** (write-spec's are an
+enriched superset) and are kept as separate per-skill files on purpose — do not collapse them
+into a shared file (same "duplicate + note" idiom as the `acceptance` ↔ `multiexpert-review`
+PoLL protocol).
+
 Exploratory QA without a spec → call the `manual-tester` agent directly via the Task tool (formerly `bug-hunt` skill — removed in v0.15.0; heuristics live in `agents/manual-tester.md` § Step 4b).

--- a/plugins/developer-workflow/README.md
+++ b/plugins/developer-workflow/README.md
@@ -41,7 +41,7 @@ change?"* (codebase-only, ephemeral plan). Use **`/research`** for *"what are th
 this feasible / which approach?"* when the answer needs more than the codebase (web, docs,
 dependencies, architecture) — it produces a durable comparative report. Use **`/write-spec`**
 to turn an already-decided feature into a permanent implementation contract under `docs/specs/`.
-For a codebase-only topic `/research` steps aside and hands off to plan mode automatically.
+For a codebase-only topic `/research` steps aside and delegates to a single inline `Explore` agent instead of running the consortium.
 
 ### Implementation
 | Skill | Purpose |

--- a/plugins/developer-workflow/README.md
+++ b/plugins/developer-workflow/README.md
@@ -34,6 +34,14 @@ Skills are independent on-demand tools — invoke them when the task calls for t
 | `/reverse-spec` | Reverse-engineer an existing feature from code into a tech-agnostic spec |
 | `/multiexpert-review` | Panel of LLM evaluators (PoLL) review of a plan, spec, or test-plan via the appropriate profile |
 
+`/research`, `/write-spec`, and built-in **plan mode** all investigate before acting, but
+answer different questions. Use **plan mode** for *"how do I build this already-decided
+change?"* (codebase-only, ephemeral plan). Use **`/research`** for *"what are the options / is
+this feasible / which approach?"* when the answer needs more than the codebase (web, docs,
+dependencies, architecture) — it produces a durable comparative report. Use **`/write-spec`**
+to turn an already-decided feature into a permanent implementation contract under `docs/specs/`.
+For a codebase-only topic `/research` steps aside and hands off to plan mode automatically.
+
 ### Implementation
 | Skill | Purpose |
 |---|---|

--- a/plugins/developer-workflow/skills/research/references/expert-prompts.md
+++ b/plugins/developer-workflow/skills/research/references/expert-prompts.md
@@ -2,6 +2,12 @@
 
 Use these prompts verbatim when launching each expert agent in Phase 2. Each agent runs independently — never share one agent's findings with another.
 
+> **Intentional overlap with the `write-spec` skill.** The Codebase / Architecture / Web
+> prompts here overlap with `../../write-spec/references/research-prompts.md`, where they
+> appear as an enriched superset. This skill instead splits Docs and Dependencies into their
+> own dedicated tracks (below). The two files are kept separate **on purpose** so each skill
+> stays self-contained — do not merge them into a shared file.
+
 All prompts must include this line: *"Respond in the same language as the research topic description."*
 
 ---

--- a/plugins/developer-workflow/skills/write-spec/references/research-prompts.md
+++ b/plugins/developer-workflow/skills/write-spec/references/research-prompts.md
@@ -1,5 +1,13 @@
 Referenced from: `plugins/developer-workflow/skills/write-spec/SKILL.md` (§Phase 1.1 Launch research consortium).
 
+> **Intentional overlap with the `research` skill.** The Codebase / Architecture / Web prompts
+> below are an enriched **superset** of the ones in
+> `../../research/references/expert-prompts.md` (here they add integration-points and
+> test-infra, plus the spec-only Business Analyst / Critical Evaluation / Dependency Chain
+> tracks). The two files are kept separate **on purpose** — each skill stays self-contained
+> per the toolbox model — so do not collapse them into one shared file. This mirrors the
+> `acceptance` ↔ `multiexpert-review` "same protocol, duplicated with a note" idiom.
+
 # Research-Agent Prompt Templates
 
 ## Codebase Expert (Explore subagent) — always include


### PR DESCRIPTION
## Context

Question raised: now that Claude Code ships **plan mode**, is the `research` skill still worth keeping, does it overlap `write-spec`, and could its instructions just move into `CLAUDE.md`?

A full overlap audit (`research` ↔ plan mode ↔ `write-spec`) concluded: **keep both skills, merge/delete nothing, do not move to `CLAUDE.md`.** The real (small, intentional) overlap is three near-identical consortium prompts shared by `research` and `write-spec`. The skills otherwise diverge on purpose, and the repo already uses a "duplicate + note" idiom for this exact situation (`acceptance` ↔ `multiexpert-review` PoLL protocol). So the only actionable gap was the *absence of a documented boundary* and the *risk that the deliberate prompt duplication gets "fixed" into drift*.

## Summary

- Add a `research` vs **plan mode** vs `/write-spec` decision matrix to `plugins/developer-workflow/CLAUDE.md` (canonical, guides skill selection) and a human-facing mirror in `README.md`.
- Mark the overlapping Codebase / Architecture / Web consortium prompts as **intentional duplication** in both reference files, with reciprocal pointers and a "do not collapse into a shared file" note.

Docs-only, non-functional change: no skill behavior changes, no version bump, evals untouched.

## Why no merge / no extract-to-shared

- `research` answers *"what / whether / which option"* via multi-source investigation → durable comparative report; `write-spec` specifies an *already-decided* feature → permanent spec; **plan mode** plans *how* to build a decided change (codebase-only). Different stages.
- `research`'s min-2-tracks rule already redirects codebase-only topics to a plain Explore agent — it deliberately yields to plan mode.
- Extracting a shared prompt file would add cross-skill coupling against the documented "skills are independent" toolbox principle, for a ~45-line gain.

## Test plan

- [x] `bash scripts/validate.sh` — green
- [x] Relative reference paths between the two prompt files resolve correctly
- [ ] (optional, per release checklist) run `plugin-dev:plugin-validator` on `developer-workflow` — expect PASS / Minor only

https://claude.ai/code/session_013dtQyKUbLP6SJ4B2wKkzmB

---
_Generated by [Claude Code](https://claude.ai/code/session_013dtQyKUbLP6SJ4B2wKkzmB)_