### PR TITLE
Add issue-manager skill: GitHub backlog supervisor (Phase 1)

### DIFF
--- a/docs/specs/2026-05-27-issue-manager.md
+++ b/docs/specs/2026-05-27-issue-manager.md
@@ -68,7 +68,7 @@ Phase 1 (эта спека): общее ядро + единственный exec
       write-операции `scripts/gh/` идемпотентны (read-before-write или upsert-by-marker), не только
       переход статуса — `add_comment`/`link_pr` на resume не дублируют коммент/связь.
 - [ ] **AC-6** — Задача, провалившая свой флоу (completion signal `failed`/`blocked`), НЕ доходит
-      до PR: помечается на доске состоянием **blocked** (label `blocked`, и при наличии Project v2 —
+      до PR: помечается на доске состоянием **blocked** (label `status:blocked`, и при наличии Project v2 —
       соответствующий status-option), не имеет связанного PR, и зависящие от неё issues НЕ
       переводятся в In-Progress и не диспетчатся. Блокировка распространяется на всю downstream-ветку
       DAG от заблокированного узла (транзитивно зависящие тоже не диспетчатся). Blocked-список
@@ -216,7 +216,7 @@ adapter-скрипта (gh недоступен/нет прав) → стоп с
 | Граница прогона | До открытого PR | Внутри автономного прогона нет места человеческим гейтам; merge — необратим, оставлен человеку |
 | Точка останова PR | Ready-for-review (не draft) | Память `feedback_pr_ready_immediately`: в batch-обработке issues PR открывается сразу ready; более специфичное правило, чем generic draft→promote; merge всё равно остаётся человеческим гейтом (AC-9) |
 | Гейт менеджера | Один — Phase0 (план+DAG→одобрение) | Порядок решается раз; повторное одобрение на каждой задаче = confirmation-spam; внутреннее качество гарантируют finalize/acceptance |
-| Модель статуса доски | detect Project v2 status field → fallback open/closed + label-конвенция (`status:in-progress`, `blocked`) | Не у всех репо есть Project v2; нужен носитель для In-Progress/blocked (AC-3/AC-6) |
+| Модель статуса доски | detect Project v2 status field → fallback open/closed + label-конвенция (`status:in-progress`, `status:blocked`) | Не у всех репо есть Project v2; нужен носитель для In-Progress/blocked (AC-3/AC-6) |
 | DAG на GitHub | Эвристический (sub-issues + parse «blocked by») + ручное подтверждение в Phase0 | У GitHub нет типизированных blocks/blocked-by; эвристика ненадёжна → человек подтверждает |
 | Per-task флоу | Адаптивная глубина: implement→check→finalize→acceptance→create-pr обязательны; research/spec по необходимости | Пользователь кладёт исчерпывающую инфу в issue → research/spec нужны не всем; finalize/acceptance — обязательные quality/acceptance гейты |
 | Трекеры | Только GitHub | Явный фокус, не распыляться; другие — Future за тем же контрактом |

--- a/docs/specs/2026-05-27-issue-manager.md
+++ b/docs/specs/2026-05-27-issue-manager.md
@@ -1,0 +1,253 @@
+---
+type: spec
+slug: issue-manager
+date: 2026-05-27
+status: approved
+platform: [generic]
+surfaces: [cli]
+risk_areas: []
+non_functional:
+  sla:
+  a11y:
+acceptance_criteria_ids: [AC-1, AC-2, AC-3, AC-4, AC-5, AC-6, AC-7, AC-8, AC-9, AC-10]
+design:
+  figma:
+  design_system:
+---
+
+# Spec: issue-manager — менеджер бэклога GitHub issues
+
+Date: 2026-05-27
+Status: approved
+Slug: issue-manager
+Plugin owner: `developer-workflow` (рядом с оркестраторными skills и manual-tester)
+
+---
+
+## Context and Motivation
+
+Сейчас работа над набором задач из трекера ведётся вручную: разработчик сам читает issues,
+прикидывает зависимости и порядок, по одной прогоняет их через стандартный dev-workflow и руками
+двигает статусы на доске. Нужен skill-оркестратор, которому даёшь scope (ссылку на issue, эпик,
+список или «разбери всё открытое»), а он разбирает бэклог, строит порядок с учётом зависимостей,
+предлагает план, после одобрения последовательно прогоняет каждую готовую задачу через полный
+стандартный флоу (делегируя тяжёлую работу), ведёт статусы issue и доводит каждую до открытого PR.
+Менеджер — это **supervisor**: он сам не пишет код и не запускает проверки, а оркеструет, читает
+факты завершения и ведёт доску.
+
+Phase 1 (эта спека): общее ядро + единственный execution-backend **A (single-session)** на
+**GitHub**. Backend B (Agent Teams), другие трекеры, эпики и параллелизм — в Future Phases.
+
+Полное исследование с проверкой механизмов против Claude Code docs:
+`swarm-report/research/research-issue-orchestrator.md`.
+
+## Acceptance Criteria
+
+Фича готова, когда ВСЕ пункты истинны.
+
+- [ ] **AC-1** — Получив scope (URL issue / список номеров / «все открытые» / ссылку на эпик),
+      skill возвращает JSON со списком открытых GitHub issues, их статусом и обнаруженными
+      зависимостями, полученный **исключительно через `scripts/gh/`** (проверка: ни одного
+      ad-hoc `gh`/GraphQL-вызова в теле прогона; см. AC-8).
+- [ ] **AC-2** — Skill строит DAG из GitHub sub-issues и распарсенных «blocked by #N» в
+      теле/комментариях и детектит циклы. **При обнаружении цикла** skill предъявляет участников
+      цикла и блокирует одобрение Phase0 до ручного разрешения. Иначе предъявляет предлагаемый
+      порядок; пользователь может вернуть переупорядоченный список номеров ДО одобрения (гейт Phase0).
+- [ ] **AC-3** — После одобрения Phase0 skill обрабатывает готовые issues **последовательно**: для
+      каждой переводит её в In-Progress на доске, прогоняет per-task флоу до **открытого PR**,
+      связанного с issue, и НЕ мёржит. Обязательный минимум флоу: `implement` (делегируется) →
+      `/check` → `/finalize` → `/acceptance` → `/create-pr`. `/research` и `/write-spec`
+      запускаются опционально — только когда issue не содержит достаточной информации для прямой
+      реализации (адаптивная глубина).
+- [ ] **AC-4** — Skill сам НЕ редактирует исходный код проекта и НЕ запускает проверки/тесты — вся
+      работа с кодом делегируется субагентам/скиллам; менеджер читает только **completion signal**
+      (см. AC-10) и факты трекера (PR открыт/смержен) для продвижения доски.
+- [ ] **AC-5** — Переходы статусов идемпотентны: повторный запуск skill на том же бэклоге читает
+      текущее состояние GitHub и не применяет переход дважды (не переоткрывает/не перезакрывает
+      уже корректную issue; `transition_status` пишет только при `current != target`). Все
+      write-операции `scripts/gh/` идемпотентны (read-before-write или upsert-by-marker), не только
+      переход статуса — `add_comment`/`link_pr` на resume не дублируют коммент/связь.
+- [ ] **AC-6** — Задача, провалившая свой флоу (completion signal `failed`/`blocked`), НЕ доходит
+      до PR: помечается на доске состоянием **blocked** (label `blocked`, и при наличии Project v2 —
+      соответствующий status-option), не имеет связанного PR, и зависящие от неё issues НЕ
+      переводятся в In-Progress и не диспетчатся. Блокировка распространяется на всю downstream-ветку
+      DAG от заблокированного узла (транзитивно зависящие тоже не диспетчатся). Blocked-список
+      всплывает в сводке батча.
+- [ ] **AC-7** — Skill переживает компакцию контекста: при возобновлении перечитывает свой
+      state-файл, re-fetch'ит ground-truth доски GitHub и продолжает с первой незавершённой задачи,
+      не переделывая завершённые (derived-маркеры верифицируются против трекера; конфликт → трекер).
+- [ ] **AC-8** — Все операции с GitHub идут исключительно через бандлированные скрипты в
+      `scripts/gh/` (тело skill не выдаёт ad-hoc `gh`/GraphQL-команд); скрипты возвращают
+      структурированный JSON. Перед ANALYZE skill прогоняет prerequisite-проверки (см. Prerequisites)
+      и при провале останавливается с понятным сообщением (fail-fast), без частичных записей.
+- [ ] **AC-9** — Merge и promotion PR остаются человеческими гейтами в части merge: skill
+      останавливается на открытом PR и **не мёржит** без явного действия пользователя. PR
+      открывается сразу как **ready-for-review** (см. Decisions).
+- [ ] **AC-10** — `references/exec-contract.md` определяет **completion-signal** схему и интерфейс
+      execution-backend; Backend A ему соответствует. Проверка: файл существует и содержит JSON-схему
+      `{status: done|failed|blocked, pr_url?, failed_gate?, blocked_reason?}` + сигнатуру вызова
+      backend'а (вход: task id + scope + допустимая глубина флоу; выход: completion signal); ядро
+      вызывает backend только через эту форму, не зная конкретный backend.
+
+**Authoritative definition of done.** Имплементирующий агент валидирует против этого списка перед
+тем, как пометить любую задачу завершённой.
+
+## Prerequisites
+
+Каждое предусловие skill проверяет на старте ANALYZE (fail-fast, AC-8).
+
+| Prerequisite | Status | Owner | Exit-criterion (как проверяется) |
+|--------------|--------|-------|----------------------------------|
+| `gh` CLI установлен и аутентифицирован (scope `repo`; при Projects — `project`) | ⬜ Todo | Human | `gh auth status` завершается с кодом 0 |
+| Целевой GitHub-репозиторий с открытыми issues | ⬜ Todo | Human | `gh issue list -R <repo> --state open --json number` возвращает валидный JSON |
+| (Опционально) GitHub Project v2 для статус-колонок | ⬜ Todo | Human | `gh project list --owner <owner>` содержит целевой проект; иначе fallback на open/closed + labels |
+
+## Affected Modules and Files
+
+| Module / File | Change type | Notes |
+|---------------|-------------|-------|
+| `plugins/developer-workflow/skills/issue-manager/SKILL.md` | New | Стабильный контракт оркестрации: ANALYZE → Phase0 → EXECUTE(A) → RECONCILE |
+| `plugins/developer-workflow/skills/issue-manager/scripts/gh/fetch_issue.sh` | New | Один issue по ref → JSON |
+| `plugins/developer-workflow/skills/issue-manager/scripts/gh/list_issues.sh` | New | Список по фильтру → JSON |
+| `plugins/developer-workflow/skills/issue-manager/scripts/gh/get_dependencies.sh` | New | sub-issues + parse «blocked by #N» → JSON-рёбра |
+| `plugins/developer-workflow/skills/issue-manager/scripts/gh/transition_status.sh` | New | Идемпотентный переход (read-before-write); open/closed + Project v2 GraphQL field/option id |
+| `plugins/developer-workflow/skills/issue-manager/scripts/gh/link_pr.sh` | New | Связать PR с issue |
+| `plugins/developer-workflow/skills/issue-manager/scripts/gh/add_comment.sh` | New | Коммент к issue |
+| `plugins/developer-workflow/skills/issue-manager/scripts/gh/get_completion_signal.sh` | New | Факт завершения: смержен ли связанный PR / открыт ли → JSON |
+| `plugins/developer-workflow/skills/issue-manager/references/adapter-contract.md` | New | Контракт tracker-adapter (abstract actions, JSON-схемы) + **adapter-resolver** (action → скрипт) |
+| `plugins/developer-workflow/skills/issue-manager/references/exec-contract.md` | New | Интерфейс execution-backend + **completion-signal** схема (см. AC-10) |
+| `plugins/developer-workflow/skills/issue-manager/references/exec-single.md` | New | Backend A: per-task флоу, offload в субагентов, реализация exec-contract |
+| `plugins/developer-workflow/skills/issue-manager/references/phase0.md` | New | DAG, детект циклов, формат правки порядка, scope-cap, гейт одобрения |
+| `plugins/developer-workflow/skills/issue-manager/references/reconcile.md` | New | Reconcile-проход, idempotent transition, схема state-файла, compaction-resume |
+| `plugins/developer-workflow/CLAUDE.md` | Modified | Добавить issue-manager в roster скиллов (счётчик +1) и в раздел планирования |
+| `plugins/developer-workflow/.claude-plugin/plugin.json` | Modified (опц.) | Обновить `description`, если он перечисляет roster skills (skills auto-discovery — регистрация не требуется) |
+
+Key integration points:
+- Reuse существующих скиллов того же plugin-семейства per task: `/research`, `/write-spec` (по
+  необходимости), `/finalize`, `/acceptance`, `/create-pr` — вызываются из main-session.
+- Engineer-субагенты (`kotlin-engineer`/`compose-developer`/…) и Explore — куда уходит тяжёлая
+  skill-free работа.
+- Структурный прецедент: `skills/drive-to-merge/` (state-machine loop, references-pattern,
+  ScheduleWakeup, always-ask merge gate).
+
+## Technical Approach
+
+**Структура.** Один skill = стабильное ядро (SKILL.md) + волатильные процедуры в `references/`.
+Ядро: ANALYZE (разбор бэклога, DAG, readiness) → Phase0 (предъявить порядок, одобрение) →
+EXECUTE (Backend A) → RECONCILE (продвижение доски). Главное ядро держит **только** оркестрацию и
+state; каждый per-task флоу offload-ится в субагентов/скиллы (снимает кажущееся напряжение с
+правилом оркестрации «main-session не держит длинные процессы» — тяжёлое уходит за границу контекста).
+
+**Execution-backend контракт (AC-10).** `references/exec-contract.md` определяет интерфейс между
+ядром и исполнителем, чтобы Phase 2 (Backend B) реализовал тот же контракт без правок ядра:
+- **Вход:** `task_id`, `scope` (issue ref + контекст), `allowed_depth` (адаптивная глубина флоу).
+- **Выход (completion signal, JSON):** `{ "status": "done|failed|blocked", "pr_url": "<url|null>",
+  "failed_gate": "<string|null>", "blocked_reason": "<string|null>" }`. `failed_gate` —
+  **backend-определяемая свободная строка**; набор значений задаёт конкретный backend
+  (для Backend A рекомендованный словарь — `check|finalize|acceptance|create-pr`). Ядро не
+  интерпретирует это значение как enum — иначе Backend B пришлось бы расширять «контракт» (= правка
+  ядра), что нарушило бы инвариант AC-10.
+- **Инвариант:** ядро вызывает backend только через эту форму, не зная, какой backend исполняет.
+`exec-single.md` — реализация Backend A; `exec-team.md` (Future) — Backend B.
+
+**Backend A (single-session).** Менеджер в main-session последовательно, по одной готовой задаче:
+переводит issue в In-Progress → прогоняет per-task флоу (AC-3) до открытого PR, максимально сгружая
+контекстно-тяжёлую работу в субагентов → формирует completion signal → продвигает доску → берёт
+следующую. Останов на открытом PR (merge исключён).
+
+**Tracker-adapter = бандлированные скрипты + resolver.** Ядро ссылается на **abstract actions**
+(`list_issues`, `transition_status`, …); `adapter-contract.md` задаёт **adapter-resolver** — маппинг
+action → конкретный скрипт (через переменную пути / dispatch-таблицу). Resolver-lookup живёт в
+`adapter-contract.md` (или env/конфиге), **не в SKILL.md**: ядро ссылается только на abstract
+action и не знает имён конкретных скриптов, так что Phase 3 добавит `scripts/gitlab/` без правок
+SKILL.md. Каждый скрипт детерминирован, отдаёт JSON, и инкапсулирует
+квирки GitHub: глобальный issue id для sub-issues, GraphQL `field_id`/`option_id` для статусов
+Projects v2, парсинг «blocked by #N». Тело skill не строит `gh`/GraphQL на лету и не содержит
+`if tracker == github`.
+
+**Состояние и идемпотентность.** Трекер (GitHub) — единственный source of truth для lifecycle-статуса:
+`transition_status` читает текущий статус и пишет только при `current != target`. Orchestration-state
+— в `swarm-report/issue-manager-<batch>-state.md`, где `<batch>` = слаг из scope (имя эпика / хэш
+списка номеров / `all-open-<YYYYMMDD-HHMM>`). **Схема state-файла** (в `reconcile.md`): на issue —
+`number`, derived-`phase` (analyzed/in-progress/pr-open/done/blocked), `pr_url`, `last_verified_at`.
+Никаких полей, которые нельзя пересчитать из трекера+gh. Phase-маркеры derived: на resume
+верифицируются против ground-truth (PR по URL существует? статус issue совпал?), конфликт → доверять
+трекеру и переписывать файл.
+
+**Phase0-протокол.** Skill предъявляет: список готовых issue, DAG, предлагаемый порядок. Пользователь
+правит, возвращая переупорядоченный список номеров (или подтверждает). Для scope «все открытые» —
+**cap** на размер батча (дефолтное значение фиксируется и настраивается в `phase0.md`; сверх cap —
+предупреждение и запрос сузить scope), т.к. большой бэклог упирается в потолок контекста Backend A.
+
+**Compaction-resilience.** На возобновлении первым действием — re-read state-файла + re-fetch доски;
+продолжение с первой незавершённой задачи. Это governing-ограничение Backend A (потолок контекста
+main-session при N задачах).
+
+**Обработка ошибок.** Сбой per-task флоу → completion signal `failed`/`blocked` → issue получает
+состояние blocked (label + опц. Project v2 option), остаётся не-Done, зависящие issues не диспетчатся,
+батч продолжает остальные независимые ветки и поднимает blocked-список пользователю. Сбой
+adapter-скрипта (gh недоступен/нет прав) → стоп с понятным сообщением, без частичных записей.
+
+## Technical Constraints
+
+- Весь контент skill — на **английском** (PLUGIN-STANDARDS: shipped extension content). Эта спека в
+  `docs/` — исключение (maintainer-facing).
+- Менеджер **НЕ** делает Edit/Write по project-source и не запускает проверки — всё делегируется
+  (несущий инвариант, зафиксировать в SKILL.md как Non-negotiable).
+- GitHub-операции — только через бандлированные скрипты; никаких ad-hoc `gh`/GraphQL в теле skill;
+  никаких `if tracker == github` в ядре (ветвление — забота adapter-resolver'а).
+- `disable-model-invocation: true` — запуск только явной командой (операция тяжёлая, побочные
+  эффекты в трекере).
+- Реюз существующих скиллов семейства, без дублирования их логики; если нужен форк поведения —
+  extension-point в ядре, не копия.
+- Новые внешние зависимости не добавлять (только `gh`, уже используемый в create-pr/drive-to-merge).
+
+## Decisions Made
+
+Выбор зафиксирован; имплементирующий агент его не пересматривает.
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Роль менеджера | Supervisor (не executor) | Не дублирует pipeline; единственная безопасная топология (flat-сети агентов амплифицируют ошибки ~17×) |
+| Форм-фактор | Skill в main-session | Только main-session вызывает skills; subagent скиллы не вызывает и не спавнит (verified, issue #38719) |
+| Execution-механизм | Backend A: всё в одной сессии, offload в субагентов | Пользовательское требование; `claude -p`/SDK отклонены (отдельные лимиты, отдельный процесс) |
+| Source of truth | Трекер (GitHub) | Идемпотентность через read-before-write; тяжёлый resumable state-файл не нужен |
+| GitHub-операции | Бандлированные скрипты с JSON + adapter-resolver | Дешевле по токенам, детерминированнее, инкапсулируют квирки API; resolver не пускает GitHub-специфику в ядро |
+| Граница прогона | До открытого PR | Внутри автономного прогона нет места человеческим гейтам; merge — необратим, оставлен человеку |
+| Точка останова PR | Ready-for-review (не draft) | Память `feedback_pr_ready_immediately`: в batch-обработке issues PR открывается сразу ready; более специфичное правило, чем generic draft→promote; merge всё равно остаётся человеческим гейтом (AC-9) |
+| Гейт менеджера | Один — Phase0 (план+DAG→одобрение) | Порядок решается раз; повторное одобрение на каждой задаче = confirmation-spam; внутреннее качество гарантируют finalize/acceptance |
+| Модель статуса доски | detect Project v2 status field → fallback open/closed + label-конвенция (`status:in-progress`, `blocked`) | Не у всех репо есть Project v2; нужен носитель для In-Progress/blocked (AC-3/AC-6) |
+| DAG на GitHub | Эвристический (sub-issues + parse «blocked by») + ручное подтверждение в Phase0 | У GitHub нет типизированных blocks/blocked-by; эвристика ненадёжна → человек подтверждает |
+| Per-task флоу | Адаптивная глубина: implement→check→finalize→acceptance→create-pr обязательны; research/spec по необходимости | Пользователь кладёт исчерпывающую инфу в issue → research/spec нужны не всем; finalize/acceptance — обязательные quality/acceptance гейты |
+| Трекеры | Только GitHub | Явный фокус, не распыляться; другие — Future за тем же контрактом |
+
+## Out of Scope
+
+- **Backend B (Agent Teams)** и любой мультиагентный режим — Future Phase 2.
+- **Другие трекеры** (GitLab, Linear) — Future.
+- **Синхронизация эпиков** (epic-transition по завершении детей) — Future.
+- **Параллельный dispatch** задач и file-overlap-guard — Future; Phase 1 строго sequential.
+- **Real-time мониторинг** исполнения — менеджер читает факты по чекпоинтам, не следит непрерывно.
+- **Автоматический merge** PR — человеческий гейт.
+- **`claude -p` / Agent SDK** как механизм исполнения — отклонены.
+
+## Open Questions
+
+None — открытые вопросы закрыты в Decisions Made (точка останова PR, модель статуса доски,
+адаптивность глубины per-task флоу).
+
+## Future Phases
+
+**Phase 2 — Backend B (Agent Teams):** второй execution-backend, реализующий тот же
+`exec-contract.md` — teammate'ы со своим контекстом и доступом к skills (флаг
+`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`), shared task list = backlog-DAG, detect-and-degrade на A.
+Снимает потолок контекста Backend A. Известные риски: no session resumption с in-process
+teammate'ами, отставание task-status.
+
+**Phase 3 — Мульти-трекер:** реализации adapter'а для GitLab (`glab` + GraphQL Work Items) и Linear
+(soft-ref MCP) за тем же контрактом и через adapter-resolver.
+
+**Phase 4 — Эпики и параллелизм:** синхронизация статуса эпиков по завершении детей; контролируемый
+параллельный dispatch с file-overlap-guard.
+
+Специфицируются отдельно после реализации и валидации Phase 1.

--- a/plugins/developer-workflow/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "developer-workflow",
   "version": "0.20.0",
-  "description": "Developer workflow toolbox \u2014 on-demand skills for research, specification (write-spec, reverse-spec), multiexpert review, retroactive tests, code-quality finalize, mechanical /check, QA (test plans, acceptance), PR creation, and autonomous drive-to-merge (CI monitor, review handler, re-request, poll). Exploratory QA without a spec is performed by calling the manual-tester agent directly. Platform-neutral; platform-specific engineers live in developer-workflow-kotlin and developer-workflow-swift.",
+  "description": "Developer workflow toolbox \u2014 on-demand skills for research, specification (write-spec, reverse-spec), multiexpert review, retroactive tests, code-quality finalize, mechanical /check, QA (test plans, acceptance), PR creation, autonomous drive-to-merge (CI monitor, review handler, re-request, poll), and issue-manager (backlog orchestrator: DAG-ordered sequential issue pipeline with board advancement). Exploratory QA without a spec is performed by calling the manual-tester agent directly. Platform-neutral; platform-specific engineers live in developer-workflow-kotlin and developer-workflow-swift.",
   "author": {
     "name": "kirich1409"
   },

--- a/plugins/developer-workflow/CLAUDE.md
+++ b/plugins/developer-workflow/CLAUDE.md
@@ -11,7 +11,7 @@ Rules that are not open for discussion. Violating these is an error, not a judgm
 ## Structure
 
 ```
-skills/<name>/SKILL.md    # 12 on-demand skills, each a directory with YAML frontmatter
+skills/<name>/SKILL.md    # 13 on-demand skills, each a directory with YAML frontmatter
 agents/manual-tester.md   # only agent in core (QA executor; covers exploratory mode)
 evals/                    # eval-harness fixtures (gitignored iterations + tracked README)
 ```
@@ -22,7 +22,7 @@ This plugin is part of a split family. Depending on the task, Claude Code will h
 
 | Plugin | Contributes |
 |---|---|
-| `developer-workflow` (this) | 12 on-demand skills + `manual-tester` |
+| `developer-workflow` (this) | 13 on-demand skills + `manual-tester` |
 | `developer-workflow-experts` | `code-reviewer`, `architecture-expert`, `security-expert`, `performance-expert`, `ux-expert`, `build-engineer`, `devops-expert`, `business-analyst`, `debugging-expert` — required, auto-installed as a dependency |
 | `developer-workflow-kotlin` | `kotlin-engineer`, `compose-developer`; skills `migration`, `snapshot` — install for Kotlin/Android/KMP work |
 | `developer-workflow-swift` | `swift-engineer`, `swiftui-developer` — install for Swift/iOS/macOS work |
@@ -43,12 +43,12 @@ Skills in this plugin delegate to engineer agents (kotlin-engineer / compose-dev
 - Skills use YAML frontmatter: `name`, `description` (≤ 1024 chars), optionally `disable-model-invocation`.
 - `code-reviewer` (in `developer-workflow-experts`) is read-only — no Edit, Write, NotebookEdit, or Bash tools.
 
-## Skills roster (12)
+## Skills roster (13)
 
 - Planning / research: `research`, `write-spec`, `reverse-spec`, `multiexpert-review`, `evaluate-dependency`
 - Implementation: `check`, `finalize`, `write-tests`
 - QA: `generate-test-plan`, `acceptance`
-- PR: `create-pr`, `drive-to-merge`
+- PR / orchestration: `create-pr`, `drive-to-merge`, `issue-manager` (backlog driver: DAG → sequential issue pipeline → board advancement)
 
 ### Planning: which tool to reach for
 

--- a/plugins/developer-workflow/skills/issue-manager/SKILL.md
+++ b/plugins/developer-workflow/skills/issue-manager/SKILL.md
@@ -88,7 +88,7 @@ received and RECONCILE has written its result to the state file.
 Advances the board after each backend completion. Detail in [`references/reconcile.md`](references/reconcile.md).
 
 **Summary:**
-- `status == "done"`: call `transition_status("done")`, `link_pr`, `add_comment`; update state (phase → `pr-open`).
+- `status == "done"`: call `link_pr`, `add_comment`; keep issue open (merge is a human gate — AC-9); update state (phase → `pr-open`). Do NOT call `transition_status("done")` — that happens only when a later reconcile observes the PR is merged or the issue is closed-as-done.
 - `status == "failed"` or `"blocked"`: call `transition_status("blocked")`, `add_comment`;
   hold the entire transitive downstream DAG branch (all issues that directly or transitively
   depend on this one). Do NOT transition them to `in-progress`. Add all to Blocked List.

--- a/plugins/developer-workflow/skills/issue-manager/SKILL.md
+++ b/plugins/developer-workflow/skills/issue-manager/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: issue-manager
+description: >
+  Drives a GitHub issue backlog end-to-end: resolves scope, builds a dependency DAG, presents
+  an ordered execution plan for one-time user approval, then processes each ready issue
+  sequentially — transitioning it to In-Progress, running the full implementation pipeline
+  (implement → /check → /finalize → /acceptance → /create-pr), and advancing the board.
+  Stops at an open, ready-for-review PR; merge is always a human action.
+
+  Triggers: "process the backlog", "work through these issues", "implement issues #3 #7 #12",
+  "drive all open issues", "work the epic", "run the backlog", "implement the milestone".
+
+  Do NOT use for: a single issue with no GitHub board tracking needed (use the pipeline skills individually);
+  merging PRs (use /drive-to-merge); code review only (use /finalize); ad-hoc GitHub queries.
+disable-model-invocation: true
+---
+
+# Issue Manager
+
+Backlog orchestrator. Resolves scope → builds DAG → gets one approval → drives each ready
+issue through the full implementation pipeline → advances the board. All GitHub access is
+through abstract actions resolved in [`references/adapter-contract.md`](references/adapter-contract.md).
+
+## Prerequisites (fail-fast, before any writes)
+
+Run these checks before ANALYZE. On any failure: stop with a clear message, no partial writes.
+
+1. **Repo access + auth:** call `list_issues --state open --limit 1` via the abstract action.
+   A valid JSON array (including `[]`) → auth and repo access are confirmed. An error object
+   or non-zero exit → stop with the error message before any writes.
+2. **Project v2 detection (optional):** attempt to detect a linked GitHub Project v2 on the
+   repo. If detected, `transition_status` will use the project status field; otherwise it falls
+   back to open/closed state + label convention (`status:in-progress`, `status:blocked`). Log
+   which mechanism will be used.
+
+## ANALYZE Phase
+
+**Goal:** build the board — a structured view of all in-scope issues with their statuses and
+dependency edges.
+
+1. **Resolve scope** from the user's input (issue URL / number list / epic ref / "all open")
+   — detail in [`references/phase0.md`](references/phase0.md).
+2. For each resolved issue: call `fetch_issue` to get title, body, labels, state.
+3. For each resolved issue: call `get_dependencies` to retrieve dependency edges.
+4. Call `get_completion_signal` for any issue that already has a linked PR (from labels or
+   body scan) to check if it is already done.
+5. Assemble the board JSON:
+   ```
+   { issues: [...], edges: [...], ready_set: [...], blocked_set: [...] }
+   ```
+6. Mark issues that are already `done` (signal == "done") — skip them in Phase 0.
+
+All data access is via abstract actions — no ad-hoc GitHub calls anywhere in this flow.
+
+## Phase 0 — Plan and Approval
+
+Single human gate. Detail in [`references/phase0.md`](references/phase0.md).
+
+**Summary of steps:**
+1. Build DAG from edges; detect cycles.
+2. On cycle: present members, BLOCK until manually resolved. Do not proceed.
+3. Apply scope cap (default **5** ready issues; overridable via `--cap N`).
+4. On over-cap: warn + ask user to narrow scope. Do not proceed without confirmation.
+5. Present the execution plan: dependency graph, proposed order, blocked issues.
+6. Accept user approval or a reordered number list.
+7. Initialize the state file at `swarm-report/issue-manager-<batch>-state.md`.
+
+This is the only gate. After approval, EXECUTE runs without additional per-issue confirmation.
+
+## EXECUTE Phase
+
+Processes the approved execution order sequentially. For each ready issue:
+
+1. Call `transition_status(issue_ref, "in-progress")` via abstract action (idempotent).
+2. Update state file: phase → `in-progress`.
+3. Invoke the execution backend via the interface in
+   [`references/exec-contract.md`](references/exec-contract.md).
+   - Active backend: Backend A — [`references/exec-single.md`](references/exec-single.md).
+   - The core passes `{ task_id, scope, allowed_depth }` and receives a completion signal.
+   - The core does NOT know or care which backend executes — it only reads the signal.
+4. Pass the completion signal to RECONCILE (below).
+
+**Strictly sequential:** do not start the next issue until the current one's signal is
+received and RECONCILE has written its result to the state file.
+
+## RECONCILE Phase
+
+Advances the board after each backend completion. Detail in [`references/reconcile.md`](references/reconcile.md).
+
+**Summary:**
+- `status == "done"`: call `transition_status("done")`, `link_pr`, `add_comment`; update state (phase → `pr-open`).
+- `status == "failed"` or `"blocked"`: call `transition_status("blocked")`, `add_comment`;
+  hold the entire transitive downstream DAG branch (all issues that directly or transitively
+  depend on this one). Do NOT transition them to `in-progress`. Add all to Blocked List.
+- After last issue (or all remaining blocked): surface batch summary to user.
+
+All actions are idempotent — safe to replay on resume.
+
+## Non-Negotiables
+
+These rules are non-negotiable. Violating them is an error, not a judgment call.
+
+- **Never edit or write project source code.** The skill is a supervisor, not an executor.
+  All code work is delegated to subagents and skills (Backend A in exec-single.md).
+- **Never run checks, tests, or builds directly.** All verification is delegated via
+  `/check`, `/finalize`, `/acceptance` (invoked by the backend, not the core).
+- **GitHub access exclusively through abstract actions** resolved in adapter-contract.md.
+  No ad-hoc `gh` or GraphQL invocations in the skill body or any reference file.
+- **Stop at the open, ready-for-review PR.** Never merge. Never promote a draft to ready
+  without user confirmation. (Per Backend A: PRs open immediately as ready-for-review —
+  see exec-single.md. The human gate is merge, not promotion.)
+- **Compaction resume:** on resume, FIRST re-read the state file AND re-fetch board
+  ground-truth from GitHub. Trust the tracker on any conflict. Do not use conversation
+  memory as the source of truth. See reconcile.md for the full protocol.
+- **Blocked propagates transitively:** when an issue is set to `blocked`, every issue that
+  directly or transitively depends on it is also held — not transitioned, not dispatched.
+
+## References
+
+Volatile detail lives in references — load on demand:
+
+- [`references/adapter-contract.md`](references/adapter-contract.md) — abstract action → concrete script mapping (the only place script names appear)
+- [`references/exec-contract.md`](references/exec-contract.md) — backend interface + completion-signal schema
+- [`references/exec-single.md`](references/exec-single.md) — Backend A: per-task flow, subagent routing, skill chaining
+- [`references/phase0.md`](references/phase0.md) — DAG build, cycle detection, scope cap, approval format
+- [`references/reconcile.md`](references/reconcile.md) — idempotent transitions, state-file schema, compaction-resume protocol

--- a/plugins/developer-workflow/skills/issue-manager/references/adapter-contract.md
+++ b/plugins/developer-workflow/skills/issue-manager/references/adapter-contract.md
@@ -1,0 +1,122 @@
+# Adapter Contract — GitHub Tracker
+
+This is the ONLY file where concrete script names appear. SKILL.md and all other
+references use abstract action names only. The adapter-resolver table below maps each
+abstract action to its GitHub implementation, making Phase 3 (multi-tracker) possible
+without touching the core.
+
+## Adapter-Resolver Table
+
+| Abstract action | Concrete invocation | Notes |
+|---|---|---|
+| `list_issues` | `bash ${CLAUDE_PLUGIN_ROOT}/skills/issue-manager/scripts/gh/list_issues.sh [--state open\|closed\|all] [--label <name>]... [--limit N] [--numbers n1,n2,...] [-R <owner/repo>]` | `--numbers` bypasses state/label filters |
+| `fetch_issue` | `bash ${CLAUDE_PLUGIN_ROOT}/skills/issue-manager/scripts/gh/fetch_issue.sh <issue-ref> [-R <owner/repo>]` | Returns full body + node_id |
+| `get_dependencies` | `bash ${CLAUDE_PLUGIN_ROOT}/skills/issue-manager/scripts/gh/get_dependencies.sh <issue-ref> [-R <owner/repo>]` | Returns edge list; empty deps → `[]` |
+| `get_completion_signal` | `bash ${CLAUDE_PLUGIN_ROOT}/skills/issue-manager/scripts/gh/get_completion_signal.sh <issue-ref> [-R <owner/repo>]` | Polls tracker-side PR linkage |
+| `transition_status` | `bash ${CLAUDE_PLUGIN_ROOT}/skills/issue-manager/scripts/gh/transition_status.sh <issue-ref> <target-status> [-R <owner/repo>] [--project-id <id>] [--dry-run]` | Read-before-write; writes only if current != target |
+| `link_pr` | `bash ${CLAUDE_PLUGIN_ROOT}/skills/issue-manager/scripts/gh/link_pr.sh <issue-ref> <pr-ref> [-R <owner/repo>] [--dry-run]` | Idempotent via marker |
+| `add_comment` | `bash ${CLAUDE_PLUGIN_ROOT}/skills/issue-manager/scripts/gh/add_comment.sh <issue-ref> --key <marker-key> --body <text> [-R <owner/repo>] [--dry-run]` | Idempotent via marker |
+
+## Output JSON Schemas
+
+All scripts write to stdout. On error: `{"error":"<msg>","code":"<code>"}` + non-zero exit.
+
+### `list_issues`
+```json
+[
+  {
+    "number": 42,
+    "title": "string",
+    "state": "open|closed",
+    "labels": [{"id": "string", "name": "string", "color": "string"}],
+    "url": "string"
+  }
+]
+```
+
+### `fetch_issue`
+```json
+{
+  "number": 42,
+  "title": "string",
+  "state": "open|closed",
+  "body": "string",
+  "labels": [{"id": "string", "name": "string", "color": "string"}],
+  "url": "string",
+  "node_id": "I_kwDORg45R88..."
+}
+```
+`node_id` is the GraphQL global node id, required for Project v2 mutations.
+
+### `get_dependencies`
+```json
+[
+  {"from": 17, "to": 12, "source": "sub-issue|blocked-by|depends-on"}
+]
+```
+Direction: `from` is the BLOCKED issue, `to` is the BLOCKER. Sub-issue edge: `from` = child
+number, `to` = parent number. Empty dependency set → `[]`.
+
+### `get_completion_signal`
+```json
+{
+  "signal": "done|pr-open|none",
+  "pr_url": "<string|null>",
+  "pr_state": "<string|null>",
+  "pr_number": "<int|null>"
+}
+```
+- `done` — associated PR is merged or issue is closed-as-done.
+- `pr-open` — associated PR exists and is open (ready-for-review or draft).
+- `none` — no associated PR and issue is still open.
+
+### `transition_status`
+```json
+{
+  "action": "transition|noop",
+  "from": "todo|in-progress|blocked|done",
+  "to": "todo|in-progress|blocked|done",
+  "mechanism": "project-v2|labels",
+  "dry_run": false
+}
+```
+`--dry-run` adds `resolved_payload`. Target statuses accepted: `todo`, `in-progress`,
+`blocked`, `done` (also accepts `open`→`todo`, `closed`→`done` for convenience). Project v2
+detected → uses status option; else fallback: open/closed state + label convention
+(`status:in-progress`, `status:blocked`).
+
+### `link_pr`
+```json
+{
+  "action": "linked|noop",
+  "issue": 42,
+  "pr": 99,
+  "comment_id": "<string|null>",
+  "dry_run": false
+}
+```
+Idempotent: checks for marker `<!-- issue-manager:link-pr:<pr-number> -->` before posting.
+
+### `add_comment`
+```json
+{
+  "action": "commented|noop",
+  "issue": 42,
+  "key": "marker-key",
+  "comment_id": "<string|null>",
+  "dry_run": false
+}
+```
+Idempotent: checks for marker `<!-- issue-manager:<key> -->` before posting.
+
+## Adapter-Resolver Concept
+
+The core references abstract action names (e.g. `transition_status`) only — never concrete
+script paths. This file maps each action to its GitHub-specific implementation.
+
+To add a GitLab adapter (Phase 3): create `scripts/gitlab/` with matching scripts and add a
+second resolver column or a separate `adapter-contract-gitlab.md`. The core SKILL.md requires
+no changes.
+
+No GitHub-specific logic (`gh`, GraphQL) appears anywhere outside this file's resolver table
+and the bundled `scripts/gh/` scripts.

--- a/plugins/developer-workflow/skills/issue-manager/references/adapter-contract.md
+++ b/plugins/developer-workflow/skills/issue-manager/references/adapter-contract.md
@@ -27,19 +27,20 @@ All scripts write to stdout. On error: `{"error":"<msg>","code":"<code>"}` + non
   {
     "number": 42,
     "title": "string",
-    "state": "open|closed",
+    "state": "OPEN|CLOSED",
     "labels": [{"id": "string", "name": "string", "color": "string"}],
     "url": "string"
   }
 ]
 ```
+Note: `state` is the GitHub-native uppercase value (`"OPEN"` or `"CLOSED"`).
 
 ### `fetch_issue`
 ```json
 {
   "number": 42,
   "title": "string",
-  "state": "open|closed",
+  "state": "OPEN|CLOSED",
   "body": "string",
   "labels": [{"id": "string", "name": "string", "color": "string"}],
   "url": "string",
@@ -47,6 +48,7 @@ All scripts write to stdout. On error: `{"error":"<msg>","code":"<code>"}` + non
 }
 ```
 `node_id` is the GraphQL global node id, required for Project v2 mutations.
+`state` is the GitHub-native uppercase value (`"OPEN"` or `"CLOSED"`).
 
 ### `get_dependencies`
 ```json
@@ -54,8 +56,9 @@ All scripts write to stdout. On error: `{"error":"<msg>","code":"<code>"}` + non
   {"from": 17, "to": 12, "source": "sub-issue|blocked-by|depends-on"}
 ]
 ```
-Direction: `from` is the BLOCKED issue, `to` is the BLOCKER. Sub-issue edge: `from` = child
-number, `to` = parent number. Empty dependency set → `[]`.
+Direction: `from` is the BLOCKED issue, `to` is the BLOCKER. Sub-issue edge: the parent is
+blocked by each child (children must complete before the parent can close) — `from` = parent
+number, `to` = child number. Empty dependency set → `[]`.
 
 ### `get_completion_signal`
 ```json
@@ -80,10 +83,11 @@ number, `to` = parent number. Empty dependency set → `[]`.
   "dry_run": false
 }
 ```
-`--dry-run` adds `resolved_payload`. Target statuses accepted: `todo`, `in-progress`,
-`blocked`, `done` (also accepts `open`→`todo`, `closed`→`done` for convenience). Project v2
-detected → uses status option; else fallback: open/closed state + label convention
-(`status:in-progress`, `status:blocked`).
+`from` is always a non-null string (current normalized status). `--dry-run` adds
+`resolved_payload` with the write that would be sent. Target statuses accepted: `todo`,
+`in-progress`, `blocked`, `done` (also accepts `open`→`todo`, `closed`→`done` for
+convenience). Project v2 detected → uses status option; else fallback: open/closed state +
+label convention (`status:in-progress`, `status:blocked`).
 
 ### `link_pr`
 ```json
@@ -95,6 +99,9 @@ detected → uses status option; else fallback: open/closed state + label conven
   "dry_run": false
 }
 ```
+`comment_id` is the GitHub GraphQL node id string (e.g. `IC_kwDO...`) of the newly posted
+comment, or `null` on noop or dry-run. On `--dry-run` (non-noop path), a `would_post` field
+contains the comment body that would be posted.
 Idempotent: checks for marker `<!-- issue-manager:link-pr:<pr-number> -->` before posting.
 
 ### `add_comment`
@@ -107,6 +114,9 @@ Idempotent: checks for marker `<!-- issue-manager:link-pr:<pr-number> -->` befor
   "dry_run": false
 }
 ```
+`comment_id` is the GitHub GraphQL node id string (e.g. `IC_kwDO...`) of the newly posted
+comment, or `null` on noop or dry-run. On `--dry-run` (non-noop path), a `would_post` field
+contains the comment body that would be posted.
 Idempotent: checks for marker `<!-- issue-manager:<key> -->` before posting.
 
 ## Adapter-Resolver Concept

--- a/plugins/developer-workflow/skills/issue-manager/references/adapter-contract.md
+++ b/plugins/developer-workflow/skills/issue-manager/references/adapter-contract.md
@@ -29,7 +29,8 @@ All scripts write to stdout. On error: `{"error":"<msg>","code":"<code>"}` + non
     "title": "string",
     "state": "OPEN|CLOSED",
     "labels": [{"id": "string", "name": "string", "color": "string"}],
-    "url": "string"
+    "url": "string",
+    "node_id": "string"
   }
 ]
 ```

--- a/plugins/developer-workflow/skills/issue-manager/references/exec-contract.md
+++ b/plugins/developer-workflow/skills/issue-manager/references/exec-contract.md
@@ -60,9 +60,11 @@ signal = call_backend(task_id, scope, allowed_depth)
 
 if signal.status == "done":
     record pr_url in state file
-    call transition_status(issue_ref, "done")   # abstract action
     call link_pr(issue_ref, pr_ref)             # abstract action
     call add_comment(issue_ref, key="batch-done", body="PR: " + signal.pr_url)
+    # Keep issue IN-PROGRESS (do NOT call transition_status here). Board phase → pr-open.
+    # transition_status(issue_ref, "done") is called only during a later RECONCILE/resume
+    # when get_completion_signal returns signal: done (PR merged or issue closed-as-done).
 
 elif signal.status == "failed":
     log "Gate failed: " + signal.failed_gate    # log only — no branching on the value

--- a/plugins/developer-workflow/skills/issue-manager/references/exec-contract.md
+++ b/plugins/developer-workflow/skills/issue-manager/references/exec-contract.md
@@ -1,0 +1,83 @@
+# Execution-Backend Contract
+
+Defines the interface between the issue-manager core and any execution backend. The core
+calls backends ONLY through this form — it does not know which backend is active.
+
+## Backend Call Signature
+
+```
+input:
+  task_id:       string          # issue number (or "owner/repo#N" for cross-repo)
+  scope:         object          # { issue_ref, title, body, labels, url }
+  allowed_depth: string          # "minimal" | "standard" | "deep"
+                                 #   minimal — implement→check→finalize→acceptance→create-pr
+                                 #   standard — adds /write-spec if issue lacks implementation detail
+                                 #   deep     — adds /research + /write-spec as needed
+
+output:  <completion-signal>     # JSON object, schema below
+```
+
+## Completion Signal Schema
+
+```json
+{
+  "status":         "done | failed | blocked",
+  "pr_url":         "<url | null>",
+  "failed_gate":    "<string | null>",
+  "blocked_reason": "<string | null>"
+}
+```
+
+Field semantics:
+
+| Field | When set | Value |
+|---|---|---|
+| `status` | always | `done` — open PR exists, ready-for-review; `failed` — a gate in the pipeline did not pass and was not recoverable; `blocked` — an external blocker was detected (dependency unresolved, environment issue, manual input required) |
+| `pr_url` | when `status == "done"` | URL of the open, ready-for-review PR |
+| `failed_gate` | when `status == "failed"` | Free-form string identifying which gate failed (see invariant below) |
+| `blocked_reason` | when `status == "blocked"` | Human-readable description of the blocker |
+
+## Invariant: `failed_gate` Is Not a Core Enum
+
+`failed_gate` is a **backend-defined free-form string**. The core MUST NEVER interpret or
+branch on `failed_gate` as a closed enumeration. Concretely:
+
+- The core MAY log the value for the user.
+- The core MUST NOT use `if failed_gate == "check"` or equivalent branching.
+- A Backend B that emits a different vocabulary (e.g. `"lint-gate"`, `"e2e-timeout"`) must
+  not require any change to the core — if the core branched on `failed_gate` values, Backend B
+  would need to "extend the contract" by editing the core, which violates AC-10.
+
+For Backend A (single-session), the recommended (non-binding) vocabulary is:
+`check | finalize | acceptance | create-pr`
+
+These are illustrative examples, not an exhaustive closed set. Any string is valid.
+
+## Core-Side Handling
+
+```
+signal = call_backend(task_id, scope, allowed_depth)
+
+if signal.status == "done":
+    record pr_url in state file
+    call transition_status(issue_ref, "done")   # abstract action
+    call link_pr(issue_ref, pr_ref)             # abstract action
+    call add_comment(issue_ref, key="batch-done", body="PR: " + signal.pr_url)
+
+elif signal.status == "failed":
+    log "Gate failed: " + signal.failed_gate    # log only — no branching on the value
+    call transition_status(issue_ref, "blocked")
+    hold entire transitive downstream DAG branch
+
+elif signal.status == "blocked":
+    log "Blocked: " + signal.blocked_reason
+    call transition_status(issue_ref, "blocked")
+    hold entire transitive downstream DAG branch
+```
+
+## Backend Registry
+
+| Backend ID | Reference | Description |
+|---|---|---|
+| `A` (default) | [`exec-single.md`](exec-single.md) | Single-session; sequential per-task flow via subagents/skills |
+| `B` (future) | `exec-team.md` (not yet authored) | Agent Teams; removes Backend A context ceiling |

--- a/plugins/developer-workflow/skills/issue-manager/references/exec-contract.md
+++ b/plugins/developer-workflow/skills/issue-manager/references/exec-contract.md
@@ -75,6 +75,33 @@ elif signal.status == "blocked":
     hold entire transitive downstream DAG branch
 ```
 
+## Two Distinct Signals: Completion Signal vs Tracker Completion Fact
+
+These two vocabularies share some words but are different concepts — do not conflate them.
+
+**Completion signal** (this file's schema, emitted by the backend to the core):
+- `status: done` = the per-task flow finished and produced an **open, ready-for-review PR**. The core never merges.
+- `status: failed` = a gate did not pass; `status: blocked` = external blocker.
+
+**Tracker completion fact** (emitted by `get_completion_signal.sh`, used during RECONCILE
+and compaction-resume to read GitHub ground-truth):
+- `signal: done` = a linked PR is **merged** (or issue closed-as-done).
+- `signal: pr-open` = a linked PR exists and is open.
+- `signal: none` = no linked PR.
+
+**Mapping during reconcile/resume:** a task whose backend returned `status: done` (open PR)
+corresponds to the tracker fact `pr-open` until a human merges it, at which point the tracker
+fact becomes `done`. The core MUST NOT assume `signal: done` (merged) just because the backend
+returned `status: done` (open PR).
+
+## Field Mutual-Exclusivity Invariants
+
+The following MUST invariants hold for every completion signal:
+
+- `pr_url` is non-null ONLY when `status == "done"`; it MUST be null for `failed` and `blocked`.
+- `failed_gate` is non-null ONLY when `status == "failed"`; it MUST be null for `done` and `blocked`.
+- `blocked_reason` is non-null ONLY when `status == "blocked"`; it MUST be null for `done` and `failed`.
+
 ## Backend Registry
 
 | Backend ID | Reference | Description |

--- a/plugins/developer-workflow/skills/issue-manager/references/exec-single.md
+++ b/plugins/developer-workflow/skills/issue-manager/references/exec-single.md
@@ -1,0 +1,109 @@
+# Backend A — Single-Session Execution
+
+Implements the exec-contract for a single issue. Called by the EXECUTE phase of the core.
+The backend runs entirely within the main session, delegating all code work to subagents
+and skills.
+
+## Input
+
+```
+task_id:       string   # issue number or "owner/repo#N"
+scope:         object   # { issue_ref, title, body, labels, url }
+allowed_depth: string   # "minimal" | "standard" | "deep"
+```
+
+## Step 1 — Transition to In-Progress
+
+Call abstract action `transition_status(issue_ref, "in-progress")`.
+
+Read-before-write is enforced by the script — if the issue is already in-progress this is
+a no-op.
+
+## Step 2 — Adaptive Depth (Research + Spec)
+
+Evaluate whether the issue has enough information for direct implementation:
+
+- Issue body contains clear acceptance criteria, implementation detail, and no open questions
+  → skip research and spec (depth = `minimal`)
+- Issue body is underspecified (vague "do X", no ACs, no implementation pointers)
+  → if `allowed_depth` is `standard` or `deep`: invoke `/write-spec` via the Skill tool
+  → if `allowed_depth` is `deep`: first invoke `/research` via the Skill tool, then `/write-spec`
+
+`/research` and `/write-spec` are invoked via the Skill tool (same chaining pattern that
+`/finalize` uses when it chains `/simplify` and `/check`). Do not spawn separate agents for
+these — they are skills in the same plugin family.
+
+## Step 3 — Implement (Delegate to Engineer Subagent)
+
+`implement` has no skill. Route by detected stack using the Task/Agent tool:
+
+| Detected stack | Subagent |
+|---|---|
+| Kotlin / Android (ViewModel, UseCase, Repository, DI, mappers, unit tests) | `developer-workflow-kotlin:kotlin-engineer` |
+| Compose UI (composables, theme, navigation, modifiers, previews) | `developer-workflow-kotlin:compose-developer` |
+| Swift / iOS / macOS | `developer-workflow-swift:swift-engineer` |
+| Any other / mixed / unknown | general-purpose (Sonnet) |
+
+Stack detection: check repo file tree (`.kt`, `.swift`, `build.gradle*`, `Package.swift`),
+issue labels, and existing code patterns. When ambiguous, prefer general-purpose.
+
+The subagent receives: task description from issue body + spec (if produced in Step 2) +
+repo context. It must not be given the issue-manager state file — it works on the code only.
+
+## Step 4 — Check
+
+Invoke `/check` via the Skill tool.
+
+`/check` runs the project's static analysis and build gate. On failure: capture the error
+output, emit completion signal `{ "status": "failed", "failed_gate": "check", "pr_url": null,
+"blocked_reason": null }` and return.
+
+## Step 5 — Finalize
+
+Invoke `/finalize` via the Skill tool.
+
+`/finalize` runs the full review→fix→simplify loop until no findings above Minor severity
+remain. On ESCALATE (user decision required): emit `{ "status": "failed", "failed_gate":
+"finalize", "pr_url": null, "blocked_reason": null }` and return.
+
+## Step 6 — Acceptance
+
+Invoke `/acceptance` via the Skill tool.
+
+`/acceptance` verifies the implementation against the source of truth (spec produced in
+Step 2, or issue ACs, or behavioral baseline). On failure: emit `{ "status": "failed",
+"failed_gate": "acceptance", "pr_url": null, "blocked_reason": null }` and return.
+
+## Step 7 — Create PR (Ready-for-Review)
+
+Invoke `/create-pr` (default mode — ready-for-review) via the Skill tool.
+
+Per the project feedback rule (feedback_pr_ready_immediately): in batch processing, PRs open
+immediately as ready-for-review. Do NOT open as draft. Do NOT merge.
+
+On success: capture `pr_url` from the PR creation output.
+
+## Step 8 — Emit Completion Signal
+
+Success path:
+```json
+{
+  "status": "done",
+  "pr_url": "<url of the open, ready-for-review PR>",
+  "failed_gate": null,
+  "blocked_reason": null
+}
+```
+
+The core (RECONCILE phase) reads this signal and calls `link_pr` + `add_comment` + `transition_status("done")`.
+
+## Context Ceiling Note
+
+Backend A runs all steps in the main session. Each task consumes the context of Steps 2–7
+(research, spec, implement delegation, check, finalize, acceptance, create-pr). The practical
+ceiling before context compaction is approximately 3–6 tasks per batch, depending on issue
+complexity. Phase0's scope cap (default 5) is calibrated against this ceiling — see
+[`phase0.md`](phase0.md).
+
+On compaction mid-batch: the RECONCILE state file + GitHub ground-truth allow resuming from
+the first incomplete task — see [`reconcile.md`](reconcile.md).

--- a/plugins/developer-workflow/skills/issue-manager/references/exec-single.md
+++ b/plugins/developer-workflow/skills/issue-manager/references/exec-single.md
@@ -95,7 +95,9 @@ Success path:
 }
 ```
 
-The core (RECONCILE phase) reads this signal and calls `link_pr` + `add_comment` + `transition_status("done")`.
+The core (RECONCILE phase) reads this signal, calls `link_pr` + `add_comment`, and keeps the
+issue open (phase → `pr-open`). The board advances to `done` only later, when
+`get_completion_signal` returns `signal: done` (PR merged or issue closed-as-done).
 
 ## Context Ceiling Note
 

--- a/plugins/developer-workflow/skills/issue-manager/references/phase0.md
+++ b/plugins/developer-workflow/skills/issue-manager/references/phase0.md
@@ -1,0 +1,131 @@
+# Phase 0 — Board Analysis and Approval Gate
+
+Phase 0 transforms raw GitHub issue data into an ordered execution plan and presents it
+to the user for a single approval. It is the only human gate before execution begins.
+
+## Step 1 — Scope Resolution
+
+Resolve the input to a concrete issue list:
+
+| Input form | Resolution |
+|---|---|
+| Issue URL or `#N` | Single issue: fetch via `fetch_issue`, check it is open |
+| Comma-separated list (`#3,#7,#12`) | Multi-issue: `list_issues --numbers 3,7,12` |
+| Epic reference (`#N` labeled as epic, or `epic/<name>`) | Fetch epic, then `list_issues` filtered by sub-issues of that epic |
+| `"all open"` / no scope | `list_issues --state open` — subject to scope cap (see below) |
+
+For each resolved issue, call `get_dependencies` to retrieve edges.
+
+## Step 2 — DAG Construction
+
+Build a directed acyclic graph from the dependency edges:
+
+```
+edge: { from: BLOCKED, to: BLOCKER }
+```
+
+- `from` is the issue that cannot start until `to` is done.
+- Sub-issue edges (from=child, to=parent) mean the child is blocked by the parent.
+
+**Ready set** = issues with no unsatisfied BLOCKER dependencies (all `to` nodes in their
+edges are either absent from the scope, already Done, or resolved externally).
+
+**Topological order** = a valid execution sequence respecting all edges. Any valid
+topological sort is acceptable; prefer ordering by label priority or issue number when
+multiple orderings are valid.
+
+## Step 3 — Cycle Detection
+
+Detect cycles using DFS on the dependency graph.
+
+**On cycle detected:**
+1. Identify all issues that are members of the cycle.
+2. Present to the user:
+   ```
+   Cycle detected — cannot build a valid execution order.
+   Cycle members: #12 → #15 → #18 → #12
+   
+   Resolution required: remove at least one edge in the cycle before approving.
+   Options:
+     a) Edit issue body to remove a "blocked by" reference
+     b) Close one of the issues as won't-do
+     c) Provide a manual order that breaks the cycle (list numbers in execution order)
+   
+   Phase 0 is blocked until the cycle is resolved.
+   ```
+3. Wait for user input. Do not proceed until the cycle is eliminated.
+
+## Step 4 — Scope Cap
+
+**Default cap: 5 issues per batch.**
+
+This limit is calibrated against the Backend A context ceiling (~3–6 tasks before
+compaction, depending on issue complexity). It should be tuned based on observed behavior
+in L5 dry runs on the target repo.
+
+To override: user may specify `--cap N` (e.g. `/issue-manager --cap 8`). Cap applies
+to the ready set only — issues that are blocked by unresolved dependencies do not count.
+
+**On cap exceeded:**
+```
+Scope contains N ready issues, which exceeds the batch cap of 5.
+Processing more than 5 issues in a single session risks context compaction mid-batch.
+
+Options:
+  a) Narrow scope: provide a comma-separated list of ≤5 issue numbers to process now
+  b) Override cap: confirm "proceed with N" (acknowledged risk of mid-batch compaction)
+  c) Increase cap: /issue-manager --cap N
+```
+Do not proceed without user confirmation when over cap.
+
+## Step 5 — Approval Gate Presentation
+
+Present the execution plan in this format:
+
+```
+## Issue Manager — Phase 0: Execution Plan
+
+**Scope:** <description of resolved scope>
+**Ready issues:** N (of M total in scope)
+**Blocked issues:** <list with reason>
+
+### Dependency Graph
+<ASCII or text representation of DAG edges>
+  #12 → depends on → #9 (open, will be processed first)
+  #15 → no dependencies
+
+### Proposed Execution Order
+1. #9  — <title>
+2. #12 — <title>  (unblocked after #9)
+3. #15 — <title>
+
+### Per-Issue Flow (Backend A)
+Each issue: transition In-Progress → [research?] → [spec?] → implement → /check → /finalize → /acceptance → /create-pr (ready-for-review)
+
+**Blocked (not in this batch):**
+- #18 — blocked by #22 (not in scope / not done)
+
+---
+Confirm to proceed, or reply with a reordered number list (e.g. "15, 9, 12").
+```
+
+Accept one of:
+- `"ok"` / `"yes"` / `"proceed"` / `"confirm"` → proceed with proposed order
+- A number list (e.g. `"15, 9, 12"`) → adopt user's order, validate it is a valid
+  topological sort (warn if not, but accept if user insists)
+- `"stop"` / `"cancel"` → abort with no writes to tracker
+
+This is the ONLY approval gate. Once approved, EXECUTE runs without further confirmation
+(except the implicit human merge gate that exists because the skill stops at open PRs).
+
+## State File Initialization
+
+After approval, write the initial state file at:
+`swarm-report/issue-manager-<batch>-state.md`
+
+Where `<batch>` is:
+- Epic name (kebab-case) if scope is an epic
+- SHA-1 hash of the sorted number list (first 8 chars) if scope is a number list
+- `all-open-<YYYYMMDD-HHMM>` if scope is "all open"
+
+See [`reconcile.md`](reconcile.md) for the state file schema.

--- a/plugins/developer-workflow/skills/issue-manager/references/phase0.md
+++ b/plugins/developer-workflow/skills/issue-manager/references/phase0.md
@@ -112,8 +112,12 @@ Confirm to proceed, or reply with a reordered number list (e.g. "15, 9, 12").
 
 Accept one of:
 - `"ok"` / `"yes"` / `"proceed"` / `"confirm"` → proceed with proposed order
-- A number list (e.g. `"15, 9, 12"`) → adopt user's order, validate it is a valid
-  topological sort (warn if not, but accept if user insists)
+- A number list (e.g. `"15, 9, 12"`) → adopt user's order IF it is a valid topological sort.
+  If not, REJECT it: present the specific violating pair(s) (e.g. "#12 before #9, but #12
+  depends on #9") and re-prompt for a valid order. Proceed only if the user provides a
+  DAG-respecting order, OR if the user explicitly states they want to override the constraint
+  — in that case emit a prominent warning naming which dependencies will be ignored, then
+  proceed. Never silently accept a DAG-violating order.
 - `"stop"` / `"cancel"` → abort with no writes to tracker
 
 This is the ONLY approval gate. Once approved, EXECUTE runs without further confirmation

--- a/plugins/developer-workflow/skills/issue-manager/references/phase0.md
+++ b/plugins/developer-workflow/skills/issue-manager/references/phase0.md
@@ -25,7 +25,8 @@ edge: { from: BLOCKED, to: BLOCKER }
 ```
 
 - `from` is the issue that cannot start until `to` is done.
-- Sub-issue edges (from=child, to=parent) mean the child is blocked by the parent.
+- Sub-issue edges (from=parent, to=child) mean the parent is blocked by each child: children
+  must complete before the parent can close.
 
 **Ready set** = issues with no unsatisfied BLOCKER dependencies (all `to` nodes in their
 edges are either absent from the scope, already Done, or resolved externally).

--- a/plugins/developer-workflow/skills/issue-manager/references/reconcile.md
+++ b/plugins/developer-workflow/skills/issue-manager/references/reconcile.md
@@ -66,11 +66,14 @@ to the next issue — partial state is better than inconsistent state.
 1. Read completion signal from backend.
 2. Based on `signal.status`:
 
-   **`done`:**
-   - Call `transition_status(issue_ref, "done")`
+   **`done`** (backend produced an open, ready-for-review PR — AC-9: merge is a human gate):
+   - Do NOT call `transition_status`. The issue must stay open until the PR is merged or the
+     issue is closed by a human.
    - Call `link_pr(issue_ref, pr_ref)` using `signal.pr_url`
    - Call `add_comment(issue_ref, key="batch-summary-done", body="Batch completed. PR: <pr_url>")`
    - Update state file: phase → `pr-open`, pr_url → `signal.pr_url`
+   - Note: `transition_status("done")` is called only during a later reconcile or compaction-resume
+     when `get_completion_signal` returns `signal: done` (PR merged or issue closed-as-done).
 
    **`failed` or `blocked`:**
    - Call `transition_status(issue_ref, "blocked")`

--- a/plugins/developer-workflow/skills/issue-manager/references/reconcile.md
+++ b/plugins/developer-workflow/skills/issue-manager/references/reconcile.md
@@ -1,0 +1,126 @@
+# Reconcile — Board Advancement and State Management
+
+The RECONCILE phase runs after each backend call and at the start of every resume. It
+advances the board using idempotent abstract actions and keeps the state file synchronized
+with GitHub ground-truth.
+
+## State File
+
+**Path:** `swarm-report/issue-manager-<batch>-state.md`
+
+`<batch>` slug is determined in Phase 0 — see [`phase0.md`](phase0.md).
+
+**Schema:**
+
+```markdown
+# State: issue-manager-<batch>
+Goal: <one-line scope description>
+Started: <ISO timestamp>
+Last verified: <ISO timestamp>
+
+## Issues
+
+| number | phase | pr_url | last_verified_at |
+|--------|-------|--------|-----------------|
+| 9      | done  | https://github.com/owner/repo/pull/101 | 2026-05-27T14:23:00Z |
+| 12     | in-progress | null | 2026-05-27T14:30:00Z |
+| 15     | analyzed | null | 2026-05-27T14:00:00Z |
+
+## Blocked List
+- #18: blocked by failure in #12 (failed_gate: finalize)
+
+## Execution Order (approved)
+9, 12, 15
+
+## Notes
+<free text for mid-batch observations>
+```
+
+**Phase values** (derived — always recomputable from tracker + GitHub):
+
+| Phase | Meaning |
+|---|---|
+| `analyzed` | In scope, not yet started |
+| `in-progress` | Backend A is running or was running for this issue |
+| `pr-open` | Backend A completed; PR is open, ready-for-review |
+| `done` | PR merged OR issue closed-as-done |
+| `blocked` | Failed or externally blocked; downstream held |
+
+**Rule:** only store fields that can be independently verified against the tracker. No
+fields that are only derivable from conversation history.
+
+## Idempotent Write Rules
+
+All abstract actions used in RECONCILE are idempotent:
+
+- `transition_status` — reads current status first; writes only if `current != target`.
+- `link_pr` — checks for existing marker comment before posting.
+- `add_comment` — checks for existing marker before posting; key must be unique per comment purpose.
+- `fetch_issue` / `get_completion_signal` — read-only, safe to repeat.
+
+On any write failure (script exits non-zero): stop with the error message. Do NOT proceed
+to the next issue — partial state is better than inconsistent state.
+
+## Post-Task Reconcile (after each backend completion signal)
+
+1. Read completion signal from backend.
+2. Based on `signal.status`:
+
+   **`done`:**
+   - Call `transition_status(issue_ref, "done")`
+   - Call `link_pr(issue_ref, pr_ref)` using `signal.pr_url`
+   - Call `add_comment(issue_ref, key="batch-summary-done", body="Batch completed. PR: <pr_url>")`
+   - Update state file: phase → `pr-open`, pr_url → `signal.pr_url`
+
+   **`failed` or `blocked`:**
+   - Call `transition_status(issue_ref, "blocked")`
+   - Call `add_comment(issue_ref, key="batch-blocked", body="Blocked. Reason: <failed_gate or blocked_reason>")`
+   - Update state file: phase → `blocked`
+   - **Hold transitive downstream DAG branch** — find all issues that directly or transitively
+     depend on this issue (follow `from` edges where `to == blocked_issue`, recursively).
+     Add all to the Blocked List in the state file. Do NOT transition them to `in-progress`.
+   - Note: `failed_gate` is logged for the user but never branched on — see [`exec-contract.md`](exec-contract.md).
+
+3. Update `last_verified_at` in the state file.
+
+## Batch Summary
+
+After the last issue in the execution order is processed (or all remaining are blocked),
+surface a summary to the user:
+
+```
+## Issue Manager — Batch Complete
+
+**Processed:** N issues
+**Done (PR open):**
+  - #9 — <title> → PR #101: <url>
+  - #15 — <title> → PR #103: <url>
+
+**Blocked (require attention):**
+  - #12 — blocked at gate: finalize (needs user decision on ESCALATE finding)
+    ↳ Downstream held: #18, #22
+
+**Skipped (unresolved dependencies):**
+  - #25 — depends on #12 (blocked)
+
+Merge is a human action. Review and merge the open PRs above when ready.
+```
+
+## Compaction Resume Protocol (AC-7)
+
+When resuming after context compaction:
+
+1. **Re-read the state file** — this is the recovery point.
+2. **Re-fetch board ground-truth** from GitHub for every issue in scope:
+   - Call `fetch_issue(issue_ref)` for each → current state and labels.
+   - Call `get_completion_signal(issue_ref)` for each → PR existence and state.
+3. **Reconcile state file against tracker:**
+   - For each issue in the state file, compare `phase` against the fetched data:
+     - `phase == pr-open` but `get_completion_signal` returns `done` → update to `done`.
+     - `phase == in-progress` but issue is closed → update to `done` or `blocked` per signal.
+     - `phase == done` but PR URL returns 404 → investigate; mark `blocked`.
+   - **On any conflict: trust the tracker, rewrite the state file.**
+4. **Resume from the first issue whose `phase` is not `done`** in the approved execution order.
+   Do not re-run any issue with `phase == done`.
+
+The state file is a cache; GitHub is the source of truth. The resume protocol enforces this.

--- a/plugins/developer-workflow/skills/issue-manager/scripts/gh/add_comment.sh
+++ b/plugins/developer-workflow/skills/issue-manager/scripts/gh/add_comment.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# add_comment.sh — add a comment to a GitHub issue, idempotently.
+#
+# USAGE:
+#   add_comment.sh <issue-ref> --key <marker-key> --body <text> [OPTIONS]
+#
+# <issue-ref>         Plain number, owner/repo#number, or full URL.
+# --key <marker-key>  Unique marker key for idempotency. Must be non-empty.
+#                     The marker embedded in the comment is:
+#                       <!-- issue-manager:<marker-key> -->
+#                     If any existing comment already contains this marker, the
+#                     script exits with action "noop" (no duplicate).
+# --body <text>       Comment body text. Required.
+#
+# OPTIONS:
+#   -R <owner/repo>   Target repository (default: current repo from git)
+#   --dry-run         Print what would be posted, without writing.
+#
+# IDEMPOTENCY:
+#   Scans existing issue comments for <!-- issue-manager:<marker-key> -->.
+#   If found → noop. If not found → post once.
+#   On resume the comment will already exist → noop, no duplicate.
+#
+# OUTPUT (stdout, JSON):
+#   {
+#     "action":     "commented" | "noop",
+#     "issue":      <int>,
+#     "key":        <string>,
+#     "comment_id": <int|null>,   -- new comment id (null on noop or dry-run)
+#     "dry_run":    <bool>
+#   }
+#
+#   Error: {"error":<string>,"code":<string>}
+#   Exit code is non-zero on error.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+im_error() {
+  local msg="$1" code="${2:-unknown}"
+  printf '{"error":%s,"code":%s}\n' "$(printf '%s' "$msg" | jq -Rs .)" "$(printf '%s' "$code" | jq -Rs .)"
+}
+
+im_parse_ref() {
+  IM_NUMBER=""
+  IM_REPO=""
+  local ref="$1"
+  if [[ "$ref" =~ ^https?://github\.com/([^/]+/[^/]+)/issues/([0-9]+) ]]; then
+    IM_REPO="${BASH_REMATCH[1]}"
+    IM_NUMBER="${BASH_REMATCH[2]}"
+  elif [[ "$ref" =~ ^([^#]+)#([0-9]+)$ ]]; then
+    IM_REPO="${BASH_REMATCH[1]}"
+    IM_NUMBER="${BASH_REMATCH[2]}"
+  elif [[ "$ref" =~ ^([0-9]+)$ ]]; then
+    IM_NUMBER="${BASH_REMATCH[1]}"
+  else
+    return 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+if [[ $# -lt 1 ]]; then
+  im_error "Usage: add_comment.sh <issue-ref> --key <marker-key> --body <text> [-R <owner/repo>] [--dry-run]" "usage"
+  exit 1
+fi
+
+RAW_REF="$1"
+shift
+
+REPO_OVERRIDE=""
+DRY_RUN=false
+MARKER_KEY=""
+BODY_TEXT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -R)        REPO_OVERRIDE="$2"; shift 2 ;;
+    --key)     MARKER_KEY="$2"; shift 2 ;;
+    --body)    BODY_TEXT="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    *)         im_error "Unknown flag: $1" "usage"; exit 1 ;;
+  esac
+done
+
+if [[ -z "$MARKER_KEY" ]]; then
+  im_error "--key is required" "usage"
+  exit 1
+fi
+
+if [[ -z "$BODY_TEXT" ]]; then
+  im_error "--body is required" "usage"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve repo and number
+# ---------------------------------------------------------------------------
+
+if ! im_parse_ref "$RAW_REF"; then
+  im_error "Cannot parse issue ref: $RAW_REF" "invalid_ref"
+  exit 1
+fi
+
+if [[ -n "$REPO_OVERRIDE" ]]; then
+  IM_REPO="$REPO_OVERRIDE"
+fi
+
+if [[ -z "$IM_REPO" ]]; then
+  out=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1); rc=$?
+  if [[ $rc -ne 0 ]]; then
+    im_error "Cannot resolve repo: $out" "repo_resolve_failed"
+    exit 1
+  fi
+  IM_REPO="$out"
+fi
+
+if [[ -z "$IM_NUMBER" ]]; then
+  im_error "No issue number in ref: $RAW_REF" "invalid_ref"
+  exit 1
+fi
+
+ISSUE_NUMBER="$IM_NUMBER"
+MARKER="<!-- issue-manager:${MARKER_KEY} -->"
+
+# ---------------------------------------------------------------------------
+# Idempotency check — scan existing comments for marker
+# ---------------------------------------------------------------------------
+
+out=$(gh issue view "$ISSUE_NUMBER" -R "$IM_REPO" \
+  --json comments 2>&1); rc=$?
+if [[ $rc -ne 0 ]]; then
+  im_error "$out" "gh_failed"
+  exit 1
+fi
+
+EXISTING=$(printf '%s' "$out" | jq -r --arg marker "$MARKER" \
+  '.comments[] | select(.body | contains($marker)) | .id' 2>/dev/null | head -1 || true)
+
+if [[ -n "$EXISTING" ]]; then
+  jq -n \
+    --argjson issue "$ISSUE_NUMBER" \
+    --arg key "$MARKER_KEY" \
+    --argjson dry_run "$DRY_RUN" \
+    '{action:"noop",issue:$issue,key:$key,comment_id:null,dry_run:$dry_run}'
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Build comment body (marker appended as last line)
+# ---------------------------------------------------------------------------
+
+FULL_BODY="${BODY_TEXT}
+
+${MARKER}"
+
+if [[ "$DRY_RUN" == true ]]; then
+  jq -n \
+    --argjson issue "$ISSUE_NUMBER" \
+    --arg key "$MARKER_KEY" \
+    --arg body "$FULL_BODY" \
+    '{action:"commented",issue:$issue,key:$key,comment_id:null,dry_run:true,would_post:$body}'
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Post comment
+# ---------------------------------------------------------------------------
+
+new_out=$(gh issue comment "$ISSUE_NUMBER" -R "$IM_REPO" \
+  --body "$FULL_BODY" 2>&1); rc=$?
+if [[ $rc -ne 0 ]]; then
+  im_error "$new_out" "gh_failed"
+  exit 1
+fi
+
+# Fetch the new comment id by rescanning
+out2=$(gh issue view "$ISSUE_NUMBER" -R "$IM_REPO" \
+  --json comments 2>&1); rc=$?
+if [[ $rc -ne 0 ]]; then
+  im_error "$out2" "gh_failed"
+  exit 1
+fi
+
+NEW_COMMENT_ID=$(printf '%s' "$out2" | jq -r --arg marker "$MARKER" \
+  '.comments[] | select(.body | contains($marker)) | .id' 2>/dev/null | tail -1 || true)
+
+jq -n \
+  --argjson issue "$ISSUE_NUMBER" \
+  --arg key "$MARKER_KEY" \
+  --arg comment_id "$NEW_COMMENT_ID" \
+  '{action:"commented",issue:$issue,key:$key,comment_id:$comment_id,dry_run:false}'

--- a/plugins/developer-workflow/skills/issue-manager/scripts/gh/add_comment.sh
+++ b/plugins/developer-workflow/skills/issue-manager/scripts/gh/add_comment.sh
@@ -117,8 +117,7 @@ if [[ -n "$REPO_OVERRIDE" ]]; then
 fi
 
 if [[ -z "$IM_REPO" ]]; then
-  out=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1); rc=$?
-  if [[ $rc -ne 0 ]]; then
+  if ! out=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1); then
     im_error "Cannot resolve repo: $out" "repo_resolve_failed"
     exit 1
   fi
@@ -137,9 +136,8 @@ MARKER="<!-- issue-manager:${MARKER_KEY} -->"
 # Idempotency check — scan existing comments for marker
 # ---------------------------------------------------------------------------
 
-out=$(gh issue view "$ISSUE_NUMBER" -R "$IM_REPO" \
-  --json comments 2>&1); rc=$?
-if [[ $rc -ne 0 ]]; then
+if ! out=$(gh issue view "$ISSUE_NUMBER" -R "$IM_REPO" \
+  --json comments 2>&1); then
   im_error "$out" "gh_failed"
   exit 1
 fi
@@ -180,17 +178,15 @@ fi
 # Post comment
 # ---------------------------------------------------------------------------
 
-new_out=$(gh issue comment "$ISSUE_NUMBER" -R "$IM_REPO" \
-  --body "$FULL_BODY" 2>&1); rc=$?
-if [[ $rc -ne 0 ]]; then
+if ! new_out=$(gh issue comment "$ISSUE_NUMBER" -R "$IM_REPO" \
+  --body "$FULL_BODY" 2>&1); then
   im_error "$new_out" "gh_failed"
   exit 1
 fi
 
 # Fetch the new comment id by rescanning
-out2=$(gh issue view "$ISSUE_NUMBER" -R "$IM_REPO" \
-  --json comments 2>&1); rc=$?
-if [[ $rc -ne 0 ]]; then
+if ! out2=$(gh issue view "$ISSUE_NUMBER" -R "$IM_REPO" \
+  --json comments 2>&1); then
   im_error "$out2" "gh_failed"
   exit 1
 fi

--- a/plugins/developer-workflow/skills/issue-manager/scripts/gh/add_comment.sh
+++ b/plugins/developer-workflow/skills/issue-manager/scripts/gh/add_comment.sh
@@ -26,7 +26,7 @@
 #     "action":     "commented" | "noop",
 #     "issue":      <int>,
 #     "key":        <string>,
-#     "comment_id": <int|null>,   -- new comment id (null on noop or dry-run)
+#     "comment_id": <string|null>,   -- new comment id (null on noop or dry-run)
 #     "dry_run":    <bool>
 #   }
 #

--- a/plugins/developer-workflow/skills/issue-manager/scripts/gh/add_comment.sh
+++ b/plugins/developer-workflow/skills/issue-manager/scripts/gh/add_comment.sh
@@ -93,6 +93,11 @@ if [[ -z "$MARKER_KEY" ]]; then
   exit 1
 fi
 
+if [[ ! "$MARKER_KEY" =~ ^[A-Za-z0-9:_.-]+$ ]]; then
+  im_error "--key must match [A-Za-z0-9:_.-]+" "usage"
+  exit 1
+fi
+
 if [[ -z "$BODY_TEXT" ]]; then
   im_error "--body is required" "usage"
   exit 1
@@ -140,7 +145,10 @@ if [[ $rc -ne 0 ]]; then
 fi
 
 EXISTING=$(printf '%s' "$out" | jq -r --arg marker "$MARKER" \
-  '.comments[] | select(.body | contains($marker)) | .id' 2>/dev/null | head -1 || true)
+  '.comments[] | select(.body | contains($marker)) | .id' 2>/dev/null | head -1) || {
+  im_error "Failed to parse comments while checking idempotency marker" "parse_failed"
+  exit 1
+}
 
 if [[ -n "$EXISTING" ]]; then
   jq -n \
@@ -188,10 +196,13 @@ if [[ $rc -ne 0 ]]; then
 fi
 
 NEW_COMMENT_ID=$(printf '%s' "$out2" | jq -r --arg marker "$MARKER" \
-  '.comments[] | select(.body | contains($marker)) | .id' 2>/dev/null | tail -1 || true)
+  '.comments[] | select(.body | contains($marker)) | .id' 2>/dev/null | tail -1) || {
+  im_error "Failed to parse comments after posting (id rescan)" "parse_failed"
+  exit 1
+}
 
 jq -n \
   --argjson issue "$ISSUE_NUMBER" \
   --arg key "$MARKER_KEY" \
-  --arg comment_id "$NEW_COMMENT_ID" \
-  '{action:"commented",issue:$issue,key:$key,comment_id:$comment_id,dry_run:false}'
+  --arg cid "$NEW_COMMENT_ID" \
+  '{action:"commented",issue:$issue,key:$key,comment_id:($cid | if . == "" then null else . end),dry_run:false}'

--- a/plugins/developer-workflow/skills/issue-manager/scripts/gh/fetch_issue.sh
+++ b/plugins/developer-workflow/skills/issue-manager/scripts/gh/fetch_issue.sh
@@ -91,8 +91,7 @@ if [[ -n "$REPO_OVERRIDE" ]]; then
 fi
 
 if [[ -z "$IM_REPO" ]]; then
-  out=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1); rc=$?
-  if [[ $rc -ne 0 ]]; then
+  if ! out=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1); then
     im_error "Cannot resolve repo: $out" "repo_resolve_failed"
     exit 1
   fi
@@ -111,10 +110,8 @@ REPO_NAME="${IM_REPO##*/}"
 # Fetch via REST (gh issue view)
 # ---------------------------------------------------------------------------
 
-out=$(gh issue view "$IM_NUMBER" -R "$IM_REPO" \
-  --json id,number,title,state,body,labels,url 2>&1); rc=$?
-
-if [[ $rc -ne 0 ]]; then
+if ! out=$(gh issue view "$IM_NUMBER" -R "$IM_REPO" \
+  --json id,number,title,state,body,labels,url 2>&1); then
   im_error "$out" "gh_failed"
   exit 1
 fi

--- a/plugins/developer-workflow/skills/issue-manager/scripts/gh/fetch_issue.sh
+++ b/plugins/developer-workflow/skills/issue-manager/scripts/gh/fetch_issue.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# fetch_issue.sh — fetch a single GitHub issue by ref and output JSON.
+#
+# USAGE:
+#   fetch_issue.sh <issue-ref> [-R <owner/repo>]
+#
+# <issue-ref> accepts:
+#   - plain number:              206
+#   - owner/repo#number:         kirich1409/krozov-ai-tools#206
+#   - full URL:                  https://github.com/kirich1409/krozov-ai-tools/issues/206
+#
+# -R <owner/repo>  Override repository (takes precedence over ref-embedded repo).
+#                  If omitted, resolved from ref or from `gh repo view`.
+#
+# OUTPUT (stdout, JSON):
+#   Success:
+#     {
+#       "number":   <int>,
+#       "title":    <string>,
+#       "state":    "OPEN"|"CLOSED",
+#       "body":     <string>,
+#       "labels":   [{"id":<string>,"name":<string>,"color":<string>},...],
+#       "url":      <string>,
+#       "node_id":  <string>   -- GraphQL global node id (e.g. "I_kwDO...")
+#     }
+#   Error:
+#     {"error":<string>,"code":<string>}
+#   Exit code is non-zero on error.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+im_error() {
+  local msg="$1" code="${2:-unknown}"
+  printf '{"error":%s,"code":%s}\n' "$(printf '%s' "$msg" | jq -Rs .)" "$(printf '%s' "$code" | jq -Rs .)"
+}
+
+im_parse_ref() {
+  # Sets globals: IM_NUMBER, IM_REPO (may be empty)
+  local ref="$1"
+  IM_NUMBER=""
+  IM_REPO=""
+
+  if [[ "$ref" =~ ^https?://github\.com/([^/]+/[^/]+)/issues/([0-9]+) ]]; then
+    IM_REPO="${BASH_REMATCH[1]}"
+    IM_NUMBER="${BASH_REMATCH[2]}"
+  elif [[ "$ref" =~ ^([^#]+)#([0-9]+)$ ]]; then
+    IM_REPO="${BASH_REMATCH[1]}"
+    IM_NUMBER="${BASH_REMATCH[2]}"
+  elif [[ "$ref" =~ ^([0-9]+)$ ]]; then
+    IM_NUMBER="${BASH_REMATCH[1]}"
+  else
+    return 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+if [[ $# -lt 1 ]]; then
+  im_error "Usage: fetch_issue.sh <issue-ref> [-R <owner/repo>]" "usage"
+  exit 1
+fi
+
+RAW_REF="$1"
+shift
+REPO_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -R) REPO_OVERRIDE="$2"; shift 2 ;;
+    *)  im_error "Unknown flag: $1" "usage"; exit 1 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Resolve repo and number
+# ---------------------------------------------------------------------------
+
+if ! im_parse_ref "$RAW_REF"; then
+  im_error "Cannot parse issue ref: $RAW_REF" "invalid_ref"
+  exit 1
+fi
+
+if [[ -n "$REPO_OVERRIDE" ]]; then
+  IM_REPO="$REPO_OVERRIDE"
+fi
+
+if [[ -z "$IM_REPO" ]]; then
+  out=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1); rc=$?
+  if [[ $rc -ne 0 ]]; then
+    im_error "Cannot resolve repo: $out" "repo_resolve_failed"
+    exit 1
+  fi
+  IM_REPO="$out"
+fi
+
+if [[ -z "$IM_NUMBER" ]]; then
+  im_error "No issue number in ref: $RAW_REF" "invalid_ref"
+  exit 1
+fi
+
+REPO_OWNER="${IM_REPO%%/*}"
+REPO_NAME="${IM_REPO##*/}"
+
+# ---------------------------------------------------------------------------
+# Fetch via REST (gh issue view)
+# ---------------------------------------------------------------------------
+
+out=$(gh issue view "$IM_NUMBER" -R "$IM_REPO" \
+  --json id,number,title,state,body,labels,url 2>&1); rc=$?
+
+if [[ $rc -ne 0 ]]; then
+  im_error "$out" "gh_failed"
+  exit 1
+fi
+
+# Remap: gh uses "id" for the GraphQL node id; expose as "node_id" for clarity.
+result=$(printf '%s' "$out" | jq '{
+  number:  .number,
+  title:   .title,
+  state:   .state,
+  body:    .body,
+  labels:  [.labels[] | {id: .id, name: .name, color: .color}],
+  url:     .url,
+  node_id: .id
+}')
+
+printf '%s\n' "$result"

--- a/plugins/developer-workflow/skills/issue-manager/scripts/gh/get_completion_signal.sh
+++ b/plugins/developer-workflow/skills/issue-manager/scripts/gh/get_completion_signal.sh
@@ -102,8 +102,7 @@ if [[ -n "$REPO_OVERRIDE" ]]; then
 fi
 
 if [[ -z "$IM_REPO" ]]; then
-  out=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1); rc=$?
-  if [[ $rc -ne 0 ]]; then
+  if ! out=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1); then
     im_error "Cannot resolve repo: $out" "repo_resolve_failed"
     exit 1
   fi
@@ -123,15 +122,15 @@ REPO_NAME="${IM_REPO##*/}"
 # Returns PRs that closed this issue via "Closes #N" or "Fixes #N" keywords.
 # ---------------------------------------------------------------------------
 
-out=$(gh issue view "$IM_NUMBER" -R "$IM_REPO" \
-  --json closedByPullRequestsReferences 2>&1); rc=$?
-
-if [[ $rc -ne 0 ]]; then
+if ! out=$(gh issue view "$IM_NUMBER" -R "$IM_REPO" \
+  --json closedByPullRequestsReferences,state,stateReason 2>&1); then
   im_error "$out" "gh_failed"
   exit 1
 fi
 
 CLOSED_BY_PRS=$(printf '%s' "$out" | jq '.closedByPullRequestsReferences // []')
+ISSUE_STATE=$(printf '%s' "$out" | jq -r '.state // "OPEN"')
+ISSUE_STATE_REASON=$(printf '%s' "$out" | jq -r '.stateReason // ""')
 
 # ---------------------------------------------------------------------------
 # Source B: cross-referenced PRs from timeline via GraphQL
@@ -157,31 +156,45 @@ graphql_query='query($owner:String!,$repo:String!,$number:Int!){
               }
             }
           }
+          ... on ConnectedEvent {
+            subject {
+              __typename
+              ... on PullRequest {
+                number
+                state
+                url
+                merged
+                title
+              }
+            }
+          }
         }
       }
     }
   }
 }'
 
-gql_out=$(gh api graphql \
+if ! gql_out=$(gh api graphql \
   -f query="$graphql_query" \
   -f owner="$REPO_OWNER" \
   -f repo="$REPO_NAME" \
-  -F number="$IM_NUMBER" 2>&1); rc=$?
-
-if [[ $rc -ne 0 ]]; then
+  -F number="$IM_NUMBER" 2>&1); then
   im_error "$gql_out" "graphql_failed"
   exit 1
 fi
 
 im_check_graphql_errors "$gql_out"
 
-# Extract PRs from timeline
+# Extract PRs from timeline (both CrossReferencedEvent and ConnectedEvent)
 TIMELINE_PRS=$(printf '%s' "$gql_out" | jq '
   [.data.repository.issue.timelineItems.nodes[]
-   | select(.__typename == "CrossReferencedEvent")
-   | .source
-   | select(.__typename == "PullRequest")
+   | (
+       if .__typename == "CrossReferencedEvent" then .source
+       elif .__typename == "ConnectedEvent" then .subject
+       else null
+       end
+     )
+   | select(. != null and .__typename == "PullRequest")
    | {
        number: .number,
        state:  (if .merged then "MERGED" elif .state == "OPEN" then "OPEN" else "CLOSED" end),
@@ -206,9 +219,13 @@ ALL_PRS=$(jq -n \
   --argjson b "$TIMELINE_PRS" \
   '($a + $b) | unique_by(.number)')
 
-# Derive signal
-RESULT=$(printf '%s' "$ALL_PRS" | jq '
-  . as $prs |
+# Derive signal (merged PR > open PR > closed-as-done > none)
+RESULT=$(printf '%s' "$ALL_PRS" \
+  --arg issue_state "$ISSUE_STATE" \
+  --arg issue_state_reason "$ISSUE_STATE_REASON" | jq -n \
+  --argjson prs "$(printf '%s' "$ALL_PRS")" \
+  --arg issue_state "$ISSUE_STATE" \
+  --arg issue_state_reason "$ISSUE_STATE_REASON" '
   if ($prs | map(select(.state == "MERGED")) | length) > 0
   then
     ($prs | map(select(.state == "MERGED")) | first) as $pr |
@@ -217,6 +234,9 @@ RESULT=$(printf '%s' "$ALL_PRS" | jq '
   then
     ($prs | map(select(.state == "OPEN")) | first) as $pr |
     {signal: "pr-open", pr_url: $pr.url, pr_state: "OPEN", pr_number: $pr.number}
+  elif ($issue_state == "CLOSED" and $issue_state_reason == "COMPLETED")
+  then
+    {signal: "done", pr_url: null, pr_state: null, pr_number: null}
   else
     {signal: "none", pr_url: null, pr_state: null, pr_number: null}
   end

--- a/plugins/developer-workflow/skills/issue-manager/scripts/gh/get_completion_signal.sh
+++ b/plugins/developer-workflow/skills/issue-manager/scripts/gh/get_completion_signal.sh
@@ -220,10 +220,8 @@ ALL_PRS=$(jq -n \
   '($a + $b) | unique_by(.number)')
 
 # Derive signal (merged PR > open PR > closed-as-done > none)
-RESULT=$(printf '%s' "$ALL_PRS" \
-  --arg issue_state "$ISSUE_STATE" \
-  --arg issue_state_reason "$ISSUE_STATE_REASON" | jq -n \
-  --argjson prs "$(printf '%s' "$ALL_PRS")" \
+RESULT=$(jq -n \
+  --argjson prs "$ALL_PRS" \
   --arg issue_state "$ISSUE_STATE" \
   --arg issue_state_reason "$ISSUE_STATE_REASON" '
   if ($prs | map(select(.state == "MERGED")) | length) > 0

--- a/plugins/developer-workflow/skills/issue-manager/scripts/gh/get_completion_signal.sh
+++ b/plugins/developer-workflow/skills/issue-manager/scripts/gh/get_completion_signal.sh
@@ -1,0 +1,225 @@
+#!/bin/bash
+# get_completion_signal.sh — derive the completion signal for a GitHub issue
+#                            based on its linked/cross-referenced pull requests.
+#
+# USAGE:
+#   get_completion_signal.sh <issue-ref> [-R <owner/repo>]
+#
+# <issue-ref> accepts: plain number, owner/repo#number, or full URL.
+# -R <owner/repo>  Override repository.
+#
+# LOGIC:
+#   Uses `gh issue view --json closedByPullRequestsReferences` to get PRs that
+#   closed this issue, plus cross-referenced PRs from the timeline.
+#
+#   Signal derivation (first matching rule wins):
+#     done     — at least one linked PR is merged (MERGED state)
+#     pr-open  — at least one linked PR is open (OPEN state) and none merged
+#     none     — no linked PRs found (or issue is closed but no PR reference)
+#
+# OUTPUT (stdout, JSON):
+#   Success:
+#     {
+#       "signal":   "done" | "pr-open" | "none",
+#       "pr_url":   <string|null>,    -- URL of the most relevant PR (merged>open>null)
+#       "pr_state": <string|null>,    -- "MERGED" | "OPEN" | "CLOSED" | null
+#       "pr_number": <int|null>
+#     }
+#
+#   Error:
+#     {"error":<string>,"code":<string>}
+#   Exit code is non-zero on error.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+im_error() {
+  local msg="$1" code="${2:-unknown}"
+  printf '{"error":%s,"code":%s}\n' "$(printf '%s' "$msg" | jq -Rs .)" "$(printf '%s' "$code" | jq -Rs .)"
+}
+
+im_parse_ref() {
+  IM_NUMBER=""
+  IM_REPO=""
+  local ref="$1"
+  if [[ "$ref" =~ ^https?://github\.com/([^/]+/[^/]+)/issues/([0-9]+) ]]; then
+    IM_REPO="${BASH_REMATCH[1]}"
+    IM_NUMBER="${BASH_REMATCH[2]}"
+  elif [[ "$ref" =~ ^([^#]+)#([0-9]+)$ ]]; then
+    IM_REPO="${BASH_REMATCH[1]}"
+    IM_NUMBER="${BASH_REMATCH[2]}"
+  elif [[ "$ref" =~ ^([0-9]+)$ ]]; then
+    IM_NUMBER="${BASH_REMATCH[1]}"
+  else
+    return 1
+  fi
+}
+
+im_check_graphql_errors() {
+  local response="$1"
+  if printf '%s' "$response" | jq -e '.errors' >/dev/null 2>&1; then
+    local errmsg
+    errmsg=$(printf '%s' "$response" | jq -r '.errors[0].message // "GraphQL error"')
+    im_error "$errmsg" "graphql_error"
+    exit 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+if [[ $# -lt 1 ]]; then
+  im_error "Usage: get_completion_signal.sh <issue-ref> [-R <owner/repo>]" "usage"
+  exit 1
+fi
+
+RAW_REF="$1"
+shift
+REPO_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -R) REPO_OVERRIDE="$2"; shift 2 ;;
+    *)  im_error "Unknown flag: $1" "usage"; exit 1 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Resolve repo and number
+# ---------------------------------------------------------------------------
+
+if ! im_parse_ref "$RAW_REF"; then
+  im_error "Cannot parse issue ref: $RAW_REF" "invalid_ref"
+  exit 1
+fi
+
+if [[ -n "$REPO_OVERRIDE" ]]; then
+  IM_REPO="$REPO_OVERRIDE"
+fi
+
+if [[ -z "$IM_REPO" ]]; then
+  out=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1); rc=$?
+  if [[ $rc -ne 0 ]]; then
+    im_error "Cannot resolve repo: $out" "repo_resolve_failed"
+    exit 1
+  fi
+  IM_REPO="$out"
+fi
+
+if [[ -z "$IM_NUMBER" ]]; then
+  im_error "No issue number in ref: $RAW_REF" "invalid_ref"
+  exit 1
+fi
+
+REPO_OWNER="${IM_REPO%%/*}"
+REPO_NAME="${IM_REPO##*/}"
+
+# ---------------------------------------------------------------------------
+# Source A: closedByPullRequestsReferences (REST via gh)
+# Returns PRs that closed this issue via "Closes #N" or "Fixes #N" keywords.
+# ---------------------------------------------------------------------------
+
+out=$(gh issue view "$IM_NUMBER" -R "$IM_REPO" \
+  --json closedByPullRequestsReferences 2>&1); rc=$?
+
+if [[ $rc -ne 0 ]]; then
+  im_error "$out" "gh_failed"
+  exit 1
+fi
+
+CLOSED_BY_PRS=$(printf '%s' "$out" | jq '.closedByPullRequestsReferences // []')
+
+# ---------------------------------------------------------------------------
+# Source B: cross-referenced PRs from timeline via GraphQL
+# Captures PRs that mention this issue in their body or commits but do not
+# use the auto-close keywords.
+# ---------------------------------------------------------------------------
+
+graphql_query='query($owner:String!,$repo:String!,$number:Int!){
+  repository(owner:$owner,name:$repo){
+    issue(number:$number){
+      timelineItems(first:50 itemTypes:[CROSS_REFERENCED_EVENT,CONNECTED_EVENT]){
+        nodes{
+          __typename
+          ... on CrossReferencedEvent {
+            source {
+              __typename
+              ... on PullRequest {
+                number
+                state
+                url
+                merged
+                title
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+
+gql_out=$(gh api graphql \
+  -f query="$graphql_query" \
+  -f owner="$REPO_OWNER" \
+  -f repo="$REPO_NAME" \
+  -F number="$IM_NUMBER" 2>&1); rc=$?
+
+if [[ $rc -ne 0 ]]; then
+  im_error "$gql_out" "graphql_failed"
+  exit 1
+fi
+
+im_check_graphql_errors "$gql_out"
+
+# Extract PRs from timeline
+TIMELINE_PRS=$(printf '%s' "$gql_out" | jq '
+  [.data.repository.issue.timelineItems.nodes[]
+   | select(.__typename == "CrossReferencedEvent")
+   | .source
+   | select(.__typename == "PullRequest")
+   | {
+       number: .number,
+       state:  (if .merged then "MERGED" elif .state == "OPEN" then "OPEN" else "CLOSED" end),
+       url:    .url
+     }
+  ]')
+
+# ---------------------------------------------------------------------------
+# Merge all PR references and derive signal
+# ---------------------------------------------------------------------------
+
+# Normalize closedByPullRequestsReferences to same shape
+CLOSED_BY_NORMALIZED=$(printf '%s' "$CLOSED_BY_PRS" | jq '
+  [.[] | {
+    number: .number,
+    state:  (if .mergedAt != null then "MERGED" elif .state == "OPEN" then "OPEN" else "CLOSED" end),
+    url:    .url
+  }]')
+
+ALL_PRS=$(jq -n \
+  --argjson a "$CLOSED_BY_NORMALIZED" \
+  --argjson b "$TIMELINE_PRS" \
+  '($a + $b) | unique_by(.number)')
+
+# Derive signal
+RESULT=$(printf '%s' "$ALL_PRS" | jq '
+  . as $prs |
+  if ($prs | map(select(.state == "MERGED")) | length) > 0
+  then
+    ($prs | map(select(.state == "MERGED")) | first) as $pr |
+    {signal: "done", pr_url: $pr.url, pr_state: "MERGED", pr_number: $pr.number}
+  elif ($prs | map(select(.state == "OPEN")) | length) > 0
+  then
+    ($prs | map(select(.state == "OPEN")) | first) as $pr |
+    {signal: "pr-open", pr_url: $pr.url, pr_state: "OPEN", pr_number: $pr.number}
+  else
+    {signal: "none", pr_url: null, pr_state: null, pr_number: null}
+  end
+')
+
+printf '%s\n' "$RESULT"

--- a/plugins/developer-workflow/skills/issue-manager/scripts/gh/get_dependencies.sh
+++ b/plugins/developer-workflow/skills/issue-manager/scripts/gh/get_dependencies.sh
@@ -138,20 +138,16 @@ fi
 
 NODE_ID=$(printf '%s' "$out" | jq -r '.id')
 BODY=$(printf '%s' "$out" | jq -r '.body // ""')
-COMMENTS_TEXT=$(printf '%s' "$out" | jq -r '[.comments[].body] | join("\n")' 2>/dev/null || echo "")
+COMMENTS_TEXT=$(printf '%s' "$out" | jq -r '[.comments[].body] | join("\n")') || {
+  im_error "Failed to parse comments from issue response" "parse_failed"
+  exit 1
+}
 
 # ---------------------------------------------------------------------------
 # Source A: sub-issues via GraphQL
-# Note: subIssues returns issues that are children of this issue.
-# A sub-issue's parent is the blocker/dependency; the sub-issue depends on its parent
-# completing context — but in GitHub sub-issues model, parent contains sub-issues.
-# We emit: sub-issue depends-on (is a child of) parent. Direction: from=sub to=parent.
-# However the spec requests: from=blocked, to=blocker.
-# GitHub sub-issues: parent CONTAINS sub-issues. Sub-issues are tasks within parent.
-# We represent: parent blocks sub-issues? No — the conventional reading is sub-issues
-# must be done for parent to complete. So sub-issue -> parent would be "enables", not "blocks".
-# Per spec the direction chosen: sub-issue IS a dependency edge where THIS issue has sub-issues
-# that must be completed. We emit: from=sub-issue-number, to=THIS (meaning sub blocks parent).
+# Sub-issue edge: the parent is blocked by each child (children must complete before the
+# parent can close). Per the contract {from=blocked, to=blocker}, this is
+# {from=parent, to=child}.
 # ---------------------------------------------------------------------------
 
 graphql_query='query($nodeId:ID!){
@@ -175,9 +171,9 @@ fi
 
 im_check_graphql_errors "$gql_out"
 
-# Build sub-issue edges: sub-issue depends on (from=sub, to=parent)
+# Build sub-issue edges: parent blocked by each child (from=parent, to=child)
 SUBISSUE_EDGES=$(printf '%s' "$gql_out" | jq --argjson parent "$THIS_NUMBER" \
-  '[.data.node.subIssues.nodes[]? | {from: .number, to: $parent, source: "sub-issue"}]')
+  '[.data.node.subIssues.nodes[]? | {from: $parent, to: .number, source: "sub-issue"}]')
 
 # ---------------------------------------------------------------------------
 # Source B: regex parse — "blocked by #N" and "depends on #N"

--- a/plugins/developer-workflow/skills/issue-manager/scripts/gh/get_dependencies.sh
+++ b/plugins/developer-workflow/skills/issue-manager/scripts/gh/get_dependencies.sh
@@ -108,8 +108,7 @@ if [[ -n "$REPO_OVERRIDE" ]]; then
 fi
 
 if [[ -z "$IM_REPO" ]]; then
-  out=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1); rc=$?
-  if [[ $rc -ne 0 ]]; then
+  if ! out=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1); then
     im_error "Cannot resolve repo: $out" "repo_resolve_failed"
     exit 1
   fi
@@ -129,9 +128,8 @@ THIS_NUMBER="$IM_NUMBER"
 # Fetch issue data (node_id, body, comments)
 # ---------------------------------------------------------------------------
 
-out=$(gh issue view "$THIS_NUMBER" -R "$IM_REPO" \
-  --json id,body,comments 2>&1); rc=$?
-if [[ $rc -ne 0 ]]; then
+if ! out=$(gh issue view "$THIS_NUMBER" -R "$IM_REPO" \
+  --json id,body,comments 2>&1); then
   im_error "$out" "gh_failed"
   exit 1
 fi
@@ -160,11 +158,9 @@ graphql_query='query($nodeId:ID!){
   }
 }'
 
-gql_out=$(gh api graphql \
+if ! gql_out=$(gh api graphql \
   -f query="$graphql_query" \
-  -F nodeId="$NODE_ID" 2>&1); rc=$?
-
-if [[ $rc -ne 0 ]]; then
+  -F nodeId="$NODE_ID" 2>&1); then
   im_error "$gql_out" "graphql_failed"
   exit 1
 fi

--- a/plugins/developer-workflow/skills/issue-manager/scripts/gh/get_dependencies.sh
+++ b/plugins/developer-workflow/skills/issue-manager/scripts/gh/get_dependencies.sh
@@ -1,0 +1,228 @@
+#!/bin/bash
+# get_dependencies.sh — derive dependency edges for a GitHub issue.
+#
+# USAGE:
+#   get_dependencies.sh <issue-ref> [-R <owner/repo>]
+#
+# <issue-ref> accepts: plain number, owner/repo#number, or full URL.
+# -R <owner/repo>  Override repository.
+#
+# SOURCES (both are always queried and merged):
+#   A. GitHub sub-issues via GraphQL `subIssues` field (uses issue global node id).
+#      Note: no special GraphQL-Features header required — field is GA.
+#   B. Regex parse of issue body + all comments for:
+#        "blocked by #N"   (case-insensitive)
+#        "depends on #N"   (case-insensitive)
+#      Both imply: issue <this> is blocked by issue <N>.
+#
+# EDGE DIRECTION:
+#   from = the issue that is blocked / depends on another
+#   to   = the blocker / dependency
+#   A "from" issue cannot proceed until "to" is done.
+#
+# OUTPUT (stdout, JSON):
+#   Success:
+#     [
+#       {
+#         "from":   <int>,   -- blocked issue number
+#         "to":     <int>,   -- blocker issue number
+#         "source": "sub-issue" | "blocked-by" | "depends-on"
+#       },
+#       ...
+#     ]
+#   Empty result when no edges found: []
+#
+#   Error:
+#     {"error":<string>,"code":<string>}
+#   Exit code is non-zero on error.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+im_error() {
+  local msg="$1" code="${2:-unknown}"
+  printf '{"error":%s,"code":%s}\n' "$(printf '%s' "$msg" | jq -Rs .)" "$(printf '%s' "$code" | jq -Rs .)"
+}
+
+im_parse_ref() {
+  IM_NUMBER=""
+  IM_REPO=""
+  local ref="$1"
+  if [[ "$ref" =~ ^https?://github\.com/([^/]+/[^/]+)/issues/([0-9]+) ]]; then
+    IM_REPO="${BASH_REMATCH[1]}"
+    IM_NUMBER="${BASH_REMATCH[2]}"
+  elif [[ "$ref" =~ ^([^#]+)#([0-9]+)$ ]]; then
+    IM_REPO="${BASH_REMATCH[1]}"
+    IM_NUMBER="${BASH_REMATCH[2]}"
+  elif [[ "$ref" =~ ^([0-9]+)$ ]]; then
+    IM_NUMBER="${BASH_REMATCH[1]}"
+  else
+    return 1
+  fi
+}
+
+im_check_graphql_errors() {
+  local response="$1"
+  if printf '%s' "$response" | jq -e '.errors' >/dev/null 2>&1; then
+    local errmsg
+    errmsg=$(printf '%s' "$response" | jq -r '.errors[0].message // "GraphQL error"')
+    im_error "$errmsg" "graphql_error"
+    exit 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+if [[ $# -lt 1 ]]; then
+  im_error "Usage: get_dependencies.sh <issue-ref> [-R <owner/repo>]" "usage"
+  exit 1
+fi
+
+RAW_REF="$1"
+shift
+REPO_OVERRIDE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -R) REPO_OVERRIDE="$2"; shift 2 ;;
+    *)  im_error "Unknown flag: $1" "usage"; exit 1 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Resolve repo and number
+# ---------------------------------------------------------------------------
+
+if ! im_parse_ref "$RAW_REF"; then
+  im_error "Cannot parse issue ref: $RAW_REF" "invalid_ref"
+  exit 1
+fi
+
+if [[ -n "$REPO_OVERRIDE" ]]; then
+  IM_REPO="$REPO_OVERRIDE"
+fi
+
+if [[ -z "$IM_REPO" ]]; then
+  out=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1); rc=$?
+  if [[ $rc -ne 0 ]]; then
+    im_error "Cannot resolve repo: $out" "repo_resolve_failed"
+    exit 1
+  fi
+  IM_REPO="$out"
+fi
+
+if [[ -z "$IM_NUMBER" ]]; then
+  im_error "No issue number in ref: $RAW_REF" "invalid_ref"
+  exit 1
+fi
+
+REPO_OWNER="${IM_REPO%%/*}"
+REPO_NAME="${IM_REPO##*/}"
+THIS_NUMBER="$IM_NUMBER"
+
+# ---------------------------------------------------------------------------
+# Fetch issue data (node_id, body, comments)
+# ---------------------------------------------------------------------------
+
+out=$(gh issue view "$THIS_NUMBER" -R "$IM_REPO" \
+  --json id,body,comments 2>&1); rc=$?
+if [[ $rc -ne 0 ]]; then
+  im_error "$out" "gh_failed"
+  exit 1
+fi
+
+NODE_ID=$(printf '%s' "$out" | jq -r '.id')
+BODY=$(printf '%s' "$out" | jq -r '.body // ""')
+COMMENTS_TEXT=$(printf '%s' "$out" | jq -r '[.comments[].body] | join("\n")' 2>/dev/null || echo "")
+
+# ---------------------------------------------------------------------------
+# Source A: sub-issues via GraphQL
+# Note: subIssues returns issues that are children of this issue.
+# A sub-issue's parent is the blocker/dependency; the sub-issue depends on its parent
+# completing context — but in GitHub sub-issues model, parent contains sub-issues.
+# We emit: sub-issue depends-on (is a child of) parent. Direction: from=sub to=parent.
+# However the spec requests: from=blocked, to=blocker.
+# GitHub sub-issues: parent CONTAINS sub-issues. Sub-issues are tasks within parent.
+# We represent: parent blocks sub-issues? No — the conventional reading is sub-issues
+# must be done for parent to complete. So sub-issue -> parent would be "enables", not "blocks".
+# Per spec the direction chosen: sub-issue IS a dependency edge where THIS issue has sub-issues
+# that must be completed. We emit: from=sub-issue-number, to=THIS (meaning sub blocks parent).
+# ---------------------------------------------------------------------------
+
+graphql_query='query($nodeId:ID!){
+  node(id:$nodeId){
+    ... on Issue {
+      subIssues(first:50){
+        nodes{ number }
+      }
+    }
+  }
+}'
+
+gql_out=$(gh api graphql \
+  -f query="$graphql_query" \
+  -F nodeId="$NODE_ID" 2>&1); rc=$?
+
+if [[ $rc -ne 0 ]]; then
+  im_error "$gql_out" "graphql_failed"
+  exit 1
+fi
+
+im_check_graphql_errors "$gql_out"
+
+# Build sub-issue edges: sub-issue depends on (from=sub, to=parent)
+SUBISSUE_EDGES=$(printf '%s' "$gql_out" | jq --argjson parent "$THIS_NUMBER" \
+  '[.data.node.subIssues.nodes[]? | {from: .number, to: $parent, source: "sub-issue"}]')
+
+# ---------------------------------------------------------------------------
+# Source B: regex parse — "blocked by #N" and "depends on #N"
+# Both patterns in body and comments mean THIS issue is blocked by issue N.
+# Edge: from=THIS, to=N
+# ---------------------------------------------------------------------------
+
+# Combine body + comments into one text blob for scanning
+ALL_TEXT="${BODY}
+${COMMENTS_TEXT}"
+
+BLOCKED_BY_NUMS=$(printf '%s' "$ALL_TEXT" | \
+  { grep -ioE 'blocked[[:space:]]+by[[:space:]]+#([0-9]+)' || true; } | \
+  { grep -oE '[0-9]+$' || true; } | sort -un)
+
+DEPENDS_ON_NUMS=$(printf '%s' "$ALL_TEXT" | \
+  { grep -ioE 'depends[[:space:]]+on[[:space:]]+#([0-9]+)' || true; } | \
+  { grep -oE '[0-9]+$' || true; } | sort -un)
+
+# Build blocked-by edges
+BLOCKED_EDGES="[]"
+while IFS= read -r n; do
+  [[ -z "$n" ]] && continue
+  edge=$(jq -n --argjson from "$THIS_NUMBER" --argjson to "$n" \
+    '{from:$from,to:$to,source:"blocked-by"}')
+  BLOCKED_EDGES=$(printf '%s' "$BLOCKED_EDGES" | jq --argjson e "$edge" '. + [$e]')
+done <<< "$BLOCKED_BY_NUMS"
+
+# Build depends-on edges
+DEPENDS_EDGES="[]"
+while IFS= read -r n; do
+  [[ -z "$n" ]] && continue
+  edge=$(jq -n --argjson from "$THIS_NUMBER" --argjson to "$n" \
+    '{from:$from,to:$to,source:"depends-on"}')
+  DEPENDS_EDGES=$(printf '%s' "$DEPENDS_EDGES" | jq --argjson e "$edge" '. + [$e]')
+done <<< "$DEPENDS_ON_NUMS"
+
+# ---------------------------------------------------------------------------
+# Merge all edges and deduplicate by (from,to,source)
+# ---------------------------------------------------------------------------
+
+MERGED=$(jq -n \
+  --argjson a "$SUBISSUE_EDGES" \
+  --argjson b "$BLOCKED_EDGES" \
+  --argjson c "$DEPENDS_EDGES" \
+  '($a + $b + $c) | unique_by({from,to,source})')
+
+printf '%s\n' "$MERGED"

--- a/plugins/developer-workflow/skills/issue-manager/scripts/gh/link_pr.sh
+++ b/plugins/developer-workflow/skills/issue-manager/scripts/gh/link_pr.sh
@@ -112,8 +112,7 @@ if [[ -n "$REPO_OVERRIDE" ]]; then
 fi
 
 if [[ -z "$IM_REPO" ]]; then
-  out=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1); rc=$?
-  if [[ $rc -ne 0 ]]; then
+  if ! out=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1); then
     im_error "Cannot resolve repo: $out" "repo_resolve_failed"
     exit 1
   fi
@@ -128,9 +127,8 @@ MARKER="<!-- issue-manager:link-pr:${PR_NUMBER} -->"
 # Idempotency check — scan existing comments for marker
 # ---------------------------------------------------------------------------
 
-out=$(gh issue view "$ISSUE_NUMBER" -R "$IM_REPO" \
-  --json comments 2>&1); rc=$?
-if [[ $rc -ne 0 ]]; then
+if ! out=$(gh issue view "$ISSUE_NUMBER" -R "$IM_REPO" \
+  --json comments 2>&1); then
   im_error "$out" "gh_failed"
   exit 1
 fi
@@ -171,17 +169,15 @@ fi
 # Post comment
 # ---------------------------------------------------------------------------
 
-new_out=$(gh issue comment "$ISSUE_NUMBER" -R "$IM_REPO" \
-  --body "$COMMENT_BODY" 2>&1); rc=$?
-if [[ $rc -ne 0 ]]; then
+if ! new_out=$(gh issue comment "$ISSUE_NUMBER" -R "$IM_REPO" \
+  --body "$COMMENT_BODY" 2>&1); then
   im_error "$new_out" "gh_failed"
   exit 1
 fi
 
 # Fetch the new comment id by rescanning (gh issue comment doesn't return JSON)
-out2=$(gh issue view "$ISSUE_NUMBER" -R "$IM_REPO" \
-  --json comments 2>&1); rc=$?
-if [[ $rc -ne 0 ]]; then
+if ! out2=$(gh issue view "$ISSUE_NUMBER" -R "$IM_REPO" \
+  --json comments 2>&1); then
   im_error "$out2" "gh_failed"
   exit 1
 fi

--- a/plugins/developer-workflow/skills/issue-manager/scripts/gh/link_pr.sh
+++ b/plugins/developer-workflow/skills/issue-manager/scripts/gh/link_pr.sh
@@ -136,7 +136,10 @@ if [[ $rc -ne 0 ]]; then
 fi
 
 EXISTING=$(printf '%s' "$out" | jq -r --arg marker "$MARKER" \
-  '.comments[] | select(.body | contains($marker)) | .id' 2>/dev/null | head -1 || true)
+  '.comments[] | select(.body | contains($marker)) | .id' 2>/dev/null | head -1) || {
+  im_error "Failed to parse comments while checking idempotency marker" "parse_failed"
+  exit 1
+}
 
 if [[ -n "$EXISTING" ]]; then
   jq -n \
@@ -184,10 +187,13 @@ if [[ $rc -ne 0 ]]; then
 fi
 
 NEW_COMMENT_ID=$(printf '%s' "$out2" | jq -r --arg marker "$MARKER" \
-  '.comments[] | select(.body | contains($marker)) | .id' 2>/dev/null | tail -1 || true)
+  '.comments[] | select(.body | contains($marker)) | .id' 2>/dev/null | tail -1) || {
+  im_error "Failed to parse comments after posting (id rescan)" "parse_failed"
+  exit 1
+}
 
 jq -n \
   --argjson issue "$ISSUE_NUMBER" \
   --argjson pr "$PR_NUMBER" \
-  --arg comment_id "$NEW_COMMENT_ID" \
-  '{action:"linked",issue:$issue,pr:$pr,comment_id:$comment_id,dry_run:false}'
+  --arg cid "$NEW_COMMENT_ID" \
+  '{action:"linked",issue:$issue,pr:$pr,comment_id:($cid | if . == "" then null else . end),dry_run:false}'

--- a/plugins/developer-workflow/skills/issue-manager/scripts/gh/link_pr.sh
+++ b/plugins/developer-workflow/skills/issue-manager/scripts/gh/link_pr.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+# link_pr.sh — associate a PR with a GitHub issue via a comment, idempotently.
+#
+# USAGE:
+#   link_pr.sh <issue-ref> <pr-ref> [OPTIONS]
+#
+# <issue-ref>  Plain number, owner/repo#number, or full URL (issue).
+# <pr-ref>     PR number (int) or full PR URL.
+#
+# OPTIONS:
+#   -R <owner/repo>   Target repository (default: current repo from git)
+#   --dry-run         Print what would be posted, without writing.
+#
+# IDEMPOTENCY:
+#   Uses a hidden HTML comment marker: <!-- issue-manager:link-pr:<pr-number> -->
+#   If any existing comment on the issue already contains this marker, the script
+#   exits with action "noop" and does NOT create a duplicate comment.
+#
+# OUTPUT (stdout, JSON):
+#   {
+#     "action":     "linked" | "noop",
+#     "issue":      <int>,
+#     "pr":         <int>,
+#     "comment_id": <int|null>,   -- new comment id (null on noop or dry-run)
+#     "dry_run":    <bool>
+#   }
+#
+#   Error: {"error":<string>,"code":<string>}
+#   Exit code is non-zero on error.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+im_error() {
+  local msg="$1" code="${2:-unknown}"
+  printf '{"error":%s,"code":%s}\n' "$(printf '%s' "$msg" | jq -Rs .)" "$(printf '%s' "$code" | jq -Rs .)"
+}
+
+im_parse_ref() {
+  IM_NUMBER=""
+  IM_REPO=""
+  local ref="$1"
+  if [[ "$ref" =~ ^https?://github\.com/([^/]+/[^/]+)/issues/([0-9]+) ]]; then
+    IM_REPO="${BASH_REMATCH[1]}"
+    IM_NUMBER="${BASH_REMATCH[2]}"
+  elif [[ "$ref" =~ ^([^#]+)#([0-9]+)$ ]]; then
+    IM_REPO="${BASH_REMATCH[1]}"
+    IM_NUMBER="${BASH_REMATCH[2]}"
+  elif [[ "$ref" =~ ^([0-9]+)$ ]]; then
+    IM_NUMBER="${BASH_REMATCH[1]}"
+  else
+    return 1
+  fi
+}
+
+im_parse_pr_ref() {
+  # Sets IM_PR_NUMBER
+  IM_PR_NUMBER=""
+  local ref="$1"
+  if [[ "$ref" =~ ^https?://github\.com/[^/]+/[^/]+/pull/([0-9]+) ]]; then
+    IM_PR_NUMBER="${BASH_REMATCH[1]}"
+  elif [[ "$ref" =~ ^([0-9]+)$ ]]; then
+    IM_PR_NUMBER="$ref"
+  else
+    return 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+if [[ $# -lt 2 ]]; then
+  im_error "Usage: link_pr.sh <issue-ref> <pr-ref> [-R <owner/repo>] [--dry-run]" "usage"
+  exit 1
+fi
+
+RAW_ISSUE_REF="$1"
+RAW_PR_REF="$2"
+shift 2
+
+REPO_OVERRIDE=""
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -R)        REPO_OVERRIDE="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    *)         im_error "Unknown flag: $1" "usage"; exit 1 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Resolve refs
+# ---------------------------------------------------------------------------
+
+if ! im_parse_ref "$RAW_ISSUE_REF"; then
+  im_error "Cannot parse issue ref: $RAW_ISSUE_REF" "invalid_ref"
+  exit 1
+fi
+
+if ! im_parse_pr_ref "$RAW_PR_REF"; then
+  im_error "Cannot parse PR ref: $RAW_PR_REF (expected: number or https://github.com/.../pull/N)" "invalid_ref"
+  exit 1
+fi
+
+if [[ -n "$REPO_OVERRIDE" ]]; then
+  IM_REPO="$REPO_OVERRIDE"
+fi
+
+if [[ -z "$IM_REPO" ]]; then
+  out=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1); rc=$?
+  if [[ $rc -ne 0 ]]; then
+    im_error "Cannot resolve repo: $out" "repo_resolve_failed"
+    exit 1
+  fi
+  IM_REPO="$out"
+fi
+
+ISSUE_NUMBER="$IM_NUMBER"
+PR_NUMBER="$IM_PR_NUMBER"
+MARKER="<!-- issue-manager:link-pr:${PR_NUMBER} -->"
+
+# ---------------------------------------------------------------------------
+# Idempotency check — scan existing comments for marker
+# ---------------------------------------------------------------------------
+
+out=$(gh issue view "$ISSUE_NUMBER" -R "$IM_REPO" \
+  --json comments 2>&1); rc=$?
+if [[ $rc -ne 0 ]]; then
+  im_error "$out" "gh_failed"
+  exit 1
+fi
+
+EXISTING=$(printf '%s' "$out" | jq -r --arg marker "$MARKER" \
+  '.comments[] | select(.body | contains($marker)) | .id' 2>/dev/null | head -1 || true)
+
+if [[ -n "$EXISTING" ]]; then
+  jq -n \
+    --argjson issue "$ISSUE_NUMBER" \
+    --argjson pr "$PR_NUMBER" \
+    --argjson dry_run "$DRY_RUN" \
+    '{action:"noop",issue:$issue,pr:$pr,comment_id:null,dry_run:$dry_run}'
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Build comment body
+# ---------------------------------------------------------------------------
+
+PR_URL="https://github.com/${IM_REPO}/pull/${PR_NUMBER}"
+COMMENT_BODY="${MARKER}
+Linked PR: ${PR_URL}"
+
+if [[ "$DRY_RUN" == true ]]; then
+  jq -n \
+    --argjson issue "$ISSUE_NUMBER" \
+    --argjson pr "$PR_NUMBER" \
+    --arg body "$COMMENT_BODY" \
+    '{action:"linked",issue:$issue,pr:$pr,comment_id:null,dry_run:true,would_post:$body}'
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Post comment
+# ---------------------------------------------------------------------------
+
+new_out=$(gh issue comment "$ISSUE_NUMBER" -R "$IM_REPO" \
+  --body "$COMMENT_BODY" 2>&1); rc=$?
+if [[ $rc -ne 0 ]]; then
+  im_error "$new_out" "gh_failed"
+  exit 1
+fi
+
+# Fetch the new comment id by rescanning (gh issue comment doesn't return JSON)
+out2=$(gh issue view "$ISSUE_NUMBER" -R "$IM_REPO" \
+  --json comments 2>&1); rc=$?
+if [[ $rc -ne 0 ]]; then
+  im_error "$out2" "gh_failed"
+  exit 1
+fi
+
+NEW_COMMENT_ID=$(printf '%s' "$out2" | jq -r --arg marker "$MARKER" \
+  '.comments[] | select(.body | contains($marker)) | .id' 2>/dev/null | tail -1 || true)
+
+jq -n \
+  --argjson issue "$ISSUE_NUMBER" \
+  --argjson pr "$PR_NUMBER" \
+  --arg comment_id "$NEW_COMMENT_ID" \
+  '{action:"linked",issue:$issue,pr:$pr,comment_id:$comment_id,dry_run:false}'

--- a/plugins/developer-workflow/skills/issue-manager/scripts/gh/link_pr.sh
+++ b/plugins/developer-workflow/skills/issue-manager/scripts/gh/link_pr.sh
@@ -21,7 +21,7 @@
 #     "action":     "linked" | "noop",
 #     "issue":      <int>,
 #     "pr":         <int>,
-#     "comment_id": <int|null>,   -- new comment id (null on noop or dry-run)
+#     "comment_id": <string|null>,   -- new comment id (null on noop or dry-run)
 #     "dry_run":    <bool>
 #   }
 #

--- a/plugins/developer-workflow/skills/issue-manager/scripts/gh/list_issues.sh
+++ b/plugins/developer-workflow/skills/issue-manager/scripts/gh/list_issues.sh
@@ -40,8 +40,7 @@ im_error() {
 }
 
 im_resolve_repo() {
-  out=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1); rc=$?
-  if [[ $rc -ne 0 ]]; then
+  if ! out=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1); then
     im_error "Cannot resolve repo: $out" "repo_resolve_failed"
     exit 1
   fi
@@ -88,9 +87,8 @@ if [[ -n "$NUMBERS" ]]; then
       im_error "Invalid issue number: $n" "invalid_ref"
       exit 1
     fi
-    out=$(gh issue view "$n" -R "$REPO" \
-      --json id,number,title,state,labels,url 2>&1); rc=$?
-    if [[ $rc -ne 0 ]]; then
+    if ! out=$(gh issue view "$n" -R "$REPO" \
+      --json id,number,title,state,labels,url 2>&1); then
       im_error "$out" "gh_failed"
       exit 1
     fi
@@ -114,13 +112,11 @@ for lbl in "${LABELS[@]+"${LABELS[@]}"}"; do
   LABEL_FLAGS+=("--label" "$lbl")
 done
 
-out=$(gh issue list -R "$REPO" \
+if ! out=$(gh issue list -R "$REPO" \
   --state "$STATE" \
   --limit "$LIMIT" \
   "${LABEL_FLAGS[@]+"${LABEL_FLAGS[@]}"}" \
-  --json id,number,title,state,labels,url 2>&1); rc=$?
-
-if [[ $rc -ne 0 ]]; then
+  --json id,number,title,state,labels,url 2>&1); then
   im_error "$out" "gh_failed"
   exit 1
 fi

--- a/plugins/developer-workflow/skills/issue-manager/scripts/gh/list_issues.sh
+++ b/plugins/developer-workflow/skills/issue-manager/scripts/gh/list_issues.sh
@@ -84,6 +84,10 @@ if [[ -n "$NUMBERS" ]]; then
   for n in "${NUMLIST[@]}"; do
     n="${n// /}"
     [[ -z "$n" ]] && continue
+    if [[ ! "$n" =~ ^[0-9]+$ ]]; then
+      im_error "Invalid issue number: $n" "invalid_ref"
+      exit 1
+    fi
     out=$(gh issue view "$n" -R "$REPO" \
       --json id,number,title,state,labels,url 2>&1); rc=$?
     if [[ $rc -ne 0 ]]; then

--- a/plugins/developer-workflow/skills/issue-manager/scripts/gh/list_issues.sh
+++ b/plugins/developer-workflow/skills/issue-manager/scripts/gh/list_issues.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# list_issues.sh — list GitHub issues with optional filters and output a JSON array.
+#
+# USAGE:
+#   list_issues.sh [OPTIONS] [-R <owner/repo>]
+#
+# OPTIONS (all optional; defaults: state=open, limit=30):
+#   --state <open|closed|all>      Filter by state (default: open)
+#   --label <name>                 Filter by label name (repeatable)
+#   --limit <n>                    Max number of issues to return (default: 30)
+#   --numbers <n1,n2,...>          Fetch only these specific issue numbers (overrides other filters)
+#   -R <owner/repo>                Target repository (default: current repo from git)
+#
+# OUTPUT (stdout, JSON):
+#   Success: JSON array of issue objects. Each object:
+#     {
+#       "number":  <int>,
+#       "title":   <string>,
+#       "state":   "OPEN"|"CLOSED",
+#       "labels":  [{"id":<string>,"name":<string>,"color":<string>},...],
+#       "url":     <string>,
+#       "node_id": <string>
+#     }
+#   Note: body is omitted for list output to keep payloads compact.
+#         Use fetch_issue.sh to retrieve the full body of a specific issue.
+#
+#   Error:
+#     {"error":<string>,"code":<string>}
+#   Exit code is non-zero on error.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+im_error() {
+  local msg="$1" code="${2:-unknown}"
+  printf '{"error":%s,"code":%s}\n' "$(printf '%s' "$msg" | jq -Rs .)" "$(printf '%s' "$code" | jq -Rs .)"
+}
+
+im_resolve_repo() {
+  out=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1); rc=$?
+  if [[ $rc -ne 0 ]]; then
+    im_error "Cannot resolve repo: $out" "repo_resolve_failed"
+    exit 1
+  fi
+  printf '%s' "$out"
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+REPO=""
+STATE="open"
+LIMIT="30"
+LABELS=()
+NUMBERS=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -R)          REPO="$2"; shift 2 ;;
+    --state)     STATE="$2"; shift 2 ;;
+    --label)     LABELS+=("$2"); shift 2 ;;
+    --limit)     LIMIT="$2"; shift 2 ;;
+    --numbers)   NUMBERS="$2"; shift 2 ;;
+    *)           im_error "Unknown flag: $1" "usage"; exit 1 ;;
+  esac
+done
+
+if [[ -z "$REPO" ]]; then
+  REPO=$(im_resolve_repo)
+fi
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+
+if [[ -n "$NUMBERS" ]]; then
+  # Fetch each numbered issue individually and merge into array.
+  IFS=',' read -ra NUMLIST <<< "$NUMBERS"
+  results="[]"
+  for n in "${NUMLIST[@]}"; do
+    n="${n// /}"
+    [[ -z "$n" ]] && continue
+    out=$(gh issue view "$n" -R "$REPO" \
+      --json id,number,title,state,labels,url 2>&1); rc=$?
+    if [[ $rc -ne 0 ]]; then
+      im_error "$out" "gh_failed"
+      exit 1
+    fi
+    item=$(printf '%s' "$out" | jq '{
+      number:  .number,
+      title:   .title,
+      state:   .state,
+      labels:  [.labels[] | {id: .id, name: .name, color: .color}],
+      url:     .url,
+      node_id: .id
+    }')
+    results=$(printf '%s' "$results" | jq --argjson item "$item" '. + [$item]')
+  done
+  printf '%s\n' "$results"
+  exit 0
+fi
+
+# Build label flags
+LABEL_FLAGS=()
+for lbl in "${LABELS[@]+"${LABELS[@]}"}"; do
+  LABEL_FLAGS+=("--label" "$lbl")
+done
+
+out=$(gh issue list -R "$REPO" \
+  --state "$STATE" \
+  --limit "$LIMIT" \
+  "${LABEL_FLAGS[@]+"${LABEL_FLAGS[@]}"}" \
+  --json id,number,title,state,labels,url 2>&1); rc=$?
+
+if [[ $rc -ne 0 ]]; then
+  im_error "$out" "gh_failed"
+  exit 1
+fi
+
+printf '%s' "$out" | jq '[.[] | {
+  number:  .number,
+  title:   .title,
+  state:   .state,
+  labels:  [.labels[] | {id: .id, name: .name, color: .color}],
+  url:     .url,
+  node_id: .id
+}]'

--- a/plugins/developer-workflow/skills/issue-manager/scripts/gh/transition_status.sh
+++ b/plugins/developer-workflow/skills/issue-manager/scripts/gh/transition_status.sh
@@ -210,7 +210,7 @@ detect_project() {
     -f query='query($projId:ID!){node(id:$projId){... on ProjectV2{fields(first:30){nodes{... on ProjectV2FieldCommon{id name} ... on ProjectV2SingleSelectField{id name options{id name}}}}}}}' \
     -f projId="$project_id_to_use" 2>&1); local rc=$?
   if [[ $rc -ne 0 ]]; then return 1; fi
-  im_check_graphql_errors "$fields_out" 2>/dev/null || return 1
+  if jq -e '.errors' >/dev/null 2>&1 <<<"$fields_out"; then return 1; fi
 
   local status_field_id
   status_field_id=$(printf '%s' "$fields_out" | jq -r \
@@ -238,7 +238,7 @@ detect_project() {
     -f query='query($nodeId:ID!){node(id:$nodeId){... on Issue{projectItems(first:10){nodes{id project{id} fieldValues(first:20){nodes{... on ProjectV2ItemFieldSingleSelectValue{name optionId field{... on ProjectV2FieldCommon{name}}}}}}}}}}}' \
     -f nodeId="$ISSUE_NODE_ID" 2>&1); local rc2=$?
   if [[ $rc2 -ne 0 ]]; then return 1; fi
-  im_check_graphql_errors "$items_out" 2>/dev/null || return 1
+  if jq -e '.errors' >/dev/null 2>&1 <<<"$items_out"; then return 1; fi
 
   local item_id
   item_id=$(printf '%s' "$items_out" | jq -r \
@@ -365,17 +365,7 @@ if [[ "$MECHANISM" == "project-v2" ]]; then
   im_check_graphql_errors "$mut_out"
 else
   # Apply label changes and state changes
-  # Remove old status labels first
-  for lbl in "status:in-progress" "status:blocked"; do
-    if printf '%s' "$ISSUE_LABELS" | grep -qF "$lbl"; then
-      rm_out=$(gh issue edit "$IM_NUMBER" -R "$IM_REPO" --remove-label "$lbl" 2>&1) || {
-        im_error "Failed to remove label $lbl: $rm_out" "gh_failed"
-        exit 1
-      }
-    fi
-  done
-
-  # Add new status label if needed
+  # Add new status label first (before removing old ones) to avoid label-less limbo.
   for lbl in "${TARGET_ADD_LABELS[@]+"${TARGET_ADD_LABELS[@]}"}"; do
     # Ensure label exists; gh label create exits non-zero when label already exists —
     # tolerate that case but error on real failures (e.g. permission denied).
@@ -383,13 +373,23 @@ else
     create_out=$(gh label create "$lbl" -R "$IM_REPO" --color "ededed" --description "Issue status: $lbl" 2>&1) || true
     # After attempted create, verify the label actually exists (handles both success and "already exists").
     if ! gh label list -R "$IM_REPO" --search "$lbl" --json name -q '.[].name' 2>/dev/null | grep -qF "$lbl"; then
-      im_error "Failed to create label $lbl and label does not exist: $create_out" "gh_failed"
+      im_error "Failed to ensure label $lbl exists: $create_out" "gh_failed"
       exit 1
     fi
     add_out=$(gh issue edit "$IM_NUMBER" -R "$IM_REPO" --add-label "$lbl" 2>&1) || {
       im_error "Failed to add label $lbl: $add_out" "gh_failed"
       exit 1
     }
+  done
+
+  # Remove old status labels only after the new one is in place
+  for lbl in "status:in-progress" "status:blocked"; do
+    if printf '%s' "$ISSUE_LABELS" | grep -qF "$lbl"; then
+      rm_out=$(gh issue edit "$IM_NUMBER" -R "$IM_REPO" --remove-label "$lbl" 2>&1) || {
+        im_error "Failed to remove label $lbl: $rm_out" "gh_failed"
+        exit 1
+      }
+    fi
   done
 
   # Apply open/closed state

--- a/plugins/developer-workflow/skills/issue-manager/scripts/gh/transition_status.sh
+++ b/plugins/developer-workflow/skills/issue-manager/scripts/gh/transition_status.sh
@@ -172,6 +172,10 @@ if [[ $rc -ne 0 ]]; then
 fi
 
 ISSUE_NODE_ID=$(printf '%s' "$out" | jq -r '.id')
+if [[ -z "$ISSUE_NODE_ID" || "$ISSUE_NODE_ID" == "null" ]]; then
+  im_error "Could not resolve issue node id for $IM_NUMBER" "invalid_ref"
+  exit 1
+fi
 ISSUE_STATE=$(printf '%s' "$out" | jq -r '.state') # OPEN or CLOSED
 ISSUE_LABELS=$(printf '%s' "$out" | jq -r '[.labels[].name] | join(",")')
 
@@ -268,7 +272,10 @@ else
   # Scan owner's projects
   proj_list_out=$(gh project list --owner "$REPO_OWNER" --format json 2>&1); proj_rc=$?
   if [[ $proj_rc -eq 0 ]]; then
-    proj_ids=$(printf '%s' "$proj_list_out" | jq -r '.projects[].id' 2>/dev/null || true)
+    proj_ids=$(printf '%s' "$proj_list_out" | jq -r '.projects[].id') || {
+      im_error "Failed to parse project list response" "parse_failed"
+      exit 1
+    }
     while IFS= read -r pid; do
       [[ -z "$pid" ]] && continue
       if detect_project "$pid" 2>/dev/null; then
@@ -361,22 +368,41 @@ else
   # Remove old status labels first
   for lbl in "status:in-progress" "status:blocked"; do
     if printf '%s' "$ISSUE_LABELS" | grep -qF "$lbl"; then
-      gh issue edit "$IM_NUMBER" -R "$IM_REPO" --remove-label "$lbl" >/dev/null 2>&1 || true
+      rm_out=$(gh issue edit "$IM_NUMBER" -R "$IM_REPO" --remove-label "$lbl" 2>&1) || {
+        im_error "Failed to remove label $lbl: $rm_out" "gh_failed"
+        exit 1
+      }
     fi
   done
 
   # Add new status label if needed
   for lbl in "${TARGET_ADD_LABELS[@]+"${TARGET_ADD_LABELS[@]}"}"; do
-    # Ensure label exists
-    gh label create "$lbl" -R "$IM_REPO" --color "ededed" --description "Issue status: $lbl" 2>/dev/null || true
-    gh issue edit "$IM_NUMBER" -R "$IM_REPO" --add-label "$lbl" >/dev/null 2>&1
+    # Ensure label exists; gh label create exits non-zero when label already exists —
+    # tolerate that case but error on real failures (e.g. permission denied).
+    # Use explicit rc capture protected from set -e via "|| true" then re-check existence.
+    create_out=$(gh label create "$lbl" -R "$IM_REPO" --color "ededed" --description "Issue status: $lbl" 2>&1) || true
+    # After attempted create, verify the label actually exists (handles both success and "already exists").
+    if ! gh label list -R "$IM_REPO" --search "$lbl" --json name -q '.[].name' 2>/dev/null | grep -qF "$lbl"; then
+      im_error "Failed to create label $lbl and label does not exist: $create_out" "gh_failed"
+      exit 1
+    fi
+    add_out=$(gh issue edit "$IM_NUMBER" -R "$IM_REPO" --add-label "$lbl" 2>&1) || {
+      im_error "Failed to add label $lbl: $add_out" "gh_failed"
+      exit 1
+    }
   done
 
   # Apply open/closed state
   if [[ "$TARGET_OPEN" == "false" && "$ISSUE_STATE" == "OPEN" ]]; then
-    gh issue close "$IM_NUMBER" -R "$IM_REPO" >/dev/null 2>&1
+    close_out=$(gh issue close "$IM_NUMBER" -R "$IM_REPO" 2>&1) || {
+      im_error "Failed to close issue $IM_NUMBER: $close_out" "gh_failed"
+      exit 1
+    }
   elif [[ "$TARGET_OPEN" == "true" && "$ISSUE_STATE" == "CLOSED" ]]; then
-    gh issue reopen "$IM_NUMBER" -R "$IM_REPO" >/dev/null 2>&1
+    reopen_out=$(gh issue reopen "$IM_NUMBER" -R "$IM_REPO" 2>&1) || {
+      im_error "Failed to reopen issue $IM_NUMBER: $reopen_out" "gh_failed"
+      exit 1
+    }
   fi
 fi
 

--- a/plugins/developer-workflow/skills/issue-manager/scripts/gh/transition_status.sh
+++ b/plugins/developer-workflow/skills/issue-manager/scripts/gh/transition_status.sh
@@ -144,8 +144,7 @@ if [[ -n "$REPO_OVERRIDE" ]]; then
 fi
 
 if [[ -z "$IM_REPO" ]]; then
-  out=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1); rc=$?
-  if [[ $rc -ne 0 ]]; then
+  if ! out=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1); then
     im_error "Cannot resolve repo: $out" "repo_resolve_failed"
     exit 1
   fi
@@ -164,9 +163,8 @@ REPO_NAME="${IM_REPO##*/}"
 # Read current issue state (always — part of read-before-write and dry-run output)
 # ---------------------------------------------------------------------------
 
-out=$(gh issue view "$IM_NUMBER" -R "$IM_REPO" \
-  --json id,number,state,labels 2>&1); rc=$?
-if [[ $rc -ne 0 ]]; then
+if ! out=$(gh issue view "$IM_NUMBER" -R "$IM_REPO" \
+  --json id,number,state,labels 2>&1); then
   im_error "$out" "gh_failed"
   exit 1
 fi
@@ -270,7 +268,7 @@ if [[ -n "$FORCED_PROJECT_ID" ]]; then
   fi
 else
   # Scan owner's projects
-  proj_list_out=$(gh project list --owner "$REPO_OWNER" --format json 2>&1); proj_rc=$?
+  if proj_list_out=$(gh project list --owner "$REPO_OWNER" --format json 2>&1); then proj_rc=0; else proj_rc=$?; fi
   if [[ $proj_rc -eq 0 ]]; then
     proj_ids=$(printf '%s' "$proj_list_out" | jq -r '.projects[].id') || {
       im_error "Failed to parse project list response" "parse_failed"
@@ -352,13 +350,12 @@ fi
 # ---------------------------------------------------------------------------
 
 if [[ "$MECHANISM" == "project-v2" ]]; then
-  mut_out=$(gh api graphql \
+  if ! mut_out=$(gh api graphql \
     -f query='mutation($projId:ID!,$itemId:ID!,$fieldId:ID!,$optId:String!){updateProjectV2ItemFieldValue(input:{projectId:$projId,itemId:$itemId,fieldId:$fieldId,value:{singleSelectOptionId:$optId}}){projectV2Item{id}}}' \
     -f projId="$PROJECT_ID" \
     -f itemId="$PROJECT_ITEM_ID" \
     -f fieldId="$PROJECT_STATUS_FIELD_ID" \
-    -f optId="$PROJECT_TARGET_OPTION_ID" 2>&1); rc=$?
-  if [[ $rc -ne 0 ]]; then
+    -f optId="$PROJECT_TARGET_OPTION_ID" 2>&1); then
     im_error "$mut_out" "graphql_failed"
     exit 1
   fi

--- a/plugins/developer-workflow/skills/issue-manager/scripts/gh/transition_status.sh
+++ b/plugins/developer-workflow/skills/issue-manager/scripts/gh/transition_status.sh
@@ -1,0 +1,387 @@
+#!/bin/bash
+# transition_status.sh — idempotent issue status transition.
+#
+# USAGE:
+#   transition_status.sh <issue-ref> <target-status> [OPTIONS]
+#
+# <issue-ref>      Plain number, owner/repo#number, or full URL.
+# <target-status>  One of: todo | in-progress | blocked | done | open | closed
+#                  Canonical form is lowercase-with-hyphens.
+#                  Aliases accepted: "in_progress" → "in-progress", "In Progress" → "in-progress", etc.
+#
+# OPTIONS:
+#   -R <owner/repo>   Target repository (default: current repo from git)
+#   --project-id <id> Force use of a specific Project v2 node id (skips auto-detect)
+#   --dry-run         Resolve current state and planned action, then EXIT without writing.
+#                     Prints the resolved payload it WOULD send. Safe to run against live issues.
+#
+# MECHANISM:
+#   1. Detect GitHub Project v2 (via `gh project list --owner <owner>`).
+#      If a project is found for this repo's owner AND the issue is linked to the project,
+#      uses GraphQL to set the Status single-select field.
+#   2. Fallback: open/closed state + labels (status:in-progress, status:blocked).
+#
+# READ-BEFORE-WRITE (AC-5):
+#   Always reads current status before writing. Writes ONLY if current != target.
+#
+# STATUS MAPPING:
+#   target          Project v2 option    Open/closed + label
+#   todo            Todo                 open (no status label)
+#   in-progress     In Progress          open + label "status:in-progress"
+#   blocked         (none — label only)  open + label "status:blocked"
+#   done            Done                 closed
+#   open            (→ todo)             open
+#   closed          (→ done)             closed
+#
+# OUTPUT (stdout, JSON):
+#   {
+#     "action":     "transition" | "noop",
+#     "from":       <string|null>,   -- current status (normalized)
+#     "to":         <string>,        -- target status (normalized)
+#     "mechanism":  "project-v2" | "labels",
+#     "dry_run":    <bool>
+#   }
+#
+#   Error: {"error":<string>,"code":<string>}
+#   Exit code is non-zero on error.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+im_error() {
+  local msg="$1" code="${2:-unknown}"
+  printf '{"error":%s,"code":%s}\n' "$(printf '%s' "$msg" | jq -Rs .)" "$(printf '%s' "$code" | jq -Rs .)"
+}
+
+im_parse_ref() {
+  IM_NUMBER=""
+  IM_REPO=""
+  local ref="$1"
+  if [[ "$ref" =~ ^https?://github\.com/([^/]+/[^/]+)/issues/([0-9]+) ]]; then
+    IM_REPO="${BASH_REMATCH[1]}"
+    IM_NUMBER="${BASH_REMATCH[2]}"
+  elif [[ "$ref" =~ ^([^#]+)#([0-9]+)$ ]]; then
+    IM_REPO="${BASH_REMATCH[1]}"
+    IM_NUMBER="${BASH_REMATCH[2]}"
+  elif [[ "$ref" =~ ^([0-9]+)$ ]]; then
+    IM_NUMBER="${BASH_REMATCH[1]}"
+  else
+    return 1
+  fi
+}
+
+im_check_graphql_errors() {
+  local response="$1"
+  if printf '%s' "$response" | jq -e '.errors' >/dev/null 2>&1; then
+    local errmsg
+    errmsg=$(printf '%s' "$response" | jq -r '.errors[0].message // "GraphQL error"')
+    im_error "$errmsg" "graphql_error"
+    exit 1
+  fi
+}
+
+im_normalize_status() {
+  # Normalize status to lowercase-with-hyphens canonical form
+  local raw
+  raw=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[_ ]/-/g')
+  case "$raw" in
+    todo|open)         printf 'todo' ;;
+    in-progress)       printf 'in-progress' ;;
+    blocked)           printf 'blocked' ;;
+    done|closed)       printf 'done' ;;
+    *)                 printf '%s' "$raw" ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+if [[ $# -lt 2 ]]; then
+  im_error "Usage: transition_status.sh <issue-ref> <target-status> [-R <owner/repo>] [--dry-run]" "usage"
+  exit 1
+fi
+
+RAW_REF="$1"
+RAW_TARGET="$2"
+shift 2
+
+REPO_OVERRIDE=""
+DRY_RUN=false
+FORCED_PROJECT_ID=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -R)            REPO_OVERRIDE="$2"; shift 2 ;;
+    --project-id)  FORCED_PROJECT_ID="$2"; shift 2 ;;
+    --dry-run)     DRY_RUN=true; shift ;;
+    *)             im_error "Unknown flag: $1" "usage"; exit 1 ;;
+  esac
+done
+
+TARGET_STATUS=$(im_normalize_status "$RAW_TARGET")
+
+# Validate target
+case "$TARGET_STATUS" in
+  todo|in-progress|blocked|done) ;;
+  *) im_error "Unknown target status: $RAW_TARGET (accepted: todo|in-progress|blocked|done)" "invalid_status"; exit 1 ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Resolve repo and number
+# ---------------------------------------------------------------------------
+
+if ! im_parse_ref "$RAW_REF"; then
+  im_error "Cannot parse issue ref: $RAW_REF" "invalid_ref"
+  exit 1
+fi
+
+if [[ -n "$REPO_OVERRIDE" ]]; then
+  IM_REPO="$REPO_OVERRIDE"
+fi
+
+if [[ -z "$IM_REPO" ]]; then
+  out=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>&1); rc=$?
+  if [[ $rc -ne 0 ]]; then
+    im_error "Cannot resolve repo: $out" "repo_resolve_failed"
+    exit 1
+  fi
+  IM_REPO="$out"
+fi
+
+if [[ -z "$IM_NUMBER" ]]; then
+  im_error "No issue number in ref: $RAW_REF" "invalid_ref"
+  exit 1
+fi
+
+REPO_OWNER="${IM_REPO%%/*}"
+REPO_NAME="${IM_REPO##*/}"
+
+# ---------------------------------------------------------------------------
+# Read current issue state (always — part of read-before-write and dry-run output)
+# ---------------------------------------------------------------------------
+
+out=$(gh issue view "$IM_NUMBER" -R "$IM_REPO" \
+  --json id,number,state,labels 2>&1); rc=$?
+if [[ $rc -ne 0 ]]; then
+  im_error "$out" "gh_failed"
+  exit 1
+fi
+
+ISSUE_NODE_ID=$(printf '%s' "$out" | jq -r '.id')
+ISSUE_STATE=$(printf '%s' "$out" | jq -r '.state') # OPEN or CLOSED
+ISSUE_LABELS=$(printf '%s' "$out" | jq -r '[.labels[].name] | join(",")')
+
+# Derive current status from labels + state (labels-mechanism baseline)
+if [[ "$ISSUE_STATE" == "CLOSED" ]]; then
+  CURRENT_LABELS_STATUS="done"
+elif printf '%s' "$ISSUE_LABELS" | grep -qi 'status:in-progress'; then
+  CURRENT_LABELS_STATUS="in-progress"
+elif printf '%s' "$ISSUE_LABELS" | grep -qi 'status:blocked'; then
+  CURRENT_LABELS_STATUS="blocked"
+else
+  CURRENT_LABELS_STATUS="todo"
+fi
+
+# ---------------------------------------------------------------------------
+# Detect Project v2 and check if issue is linked
+# ---------------------------------------------------------------------------
+
+MECHANISM="labels"
+PROJECT_ID=""
+PROJECT_ITEM_ID=""
+PROJECT_STATUS_FIELD_ID=""
+PROJECT_CURRENT_STATUS=""
+PROJECT_TARGET_OPTION_ID=""
+
+detect_project() {
+  local project_id_to_use="$1"
+
+  # Query project fields to find Status field id
+  local fields_out
+  fields_out=$(gh api graphql \
+    -f query='query($projId:ID!){node(id:$projId){... on ProjectV2{fields(first:30){nodes{... on ProjectV2FieldCommon{id name} ... on ProjectV2SingleSelectField{id name options{id name}}}}}}}' \
+    -f projId="$project_id_to_use" 2>&1); local rc=$?
+  if [[ $rc -ne 0 ]]; then return 1; fi
+  im_check_graphql_errors "$fields_out" 2>/dev/null || return 1
+
+  local status_field_id
+  status_field_id=$(printf '%s' "$fields_out" | jq -r \
+    '.data.node.fields.nodes[] | select(.name=="Status") | .id' 2>/dev/null || true)
+  [[ -z "$status_field_id" ]] && return 1
+
+  # Map target_status to option id
+  local option_name
+  case "$TARGET_STATUS" in
+    todo)        option_name="Todo" ;;
+    in-progress) option_name="In Progress" ;;
+    blocked)     option_name="Todo" ;; # no Blocked option in project; fall through to labels
+    done)        option_name="Done" ;;
+  esac
+
+  local option_id
+  option_id=$(printf '%s' "$fields_out" | jq -r \
+    --arg name "$option_name" \
+    '.data.node.fields.nodes[] | select(.name=="Status") | .options[]? | select(.name==$name) | .id' \
+    2>/dev/null || true)
+
+  # Check if issue is linked to this project
+  local items_out
+  items_out=$(gh api graphql \
+    -f query='query($nodeId:ID!){node(id:$nodeId){... on Issue{projectItems(first:10){nodes{id project{id} fieldValues(first:20){nodes{... on ProjectV2ItemFieldSingleSelectValue{name optionId field{... on ProjectV2FieldCommon{name}}}}}}}}}}}' \
+    -f nodeId="$ISSUE_NODE_ID" 2>&1); local rc2=$?
+  if [[ $rc2 -ne 0 ]]; then return 1; fi
+  im_check_graphql_errors "$items_out" 2>/dev/null || return 1
+
+  local item_id
+  item_id=$(printf '%s' "$items_out" | jq -r \
+    --arg projId "$project_id_to_use" \
+    '.data.node.projectItems.nodes[] | select(.project.id==$projId) | .id' 2>/dev/null || true)
+
+  [[ -z "$item_id" ]] && return 1  # issue not in this project
+
+  local current_option
+  current_option=$(printf '%s' "$items_out" | jq -r \
+    --arg projId "$project_id_to_use" \
+    '.data.node.projectItems.nodes[] | select(.project.id==$projId) | .fieldValues.nodes[] | select(.field.name=="Status") | .name' \
+    2>/dev/null || true)
+
+  PROJECT_STATUS_FIELD_ID="$status_field_id"
+  PROJECT_ITEM_ID="$item_id"
+  PROJECT_CURRENT_STATUS=$(im_normalize_status "${current_option:-todo}")
+  PROJECT_TARGET_OPTION_ID="$option_id"
+  PROJECT_ID="$project_id_to_use"
+  return 0
+}
+
+# Try to find a project — use forced id if provided, else scan owner's projects
+USE_PROJECT=false
+
+if [[ -n "$FORCED_PROJECT_ID" ]]; then
+  if detect_project "$FORCED_PROJECT_ID" 2>/dev/null; then
+    USE_PROJECT=true
+  fi
+else
+  # Scan owner's projects
+  proj_list_out=$(gh project list --owner "$REPO_OWNER" --format json 2>&1); proj_rc=$?
+  if [[ $proj_rc -eq 0 ]]; then
+    proj_ids=$(printf '%s' "$proj_list_out" | jq -r '.projects[].id' 2>/dev/null || true)
+    while IFS= read -r pid; do
+      [[ -z "$pid" ]] && continue
+      if detect_project "$pid" 2>/dev/null; then
+        USE_PROJECT=true
+        break
+      fi
+    done <<< "$proj_ids"
+  fi
+  # Scope/permission errors from gh project list degrade to labels silently
+fi
+
+# Determine current status and mechanism
+CURRENT_STATUS="$CURRENT_LABELS_STATUS"
+if [[ "$USE_PROJECT" == true && -n "$PROJECT_TARGET_OPTION_ID" && "$TARGET_STATUS" != "blocked" ]]; then
+  MECHANISM="project-v2"
+  CURRENT_STATUS="$PROJECT_CURRENT_STATUS"
+fi
+
+# ---------------------------------------------------------------------------
+# Idempotency check
+# ---------------------------------------------------------------------------
+
+if [[ "$CURRENT_STATUS" == "$TARGET_STATUS" ]]; then
+  jq -n \
+    --arg from "$CURRENT_STATUS" \
+    --arg to "$TARGET_STATUS" \
+    --arg mechanism "$MECHANISM" \
+    --argjson dry_run "$DRY_RUN" \
+    '{action:"noop",from:$from,to:$to,mechanism:$mechanism,dry_run:$dry_run}'
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Build dry-run or real transition
+# ---------------------------------------------------------------------------
+
+if [[ "$MECHANISM" == "project-v2" ]]; then
+  DRY_PAYLOAD=$(jq -n \
+    --arg projectId "$PROJECT_ID" \
+    --arg itemId "$PROJECT_ITEM_ID" \
+    --arg fieldId "$PROJECT_STATUS_FIELD_ID" \
+    --arg optionId "$PROJECT_TARGET_OPTION_ID" \
+    '{mutation:"updateProjectV2ItemFieldValue",projectId:$projectId,itemId:$itemId,fieldId:$fieldId,singleSelectOptionId:$optionId}')
+else
+  # Labels mechanism — determine state change and label changes
+  TARGET_OPEN="true"
+  TARGET_ADD_LABELS=()
+  TARGET_REMOVE_LABELS=("status:in-progress" "status:blocked")
+  case "$TARGET_STATUS" in
+    todo)        TARGET_OPEN="true" ;;
+    in-progress) TARGET_OPEN="true"; TARGET_ADD_LABELS+=("status:in-progress") ;;
+    blocked)     TARGET_OPEN="true"; TARGET_ADD_LABELS+=("status:blocked") ;;
+    done)        TARGET_OPEN="false" ;;
+  esac
+  DRY_PAYLOAD=$(jq -n \
+    --argjson open "$TARGET_OPEN" \
+    --argjson add_labels "$(printf '%s\n' "${TARGET_ADD_LABELS[@]+"${TARGET_ADD_LABELS[@]}"}" | jq -Rs 'split("\n") | map(select(length>0))')" \
+    --argjson remove_labels "$(printf '%s\n' "${TARGET_REMOVE_LABELS[@]}" | jq -Rs 'split("\n") | map(select(length>0))')" \
+    '{open:$open,add_labels:$add_labels,remove_labels:$remove_labels}')
+fi
+
+if [[ "$DRY_RUN" == true ]]; then
+  jq -n \
+    --arg from "$CURRENT_STATUS" \
+    --arg to "$TARGET_STATUS" \
+    --arg mechanism "$MECHANISM" \
+    --argjson payload "$DRY_PAYLOAD" \
+    '{action:"transition",from:$from,to:$to,mechanism:$mechanism,dry_run:true,resolved_payload:$payload}'
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Execute transition
+# ---------------------------------------------------------------------------
+
+if [[ "$MECHANISM" == "project-v2" ]]; then
+  mut_out=$(gh api graphql \
+    -f query='mutation($projId:ID!,$itemId:ID!,$fieldId:ID!,$optId:String!){updateProjectV2ItemFieldValue(input:{projectId:$projId,itemId:$itemId,fieldId:$fieldId,value:{singleSelectOptionId:$optId}}){projectV2Item{id}}}' \
+    -f projId="$PROJECT_ID" \
+    -f itemId="$PROJECT_ITEM_ID" \
+    -f fieldId="$PROJECT_STATUS_FIELD_ID" \
+    -f optId="$PROJECT_TARGET_OPTION_ID" 2>&1); rc=$?
+  if [[ $rc -ne 0 ]]; then
+    im_error "$mut_out" "graphql_failed"
+    exit 1
+  fi
+  im_check_graphql_errors "$mut_out"
+else
+  # Apply label changes and state changes
+  # Remove old status labels first
+  for lbl in "status:in-progress" "status:blocked"; do
+    if printf '%s' "$ISSUE_LABELS" | grep -qF "$lbl"; then
+      gh issue edit "$IM_NUMBER" -R "$IM_REPO" --remove-label "$lbl" >/dev/null 2>&1 || true
+    fi
+  done
+
+  # Add new status label if needed
+  for lbl in "${TARGET_ADD_LABELS[@]+"${TARGET_ADD_LABELS[@]}"}"; do
+    # Ensure label exists
+    gh label create "$lbl" -R "$IM_REPO" --color "ededed" --description "Issue status: $lbl" 2>/dev/null || true
+    gh issue edit "$IM_NUMBER" -R "$IM_REPO" --add-label "$lbl" >/dev/null 2>&1
+  done
+
+  # Apply open/closed state
+  if [[ "$TARGET_OPEN" == "false" && "$ISSUE_STATE" == "OPEN" ]]; then
+    gh issue close "$IM_NUMBER" -R "$IM_REPO" >/dev/null 2>&1
+  elif [[ "$TARGET_OPEN" == "true" && "$ISSUE_STATE" == "CLOSED" ]]; then
+    gh issue reopen "$IM_NUMBER" -R "$IM_REPO" >/dev/null 2>&1
+  fi
+fi
+
+jq -n \
+  --arg from "$CURRENT_STATUS" \
+  --arg to "$TARGET_STATUS" \
+  --arg mechanism "$MECHANISM" \
+  '{action:"transition",from:$from,to:$to,mechanism:$mechanism,dry_run:false}'

--- a/plugins/developer-workflow/skills/issue-manager/scripts/gh/transition_status.sh
+++ b/plugins/developer-workflow/skills/issue-manager/scripts/gh/transition_status.sh
@@ -369,7 +369,7 @@ else
     # Use explicit rc capture protected from set -e via "|| true" then re-check existence.
     create_out=$(gh label create "$lbl" -R "$IM_REPO" --color "ededed" --description "Issue status: $lbl" 2>&1) || true
     # After attempted create, verify the label actually exists (handles both success and "already exists").
-    if ! gh label list -R "$IM_REPO" --search "$lbl" --json name -q '.[].name' 2>/dev/null | grep -qF "$lbl"; then
+    if ! gh label list -R "$IM_REPO" --search "$lbl" --json name -q '.[].name' 2>/dev/null | grep -qxF "$lbl"; then
       im_error "Failed to ensure label $lbl exists: $create_out" "gh_failed"
       exit 1
     fi
@@ -379,8 +379,15 @@ else
     }
   done
 
-  # Remove old status labels only after the new one is in place
+  # Remove old status labels only after the new one is in place.
+  # Skip any label that is in TARGET_ADD_LABELS (just added — do not remove it).
   for lbl in "status:in-progress" "status:blocked"; do
+    # Check if lbl is in TARGET_ADD_LABELS
+    _skip=false
+    for _added in "${TARGET_ADD_LABELS[@]+"${TARGET_ADD_LABELS[@]}"}"; do
+      if [[ "$_added" == "$lbl" ]]; then _skip=true; break; fi
+    done
+    if [[ "$_skip" == true ]]; then continue; fi
     if printf '%s' "$ISSUE_LABELS" | grep -qF "$lbl"; then
       rm_out=$(gh issue edit "$IM_NUMBER" -R "$IM_REPO" --remove-label "$lbl" 2>&1) || {
         im_error "Failed to remove label $lbl: $rm_out" "gh_failed"


### PR DESCRIPTION
## What changed

Adds the `issue-manager` skill to the `developer-workflow` plugin (Phase 1: shared core + execution Backend A, GitHub-only). It is a **supervisor** over a GitHub issue backlog: given a scope (issue URL / number list / "all open" / epic), it parses issues, builds a dependency DAG, presents an ordered execution plan behind a single Phase0 human-approval gate, then processes each ready issue sequentially through the standard dev-workflow up to an **open, ready-for-review PR** — delegating all code work to subagents/skills. It never edits source, never runs checks, and never merges.

Delivered:
- `SKILL.md` (126 lines) — stable orchestration core: ANALYZE → Phase0 → EXECUTE(A) → RECONCILE + Non-Negotiables.
- `references/` — `adapter-contract.md` (abstract action → script resolver; the only place script names appear), `exec-contract.md` (backend interface + completion-signal schema; AC-10), `exec-single.md` (Backend A per-task flow), `phase0.md` (DAG, cycle detection, scope-cap, approval gate), `reconcile.md` (idempotent transitions, state-file schema, compaction-resume).
- `scripts/gh/` — 7 bundled Bash scripts (deterministic, structured JSON, `{"error","code"}`+nonzero on failure): `fetch_issue`, `list_issues`, `get_dependencies`, `get_completion_signal`, `transition_status` (read-before-write idempotent), `link_pr`, `add_comment` (marker-upsert idempotent).
- Roster updates: `plugins/developer-workflow/CLAUDE.md` (12 → 13 skills) and `plugin.json` description.

## Why

Working a set of tracker issues is manual today: read issues, infer dependencies/order, run each through the dev-workflow by hand, move statuses on the board. This skill orchestrates that loop while keeping merge a human gate. Topology is a single supervisor (not a flat agent network) — the only safe choice given the error-amplification of multi-agent flat networks.

## Artifacts

- Specification: `docs/specs/2026-05-27-issue-manager.md` (approved, AC-1..AC-10)
- Finalize report: `swarm-report/issue-manager-finalize.md` (3 rounds, PASS)
- Acceptance report: `swarm-report/issue-manager-acceptance.md` (ACCEPT-WITH-NOTES, all 10 ACs PASS)

## How to test

- `bash scripts/validate.sh` — green.
- Read-only scripts run live against this repo: `fetch_issue 206`, `list_issues --state open`, `get_dependencies 206`, `get_completion_signal 206` → valid JSON.
- Write scripts: `--dry-run` against the live API + a single throwaway issue (idempotency proven; throwaway issues #219/#220 closed, temp label deleted).
- L5 end-to-end: invoke `/issue-manager` on a tiny GitHub scope and walk ANALYZE→Phase0 — confirm the board JSON, DAG, proposed order, cycle handling, and that the supervisor stops at the Phase0 gate without dispatching real implementation.

## Status

| Gate | Result |
|---|---|
| validate.sh (L1) | PASS |
| skill-reviewer | PASS |
| plugin-validator | PASS (13 skills valid) |
| finalize | PASS (3 rounds) |
| acceptance (AC-1..AC-10) | ACCEPT-WITH-NOTES (AC-6/AC-7 documentary) |

## Scope

Phase 1 only: sequential, GitHub-only, single-session (Backend A). Out of scope (Future Phases): Backend B (Agent Teams), other trackers (GitLab/Linear), epic sync, parallel dispatch, real-time monitoring, auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
