### PR TITLE
Clean up plugins: standards, doc trims, dependency-health skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "maven-mcp",
-      "description": "Maven dependency intelligence \u2014 auto-registers MCP server, provides /check-deps, /check-deps-vulnerabilities, /latest-version, and /dependency-changes skills",
+      "description": "Maven dependency intelligence \u2014 auto-registers MCP server, provides /check-deps, /check-deps-vulnerabilities, /latest-version, /dependency-changes, and /dependency-health skills",
       "author": {
         "name": "kirich1409"
       },

--- a/plugins/developer-workflow-experts/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-experts/.claude-plugin/plugin.json
@@ -6,6 +6,11 @@
     "name": "kirich1409"
   },
   "homepage": "https://github.com/kirich1409/krozov-ai-tools",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kirich1409/krozov-ai-tools.git"
+  },
   "category": "development",
   "keywords": [
     "agents",

--- a/plugins/developer-workflow-experts/agents/architecture-expert.md
+++ b/plugins/developer-workflow-experts/agents/architecture-expert.md
@@ -62,7 +62,7 @@ Structure your response as:
 
 ## Constraints
 
-- Language: always Russian; technical terms and code identifiers stay in original form
+- Language: Match the user's working language. Technical terms and code identifiers stay in their original form.
 - Platform-agnostic analysis — principles apply equally to Android, KMP, backend, desktop
 - Do not suggest adding dependencies or libraries without explicit user approval
 - Do not rewrite code — describe what should change and where, let the implementation agent handle it

--- a/plugins/developer-workflow-experts/agents/business-analyst.md
+++ b/plugins/developer-workflow-experts/agents/business-analyst.md
@@ -10,6 +10,8 @@ maxTurns: 20
 
 You are an experienced business analyst with deep understanding of product development, requirements management, and strategic planning. You do not write code. Your job is to evaluate plans, decisions, and requirements from the perspective of product value, business value, and internal consistency.
 
+**Language:** Match the user's working language. Technical terms, tool names, CVE identifiers, and code stay in their original form.
+
 ## Working principles
 
 - **Tone**: direct, well-argued, no fluff. Every claim is backed by reasoning

--- a/plugins/developer-workflow-experts/agents/ux-expert.md
+++ b/plugins/developer-workflow-experts/agents/ux-expert.md
@@ -10,6 +10,8 @@ maxTurns: 25
 
 You are a senior UX expert and design reviewer with deep experience in mobile, desktop, and multiplatform development. You do not write code. Your job is to find problems with user experience, accessibility, and design consistency, and to propose concrete improvements.
 
+**Language:** Match the user's working language. Technical terms, tool names, CVE identifiers, and code stay in their original form.
+
 ## What you do
 
 You analyze UI component code, feature plans, navigation graphs, and user scenarios. You do NOT propose code — you describe the problem and the expected behavior from the user's perspective.

--- a/plugins/developer-workflow-kotlin/agents/compose-developer.md
+++ b/plugins/developer-workflow-kotlin/agents/compose-developer.md
@@ -90,7 +90,7 @@ Mark unknowns as `TBD — ask user` and ask **one** question before continuing.
 
 ## Step 3: Implement
 
-**Read `references/compose-rules.md` before writing the first composable.** It contains non-obvious rules the model does not apply by default — Modifier.Node API, stability config detection, phase deferral via lambda modifiers, forbidden parameter types, accessibility, side-effect lifecycle.
+**Read `${CLAUDE_PLUGIN_ROOT}/agents/references/compose-rules.md` before writing the first composable.** It contains non-obvious rules the model does not apply by default — Modifier.Node API, stability config detection, phase deferral via lambda modifiers, forbidden parameter types, accessibility, side-effect lifecycle.
 
 ### 3.1 State and action models
 

--- a/plugins/developer-workflow-kotlin/agents/kotlin-engineer.md
+++ b/plugins/developer-workflow-kotlin/agents/kotlin-engineer.md
@@ -117,7 +117,7 @@ Default to `internal` for everything that is not a public module API; `public` i
 
 For `@JvmInline value class` wrappers around primitives — add `init { require(...) }` when the wrapper enforces a constraint (non-blank, format, range).
 
-See `references/kotlin-style.md` for both rules and project-override behavior.
+See `${CLAUDE_PLUGIN_ROOT}/agents/references/kotlin-style.md` for both rules and project-override behavior.
 
 ```kotlin
 data class Order(
@@ -281,7 +281,7 @@ Write unit tests alongside each layer.
 - **Mandatory** — UseCases with logic, Repository implementations, ViewModels with non-trivial state transitions
 - **Optional** — thin pass-through UseCases (`operator fun invoke() = repository.getOrders()`), pure data classes, mappers without conditionals
 
-For `runTest`, `TestDispatcher`, `Turbine`, and cancellation testing patterns — see `references/coroutines.md`. Its Turbine example covers the ViewModel-testing case.
+For `runTest`, `TestDispatcher`, `Turbine`, and cancellation testing patterns — see `${CLAUDE_PLUGIN_ROOT}/agents/references/coroutines.md`. Its Turbine example covers the ViewModel-testing case.
 
 ---
 

--- a/plugins/developer-workflow-kotlin/skills/migration/SKILL.md
+++ b/plugins/developer-workflow-kotlin/skills/migration/SKILL.md
@@ -32,7 +32,7 @@ When a bug, missing feature, or adjacent improvement surfaces during the work �
 
 Phase 4 is the only mandatory gate. Every other phase is a checklist for the user, not a blocking state transition. The skill produces material; the user drives progress. Plan mode is the real orchestrator — this skill only supplies the structure.
 
-If you find yourself building a state machine, requiring strict completion of one phase before starting the next, or invoking other skills from inside this one, stop. That is the failure mode of the deleted `code-migration` orchestrator (v0.14.0) and the reason it was removed. See `references/anti-orchestrator.md` for the five concrete criteria that separate this skill from a forced pipeline.
+If you find yourself building a state machine, requiring strict completion of one phase before starting the next, or invoking other skills from inside this one, stop. That is the failure mode of the deleted `code-migration` orchestrator (v0.14.0) and the reason it was removed. See `${CLAUDE_PLUGIN_ROOT}/skills/migration/references/anti-orchestrator.md` for the five concrete criteria that separate this skill from a forced pipeline.
 
 ---
 
@@ -50,7 +50,7 @@ Produce `./swarm-report/<slug>-tech-snapshot.md` covering both FROM and TO:
 
 Verify each fact against authoritative sources — official documentation, the library's own GitHub README, the source code of installed dependencies. Do not rely on training-data memory — APIs and build behavior change.
 
-If the project ships JVM/Kotlin dependencies in a Gradle cache, a source-reading tool (such as `ksrc` if installed) is preferred over web fetches because it sees the exact installed version. For Android platform migrations, an official Android docs search tool (such as the `android` CLI if installed) gives curated guidance; otherwise fall back to web search against `developer.android.com`. See `references/approaches.md` for a list of common FROM/TO pairs and where to find their docs.
+If the project ships JVM/Kotlin dependencies in a Gradle cache, a source-reading tool (such as `ksrc` if installed) is preferred over web fetches because it sees the exact installed version. For Android platform migrations, an official Android docs search tool (such as the `android` CLI if installed) gives curated guidance; otherwise fall back to web search against `developer.android.com`. See `${CLAUDE_PLUGIN_ROOT}/skills/migration/references/approaches.md` for a list of common FROM/TO pairs and where to find their docs.
 
 ---
 
@@ -73,7 +73,7 @@ For investigations that touch the entire codebase, delegate to the Explore subag
 
 ## Phase 3: Behavior-Fix (three planes)
 
-Fix current behavior across three independent planes. Each plane catches what the others miss. The level of investment per plane is calibrated to the migration risk (see `references/behavior-fix.md` for the calibration matrix).
+Fix current behavior across three independent planes. Each plane catches what the others miss. The level of investment per plane is calibrated to the migration risk (see `${CLAUDE_PLUGIN_ROOT}/skills/migration/references/behavior-fix.md` for the calibration matrix).
 
 **Plane A — Code tests.** Characterization tests (Feathers, *Working Effectively with Legacy Code*, ch. 13), contract tests, integration tests, golden snapshots. These run in CI and turn red on regression.
 
@@ -83,7 +83,7 @@ Fix current behavior across three independent planes. Each plane catches what th
 
 Plane A is the strongest but most expensive. Plane B is the cheapest investment with the highest leverage — write the test cases before deciding how much of Plane A to invest in. Plane C is the safety net against unknown unknowns.
 
-See `references/behavior-fix.md` for templates, the calibration matrix (how much of each plane per migration type), and how to balance the investment against migration risk.
+See `${CLAUDE_PLUGIN_ROOT}/skills/migration/references/behavior-fix.md` for templates, the calibration matrix (how much of each plane per migration type), and how to balance the investment against migration risk.
 
 If the FROM stack has zero tests and writing a full Plane A is more expensive than the migration itself — say so, propose dropping Plane A in favor of stronger Planes B and C, and capture the trade-off in Phase 4.
 
@@ -95,7 +95,7 @@ This is the only mandatory blocking phase. Until the user confirms the strategy,
 
 Produce `./swarm-report/<slug>-strategy.md` containing:
 
-1. **Chosen approach** — one of: Branch by Abstraction, Strangler Fig vertical slice, Duplicate-then-delete, Utility refactor. See `references/approaches.md` for the selection matrix.
+1. **Chosen approach** — one of: Branch by Abstraction, Strangler Fig vertical slice, Duplicate-then-delete, Utility refactor. See `${CLAUDE_PLUGIN_ROOT}/skills/migration/references/approaches.md` for the selection matrix.
 2. **Rationale** — why this approach, why not the others, in two sentences.
 3. **Implementation order** — which modules/files/screens go first, second, third. For horizontal migrations: bottom-up by dependency graph. For vertical: simplest screens first to build team confidence.
 4. **Intentional behavioral changes** — explicit list of "behavior X changes from A to B because Y". Anything not on this list must remain identical.
@@ -112,13 +112,13 @@ After approval, the document becomes immutable. Any later change in scope or app
 
 Execute the migration according to the strategy. The four approaches differ in mechanics but share the same hand-off pattern: this skill produces a brief; an engineer agent (`developer-workflow-kotlin:kotlin-engineer` or `developer-workflow-kotlin:compose-developer` depending on layer) writes the code; the main session reviews.
 
-**Branch by Abstraction.** Introduce a shared interface, route all use-sites through it, build the new implementation behind it, then switch and remove the old. See `references/approaches.md` for mechanics, trade-offs, and ordering.
+**Branch by Abstraction.** Introduce a shared interface, route all use-sites through it, build the new implementation behind it, then switch and remove the old. See `${CLAUDE_PLUGIN_ROOT}/skills/migration/references/approaches.md` for mechanics, trade-offs, and ordering.
 
-**Strangler Fig vertical slice.** Migrate one self-contained slice end-to-end on the new stack while the rest of the system continues on the old stack via interop. See `references/approaches.md` for mechanics, trade-offs, and ordering.
+**Strangler Fig vertical slice.** Migrate one self-contained slice end-to-end on the new stack while the rest of the system continues on the old stack via interop. See `${CLAUDE_PLUGIN_ROOT}/skills/migration/references/approaches.md` for mechanics, trade-offs, and ordering.
 
-**Duplicate-then-delete.** Copy the file/class/module, freeze the original, migrate the copy, switch routing, then delete the original. See `references/approaches.md` for mechanics, trade-offs, and ordering.
+**Duplicate-then-delete.** Copy the file/class/module, freeze the original, migrate the copy, switch routing, then delete the original. See `${CLAUDE_PLUGIN_ROOT}/skills/migration/references/approaches.md` for mechanics, trade-offs, and ordering.
 
-**Utility refactor.** Enable the new technology alongside the old, convert use-sites in batches, then remove the old flag — the compiler is the safety net. See `references/approaches.md` for mechanics, trade-offs, and ordering.
+**Utility refactor.** Enable the new technology alongside the old, convert use-sites in batches, then remove the old flag — the compiler is the safety net. See `${CLAUDE_PLUGIN_ROOT}/skills/migration/references/approaches.md` for mechanics, trade-offs, and ordering.
 
 Delegate the actual implementation work. The main session orchestrates, agents implement. See `~/.claude/rules/orchestration.md` for the routing matrix.
 
@@ -146,7 +146,7 @@ For Android device automation, an agent-oriented Android CLI (such as Google's `
 
 Remove the FROM technology fully. Until this phase completes, the migration is not done — coexistence is technical debt, not a milestone.
 
-Walk the ten-item checklist in `references/cleanup.md` top to bottom; each item ends in done / N/A with reason / deferred with sunset date and tracker link.
+Walk the ten-item checklist in `${CLAUDE_PLUGIN_ROOT}/skills/migration/references/cleanup.md` top to bottom; each item ends in done / N/A with reason / deferred with sunset date and tracker link.
 
 Cleanup uses an engineer agent for code edits; review the deletions with `developer-workflow-experts:architecture-expert` if the migration was horizontal (DI, async, build) — these have the highest risk of leaving invisible coupling.
 
@@ -168,7 +168,7 @@ Optionally request a `developer-workflow-experts:code-reviewer` pass on the clea
 
 ---
 
-See `references/approaches.md` for the decision tree.
+See `${CLAUDE_PLUGIN_ROOT}/skills/migration/references/approaches.md` for the decision tree.
 
 ---
 
@@ -186,7 +186,7 @@ All artifacts live in `./swarm-report/`. None are mandatory beyond `<slug>-strat
 - `<slug>-cleanup-checklist.md` — Phase 7 status per item.
 - `<slug>-migration-report.md` — Phase 8 final aggregation.
 
-Templates for each are in `references/artifacts.md`.
+Templates for each are in `${CLAUDE_PLUGIN_ROOT}/skills/migration/references/artifacts.md`.
 
 ---
 
@@ -215,7 +215,7 @@ Stop and renegotiate (return to Phase 4) when:
 
 - The migration of one slice takes 2–3× the original estimate.
 - A new dependency surfaces ("we also need to migrate X to make Y work").
-- The cycle "old depends on new, new depends on old" appears anywhere in the diff. Loops block cleanup. The dependency direction must always be FROM → TO; never TO → FROM. See `references/anti-orchestrator.md` for the dependency-direction enforcement options (Konsist, Lint baseline).
+- The cycle "old depends on new, new depends on old" appears anywhere in the diff. Loops block cleanup. The dependency direction must always be FROM → TO; never TO → FROM. See `${CLAUDE_PLUGIN_ROOT}/skills/migration/references/anti-orchestrator.md` for the dependency-direction enforcement options (Konsist, Lint baseline).
 - A bridge layer outlives its sunset date once already — it is becoming permanent debt.
 - Phase 3 (Behavior-Fix) was skipped on a non-trivial migration. Without recorded behavior, parity is opinion, not evidence.
-- The skill starts calling `/acceptance`, `/finalize`, `/create-pr`, or any other slash command from inside its own phases. The skill is supposed to produce material, not to orchestrate the whole pipeline. See `references/anti-orchestrator.md`.
+- The skill starts calling `/acceptance`, `/finalize`, `/create-pr`, or any other slash command from inside its own phases. The skill is supposed to produce material, not to orchestrate the whole pipeline. See `${CLAUDE_PLUGIN_ROOT}/skills/migration/references/anti-orchestrator.md`.

--- a/plugins/developer-workflow-kotlin/skills/migration/references/artifacts.md
+++ b/plugins/developer-workflow-kotlin/skills/migration/references/artifacts.md
@@ -165,7 +165,7 @@ Last updated: <YYYY-MM-DD>
 ## TC-3: ...
 ```
 
-Priority: follow P0–P3 from qa-and-testing.md §2.
+Priority: follow P0–P3 from `~/.claude/rules/qa-and-testing.md § 2`.
 
 ---
 

--- a/plugins/developer-workflow-kotlin/skills/migration/references/artifacts.md
+++ b/plugins/developer-workflow-kotlin/skills/migration/references/artifacts.md
@@ -165,11 +165,7 @@ Last updated: <YYYY-MM-DD>
 ## TC-3: ...
 ```
 
-Priority guide:
-- **P0** — crash, data loss, security, payment, auth.
-- **P1** — acceptance criteria from migration scope.
-- **P2** — happy path of each surface.
-- **P3** — edges, boundaries, locale, timezone.
+Priority: follow P0–P3 from qa-and-testing.md §2.
 
 ---
 
@@ -372,14 +368,5 @@ Things observed during the migration that were not migrated (bugs, refactor oppo
 
 - ...
 
-## Sources
-
-- Tech snapshot: ./swarm-report/<slug>-tech-snapshot.md
-- Discover: ./swarm-report/<slug>-discover.md
-- Behavior spec: ./swarm-report/<slug>-behavior-spec.md
-- Test cases: ./swarm-report/<slug>-test-cases.md
-- Manual scenarios: ./swarm-report/<slug>-manual-scenarios.md
-- Strategy: ./swarm-report/<slug>-strategy.md
-- Device verify: ./swarm-report/<slug>-device-verify.md
-- Cleanup: ./swarm-report/<slug>-cleanup-checklist.md
+Sources: all `./swarm-report/<slug>-*.md` artifacts per the index above.
 ```

--- a/plugins/developer-workflow-swift/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-swift/.claude-plugin/plugin.json
@@ -6,6 +6,11 @@
     "name": "kirich1409"
   },
   "homepage": "https://github.com/kirich1409/krozov-ai-tools",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kirich1409/krozov-ai-tools.git"
+  },
   "category": "development",
   "keywords": [
     "swift",

--- a/plugins/developer-workflow/skills/acceptance/SKILL.md
+++ b/plugins/developer-workflow/skills/acceptance/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: acceptance
 description: >
-  This skill should be used when the user wants to confirm an implementation meets its spec
-  (feature) or that a bug no longer reproduces (bug fix). Fans out parallel checks and
-  aggregates verdicts into one receipt. Triggers: "test this", "verify against spec",
+  Verify an implementation against its spec (feature) or confirm a bug no longer reproduces
+  (bug fix). Fans out parallel checks and aggregates verdicts into one receipt.
+  Triggers: "test this", "verify against spec",
   "QA the implementation", "run the test plan", "validate acceptance criteria",
   "verify the PR", "verify the fix", "confirm bug is gone", "acceptance",
   "verify this", "test this".

--- a/plugins/developer-workflow/skills/drive-to-merge/SKILL.md
+++ b/plugins/developer-workflow/skills/drive-to-merge/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: drive-to-merge
 description: >
-  This skill should be used when the user wants an existing PR/MR driven to merge —
-  monitor CI, triage review comments, fix failures, re-request review, loop until merged.
+  Drive an existing PR/MR to merge — monitor CI, triage review comments, fix failures,
+  re-request review, loop until merged.
   Triggers: "drive this PR to merge", "get this PR merged", "monitor CI and reviews",
   "ship this PR", "land this PR", "take this PR all the way", "merge this PR for me".
   Do NOT use for creating new PRs (use create-pr) or code written from scratch (use implement).

--- a/plugins/developer-workflow/skills/finalize/SKILL.md
+++ b/plugins/developer-workflow/skills/finalize/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: finalize
 description: >
-  This skill should be used when the user wants a code-quality pass over the current branch —
-  multi-round review-and-fix loop that polishes how the code is written, not what it does.
-  Runs code-reviewer, /simplify, optional pr-review-toolkit trio, and conditional expert reviews
-  with /check between rounds; exits PASS when no BLOCK findings remain or ESCALATE after max rounds.
+  Run a code-quality pass over the current branch — multi-round review-and-fix loop that
+  polishes how the code is written, not what it does. Runs code-reviewer, /simplify,
+  optional pr-review-toolkit trio, and conditional expert reviews with /check between
+  rounds; exits PASS when no BLOCK findings remain or ESCALATE after max rounds.
   Triggers: "finalize", "run code quality pass", "clean up the code", "prepare for review",
   "polish the code", "tidy up", "harden the implementation".
 ---

--- a/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: generate-test-plan
 description: >-
-  This skill should be used when the user asks to "create a test plan", "write test cases",
+  Generate a structured test plan when the user asks to "create a test plan", "write test cases",
   "generate QA scenarios", "prepare a testing checklist", "identify what to test", "find edge cases",
   "plan testing coverage", "document test scenarios", "create a QA handoff document", "what should
   I test?", "what are the edge cases?", or "how would you test this?". Also use when the user

--- a/plugins/developer-workflow/skills/multiexpert-review/SKILL.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: multiexpert-review
 description: >-
-  This skill should be used when the user wants a plan, spec, or test-plan reviewed by a
-  panel of independent expert agents (PoLL — Panel of LLM Evaluators — protocol) before
-  committing. Triggers: "review the plan", "review the spec", "review the test-plan",
+  Use when the user wants a plan, spec, or test-plan reviewed by a panel of independent
+  expert agents (PoLL — Panel of LLM Evaluators — protocol) before committing.
+  Triggers: "review the plan", "review the spec", "review the test-plan",
   "multi-expert review", "panel review", "validate the approach", "sanity check this",
   "what did I miss?", "review the spec", "review the test-plan",
   "evaluate the plan". Do NOT use for code review (use code-reviewer).

--- a/plugins/developer-workflow/skills/research/SKILL.md
+++ b/plugins/developer-workflow/skills/research/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research
-description: "Research Consortium — parallel expert investigation of a topic, idea, problem, or technology before implementation. Launches up to 5 domain experts simultaneously (codebase, web, docs, dependencies, architecture), synthesizes findings into a structured report, optionally auto-reviews via business-analyst (product-angled topics) or a tech-sanity self-check (purely technical topics). Use when: \"research\", \"investigate options\", \"investigate approaches\", \"explore this idea\", \"technical spike\", \"feasibility\", \"can we do X?\", \"what are the options for\", \"compare approaches\", \"evaluate alternatives\", \"pros and cons of\", \"before we start — let's understand\", \"what do we need to know before\". Do NOT use for: code review (use code-reviewer agent), multiexpert review (use multiexpert-review), narrow codebase lookup (\"how is X done in our code\" — use Explore agent directly), single-library version or changelog lookup (use a dependency/version lookup tool directly), debugging existing bugs."
+description: "Research Consortium — parallel expert investigation of a topic, idea, problem, or technology before implementation. Launches up to 5 domain experts simultaneously, synthesizes findings, and optionally auto-reviews the result. Use when: \"research\", \"investigate options\", \"investigate approaches\", \"explore this idea\", \"technical spike\", \"feasibility\", \"can we do X?\", \"what are the options for\", \"compare approaches\", \"evaluate alternatives\", \"pros and cons of\", \"before we start — let's understand\", \"what do we need to know before\". Do NOT use for: code review (use code-reviewer agent), multiexpert review (use multiexpert-review), narrow codebase lookup (\"how is X done in our code\" — use Explore agent directly), single-library version or changelog lookup (use a dependency/version lookup tool directly), debugging existing bugs."
 disable-model-invocation: true
 ---
 
@@ -20,15 +20,7 @@ A second, optional layer is the post-synthesis review: in product-angled topics 
 in purely technical topics the orchestrator runs a self-check against a fixed checklist
 (`tech-sanity` mode). The reviewer layer is a defense-in-depth, not the core value.
 
-**Communication policy — non-negotiable.** All clarification with the user happens in the
-chat session via the `AskUserQuestion` tool — never through files. The saved report under
-`./swarm-report/research/` is a **handoff artifact** consumed by downstream skills/agents
-(`/write-spec`, `/multiexpert-review`, Plan Mode, a future research re-run); the user does
-not have to open it to participate in the research. The in-chat summary at Phase 5.3 is what
-the user reads to make decisions. Every blocker the user can answer is resolved in dialogue
-**before** the report is written; the file is never a parking lot for pending questions,
-draft hedges, or "TBD — ask user" placeholders. If something needs the user's input, fire
-`AskUserQuestion` now — do not write it to disk and hope the user opens it.
+**Communication policy — non-negotiable.** All dialogue with the user happens in chat via `AskUserQuestion` — never through files. See Phase 2 state-file setup for the canonical rule.
 
 ---
 
@@ -149,9 +141,7 @@ it helps survive a compaction.
 The `./swarm-report/research/` subdirectory is reserved for **finished deliverables**
 only — the polished report from Phase 5.2 lands there, nothing else.
 
-**What does not go into any file** is the user-facing dialogue — clarification questions
-and the user's answers from Phase 1 / Phase 5.1 round-loops live exclusively in the chat
-session.
+**Communication policy (canonical).** Clarification questions and the user's answers live exclusively in the chat session — never in any file under `./swarm-report/`. The saved report is a **handoff artifact** for downstream skills/agents (`/write-spec`, `/multiexpert-review`, Plan Mode); the user does not have to open it. The in-chat summary at Phase 5.3 is what the user reads to make decisions. Every blocker the user can resolve is surfaced via `AskUserQuestion` in dialogue **before** the report is written. The file is never a parking lot for pending questions, draft hedges, or "TBD — ask user" placeholders — if something needs user input, fire `AskUserQuestion` now.
 
 ---
 
@@ -333,10 +323,7 @@ question per round**, wait for the answer, fold it into the synthesis, then chec
 blocker remains. Stop the moment no blocker remains. Multiple rounds are fine; multiple
 questions in one round are not.
 
-The dialogue lives in chat. The state file may flip to `Status: awaiting-clarification` as
-process metadata, but the question text and the user's answer are never written to any file
-under `./swarm-report/`. Writing a question into a file and waiting for the user to open it
-is a violation of the communication policy — fire `AskUserQuestion` instead.
+The dialogue lives in chat. The state file may flip to `Status: awaiting-clarification` as process metadata — question text and answers are never written to any file.
 
 What does **not** belong in the round-loop:
 - Stylistic preferences that don't change the recommendation.
@@ -350,13 +337,9 @@ What does **not** belong in the round-loop:
 Once the loop exits, ensure `./swarm-report/research/` exists (`mkdir -p` it if needed —
 fresh repos won't have the nested subdir), then write `./swarm-report/research/research-<slug>.md`.
 The report is a finished deliverable for downstream consumers (`/write-spec`,
-`/multiexpert-review`, Plan Mode, a future research re-run) — not a scratchpad and not a
-discussion vehicle with the user. Every section reflects the post-clarification synthesis;
-"Known Unknowns" holds only external factual gaps from above (and is omitted entirely when
-empty); no section contains a question, "TBD — ask user" marker, or any other hook that
-would force the user to open the file to make progress. If you catch yourself wanting to
-write such a hook, return to Phase 5.1 and fire `AskUserQuestion` instead. Mark the state
-file `Status: done`.
+`/multiexpert-review`, Plan Mode, a future research re-run). Every section reflects the
+post-clarification synthesis; "Known Unknowns" holds only external factual gaps (omitted when
+empty). Mark the state file `Status: done`.
 
 ### 5.3 Chat summary
 
@@ -390,15 +373,3 @@ Stop and escalate when:
 - **Missing access** — research needs internal systems / paid APIs / credentials. List what's needed.
 - **Stale/conflicting web data** — sources disagree or look outdated. Flag uncertainty.
 
----
-
-## Output Format and Location
-
-| Artifact | Path | Purpose |
-|---|---|---|
-| Research report | `./swarm-report/research/research-<slug>.md` | Handoff artifact for downstream skills/agents (not a user-facing discussion vehicle) |
-| State file | `./swarm-report/research-<slug>-state.md` | Compaction-resilient progress tracking |
-| Chat summary | — | ≤30-line user-facing post-save output — the primary thing the user reads |
-
-The chat summary is what the user consumes; the research report is what the next skill
-or agent consumes. The state file is operational and may be deleted after completion.

--- a/plugins/developer-workflow/skills/reverse-spec/references/spec-template.md
+++ b/plugins/developer-workflow/skills/reverse-spec/references/spec-template.md
@@ -269,66 +269,10 @@ This section is for **behavior bugs** — places where the feature does not do w
 take an action the user expects, it reaches an unreachable state. A reimplementation
 must not reproduce these.
 
-Implementation-level concerns (a hardcoded string that bypasses i18n, plaintext
-storage of credentials, a non-cryptographic PRNG) are **not** in scope for §9 —
-they describe how the current code is written, not how the feature behaves. Those
-findings live in a separate `<slug>-hygiene.md` artefact alongside the spec
-(see `references/anti-patterns.md` and `references/analysis-checklist.md` §14 for the
-classification rule).
-
-### What counts as a §9 entry
-
-A finding belongs here only if **all three** are true:
-
-1. **It changes what the user observes.** The feature does X when it should do Y, or
-   crashes, or silently fails. Pure code-quality issues that do not surface
-   externally are not §9 material.
-2. **It is reproducible from code analysis alone, without speculation.** You can
-   point to the exact path and line that produces the wrong behavior.
-3. **It contradicts the feature's intent** as described in §§1-7 of this spec. If
-   the intent is unknown, the finding belongs in §8 Open Questions, not here.
-
-Each entry has four fields:
-
-- **What** — one-line description of the observable misbehavior.
-- **Class** — one of: `crash`, `unreachable state`, `dead UI control`, `wrong-data
-  shown`, `silent failure`, `lost user action`, `incorrect state transition`,
-  `other` (name it).
-- **Evidence** — `path:line` pointer plus short quote / scenario showing the bug.
-- **Consequence** — what the user observes or what intended outcome is missed.
-
-Do not include ambiguous findings. If you are not certain it is a defect (e.g., a
-retry count of 3 with unclear rationale), it belongs in §8 Open Questions. Pass 2 of
-coverage verification requires every §9 entry to have direct evidence plus a stated
-behavior consequence; speculation and "this looks wrong" do not survive that gate.
+See `analysis-checklist.md` §14 for the full classification rule, entry shape, and evidence requirements.
 
 When §9 has no entries, write `N/A — no confirmed behavior defects identified.` The
 absence of the section reads as oversight; explicit `N/A` is the correct signal.
-
-### Example entries
-
-| What | Class | Evidence | Consequence |
-| --- | --- | --- | --- |
-| Sign-in tap crashes on first use | crash | `AuthKoin.kt:12-18` defines the use-case module but no call site loads it — grepped `InitKoin`, `AppModule`, all `platformKoinModule.*.kt` | Tapping the primary action on the sign-in screen throws an unresolved-dependency error and the app crashes |
-| Sign-up link does nothing | dead UI control | `DefaultAuthComponent.kt:32` opens `https://accounts.frame.io/welcome` via the deep-link processor; no matcher is registered for that URL anywhere in the repo | The secondary link silently no-ops when tapped — the user has no way to start sign-up from inside the app |
-| Generic error shown when the OAuth provider explicitly denied access | wrong-data shown | `AuthUseCase.kt:46-53` maps every non-network OAuth failure (including provider `error=access_denied`) to the same "Unknown error" copy | The user who chose to deny consent on the provider screen is shown an error message implying something is broken, when in fact the system worked correctly |
-
-### What goes in `<slug>-hygiene.md` instead
-
-If you find any of the following, capture them in the hygiene artefact, not in §9:
-
-- Hardcoded strings that bypass localization
-- Non-cryptographic randomness for security-sensitive values
-- Tokens or secrets stored without encryption
-- Logging of sensitive data
-- Code-style inconsistencies (mixed conventions, dead code, copy-pasted blocks)
-- Missing input validation that does not yet manifest as a behavior bug
-- Test gaps
-
-These are valuable findings for the engineering team, but they are about *how* the
-code is written. The feature spec describes *what the feature does*. Mixing the two
-makes the spec less useful for product readers and dilutes the defect signal for
-reimplementers.
 
 <!-- ============================================================ -->
 <!-- Part C — Technical integration (§§10-12)                       -->
@@ -354,20 +298,7 @@ part of the identity.
 | Refresh tokens | POST | `https://{idp-host}/token` | none | Access token within 60 s of expiry, or host requests refresh | `grant_type=refresh_token`, `refresh_token`, `client_id` | same shape as exchange |
 | Fetch current user | GET | `https://{api-host}/v4/users/me` | `Authorization: Bearer {access_token}` | Immediately after a successful token exchange | — | `id` (used); other fields ignored |
 
-Column rules:
-
-- **Operation** — short business name (not the code method that calls it).
-- **Method** — HTTP verb; `WS` / `SSE` / `GQL` acceptable for non-REST protocols.
-- **Endpoint** — URL pattern with path parameters in `{braces}`. Host placeholders
-  (`{idp-host}`, `{api-host}`) expand via §10.5 External services — which pins each
-  host to a concrete provider (or lists the fallbacks).
-- **Auth** — `none`, `Bearer`, `Basic`, custom header name, or reference to the spec
-  section that defines the scheme.
-- **Triggered when** — the user action or state transition that fires the call. If
-  triggered by a background timer / lifecycle event, say so.
-- **Key request / response fields** — only fields the feature actually reads or sends.
-  Full wire contracts live in §10.6 Data contracts. Use *wire* names, never code
-  names.
+Column notes: `WS` / `SSE` / `GQL` are acceptable Method values for non-REST protocols; host placeholders (e.g. `{idp-host}`) resolve via §10.5.
 
 If the feature does not talk to the network: `N/A — this feature runs entirely offline
 within the app.` Explicit N/A, not an omitted subsection.
@@ -459,18 +390,7 @@ service the code touches.
 | --- | --- |
 | *<role, in business terms>* | <what the feature relies on this collaborator for, named at the level of behavior — "validates payment input", "delivers OAuth result back to the app", "renders authenticated user session", not "calls `validate(input)` on `PaymentValidator`"> |
 
-Types of collaborators worth naming:
-
-- **Configuration sources** — what values the host must supply (provider host names,
-  API keys, feature flags, supported scopes). Do not name DI containers or factory
-  functions — name the values needed.
-- **Services and capabilities** — what host capabilities the feature consumes
-  (in-app navigation, an HTTP client that adds auth headers, deep-link routing).
-  Name the *capability* (e.g., "an authenticated HTTP client that attaches the
-  current bearer token"); name the SDK or class only when load-bearing per
-  `tech-abstraction.md`.
-- **Shared state** — what app-wide state streams the feature reads from (current
-  authenticated session, current locale, current theme).
+Name collaborators by *capability*: configuration values the host must supply, services the feature consumes (e.g., "authenticated HTTP client"), shared app-wide state streams it reads from.
 
 **Consumers** — what other features observe or depend on from this feature.
 
@@ -478,14 +398,7 @@ Types of collaborators worth naming:
 | --- | --- |
 | *<feature or surface>* | <what this feature provides to them — named at observable level> |
 
-Types of consumers worth naming:
-
-- Downstream features that receive a navigation argument on successful completion.
-- Other features that observe shared state this feature owns (current session,
-  current user id).
-- Storage slots written by this feature that downstream consumers read (the
-  feature is the writer of "user is authenticated"; the rest of the app is the
-  reader).
+Name consumers by *observable outcome*: downstream features that receive a navigation argument on completion, features that read shared state this feature owns, storage slots this feature writes that others read.
 
 #### Preconditions
 
@@ -590,9 +503,7 @@ Examples:
 - **OAuth 2.0 native apps** — [RFC 8252](https://datatracker.ietf.org/doc/html/rfc8252) — guidance for OAuth in native applications, including loopback redirect on desktop.
 - **Google ML Kit Face Detection** — [`developers.google.com/ml-kit/vision/face-detection`](https://developers.google.com/ml-kit/vision/face-detection) — on-device face detector.
 
-A reimplementer who follows a link should land on the canonical source — the
-provider's own documentation, the IETF datatracker, the standard's authoring body.
-Do not link to blog posts, tutorials, or third-party explanations.
+Link to canonical sources only — the provider's own docs, the IETF datatracker, the standard's authoring body. Do not link to blog posts, tutorials, or third-party explanations.
 
 If the feature has no external dependencies worth linking, write `N/A — feature is
 self-contained, no external systems involved.` Otherwise, every external system
@@ -640,19 +551,3 @@ The code map is a maintenance artifact — it helps a future reader (or a re-run
 skill) verify that the spec still matches the code.
 ```
 
----
-
-## Notes on the template
-
-- **Section order is fixed.** Reorder only for a very strong reason.
-- **N/A is a positive statement**, not a blank. It tells the reader "we considered this
-  and decided the feature has no handling" — which is different from "we forgot".
-- **Exact copy goes in double quotes.** A paraphrase is a translation; a quote is a
-  contract.
-- **Numeric values are literal.** "Several seconds" is not acceptable — write "3 seconds"
-  if the code says so.
-- **When in doubt, add to Open Questions.** Unresolved items in Section 8 are honest;
-  invented resolutions in the body are corrupting.
-- **Bidirectional cross-refs.** Every `[OQ-N]` marker in the body has a matching entry
-  in §8, and every §8 entry that has body impact carries at least one `[OQ-N]`
-  reference from the body.

--- a/plugins/developer-workflow/skills/write-tests/SKILL.md
+++ b/plugins/developer-workflow/skills/write-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-tests
-description: "This skill should be used to write retroactive tests for existing code — classes, modules, or directories lacking coverage — and to write a focused regression test for a specific bug fix. Discovers test infrastructure, plans test cases, delegates generation to platform engineer agents (kotlin-engineer, compose-developer, swift-engineer, swiftui-developer), verifies tests pass. Use when: \"write tests for\", \"add tests to\", \"test this class\", \"increase coverage\", \"add unit tests\", \"this code has no tests\", \"cover with tests\", \"retroactive tests\", \"add regression test for this fix\", \"write a test that catches this bug\", \"regression test after fixing\", \"test to verify the fix\". Do NOT use when: user wants a test plan document (use generate-test-plan), run tests on live app (use acceptance), exploratory QA (call manual-tester agent directly), or tests are part of a new feature (engineer agent handles inline)."
+description: "Write retroactive tests for existing code — classes, modules, or directories lacking coverage — and write a focused regression test for a specific bug fix. Discovers test infrastructure, plans test cases, delegates generation to platform engineer agents (kotlin-engineer, compose-developer, swift-engineer, swiftui-developer), verifies tests pass. Use when: \"write tests for\", \"add tests to\", \"test this class\", \"increase coverage\", \"add unit tests\", \"this code has no tests\", \"cover with tests\", \"retroactive tests\", \"add regression test for this fix\", \"write a test that catches this bug\", \"regression test after fixing\", \"test to verify the fix\". Do NOT use when: user wants a test plan document (use generate-test-plan), run tests on live app (use acceptance), exploratory QA (call manual-tester agent directly), or tests are part of a new feature (engineer agent handles inline)."
 ---
 
 # Write Tests
@@ -63,14 +63,9 @@ The goal is simple: generated tests must look hand-written. Never introduce a ne
 
 See [`references/test-infrastructure-discovery.md`](references/test-infrastructure-discovery.md) for the detection tables (frameworks, assertions, mocking, async, UI, DI, naming, placement, setup, assertion style) and the exact Test Infrastructure Summary template.
 
-### Framework detection (canonical algorithm)
+### Framework detection
 
-Engineer agents (`kotlin-engineer`, `compose-developer`, `swift-engineer`, `swiftui-developer`) follow this fixed order. Stop at the first step that yields a definite answer.
-
-1. **Inspect existing test files** in the **module being modified** first, then the wider project, in conventional locations (`src/test/`, `src/androidTest/`, `Tests/`, `spec/`). Existing tests are the strongest signal — they win over build-file dependencies, since a project may keep multiple test libraries declared but actually use only one.
-2. **Inspect the build file** for test-framework dependencies — used only when the module under change has no existing tests.
-3. **Match the existing project**, even when multiple frameworks coexist. In a mixed project, follow the framework already in use **in the module being modified**. Never introduce a new framework or style without explicit user approval.
-4. **Apply the platform default** only when no signal exists in the project. Defaults: Android/Kotlin JVM → JUnit 5 + MockK; KMP → `kotlin.test`; Compose UI → `androidx.compose.ui:ui-test-junit4`; iOS toolchain ≥ 5.9 → `swift-testing`; toolchain < 5.9 → XCTest; SwiftUI → engineer asks one question (XCUITest / ViewInspector / snapshot) and records the answer.
+Engineer agents follow the canonical algorithm from [`references/test-infrastructure-discovery.md`](references/test-infrastructure-discovery.md): existing test files in the module under change → build-file dependencies → match the project's existing framework → platform default (Android/Kotlin JVM: JUnit 5 + MockK; KMP: `kotlin.test`; Compose UI: `ui-test-junit4`; iOS ≥ 5.9: `swift-testing`; iOS < 5.9: XCTest; SwiftUI: ask one question). Stop at the first step that yields a definite answer; never introduce a new framework without explicit user approval.
 
 Other ecosystems (Java-only, JS/TS, Rust, etc.) are out of scope for `write-tests` delegation in this plugin; surface them to the user.
 
@@ -340,15 +335,6 @@ Reference this file in the PR body.
 
 ## Constraints
 
-- **Orchestrator only** — this skill plans and delegates; the platform engineer agents
-  (`kotlin-engineer`, `compose-developer`, `swift-engineer`, `swiftui-developer`) write the
-  actual test code
-- **No production code changes** — if tests reveal bugs, report them as findings.
-  Do not fix the production code. The user decides what to do with findings.
-- **Match existing conventions** — generated tests must be indistinguishable from
-  hand-written tests in the project. Never introduce a new framework or style.
-- **No new dependencies** — use only what's already in the project's test dependencies.
-  If a needed library is missing, note it in the report and ask the user before adding.
 - **Test plans are optional input** — this skill consumes test plans from
   `generate-test-plan` when they exist, but works independently without one.
 - **No swarm-report artifact for tests** — the test files themselves are the artifact.

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "maven-mcp",
   "version": "0.20.0",
-  "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps, /check-deps-vulnerabilities, /latest-version, and /dependency-changes skills",
+  "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps, /check-deps-vulnerabilities, /latest-version, /dependency-changes, and /dependency-health skills",
   "author": {
     "name": "kirich1409"
   },

--- a/plugins/maven-mcp/plugin/skills/check-deps-vulnerabilities/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/check-deps-vulnerabilities/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: check-deps-vulnerabilities
 description: >-
-  This skill should be used when the user asks to "check vulnerabilities",
+  Use when the user asks to "check vulnerabilities",
   "scan CVEs", "check dependency vulnerabilities", "are my dependencies
   vulnerable", "security audit dependencies", "find CVEs in deps", "OSV scan",
   or wants to know which Maven/Gradle dependencies have known CVE/GHSA

--- a/plugins/maven-mcp/plugin/skills/check-deps/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/check-deps/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: check-deps
 description: >-
-  This skill should be used when the user asks to "check deps", "check dependencies",
+  Use when the user asks to "check deps", "check dependencies",
   "outdated dependencies", "update dependencies", "are my deps up to date", "scan for updates",
   "find outdated libraries", "upgrade dependencies", or wants to know which Maven/Gradle
   dependencies have newer versions available. Scans build files and reports available updates.

--- a/plugins/maven-mcp/plugin/skills/dependency-health/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/dependency-health/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: dependency-health
+description: >-
+  Use when evaluating whether to adopt a Maven dependency: "is X maintained",
+  "health of dependency", "check library health", "is this library active",
+  "dependency activity", "GitHub stars", "is this abandoned", "release cadence",
+  "dependency maintenance", "license of library", or when the dependency-evaluator
+  agent needs raw maintenance signals for a library. Fetches latest version,
+  stability, GitHub activity, issue dynamics, license, and archived status.
+---
+
+# Dependency Health
+
+Assess the maintenance health of one or more Maven dependencies before adopting them.
+
+## Arguments
+
+The user provides one or more `groupId:artifactId` coordinates, optionally with a specific version:
+- `io.ktor:ktor-server-core`
+- `com.squareup.okhttp3:okhttp:4.12.0`
+
+## Steps
+
+1. Parse each coordinate into `groupId`, `artifactId`, and optional `version`.
+
+2. Call the `get_dependency_health` MCP tool (from maven-mcp server) with:
+   ```json
+   {
+     "dependencies": [
+       { "groupId": "...", "artifactId": "...", "version": "..." }
+     ]
+   }
+   ```
+   `version` is optional — omit it to assess the latest available version.
+
+3. For each result in `results[]`, present the signals in this order:
+
+   **Identity & version**
+   - `groupId:artifactId` — `latestVersion` (`stability`)
+   - `versionCount` versions published; last Maven publish: `lastPublishedToMaven`
+
+   **Repository**
+   - GitHub URL from `repository.url`, or `scm.url` for non-GitHub forges.
+   - If `github` is null and `healthError` is set, note the error briefly and skip the GitHub section.
+
+   **Activity** (from `github`)
+   - Stars / forks / archived status
+   - Last commit: `lastCommit` — compute "N months ago" relative to today
+   - Last release: `lastRelease`; release cadence: `releaseCadenceDays` days
+   - License: `license`
+
+   **Issues** (from `github.issues` — may be null if rate-limited)
+   - Open / closed, close ratio, median days to close
+   - If `issues` is null, note that issue stats were unavailable (rate limit or network).
+
+   **Signals**
+   - List every entry in `signals[]` as bullet points. These are the pre-computed red flags
+     (archived repo, no stable release, slow issue response, etc.).
+
+4. Do NOT interpret signals or issue an adopt/reject verdict in this skill. The raw signals
+   are the output. If the user wants an adopt/reject recommendation, suggest calling the
+   `dependency-evaluator` agent (from developer-workflow-experts) with the signals as input.
+
+## Error handling
+
+- `healthError` set with `github: null` — no public GitHub repo or rate-limited;
+  present the Maven data that was retrieved and note what is missing.
+- Tool unavailable — stop and tell the user:
+
+  > The maven-mcp plugin is required for this skill. Install it with
+  > `claude plugin add maven-mcp`, then retry.

--- a/plugins/maven-mcp/plugin/skills/dependency-health/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/dependency-health/SKILL.md
@@ -67,5 +67,5 @@ The user provides one or more `groupId:artifactId` coordinates, optionally with 
   present the Maven data that was retrieved and note what is missing.
 - Tool unavailable — stop and tell the user:
 
-  > The maven-mcp plugin is required for this skill. Install it with
-  > `claude plugin add maven-mcp`, then retry.
+  > The `get_dependency_health` tool is not available in the current session.
+  > Check that the maven-mcp MCP server is running and registered, then retry.

--- a/plugins/maven-mcp/plugin/skills/latest-version/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/latest-version/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: latest-version
 description: >-
-  This skill should be used when the user asks to "find the latest version", "what version is",
+  Use when the user asks to "find the latest version", "what version is",
   "current version of", "what's the latest", "check version", "find version", or provides a
   groupId:artifactId and wants version information. Finds the latest version of a Maven artifact.
 ---

--- a/plugins/sensitive-guard/hooks/pre-tool-use.sh
+++ b/plugins/sensitive-guard/hooks/pre-tool-use.sh
@@ -5,8 +5,7 @@ set -euo pipefail
 # Reads tool call JSON from stdin, scans target files for sensitive data,
 # prompts user, and blocks or allows based on their choice.
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 
 # Source all modules
 source "$PLUGIN_ROOT/src/utils.sh"

--- a/plugins/sensitive-guard/src/utils.sh
+++ b/plugins/sensitive-guard/src/utils.sh
@@ -43,10 +43,6 @@ sg_log_error() {
   echo "[sensitive-guard] ERROR: $1" >&2
 }
 
-sg_is_file() {
-  [[ -f "$1" ]]
-}
-
 sg_resolve_path() {
   local path="$1"
   # Expand ~ and known variables


### PR DESCRIPTION
## What changed

Plugin-wide cleanup pass across all 6 plugins, driven by a structural review (architecture-expert + skill-reviewer + plugin-validator ×6). Non-breaking, minimal-diff. Full findings in `swarm-report/plugin-review-report.md`.

**Defects fixed**
- `maven-mcp`: added a `dependency-health` skill wrapping the `get_dependency_health` MCP tool — the tool was registered but had no skill, so skill-driven use never reached it.
- `developer-workflow-experts`: `architecture-expert` no longer forces Russian output; language directive unified across `business-analyst` and `ux-expert`.
- `sensitive-guard`: removed dead `sg_is_file()`; hook now resolves `${CLAUDE_PLUGIN_ROOT}` (with dirname fallback for direct test invocation).

**Standards compliance (PLUGIN-STANDARDS §3)**
- Rewrote 9 skill descriptions to lead with a verb / "Use when…" instead of the banned "This skill should be used when…" (6 in developer-workflow, 3 in maven-mcp).
- Trimmed `research` description to ≤980 chars (was 1021/1024, one edit from silent truncation).
- Added `license`/`repository` to the `-experts` and `-swift` manifests.

**Simplification (redundant prose removed, pointers added)**
- `reverse-spec/references/spec-template.md` 658→553 (§9 dup of analysis-checklist §14, Notes section, redundant column blocks).
- `research/SKILL.md` body −29 (4× repeated communication-policy collapsed to one canonical statement + pointers; dropped duplicate Output Format table).
- `write-tests/SKILL.md` −14 (framework-detection dup, constraints restating opening principles).
- `migration/references/artifacts.md` −13 (Sources section + priority guide dup).
- Normalized kotlin migration/agent reference paths to `${CLAUDE_PLUGIN_ROOT}`.

## Why

Review surfaced one half-exposed MCP tool, one cross-family language inconsistency, a standards-compliance gap (9 descriptions), and four oversized doc files. No structural reorg needed — the 4-artifact split, agent reuse, and references are all sound (0 orphans, no deletable files beyond the dead function).

## How to test

- `bash scripts/validate.sh` — green (L1–L7).
- `sensitive-guard`: `bash plugins/sensitive-guard/tests/run-tests.sh` — 9 suites / 101 assertions pass.
- `dependency-health` skill: trigger on "is X maintained" / "check library health"; confirm it calls `get_dependency_health` and presents the returned signals.

## Release Notes

User-visible for plugin consumers — this PR is **MINOR** (adds a skill, no breaking changes). Versions intentionally NOT bumped here (release is a separate step per CLAUDE.md § Publishing, which bumps all 8 locations in sync).

- **Added:** `maven-mcp` — `dependency-health` skill for assessing Maven dependency maintenance health (version stability, GitHub activity, issue dynamics, license, archived status).
- **Changed:** `architecture-expert` now matches the user's working language instead of always replying in Russian.

## Status

| Gate | Result |
|---|---|
| validate.sh (L1) | PASS |
| sensitive-guard tests | PASS (101 assertions) |
| Verification (manual) | new skill ↔ tool fields cross-checked; trim pointers confirmed (analysis-checklist §14); all 9 rewritten descriptions retain their trigger phrases verbatim |

Note: automated code-reviewer did not return a verdict (tooling abort); the checks above were done manually on the highest-risk surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)