### PR TITLE
Release v0.21.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.20.0",
+      "version": "0.21.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/maven-mcp/plugin"
@@ -23,7 +23,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.20.0",
+      "version": "0.21.0",
       "category": "security",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/sensitive-guard"
@@ -34,7 +34,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.20.0",
+      "version": "0.21.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow"
@@ -45,7 +45,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.20.0",
+      "version": "0.21.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-experts"
@@ -56,7 +56,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.20.0",
+      "version": "0.21.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-kotlin"
@@ -67,7 +67,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.20.0",
+      "version": "0.21.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-swift"

--- a/plugins/developer-workflow-experts/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-experts/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-experts",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Reusable expert agents for code review, architecture, security, performance, UX, build, DevOps, business analysis, and debugging. Safe to install standalone \u2014 no skills, no hooks, no MCP servers.",
   "author": {
     "name": "kirich1409"

--- a/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-kotlin",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Kotlin, Android, and KMP specialist agents and migration skills \u2014 kotlin-engineer, compose-developer, migration, snapshot. Extends developer-workflow for Kotlin/Android projects.",
   "author": {
     "name": "kirich1409"
@@ -18,11 +18,11 @@
   "dependencies": [
     {
       "name": "developer-workflow",
-      "version": "^0.20.0"
+      "version": "^0.21.0"
     },
     {
       "name": "developer-workflow-experts",
-      "version": "^0.20.0"
+      "version": "^0.21.0"
     }
   ]
 }

--- a/plugins/developer-workflow-swift/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-swift/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-swift",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Swift, iOS, and macOS specialist agents \u2014 swift-engineer and swiftui-developer, with references covering Swift concurrency, testing, and SwiftUI patterns/state/performance. Extends developer-workflow for Apple platforms.",
   "author": {
     "name": "kirich1409"
@@ -22,11 +22,11 @@
   "dependencies": [
     {
       "name": "developer-workflow",
-      "version": "^0.20.0"
+      "version": "^0.21.0"
     },
     {
       "name": "developer-workflow-experts",
-      "version": "^0.20.0"
+      "version": "^0.21.0"
     }
   ]
 }

--- a/plugins/developer-workflow/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Developer workflow toolbox \u2014 on-demand skills for research, specification (write-spec, reverse-spec), multiexpert review, retroactive tests, code-quality finalize, mechanical /check, QA (test plans, acceptance), PR creation, autonomous drive-to-merge (CI monitor, review handler, re-request, poll), and issue-manager (backlog orchestrator: DAG-ordered sequential issue pipeline with board advancement). Exploratory QA without a spec is performed by calling the manual-tester agent directly. Platform-neutral; platform-specific engineers live in developer-workflow-kotlin and developer-workflow-swift.",
   "author": {
     "name": "kirich1409"
@@ -18,7 +18,7 @@
   "dependencies": [
     {
       "name": "developer-workflow-experts",
-      "version": "^0.20.0"
+      "version": "^0.21.0"
     }
   ]
 }

--- a/plugins/developer-workflow/README.md
+++ b/plugins/developer-workflow/README.md
@@ -22,7 +22,7 @@ developer-workflow-kotlin          developer-workflow-swift
 
 Installing this plugin automatically pulls `developer-workflow-experts`. Installing `-kotlin` or `-swift` additionally pulls this plugin.
 
-## Skills (12)
+## Skills (13)
 
 Skills are independent on-demand tools — invoke them when the task calls for the capability. They do not orchestrate each other; the model drives sequencing through plan mode.
 
@@ -63,6 +63,7 @@ For undirected exploratory QA without a spec — call the `manual-tester` agent 
 |---|---|
 | `/create-pr` | Create a draft or ready GitHub PR / GitLab MR with generated metadata |
 | `/drive-to-merge` | Autonomous CI-monitor + review-handler + merge loop: categorize comments inline, propose concrete fixes, delegate, reply, resolve threads, re-request review (Copilot + humans), poll, confirm merge with user |
+| `/issue-manager` | Backlog orchestrator — DAG-ordered sequential issue pipeline with board advancement (GitHub) |
 
 ## Agents (1)
 

--- a/plugins/maven-mcp/package.json
+++ b/plugins/maven-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "MCP server for Maven Central dependency intelligence",
   "main": "./dist/index.js",
   "type": "module",

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maven-mcp",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps, /check-deps-vulnerabilities, /latest-version, /dependency-changes, and /dependency-health skills",
   "author": {
     "name": "kirich1409"
@@ -19,7 +19,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@krozov/maven-central-mcp@^0.20.0"
+        "@krozov/maven-central-mcp@^0.21.0"
       ]
     }
   }

--- a/plugins/sensitive-guard/.claude-plugin/plugin.json
+++ b/plugins/sensitive-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sensitive-guard",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Prevents sensitive data (secrets, PII) from reaching AI servers by scanning files before they are read into conversation",
   "author": {
     "name": "kirich1409"


### PR DESCRIPTION
Release v0.21.0 — unified version bump across all 6 plugins + npm package, with docs sync.

## v0.21.0

Unified release across all 6 plugins (`maven-mcp`, `sensitive-guard`, `developer-workflow`, `developer-workflow-experts`, `developer-workflow-kotlin`, `developer-workflow-swift`) and the `@krozov/maven-central-mcp` npm package.

### New capabilities

- **Dependency health (`maven-mcp`)** — new `get_dependency_health` MCP tool and `/dependency-health` skill. Assesses adoption-worthiness from version/stability, GitHub activity, issue dynamics, license, and ownership, fetched via the SCM coordinates resolved from the POM. (#216, #222)
- **Library evaluation before adoption** — new `/evaluate-dependency` skill (developer-workflow) backed by the new `dependency-evaluator` agent (developer-workflow-experts). Combines maven-mcp health signals with web reputation into an explicit adopt/avoid verdict before a dependency is added. (#216)
- **`/issue-manager` skill (developer-workflow)** — GitHub backlog supervisor (Phase 1): parses an issue backlog, orders it as a DAG, and drives a sequential issue pipeline with board advancement. Ships bundled `gh` scripts for fetch/list/transition/link operations. (#221)

### Workflow improvements

- **write-spec** — anti-gap defenses added to Phase 4 to catch under-specified areas before approval. (#211)
- **drive-to-merge** — review handling is now grounded in the full branch diff, so comment triage and proposed fixes reflect the entire change, not just the latest patch. (#215)
- **acceptance** — the model can now auto-invoke the skill when appropriate. (#217)
- **Docs** — clarified the research / plan-mode / write-spec boundary; plugin-standards alignment and doc trims across plugins. (#218, #222)

### Maintenance

- Dependency bumps in `maven-mcp`: `fast-uri` 3.1.0 → 3.1.2, `ip-address` and `express-rate-limit` (transitive). (#190)

---
Pre-release gate: `validate.sh` green; `plugin-validator` PASS / PASS-with-Minor on all 6 plugins (no Critical/Major). Minor findings are non-blocking (cosmetic: missing `repository` field in sensitive-guard, partial keywords in experts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
