### PR TITLE
Make issue-manager skill invocable (v0.21.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.21.0",
+      "version": "0.21.1",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/maven-mcp/plugin"
@@ -23,7 +23,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.21.0",
+      "version": "0.21.1",
       "category": "security",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/sensitive-guard"
@@ -34,7 +34,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.21.0",
+      "version": "0.21.1",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow"
@@ -45,7 +45,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.21.0",
+      "version": "0.21.1",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-experts"
@@ -56,7 +56,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.21.0",
+      "version": "0.21.1",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-kotlin"
@@ -67,7 +67,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.21.0",
+      "version": "0.21.1",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-swift"

--- a/plugins/developer-workflow-experts/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-experts/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-experts",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Reusable expert agents for code review, architecture, security, performance, UX, build, DevOps, business analysis, and debugging. Safe to install standalone \u2014 no skills, no hooks, no MCP servers.",
   "author": {
     "name": "kirich1409"

--- a/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-kotlin",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Kotlin, Android, and KMP specialist agents and migration skills \u2014 kotlin-engineer, compose-developer, migration, snapshot. Extends developer-workflow for Kotlin/Android projects.",
   "author": {
     "name": "kirich1409"

--- a/plugins/developer-workflow-swift/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-swift/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-swift",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Swift, iOS, and macOS specialist agents \u2014 swift-engineer and swiftui-developer, with references covering Swift concurrency, testing, and SwiftUI patterns/state/performance. Extends developer-workflow for Apple platforms.",
   "author": {
     "name": "kirich1409"

--- a/plugins/developer-workflow/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Developer workflow toolbox \u2014 on-demand skills for research, specification (write-spec, reverse-spec), multiexpert review, retroactive tests, code-quality finalize, mechanical /check, QA (test plans, acceptance), PR creation, autonomous drive-to-merge (CI monitor, review handler, re-request, poll), and issue-manager (backlog orchestrator: DAG-ordered sequential issue pipeline with board advancement). Exploratory QA without a spec is performed by calling the manual-tester agent directly. Platform-neutral; platform-specific engineers live in developer-workflow-kotlin and developer-workflow-swift.",
   "author": {
     "name": "kirich1409"

--- a/plugins/developer-workflow/skills/issue-manager/SKILL.md
+++ b/plugins/developer-workflow/skills/issue-manager/SKILL.md
@@ -12,7 +12,6 @@ description: >
 
   Do NOT use for: a single issue with no GitHub board tracking needed (use the pipeline skills individually);
   merging PRs (use /drive-to-merge); code review only (use /finalize); ad-hoc GitHub queries.
-disable-model-invocation: true
 ---
 
 # Issue Manager

--- a/plugins/maven-mcp/package.json
+++ b/plugins/maven-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "MCP server for Maven Central dependency intelligence",
   "main": "./dist/index.js",
   "type": "module",

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maven-mcp",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps, /check-deps-vulnerabilities, /latest-version, /dependency-changes, and /dependency-health skills",
   "author": {
     "name": "kirich1409"

--- a/plugins/sensitive-guard/.claude-plugin/plugin.json
+++ b/plugins/sensitive-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sensitive-guard",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Prevents sensitive data (secrets, PII) from reaching AI servers by scanning files before they are read into conversation",
   "author": {
     "name": "kirich1409"


### PR DESCRIPTION
## Summary
- Remove `disable-model-invocation: true` from `issue-manager/SKILL.md` — the flag currently makes the skill **uninvocable by anyone** (neither model auto-trigger nor manual `/developer-workflow:issue-manager`) due to Claude Code bug anthropics/claude-code#24042. The skill reported "not found".
- Patch bump `0.21.0 → 0.21.1` across all 7 plugin manifests + 6 `marketplace.json` entries. Dependency ranges (`^0.21.0`) already cover 0.21.1 and are left untouched.

## Why
`disable-model-invocation` was intended to keep this heavy backlog driver from auto-firing while still allowing manual invocation. In the current CC release there is no working frontmatter combination for "user-only" invocation — the flag disables the skill outright. Removing it restores invocation (model + user), mirroring the same fix applied to the `acceptance` skill in #217. The skill's tight trigger list + "Do NOT use for" guards mitigate over-eager auto-invocation.

## Test plan
- [x] `bash scripts/validate.sh` green
- [x] Flag removed; frontmatter (`name`, `description`) intact
- [x] All 8 version locations at 0.21.1; `^0.21.0` ranges unchanged
- [ ] `plugin-dev:plugin-validator` on developer-workflow — PASS
- [ ] Post-merge: tag `v0.21.1` → GH Actions publishes; verify skill invocable after plugin refresh/restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)