### PR TITLE
Fix repository field schema in plugin manifests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.21.1",
+      "version": "0.21.2",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/maven-mcp/plugin"
@@ -23,7 +23,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.21.1",
+      "version": "0.21.2",
       "category": "security",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/sensitive-guard"
@@ -34,7 +34,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.21.1",
+      "version": "0.21.2",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow"
@@ -45,7 +45,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.21.1",
+      "version": "0.21.2",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-experts"
@@ -56,7 +56,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.21.1",
+      "version": "0.21.2",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-kotlin"
@@ -67,7 +67,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.21.1",
+      "version": "0.21.2",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/developer-workflow-swift"

--- a/plugins/developer-workflow-experts/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-experts/.claude-plugin/plugin.json
@@ -7,10 +7,7 @@
   },
   "homepage": "https://github.com/kirich1409/krozov-ai-tools",
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/kirich1409/krozov-ai-tools.git"
-  },
+  "repository": "https://github.com/kirich1409/krozov-ai-tools",
   "category": "development",
   "keywords": [
     "agents",

--- a/plugins/developer-workflow-experts/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-experts/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-experts",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Reusable expert agents for code review, architecture, security, performance, UX, build, DevOps, business analysis, and debugging. Safe to install standalone \u2014 no skills, no hooks, no MCP servers.",
   "author": {
     "name": "kirich1409"

--- a/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-kotlin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-kotlin",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Kotlin, Android, and KMP specialist agents and migration skills \u2014 kotlin-engineer, compose-developer, migration, snapshot. Extends developer-workflow for Kotlin/Android projects.",
   "author": {
     "name": "kirich1409"

--- a/plugins/developer-workflow-swift/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-swift/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow-swift",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Swift, iOS, and macOS specialist agents \u2014 swift-engineer and swiftui-developer, with references covering Swift concurrency, testing, and SwiftUI patterns/state/performance. Extends developer-workflow for Apple platforms.",
   "author": {
     "name": "kirich1409"

--- a/plugins/developer-workflow-swift/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow-swift/.claude-plugin/plugin.json
@@ -7,10 +7,7 @@
   },
   "homepage": "https://github.com/kirich1409/krozov-ai-tools",
   "license": "MIT",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/kirich1409/krozov-ai-tools.git"
-  },
+  "repository": "https://github.com/kirich1409/krozov-ai-tools",
   "category": "development",
   "keywords": [
     "swift",

--- a/plugins/developer-workflow/.claude-plugin/plugin.json
+++ b/plugins/developer-workflow/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "developer-workflow",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Developer workflow toolbox \u2014 on-demand skills for research, specification (write-spec, reverse-spec), multiexpert review, retroactive tests, code-quality finalize, mechanical /check, QA (test plans, acceptance), PR creation, autonomous drive-to-merge (CI monitor, review handler, re-request, poll), and issue-manager (backlog orchestrator: DAG-ordered sequential issue pipeline with board advancement). Exploratory QA without a spec is performed by calling the manual-tester agent directly. Platform-neutral; platform-specific engineers live in developer-workflow-kotlin and developer-workflow-swift.",
   "author": {
     "name": "kirich1409"

--- a/plugins/maven-mcp/package-lock.json
+++ b/plugins/maven-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.20.0",
+  "version": "0.21.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@krozov/maven-central-mcp",
-      "version": "0.20.0",
+      "version": "0.21.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/plugins/maven-mcp/package.json
+++ b/plugins/maven-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "MCP server for Maven Central dependency intelligence",
   "main": "./dist/index.js",
   "type": "module",

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maven-mcp",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps, /check-deps-vulnerabilities, /latest-version, /dependency-changes, and /dependency-health skills",
   "author": {
     "name": "kirich1409"

--- a/plugins/sensitive-guard/.claude-plugin/plugin.json
+++ b/plugins/sensitive-guard/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sensitive-guard",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "description": "Prevents sensitive data (secrets, PII) from reaching AI servers by scanning files before they are read into conversation",
   "author": {
     "name": "kirich1409"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -257,6 +257,36 @@ check_component_paths() {
   done < <(jq -r '.plugins[] | [.name, .source] | @tsv' "$MARKETPLACE")
 }
 
+# ---------- L8: plugin.json scalar field types ----------
+#
+# Claude Code's plugin.json schema requires these fields to be plain strings.
+# npm's package.json allows object forms for some (notably
+# "repository": {"type","url"}), which Claude Code rejects with
+# "Validation errors: <field>: Invalid input: expected string, received object".
+# Catch that here so it never reaches a release.
+
+STRING_FIELDS=(name version description homepage repository license)
+
+check_field_types() {
+  echo "--- L8: plugin.json scalar field types ---"
+  while IFS=$'\t' read -r name source; do
+    plugin_json="${source}/.claude-plugin/plugin.json"
+    [ -f "$plugin_json" ] || continue
+    local plugin_ok=1
+    for field in "${STRING_FIELDS[@]}"; do
+      ftype=$(jq -r --arg f "$field" 'if has($f) then (.[$f] | type) else "absent" end' "$plugin_json")
+      case "$ftype" in
+        absent|string) ;;
+        *)
+          fail "'$name' plugin.json field '$field' must be a string, got $ftype (Claude Code rejects npm-style $ftype)"
+          plugin_ok=0
+          ;;
+      esac
+    done
+    [ "$plugin_ok" -eq 1 ] && ok "'$name' scalar field types"
+  done < <(jq -r '.plugins[] | [.name, .source] | @tsv' "$MARKETPLACE")
+}
+
 # ---------- L6: Hook scripts ----------
 
 check_hook_scripts() {
@@ -314,6 +344,7 @@ main() {
   check_component_paths
   check_hook_scripts
   check_frontmatter
+  check_field_types
 
   if [ -n "$CHECK_TAG" ]; then
     check_tag_versions "$CHECK_TAG"


### PR DESCRIPTION
## Problem

Claude Code rejects `developer-workflow-experts` and `developer-workflow-swift` with:

```
repository: Invalid input: expected string, received object
```

Both manifests used the npm-style object form `{"type":"git","url":"git+https://…git"}`, but Claude Code's `plugin.json` schema requires `repository` to be a plain string URL. The other four plugins have no `repository` field, so they were unaffected.

## Changes

- `repository` → string `"https://github.com/kirich1409/krozov-ai-tools"` in both offending manifests. `author` left as object form (the schema accepts that for `author`).
- New **L8** check in `scripts/validate.sh` (`check_field_types`) that fails the build if any of `name`/`version`/`description`/`homepage`/`repository`/`license` is not a plain string in any plugin.json — guarding this whole class of npm-contamination errors.

## Release impact

- **0.21.1 is published broken in the wild.** Installed users hit the validation error until they reinstall a fixed version.
- This mainline fix does **not** reach installed caches on its own — it needs a **0.21.2** release to propagate to npm / plugin reinstall.

## Verification

`bash scripts/validate.sh` → `=== All checks passed ===`, including the new L8 lines for all six plugins.

## Scope note

`/finalize` skipped: manifest edits are config-only mechanical changes; the L8 bash function mirrors the existing `check_component_paths` pattern and was run green. Full review→fix→simplify loop is overkill for this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)