### PR TITLE
Fix PLUGIN_ROOT path traversal in sensitive-guard hook

### DIFF
--- a/plugins/sensitive-guard/hooks/pre-tool-use.sh
+++ b/plugins/sensitive-guard/hooks/pre-tool-use.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Reads tool call JSON from stdin, scans target files for sensitive data,
 # prompts user, and blocks or allows based on their choice.
 
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
 
 # Source all modules
 source "$PLUGIN_ROOT/src/utils.sh"


### PR DESCRIPTION
## What changed

Removed the `dirname "$0"` fallback for `PLUGIN_ROOT` in `plugins/sensitive-guard/hooks/pre-tool-use.sh`. The hook now requires `${CLAUDE_PLUGIN_ROOT}` to be set by the Claude Code harness — which it always is when a plugin hook runs.

**Before:**
```bash
PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
```

**After:**
```bash
PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"
```

## Why

The `dirname "$0"` fallback introduced a path-traversal risk: if the hook was invoked with a crafted `$0` (e.g. via a symlink or relative path), `PLUGIN_ROOT` could resolve to an unintended directory, causing the hook to source files from outside the plugin's sandbox. Since `CLAUDE_PLUGIN_ROOT` is always injected by the harness, the fallback is both unnecessary and unsafe.

Fixes #202.

## How to test

1. Verify `plugins/sensitive-guard/hooks/pre-tool-use.sh` contains no `dirname` reference — `grep dirname` returns empty.
2. Verify line 8 reads `PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT}"`.
3. Install the plugin and trigger a file-write tool call with a sensitive pattern — hook should fire normally.
4. Unset `CLAUDE_PLUGIN_ROOT` and invoke the hook directly — it should exit with `unbound variable` (correct loud failure, not a silent wrong-path fallback).

## Release Notes

- **sensitive-guard**: Fixed path-traversal vulnerability in `pre-tool-use.sh` hook; `PLUGIN_ROOT` now always resolved via `${CLAUDE_PLUGIN_ROOT}` (injected by harness) instead of a `dirname`-based fallback.

## Status

| Gate | Result |
|---|---|
| `/check` | PASS |
| `/finalize` | PASS — 1 round, 0 BLOCKs |
| `/acceptance` | VERIFIED — 3/3 checks passed (code, build, ac-coverage) |

## Checklist

- [x] Single-file change, no behaviour change in normal operation
- [x] `bash -n` syntax check passes
- [x] AC verified: no `dirname` in hook, `CLAUDE_PLUGIN_ROOT` used on line 8
- [x] No new dependencies

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)