### PR TITLE
Fix agent colors: replace orange with conventional palette colors

### DIFF
--- a/plugins/developer-workflow-experts/agents/devops-expert.md
+++ b/plugins/developer-workflow-experts/agents/devops-expert.md
@@ -3,7 +3,7 @@ name: "devops-expert"
 description: "Use this agent when the user needs help with CI/CD pipelines, build systems, deployment automation, packaging, release workflows, dependency scanning, environment management, or monitoring/alerting infrastructure. Examples:\\n\\n- user: \"GitHub Actions build fails on the matrix build for iOS\"\\n  assistant: \"Launching the devops-expert agent to diagnose the CI pipeline issue.\"\\n  <uses Agent tool to launch devops-expert>\\n\\n- user: \"Need to set up automated releases with a changelog driven by tags\"\\n  assistant: \"Using devops-expert to design the release automation.\"\\n  <uses Agent tool to launch devops-expert>\\n\\n- user: \"How can I cut build time on GitLab CI? It is 25 minutes right now\"\\n  assistant: \"Handing the task to the devops-expert agent to analyze and optimize the pipeline.\"\\n  <uses Agent tool to launch devops-expert>\\n\\n- user: \"Need to build a Docker image for our service and set up staging deployment\"\\n  assistant: \"Launching devops-expert to configure containerization and deployment.\"\\n  <uses Agent tool to launch devops-expert>\\n\\n- user: \"Scan dependencies for vulnerabilities\"\\n  assistant: \"Using the devops-expert agent for dependency scanning.\"\\n  <uses Agent tool to launch devops-expert>"
 model: sonnet
 tools: Read, Write, Edit, Bash, Glob, Grep
-color: orange
+color: green
 memory: project
 maxTurns: 35
 ---

--- a/plugins/developer-workflow-swift/agents/swift-engineer.md
+++ b/plugins/developer-workflow-swift/agents/swift-engineer.md
@@ -40,7 +40,7 @@ Data layer work — the agent reads the existing network client and storage setu
 </commentary>
 </example>"
 model: sonnet
-color: orange
+color: blue
 memory: project
 ---
 


### PR DESCRIPTION
## Problem

Two agent frontmatter files used `color: orange`, which is not part of the conventional agent color palette (blue / cyan / green / yellow / magenta / red):

- `plugins/developer-workflow-experts/agents/devops-expert.md`
- `plugins/developer-workflow-swift/agents/swift-engineer.md`

## Fix

- `devops-expert.md`: `color: orange` → `color: green`
- `swift-engineer.md`: `color: orange` → `color: blue`

Both replacements use colors from the conventional palette.

## Verification

- `validate.sh`: all checks passed
- Both files confirmed to have no `color: orange`
- Both assigned colors are in the palette (blue/cyan/green/yellow/magenta/red)

Closes #203

🤖 Generated with [Claude Code](https://claude.ai/claude-code)