### PR TITLE
Split existing-code role from API truth in kotlin-engineer and compose-developer step 0.3

### DIFF
--- a/plugins/developer-workflow-kotlin/agents/compose-developer.md
+++ b/plugins/developer-workflow-kotlin/agents/compose-developer.md
@@ -33,12 +33,17 @@ You do NOT touch business logic, repositories, use cases, or domain models. View
 
 ### 0.3 Verify APIs against project versions
 
-Compose APIs evolve fast (Material 3 components, CMP resources, Navigation, Adaptive, Animation, Insets). Before using any non-trivial API:
+Compose APIs evolve fast (Material 3 components, CMP resources, Navigation, Adaptive, Animation, Insets). Before using any non-trivial API, serve both roles below — they are independent:
 
-1. **Read the project's existing code first** — single best source of truth for what works with the project's deps
-2. Project's version catalog / `build.gradle.kts` for exact dependency versions
-3. `ksrc` / Context7 / official docs if the project doesn't already use the API
-4. Never fall back to memorized signatures
+**API truth** (what composables / modifiers / types / signatures exist at the pinned version):
+1. `ksrc` — primary; reads the actual source jar from the Gradle cache
+2. Official docs / Context7 — secondary (especially for M3, CMP resources, Navigation, Adaptive)
+3. Never fall back to memorized signatures
+- Existing project code is NOT a source for API truth — it shows only what the project already uses; a composable may have been renamed, deprecated, or the parameter list may differ in the pinned version. An existing call site may also be a legacy pattern.
+
+**Style and pinned versions** (which modules are wired, what version is pinned, project UI conventions):
+1. Existing project code — primary (theme system, token names, shared UI module, preview style)
+2. `build.gradle.kts` / `libs.versions.toml` for exact dependency versions
 
 ---
 

--- a/plugins/developer-workflow-kotlin/agents/kotlin-engineer.md
+++ b/plugins/developer-workflow-kotlin/agents/kotlin-engineer.md
@@ -48,11 +48,17 @@ You do NOT write Compose UI code — `@Composable` functions, screens, component
 
 1. Read project's dependency versions — `build.gradle.kts`, `libs.versions.toml`, BOM declarations
 2. High-staleness areas — always verify before using: Ktor, Room (KMP support, `@Upsert`), SQLDelight, kotlinx.serialization, kotlinx.datetime, Hilt, Koin
-3. Verification priority:
-   1. Project's existing code — single best source of truth
-   2. Dependency source via `ksrc`
-   3. Official documentation MCP / web search
-   4. Never fall back to memorized signatures
+3. These two roles are independent — serve both:
+
+   **API truth** (what methods / types / signatures exist at the pinned version):
+   1. `ksrc` — primary; reads the actual source jar from the Gradle cache
+   2. Official documentation MCP / web search — secondary
+   3. Never fall back to memorized signatures
+   - Existing project code is NOT a source for API truth — it shows only the slice the project already uses; new methods, deprecated aliases, KMP-only forms, and alternatives may not be there. An existing call site may also be a legacy pattern.
+
+   **Style and pinned versions** (which modules are wired, what version is pinned, project conventions):
+   1. Existing project code — primary
+   2. `build.gradle.kts` / `libs.versions.toml` / BOM declarations — primary
 
 ---
 


### PR DESCRIPTION
## What changed

In `kotlin-engineer` and `compose-developer` step 0.3, the old single-priority list placed _"existing project code — single best source of truth"_ at the top before `ksrc` and official docs. This conflated two independent roles and trained the agents to use existing call sites as API truth — leading to legacy patterns and undiscovered APIs being silently propagated.

Both agents now have two explicitly labelled, independent sections:

- **API truth** — `ksrc` primary (source jar from Gradle cache), official docs/Context7 secondary. Existing project code is explicitly excluded, with concrete rationale: it shows only what the project already uses; new methods, deprecated aliases, KMP-only forms, and alternatives may not appear there.
- **Style and pinned versions** — existing project code primary (conventions, theme system, module wiring), build files for exact versions.

## Why

Addresses issue #206: the old framing caused agents to treat an existing call site as authoritative for API signatures, silently inheriting legacy patterns or missing recently-added alternatives. The fix aligns with the project's `rules/external-sources.md` principle that distinguishes API truth (T1/T2 sources) from project style (existing code as style/version signal).

## Artifacts

- Finalize: `swarm-report/issue-206-finalize.md` — PASS, 1 round, 0 findings
- Acceptance: `swarm-report/issue-206-acceptance.md` — VERIFIED (code-review + build smoke)

## How to test

1. Open `plugins/developer-workflow-kotlin/agents/kotlin-engineer.md` → section 0.3: verify "single best source of truth" phrase is gone; verify two independent labelled sections "API truth" and "Style and pinned versions" are present; verify "Existing project code is NOT a source for API truth" disclaimer with rationale.
2. Open `plugins/developer-workflow-kotlin/agents/compose-developer.md` → section 0.3: same checks adapted for Compose domain.
3. `bash scripts/validate.sh` → all checks pass.

## Status

| Gate | Result |
|---|---|
| `/check` | PASS |
| `/finalize` | PASS — 1 round, 0 findings |
| `/acceptance` | VERIFIED — code-review + build smoke |

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)