### PR TITLE
Add HTTP/SSE transport to maven-mcp via --port flag

### DIFF
--- a/plugins/maven-mcp/README.md
+++ b/plugins/maven-mcp/README.md
@@ -38,9 +38,9 @@ An MCP server registers tools that Claude can call during a conversation. The se
 
 Custom repositories are auto-discovered from Gradle `settings.gradle(.kts)`/`build.gradle(.kts)` and Maven `pom.xml`, and the server queries these alongside Maven Central. Dependency scanning additionally reads `gradle/libs.versions.toml` for declared dependencies, but version catalogs are not used for repository discovery.
 
-## HTTP / SSE mode (Claude Cloud)
+## HTTP (Streamable HTTP) mode
 
-Claude Cloud (claude.ai/code web container) requires HTTP/SSE transport — stdio servers do not work there. Start the server in HTTP mode with `--port`:
+Claude Cloud (claude.ai/code web container) requires HTTP transport — stdio servers do not work there. Start the server in HTTP mode with `--port`:
 
 ```bash
 npx @krozov/maven-central-mcp --port 3001
@@ -52,8 +52,8 @@ Then configure it in `.mcp.json`:
 {
   "mcpServers": {
     "maven-mcp": {
-      "type": "sse",
-      "url": "http://localhost:3001/sse"
+      "type": "http",
+      "url": "http://localhost:3001/mcp"
     }
   }
 }

--- a/plugins/maven-mcp/README.md
+++ b/plugins/maven-mcp/README.md
@@ -38,6 +38,29 @@ An MCP server registers tools that Claude can call during a conversation. The se
 
 Custom repositories are auto-discovered from Gradle `settings.gradle(.kts)`/`build.gradle(.kts)` and Maven `pom.xml`, and the server queries these alongside Maven Central. Dependency scanning additionally reads `gradle/libs.versions.toml` for declared dependencies, but version catalogs are not used for repository discovery.
 
+## HTTP / SSE mode (Claude Cloud)
+
+Claude Cloud (claude.ai/code web container) requires HTTP/SSE transport — stdio servers do not work there. Start the server in HTTP mode with `--port`:
+
+```bash
+npx @krozov/maven-central-mcp --port 3001
+```
+
+Then configure it in `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "maven-mcp": {
+      "type": "sse",
+      "url": "http://localhost:3001/sse"
+    }
+  }
+}
+```
+
+In stdio mode (default), start with no arguments: `npx @krozov/maven-central-mcp`.
+
 ## Prerequisites
 
 - **Node.js** 18+ (required)

--- a/plugins/maven-mcp/README.md
+++ b/plugins/maven-mcp/README.md
@@ -53,7 +53,7 @@ Then configure it in `.mcp.json`:
   "mcpServers": {
     "maven-mcp": {
       "type": "http",
-      "url": "http://localhost:3001/mcp"
+      "url": "http://127.0.0.1:3001/mcp"
     }
   }
 }

--- a/plugins/maven-mcp/package-lock.json
+++ b/plugins/maven-mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@krozov/maven-central-mcp",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@krozov/maven-central-mcp",
-      "version": "0.21.2",
+      "version": "0.22.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",

--- a/plugins/maven-mcp/src/cli/__tests__/parse-port.test.ts
+++ b/plugins/maven-mcp/src/cli/__tests__/parse-port.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { parsePortArg, InvalidPortError } from "../parse-port.js";
+
+describe("parsePortArg", () => {
+  it("parses the space form --port 8080", () => {
+    expect(parsePortArg(["--port", "8080"])).toBe(8080);
+  });
+
+  it("parses the equals form --port=8080", () => {
+    expect(parsePortArg(["--port=8080"])).toBe(8080);
+  });
+
+  it("returns null when --port is absent", () => {
+    expect(parsePortArg([])).toBeNull();
+    expect(parsePortArg(["--other", "value"])).toBeNull();
+  });
+
+  it("throws InvalidPortError when the value is missing", () => {
+    expect(() => parsePortArg(["--port"])).toThrow(InvalidPortError);
+  });
+
+  it("throws InvalidPortError for out-of-range and non-numeric values", () => {
+    expect(() => parsePortArg(["--port", "0"])).toThrow(InvalidPortError);
+    expect(() => parsePortArg(["--port", "65536"])).toThrow(InvalidPortError);
+    expect(() => parsePortArg(["--port", "-1"])).toThrow(InvalidPortError);
+    expect(() => parsePortArg(["--port", "8080.5"])).toThrow(InvalidPortError);
+    expect(() => parsePortArg(["--port", "abc"])).toThrow(InvalidPortError);
+    expect(() => parsePortArg(["--port=0"])).toThrow(InvalidPortError);
+    expect(() => parsePortArg(["--port=65536"])).toThrow(InvalidPortError);
+  });
+});

--- a/plugins/maven-mcp/src/cli/parse-port.ts
+++ b/plugins/maven-mcp/src/cli/parse-port.ts
@@ -1,0 +1,28 @@
+export class InvalidPortError extends Error {}
+
+/**
+ * Parse the `--port` argument from a CLI argv slice (i.e. `process.argv.slice(2)`).
+ *
+ * Pure: does not read `process.argv`, never calls `process.exit` or `console.error`.
+ * Supports both `--port <value>` (space form, checked first) and `--port=<value>`.
+ *
+ * @returns the parsed port, or `null` when `--port` is absent.
+ * @throws {InvalidPortError} when the value is missing or out of range (integer 1–65535).
+ */
+export function parsePortArg(args: string[]): number | null {
+  const parseValue = (value: string): number => {
+    const n = Number(value);
+    if (Number.isInteger(n) && n > 0 && n <= 65535) return n;
+    throw new InvalidPortError(`Invalid --port value: "${value}". Expected an integer in range 1–65535.`);
+  };
+  const idx = args.indexOf("--port");
+  if (idx !== -1) {
+    if (idx + 1 >= args.length) {
+      throw new InvalidPortError("--port requires a value. Usage: --port <number> or --port=<number>");
+    }
+    return parseValue(args[idx + 1]);
+  }
+  const eq = args.find((a) => a.startsWith("--port="));
+  if (eq) return parseValue(eq.slice("--port=".length));
+  return null;
+}

--- a/plugins/maven-mcp/src/index.ts
+++ b/plugins/maven-mcp/src/index.ts
@@ -19,6 +19,7 @@ import { getDependencyHealthHandler } from "./tools/get-dependency-health.js";
 import { searchArtifactsHandler } from "./tools/search-artifacts.js";
 import { auditProjectDependenciesHandler } from "./tools/audit-project-dependencies.js";
 import { PACKAGE_VERSION } from "./version.js";
+import { parsePortArg, InvalidPortError } from "./cli/parse-port.js";
 
 const server = new McpServer({
   name: "maven-central-mcp",
@@ -201,24 +202,15 @@ server.tool(
 );
 
 function parsePort(): number | null {
-  const args = process.argv.slice(2);
-  const parseValue = (value: string): number => {
-    const n = Number(value);
-    if (Number.isInteger(n) && n > 0 && n <= 65535) return n;
-    console.error(`Invalid --port value: "${value}". Expected an integer in range 1–65535.`);
-    process.exit(1);
-  };
-  const idx = args.indexOf("--port");
-  if (idx !== -1) {
-    if (idx + 1 >= args.length) {
-      console.error("--port requires a value. Usage: --port <number> or --port=<number>");
+  try {
+    return parsePortArg(process.argv.slice(2));
+  } catch (err) {
+    if (err instanceof InvalidPortError) {
+      console.error(err.message);
       process.exit(1);
     }
-    return parseValue(args[idx + 1]);
+    throw err;
   }
-  const eq = args.find((a) => a.startsWith("--port="));
-  if (eq) return parseValue(eq.slice("--port=".length));
-  return null;
 }
 
 async function main() {

--- a/plugins/maven-mcp/src/index.ts
+++ b/plugins/maven-mcp/src/index.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
+import { createServer } from "node:http";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { z } from "zod";
 import { HttpMavenRepository, MAVEN_CENTRAL, GOOGLE_MAVEN, GRADLE_PLUGIN_PORTAL } from "./maven/repository.js";
 import type { MavenRepository } from "./maven/repository.js";
@@ -198,10 +200,39 @@ server.tool(
   },
 );
 
+function parsePort(): number | null {
+  const args = process.argv.slice(2);
+  const idx = args.indexOf("--port");
+  if (idx !== -1 && idx + 1 < args.length) {
+    const n = parseInt(args[idx + 1], 10);
+    return isNaN(n) ? null : n;
+  }
+  const eq = args.find((a) => a.startsWith("--port="));
+  if (eq) {
+    const n = parseInt(eq.slice("--port=".length), 10);
+    return isNaN(n) ? null : n;
+  }
+  return null;
+}
+
 async function main() {
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-  console.error("maven-central-mcp running on stdio");
+  const port = parsePort();
+  if (port !== null) {
+    const transport = new StreamableHTTPServerTransport();
+    await server.connect(transport);
+    const httpServer = createServer((req, res) => {
+      transport.handleRequest(req, res).catch((err) => {
+        console.error("HTTP request error:", err);
+        if (!res.headersSent) res.writeHead(500).end();
+      });
+    });
+    await new Promise<void>((resolve) => httpServer.listen(port, resolve));
+    console.error(`maven-central-mcp running on HTTP port ${port}`);
+  } else {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+    console.error("maven-central-mcp running on stdio");
+  }
 }
 
 main().catch((error) => {

--- a/plugins/maven-mcp/src/index.ts
+++ b/plugins/maven-mcp/src/index.ts
@@ -202,23 +202,24 @@ server.tool(
 
 function parsePort(): number | null {
   const args = process.argv.slice(2);
+  const parseValue = (value: string): number | null => {
+    const n = Number(value);
+    if (Number.isInteger(n) && n > 0 && n <= 65535) return n;
+    console.error(`Invalid --port value: "${value}". Expected an integer in range 1–65535.`);
+    process.exit(1);
+  };
   const idx = args.indexOf("--port");
-  if (idx !== -1 && idx + 1 < args.length) {
-    const n = parseInt(args[idx + 1], 10);
-    return isNaN(n) ? null : n;
-  }
+  if (idx !== -1 && idx + 1 < args.length) return parseValue(args[idx + 1]);
   const eq = args.find((a) => a.startsWith("--port="));
-  if (eq) {
-    const n = parseInt(eq.slice("--port=".length), 10);
-    return isNaN(n) ? null : n;
-  }
+  if (eq) return parseValue(eq.slice("--port=".length));
   return null;
 }
 
 async function main() {
   const port = parsePort();
   if (port !== null) {
-    const transport = new StreamableHTTPServerTransport();
+    // Stateless mode: no session tracking — each request is independent
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
     await server.connect(transport);
     const httpServer = createServer((req, res) => {
       transport.handleRequest(req, res).catch((err) => {
@@ -226,7 +227,7 @@ async function main() {
         if (!res.headersSent) res.writeHead(500).end();
       });
     });
-    await new Promise<void>((resolve) => httpServer.listen(port, resolve));
+    await new Promise<void>((resolve) => httpServer.listen(port, "127.0.0.1", resolve));
     console.error(`maven-central-mcp running on HTTP port ${port}`);
   } else {
     const transport = new StdioServerTransport();

--- a/plugins/maven-mcp/src/index.ts
+++ b/plugins/maven-mcp/src/index.ts
@@ -202,7 +202,7 @@ server.tool(
 
 function parsePort(): number | null {
   const args = process.argv.slice(2);
-  const parseValue = (value: string): number | null => {
+  const parseValue = (value: string): number => {
     const n = Number(value);
     if (Number.isInteger(n) && n > 0 && n <= 65535) return n;
     console.error(`Invalid --port value: "${value}". Expected an integer in range 1–65535.`);

--- a/plugins/maven-mcp/src/index.ts
+++ b/plugins/maven-mcp/src/index.ts
@@ -209,7 +209,13 @@ function parsePort(): number | null {
     process.exit(1);
   };
   const idx = args.indexOf("--port");
-  if (idx !== -1 && idx + 1 < args.length) return parseValue(args[idx + 1]);
+  if (idx !== -1) {
+    if (idx + 1 >= args.length) {
+      console.error("--port requires a value. Usage: --port <number> or --port=<number>");
+      process.exit(1);
+    }
+    return parseValue(args[idx + 1]);
+  }
   const eq = args.find((a) => a.startsWith("--port="));
   if (eq) return parseValue(eq.slice("--port=".length));
   return null;
@@ -227,7 +233,9 @@ async function main() {
         if (!res.headersSent) res.writeHead(500).end();
       });
     });
-    await new Promise<void>((resolve) => httpServer.listen(port, "127.0.0.1", resolve));
+    await new Promise<void>((resolve, reject) =>
+      httpServer.listen(port, "127.0.0.1", resolve).on("error", reject),
+    );
     console.error(`maven-central-mcp running on HTTP port ${port}`);
   } else {
     const transport = new StdioServerTransport();


### PR DESCRIPTION
## What changed

Added HTTP (Streamable HTTP) transport mode to \`maven-central-mcp\`. A \`--port <N>\` flag starts the server using \`StreamableHTTPServerTransport\` from the MCP SDK instead of stdio. Without the flag, behavior is unchanged.

Changed files:
- \`plugins/maven-mcp/src/index.ts\` — \`parsePort()\` helper + branching \`main()\` for HTTP vs stdio
- \`plugins/maven-mcp/README.md\` — new "HTTP (Streamable HTTP) mode" section with \`.mcp.json\` example

## Why

Claude Cloud (claude.ai/code web container) supports only HTTP transport — stdio servers do not work there. This enables \`maven-mcp\` in Cloud without new dependencies (\`StreamableHTTPServerTransport\` is already in \`@modelcontextprotocol/sdk ^1.27.1\`; \`node:http\` is built-in).

## How to test

```bash
# Stdio (existing behavior — unchanged)
node dist/index.js
# → maven-central-mcp running on stdio

# HTTP mode
node dist/index.js --port 3001
# → maven-central-mcp running on HTTP port 3001

# HTTP endpoint
curl -H "Accept: text/event-stream" http://127.0.0.1:3001/sse
# → HTTP 200

# Invalid port
node dist/index.js --port abc
# → error: Invalid --port value: "abc". Expected an integer in range 1–65535.

# Missing port value
node dist/index.js --port
# → error: --port requires a value. Usage: --port <number> or --port=<number>
```

\`.mcp.json\` config for HTTP mode:
```json
{
  "mcpServers": {
    "maven-mcp": {
      "type": "http",
      "url": "http://127.0.0.1:3001/mcp"
    }
  }
}
```

## Release Notes

- Added \`--port <N>\` flag to \`maven-central-mcp\` — starts the server in HTTP (Streamable HTTP) transport mode for use with Claude Cloud. Stdio mode is the default and unchanged.

## Status

| Gate | Result |
|---|---|
| Build (\`npm run build\`) | ✅ |
| Tests (\`npm test\`) | ✅ 401/401 |
| HTTP smoke-test (127.0.0.1, SSE) | ✅ HTTP 200 |
| Finalize | ✅ PASS (1 round, 5 findings fixed) |
| Acceptance | ✅ VERIFIED |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)