### PR TITLE
drive-to-merge: fix merge-wait stalls — auto mode, native auto-merge, merge policy

### DIFF
--- a/plugins/developer-workflow/skills/drive-to-merge/SKILL.md
+++ b/plugins/developer-workflow/skills/drive-to-merge/SKILL.md
@@ -31,13 +31,11 @@ compaction — the user never edits it.
 
 | Mode | What it changes |
 |---|---|
-| default | Between rounds shows a decision table and waits for `approve` / `skip` / `stop` |
-| `--auto` | Same table shown for visibility, then proceeds without waiting; merge step still asks |
+| default | Between rounds shows a decision table and waits for `approve` / `skip` / `stop`; merge step asks for confirmation |
+| `--auto` | Same table shown for visibility, then proceeds without waiting; merge gate also skipped — when all Phase 5 conditions are met the skill merges automatically |
 | `--dry-run` | Runs analysis and renders the decision table once; makes no edits, pushes, or posts; exits |
 
 Trigger words equivalent to `--auto`: "act autonomously", "without confirmations", "auto mode", "don't ask". The skill echoes which mode it is running in before Phase 2.
-
-The merge step in Phase 5 **always** asks — `--auto` does not override that.
 
 ---
 
@@ -88,7 +86,7 @@ Classify:
 | PR attribute | Values that matter |
 |---|---|
 | `state` | OPEN → continue; MERGED / CLOSED → Phase 5 terminal |
-| `isDraft` | `true` → handle review comments and CI, but never enter Phase 5; surface to user with "PR is draft — promote to ready with `gh pr ready` or abort" when everything else would be merge-ready |
+| `isDraft` | `true` → handle review comments and CI, but do not enter Phase 5 until promoted. When everything else would be merge-ready: in `--auto` mode promote automatically (`gh pr ready` / `glab mr update --remove-draft`) and continue to Phase 5; in default mode surface to user with "PR is draft — promote to ready with `gh pr ready` or abort" |
 | `statusCheckRollup` | Any `FAILURE` / `CANCELLED` / `TIMED_OUT` → 2.2 CI handling; all `SUCCESS` → skip 2.2; mix of `IN_PROGRESS` + no failures → wait (Phase 4) |
 | `reviewDecision` | `CHANGES_REQUESTED` → 2.3 must run; `APPROVED` → candidate for merge; `REVIEW_REQUIRED` → 2.4 (request review) |
 | `mergeable` + `mergeStateStatus` | `CONFLICTING` → 2.6 rebase; `BLOCKED` (missing approval, failing required check) → identify and loop |
@@ -174,11 +172,14 @@ Procedure and delaySeconds matrix in [`references/polling.md`](references/pollin
 
 ---
 
-## Phase 5: Merge (always user-confirmed)
+## Phase 5: Merge
 
-Pre-merge checks → confirmation message → final re-check → `gh pr merge` / `glab mr merge`.
-`--auto` does not skip this gate — by design, final merge always requires explicit user
-approval.
+Pre-merge checks → summary message → final re-check → `gh pr merge` / `glab mr merge`.
+
+In **default mode** the summary message blocks until the user replies "merge".
+In **`--auto` mode** the summary is shown for visibility and the merge executes immediately
+without waiting. If `isDraft == true` and everything else is merge-ready, promote the PR/MR
+first (`gh pr ready` / `glab mr update --remove-draft`) before running pre-merge checks.
 
 Procedure in [`references/merge.md`](references/merge.md).
 
@@ -215,7 +216,7 @@ The skill decides these without asking, in any mode:
 
 **Autonomous by default.** The user should only see decisions that require judgement: true disagreements, unresolvable rebases, final merge. Everything mechanical happens without asking.
 
-**Approval gate ≠ merge gate.** `--auto` removes the round-level approval gate. It does not remove the merge gate — by design, final merge always requires explicit user confirmation.
+**Approval gate and merge gate.** `--auto` removes both: the round-level approval gate and the final merge gate. In `--auto` mode the skill merges automatically once all Phase 5 conditions are met. Default mode retains explicit user confirmation at the merge step — the user types "merge" to execute. True blockers (DISCUSSION on P0/P1, unresolvable rebase, integrity mismatch) still stop the loop in any mode.
 
 **Safe by construction.** Replies go through the sanitize pipeline; thread ownership is re-verified before every POST; POST bodies go through stdin, never shell args. Force-push policy per globals.
 

--- a/plugins/developer-workflow/skills/drive-to-merge/SKILL.md
+++ b/plugins/developer-workflow/skills/drive-to-merge/SKILL.md
@@ -16,10 +16,10 @@ fixes, delegate, push, re-request review, wait for new activity — until the PR
 or a true blocker requires the user.
 
 **Core principle:** keep the PR moving. Every obstacle (CI failure, review comment,
-stalled reviewer) is a loop iteration, not a stop. The skill stops only for: the final
-merge (requires user confirmation), true disagreements with a reviewer that need a
-human judgement call, or mechanical dead-ends (permission denied, rebase conflict the
-skill cannot resolve).
+stalled reviewer) is a loop iteration, not a stop. The skill stops only for: true
+disagreements with a reviewer that need a human judgement call, or mechanical dead-ends
+(permission denied, rebase conflict the skill cannot resolve). In default mode it also
+stops at the final merge step and waits for "merge"; in `--auto` mode it merges directly.
 
 **In-session, not in files.** All analysis, categorization, and proposed actions are
 rendered in the conversation as tables. A state file exists only to survive context
@@ -214,7 +214,7 @@ The skill decides these without asking, in any mode:
 
 **Proposals are concrete.** Every actionable row carries a snippet, a delegation instruction, or the exact question text. "BLOCKING / FIXABLE" alone is not a proposal.
 
-**Autonomous by default.** The user should only see decisions that require judgement: true disagreements, unresolvable rebases, final merge. Everything mechanical happens without asking.
+**Autonomous by default.** The user should only see decisions that require judgement: true disagreements, unresolvable rebases. Everything mechanical happens without asking. In default mode the final merge still waits for user confirmation; in `--auto` mode it executes automatically.
 
 **Approval gate and merge gate.** `--auto` removes both: the round-level approval gate and the final merge gate. In `--auto` mode the skill merges automatically once all Phase 5 conditions are met. Default mode retains explicit user confirmation at the merge step — the user types "merge" to execute. True blockers (DISCUSSION on P0/P1, unresolvable rebase, integrity mismatch) still stop the loop in any mode.
 

--- a/plugins/developer-workflow/skills/drive-to-merge/references/merge.md
+++ b/plugins/developer-workflow/skills/drive-to-merge/references/merge.md
@@ -1,6 +1,21 @@
-# drive-to-merge — Phase 5 Merge (always user-confirmed)
+# drive-to-merge — Phase 5 Merge
 
 Entered when: CI all green + `reviewDecision == APPROVED` + no unresolved threads owned by this skill + `mergeable == MERGEABLE` + `mergeStateStatus == CLEAN`.
+
+## Draft promotion (pre-phase)
+
+If `isDraft == true` when Phase 5 conditions are otherwise met:
+
+- **`--auto` mode** — promote automatically and continue:
+  ```bash
+  # GitHub
+  gh pr ready "$PR_NUMBER"
+  # GitLab
+  glab mr update "$MR_IID" --remove-draft
+  ```
+  Show one notification line ("Promoting PR from draft to ready") and proceed to pre-merge checks.
+
+- **default mode** — stop and surface: "PR is still a draft. Promote to ready with `gh pr ready` or type `stop`."
 
 ## Pre-merge checks
 
@@ -8,9 +23,9 @@ Entered when: CI all green + `reviewDecision == APPROVED` + no unresolved thread
 2. Re-pull PR state (reviewers may have changed their decision since last round).
 3. Confirm the branch has not diverged from origin. If `git status -sb` shows the local branch behind / ahead of `origin/$HEAD` unexpectedly — skip merge, log the delta, return to Phase 2.1 for one more round.
 
-## Merge confirmation message
+## Merge summary message
 
-Show the user:
+Always show (regardless of mode):
 
 ```
 PR ready to merge.
@@ -27,19 +42,19 @@ Proposed commit message:
   <subject>
 
   <body>
-
-Reply "merge" to execute, or supply a different method / message.
 ```
 
-Wait for explicit user confirmation. `--auto` does NOT skip this gate — by design, final merge always requires explicit user approval.
+**default mode** — append "Reply "merge" to execute, or supply a different method / message." and block until the user replies.
+
+**`--auto` mode** — append "Merging automatically (--auto mode)." and proceed immediately without waiting.
 
 ## Final re-check and execution
 
-On confirmation, re-verify state one last time before invoking merge — between the gate and the API call, CI may have failed or approval may have been dismissed:
+Before invoking the merge API, re-verify state one last time — between the summary and the API call, CI may have failed or approval may have been dismissed:
 
 ```bash
 FINAL=$(gh pr view --json statusCheckRollup,reviewDecision,mergeable,mergeStateStatus)
-# Abort merge if anything regressed since the gate; loop back to Phase 2.1.
+# Abort merge if anything regressed; loop back to Phase 2.1.
 ```
 
 If the re-check is still green:
@@ -49,6 +64,30 @@ gh pr merge "$PR_NUMBER" --<method> --subject "<subject>" --body "<body>" --dele
 # GitLab
 glab mr merge "$MR_IID" --<method-flag> --delete-source-branch
 ```
+
+## Native auto-merge path (CI still running, `--auto` mode)
+
+When Phase 2.5 would enter Phase 4 polling because CI is still in progress AND mode is `--auto`:
+
+Instead of scheduling repeated polls, delegate the wait to the platform:
+
+```bash
+# GitHub — requires repo auto-merge enabled + branch protection rules
+gh pr merge "$PR_NUMBER" --auto --squash
+```
+
+For GitLab, use `--when-pipeline-succeeds` **only** when `Merge policy` in the state file is `auto` (personal repo). For `team-strict` repos skip native auto-merge and fall through to normal polling (avoids blocking merge trains or queues without consent):
+
+```bash
+# GitLab — personal / auto policy only
+glab mr merge "$MR_IID" --when-pipeline-succeeds
+```
+
+On success: mark state file `Status: waiting-native-auto-merge`, show "Native auto-merge set — platform will merge when checks pass. Exiting loop.", and stop.
+
+On failure (e.g. GitHub repo has auto-merge disabled):
+- Show "Native auto-merge unavailable (repo setting disabled) — falling back to polling."
+- Continue to Phase 4 normally.
 
 ## After merge
 

--- a/plugins/developer-workflow/skills/drive-to-merge/references/polling.md
+++ b/plugins/developer-workflow/skills/drive-to-merge/references/polling.md
@@ -1,6 +1,40 @@
 # drive-to-merge — Phase 4 Polling (ScheduleWakeup)
 
-When the round ended with "wait" (CI running or review pending) — schedule the next round. The wake-up prompt is built from the stored `Mode` in the state file (per "Mode precedence on resume" in `references/setup.md`) — never hardcoded.
+When the round ended with "wait" (CI running or review pending) — decide whether to use
+native auto-merge (exit immediately) or schedule the next round via ScheduleWakeup.
+
+## Native auto-merge path (`--auto` mode, CI still running)
+
+When mode is `--auto` **and** `Merge policy` is `auto` **and** CI is still in progress
+(no failures, only `IN_PROGRESS` / `PENDING` checks) — delegate the wait to the platform
+instead of polling. Procedure in [`references/merge.md`](merge.md) § "Native auto-merge path".
+
+If native auto-merge succeeds: exit the loop (no ScheduleWakeup). If it fails (repo setting
+disabled), fall through to normal ScheduleWakeup below.
+
+For `team-strict` policy: skip native auto-merge entirely regardless of mode; proceed to
+ScheduleWakeup.
+
+## Proactive autonomy offer (default mode, long waits)
+
+Before scheduling ScheduleWakeup in **default mode**, when the wait will be long:
+
+- **Slow CI** (pipeline ≥5 min, detected on first entry to this wait): show once —
+  > "CI is running (slow pipeline). Type `auto-merge` to set native auto-merge and exit now, or I'll keep polling."
+- **Human reviewer not responding** (two or more consecutive 1800s polls with no new review
+  activity): show once —
+  > "No reviewer activity after two rounds. Type `auto-merge` to set native auto-merge and exit, or I'll keep polling."
+
+If the user types `auto-merge`: execute the native auto-merge path from `references/merge.md`
+and exit. Do not offer again after the user declines (silently) — offer at most once per
+category per run.
+
+In `--auto` mode this offer is unnecessary — native auto-merge is used automatically above.
+
+## ScheduleWakeup
+
+The wake-up prompt is built from the stored `Mode` in the state file (per "Mode precedence on
+resume" in `references/setup.md`) — never hardcoded.
 
 ```
 WAKEUP_PROMPT="/drive-to-merge"

--- a/plugins/developer-workflow/skills/drive-to-merge/references/setup.md
+++ b/plugins/developer-workflow/skills/drive-to-merge/references/setup.md
@@ -51,6 +51,30 @@ PROJECT=$(glab repo view --output json | jq -r '.path_with_namespace | @uri')
 
 If the PR/MR is already merged or closed — stop and report the final state.
 
+### Merge policy detection
+
+After fetching repo metadata, derive the merge policy for this run. Record in the state file as `Merge policy:`.
+
+1. **Explicit config in CLAUDE.md** — scan the repo's `CLAUDE.md` (if present) for a line matching:
+   ```
+   Merge policy: auto
+   Merge policy: team-strict
+   ```
+   Use the first match.
+
+2. **Explicit config in `.claude/settings.json`** — check key `driveToMerge.mergePolicy`; values `"auto"` or `"team-strict"`.
+
+3. **Fallback: org vs personal heuristic** (GitHub only):
+   ```bash
+   IS_ORG=$(gh repo view --json isInOrganization -q .isInOrganization)
+   # true → team-strict; false → auto
+   ```
+   For GitLab, default to `team-strict` when the project namespace is a group, `auto` when it is a personal namespace.
+
+Policy semantics:
+- `auto` — `--auto` mode skips the merge gate and may use native platform auto-merge.
+- `team-strict` — merge gate always asks in any mode; GitLab `--when-pipeline-succeeds` disabled unless the user explicitly passes `--native-auto-merge` on invocation.
+
 ## 1.3 Preconditions
 
 Abort with a clear message if any of these fail:
@@ -74,12 +98,13 @@ Verify `swarm-report/` is gitignored by running `git check-ignore -q swarm-repor
 URL: <PR URL>
 Platform: github | gitlab
 Mode: default | auto | dry-run
+Merge policy: auto | team-strict
 Principal: <@actor>            # gh api user --jq .login
 Repository node id: <graphql node id of the repository>
 PR node id: <graphql node id of the pull request>
 Copilot node id: <graphql node id of copilot-pull-request-reviewer or `unavailable`>
 Started: <ISO8601>
-Status: running | waiting-for-user | merged | blocked
+Status: running | waiting-for-user | waiting-native-auto-merge | merged | blocked
 
 ## Branch change model
 analyzed_through_sha: <abbreviated sha the model is current as of, or empty before first build>


### PR DESCRIPTION
## Summary

- In `--auto` mode the merge gate is no longer a hard stop: once all Phase 5 conditions are met (CI green, approved, threads resolved, mergeable) the skill merges immediately without waiting for "merge" reply. Default mode keeps explicit confirmation unchanged.
- Draft PRs are now promoted automatically in `--auto` mode (`gh pr ready` / `glab mr update --remove-draft`) so the loop continues to Phase 5 without surfacing to the user.
- When CI is still running and mode is `--auto`, the skill sets native platform auto-merge (`gh pr merge --auto` / `glab mr merge --when-pipeline-succeeds`) and exits instead of polling. GitLab native auto-merge is restricted to `policy=auto` repos to avoid stalling merge trains.
- Project-scoped merge policy (`auto` | `team-strict`) derived from `CLAUDE.md`, `.claude/settings.json`, or org-vs-personal heuristic; stored in state file header.
- In default mode, before long ScheduleWakeup delays, the skill proactively offers to set native auto-merge and exit instead of silently polling.

## Test plan

- [ ] Read `SKILL.md` and verify no contradictory statements about the merge gate remain
- [ ] Read `references/merge.md` and walk through the `--auto` path and the native auto-merge path
- [ ] Read `references/setup.md` and verify the policy detection logic and state file schema are consistent
- [ ] Read `references/polling.md` and verify the native auto-merge shortcut and proactive offer logic
- [ ] Run `bash scripts/validate.sh` — must be green

Closes #234

---
_Generated by [Claude Code](https://claude.ai/code/session_01MNFWw5RaJNwjQGQNzikBkV)_