### PR TITLE
Add /plan skill: autonomous plan-as-document replacement for built-in plan mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 node_modules/
 dist/
 .worktrees/
-docs/plans/
 *.tgz
 
 .DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Monorepo for Claude Code plugins by krozov. Contains six plugins:
 |--------|-----------|-------------|
 | maven-mcp | `plugins/maven-mcp/` | MCP server for Maven dependency intelligence |
 | sensitive-guard | `plugins/sensitive-guard/` | Scans files for secrets and PII before they reach AI servers |
-| developer-workflow | `plugins/developer-workflow/` | Toolbox of on-demand skills — research, write-spec, multiexpert review, evaluate-dependency, write-tests, check, finalize, generate-test-plan, acceptance, create-pr, drive-to-merge (exploratory QA: call manual-tester agent directly) |
+| developer-workflow | `plugins/developer-workflow/` | Toolbox of on-demand skills — research, write-spec, plan, multiexpert review, evaluate-dependency, write-tests, check, finalize, generate-test-plan, acceptance, create-pr, drive-to-merge (exploratory QA: call manual-tester agent directly) |
 | developer-workflow-experts | `plugins/developer-workflow-experts/` | 10 reusable review/consult agents (code-reviewer, architecture-expert, security-expert, dependency-evaluator, …) — safe standalone |
 | developer-workflow-kotlin | `plugins/developer-workflow-kotlin/` | Kotlin/Android/KMP specialists — kotlin-engineer, compose-developer |
 | developer-workflow-swift | `plugins/developer-workflow-swift/` | Swift/iOS/macOS specialists and Swift/SwiftUI references |

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Four plugins that split the dev-workflow pipeline along coherent lines. `develop
 
 #### developer-workflow (core)
 
-Toolbox of on-demand skills — research, spec authoring, multiexpert review, mechanical checks, code-quality finalize, retroactive tests, QA, and PR lifecycle. No forced sequencing; plan mode picks the right skill.
+Toolbox of on-demand skills — research, spec authoring, plan-as-document planning, multiexpert review, mechanical checks, code-quality finalize, retroactive tests, QA, and PR lifecycle. No forced sequencing; the model reaches for the right skill.
 
-**Skills (10):** `/research`, `/write-spec`, `/multiexpert-review`, `/check`, `/finalize`, `/write-tests`, `/generate-test-plan`, `/acceptance`, `/create-pr`, `/drive-to-merge`
+**Skills (12):** `/research`, `/write-spec`, `/plan`, `/multiexpert-review`, `/evaluate-dependency`, `/check`, `/finalize`, `/write-tests`, `/generate-test-plan`, `/acceptance`, `/create-pr`, `/drive-to-merge`
 
 **Agent:** `manual-tester` (covers exploratory QA without a spec — call directly via the Task tool; heuristics live in the agent file)
 

--- a/plugins/developer-workflow/CLAUDE.md
+++ b/plugins/developer-workflow/CLAUDE.md
@@ -43,23 +43,31 @@ Skills in this plugin delegate to engineer agents (kotlin-engineer / compose-dev
 - Skills use YAML frontmatter: `name`, `description` (≤ 1024 chars), optionally `disable-model-invocation`.
 - `code-reviewer` (in `developer-workflow-experts`) is read-only — no Edit, Write, NotebookEdit, or Bash tools.
 
-## Skills roster (11)
+## Skills roster (12)
 
-- Planning / research: `research`, `write-spec`, `multiexpert-review`, `evaluate-dependency`
+- Planning / research: `research`, `write-spec`, `plan`, `multiexpert-review`, `evaluate-dependency`
 - Implementation: `check`, `finalize`, `write-tests`
 - QA: `generate-test-plan`, `acceptance`
 - PR / orchestration: `create-pr`, `drive-to-merge`
 
 ### Planning: which tool to reach for
 
-`research`, `/write-spec`, and built-in **plan mode** look similar (all do read-only
-investigation first) but answer different questions. Pick by the question, not the surface:
+`research`, `/write-spec`, and `/plan` look similar (all do read-only investigation first) but
+answer different questions. Pick by the question, not the surface:
 
 | Reach for | When the question is | Output |
 |---|---|---|
-| **plan mode** (built-in) | "How do I build this *already-decided* change?" — investigation stays inside the codebase | Ephemeral plan, then implement |
 | **`research`** | "What are the options / is this feasible / which approach?" — needs ≥2 of codebase·web·docs·dependencies·architecture | Durable comparative report in `swarm-report/research/` |
 | **`/write-spec`** | "Specify this *already-decided* feature as an implementation contract" — interview-heavy | Permanent spec in `docs/specs/` |
+| **`/plan`** | "How do I build this *already-decided* change?" — investigation stays inside the codebase | Persistent, expert-reviewed plan in `docs/plans/<slug>/` (plan.md + tasks.md + progress.md), then implement |
+
+**Prefer `/plan` over built-in plan mode.** Built-in plan mode produces an *ephemeral* plan and a
+hard `ExitPlanMode` approval pause: the plan is not saved, cannot be reviewed by a multiexpert panel,
+and the pause blocks autonomous/headless runs. `/plan` removes all three — it persists the plan as a
+reviewable document, runs a mandatory adversarial multiexpert-review loop (the gate that replaces
+human approval), and proceeds without pausing by default (`--interactive` re-adds a checkpoint when
+you want one). Reach for built-in plan mode only for throwaway, codebase-only scratch planning you
+do not want to keep.
 
 `research` deliberately steps aside for codebase-only topics: its min-2-tracks rule redirects
 a single-track investigation to a plain inline Explore agent instead of running the consortium. `research` and `write-spec` each run a parallel expert consortium; their

--- a/plugins/developer-workflow/README.md
+++ b/plugins/developer-workflow/README.md
@@ -31,16 +31,22 @@ Skills are independent on-demand tools — invoke them when the task calls for t
 |---|---|
 | `/research` | Parallel expert investigation (up to 5 agents) — codebase, web, docs, dependencies, architecture |
 | `/write-spec` | Specification-Driven Development — multi-round interview producing an exhaustive spec |
+| `/plan` | Plan-as-document — the autonomous replacement for built-in plan mode. Persists `docs/plans/<slug>/` (plan.md + tasks.md + progress.md), runs a mandatory adversarial multiexpert-review loop as the gate, then proceeds without an approval pause (`--interactive` to add one back) |
 | `/multiexpert-review` | Panel of LLM evaluators (PoLL) review of a plan, spec, or test-plan via the appropriate profile |
 | `/evaluate-dependency` | Vet a new library before adding it — gathers health signals (via maven-mcp when available) + web reputation, delegates to `dependency-evaluator` for an adopt/avoid verdict |
 
-`/research`, `/write-spec`, and built-in **plan mode** all investigate before acting, but
-answer different questions. Use **plan mode** for *"how do I build this already-decided
-change?"* (codebase-only, ephemeral plan). Use **`/research`** for *"what are the options / is
-this feasible / which approach?"* when the answer needs more than the codebase (web, docs,
-dependencies, architecture) — it produces a durable comparative report. Use **`/write-spec`**
-to turn an already-decided feature into a permanent implementation contract under `docs/specs/`.
+`/research`, `/write-spec`, and `/plan` all investigate before acting, but answer different
+questions. Use **`/plan`** for *"how do I build this already-decided change?"* (codebase-only) — it
+persists a reviewable plan under `docs/plans/<slug>/` and runs a mandatory expert-review gate
+instead of a plan-mode approval pause. Use **`/research`** for *"what are the options / is this
+feasible / which approach?"* when the answer needs more than the codebase (web, docs, dependencies,
+architecture) — it produces a durable comparative report. Use **`/write-spec`** to turn an
+already-decided feature into a permanent implementation contract under `docs/specs/`.
 For a codebase-only topic `/research` steps aside and delegates to a single inline `Explore` agent instead of running the consortium.
+
+Prefer `/plan` over built-in plan mode: plan mode's plan is ephemeral (not saved, not reviewable)
+and its `ExitPlanMode` approval pause blocks autonomous runs. `/plan` removes both — keep plan mode
+only for throwaway scratch planning you don't want to persist.
 
 ### Implementation
 | Skill | Purpose |

--- a/plugins/developer-workflow/README.md
+++ b/plugins/developer-workflow/README.md
@@ -24,7 +24,7 @@ Installing this plugin automatically pulls `developer-workflow-experts`. Install
 
 ## Skills (12)
 
-Skills are independent on-demand tools — invoke them when the task calls for the capability. They do not orchestrate each other; the model drives sequencing through plan mode.
+Skills are independent on-demand tools — invoke them when the task calls for the capability. They do not orchestrate each other; the model reaches for the right skill when its capability is needed.
 
 ### Planning / research
 | Skill | Purpose |
@@ -45,8 +45,8 @@ already-decided feature into a permanent implementation contract under `docs/spe
 For a codebase-only topic `/research` steps aside and delegates to a single inline `Explore` agent instead of running the consortium.
 
 Prefer `/plan` over built-in plan mode: plan mode's plan is ephemeral (not saved, not reviewable)
-and its `ExitPlanMode` approval pause blocks autonomous runs. `/plan` removes both — keep plan mode
-only for throwaway scratch planning you don't want to persist.
+and its `ExitPlanMode` approval pause blocks autonomous runs. `/plan` removes all three — keep plan
+mode only for throwaway scratch planning you don't want to persist.
 
 ### Implementation
 | Skill | Purpose |

--- a/plugins/developer-workflow/skills/create-pr/SKILL.md
+++ b/plugins/developer-workflow/skills/create-pr/SKILL.md
@@ -106,7 +106,7 @@ Look for artifacts in `./swarm-report/` that match the current branch/task slug.
 |---|---|---|
 | research | `swarm-report/research/research-<slug>.md` | Link + 1-sentence abstract in "Context" section |
 | spec | `docs/specs/<YYYY-MM-DD>-<slug>.md` (written by `write-spec`) | Reference as "Specification" |
-| plan | `swarm-report/<slug>-plan.md` | Reference as "Plan"; acceptance criteria extracted for "How to test" |
+| plan | `docs/plans/<slug>/plan.md` (written by `plan`; falls back to legacy `swarm-report/<slug>-plan.md`) | Reference as "Plan"; task acceptance from `docs/plans/<slug>/tasks.md` feeds "How to test" |
 | debug | `swarm-report/<slug>-debug.md` | Root cause + reproduction steps — primary context for bug-fix PRs |
 | test plan | `swarm-report/<slug>-test-plan.md` | Reference; test cases become checklist in "How to test" |
 | quality | `swarm-report/<slug>-quality.md` | Gate pass/fail summary for status table |
@@ -117,7 +117,7 @@ Slug resolution:
 1. Prefer slug if the caller passed it as an argument.
 2. Fallback to branch name with common prefix stripped: `feature/`, `fix/`, `hotfix/`, `bug/`, `chore/`, `refactor/`, `docs/`.
 
-Artifacts are gitignored — include them as **references** in the body (e.g., "See `swarm-report/my-slug-plan.md`"), never inline content.
+Working artifacts under `swarm-report/` are gitignored; committed ones live under `docs/` (`docs/specs/`, `docs/plans/`). Either way, include them as **references** in the body (e.g., "See `docs/plans/my-slug/plan.md`"), never inline content.
 
 ---
 

--- a/plugins/developer-workflow/skills/create-pr/references/body-sections.md
+++ b/plugins/developer-workflow/skills/create-pr/references/body-sections.md
@@ -12,13 +12,13 @@ Available sections (include only those that apply):
 <!-- From task description or plan artifact; link ticket if URL in commits -->
 
 ## Artifacts
-<!-- Bullet list of swarm-report/ paths that exist -->
-- Plan: swarm-report/<slug>-plan.md
+<!-- Bullet list of swarm-report/ and docs/ paths that exist -->
+- Plan: docs/plans/<slug>/plan.md
 - Test plan: swarm-report/<slug>-test-plan.md
 - ...
 
 ## How to test
-<!-- From test-plan.md or plan.md acceptance criteria; checkbox list -->
+<!-- From test-plan.md or plan/tasks.md task acceptance; checkbox list -->
 - [ ] Scenario 1
 - [ ] Scenario 2
 

--- a/plugins/developer-workflow/skills/finalize/SKILL.md
+++ b/plugins/developer-workflow/skills/finalize/SKILL.md
@@ -23,7 +23,7 @@ Code-quality pass over the current branch. Multi-round review-and-fix loop focus
 
 - **`slug`** — task slug for artifact naming.
 - **Branch state** — reads the current branch; never switches.
-- **Context artifact (optional)** — Phase A `code-reviewer` anchor: feature plan (`swarm-report/<slug>-plan.md`) or, for bug fixes, debug artifact (`swarm-report/<slug>-debug.md`).
+- **Context artifact (optional)** — Phase A `code-reviewer` anchor: feature plan (`docs/plans/<slug>/plan.md`, written by `plan`; falls back to legacy `swarm-report/<slug>-plan.md`) or, for bug fixes, debug artifact (`swarm-report/<slug>-debug.md`).
 - **Diff artifact (derived)** — before invoking `code-reviewer`, materialize the diff to `swarm-report/<slug>-diff.txt`. Do not hardcode `origin/main`: derive the remote's default branch (same as `create-pr` — `git remote show origin | grep "HEAD branch" | awk '{print $NF}'`, fallbacks `main` / `master` / `develop`), then `git merge-base origin/<base> HEAD`.
 
 **Tolerance flags (optional):**
@@ -57,7 +57,7 @@ Round N:
 
 ## Phase A — Semantic review (code-reviewer)
 
-Launch `code-reviewer` (from `developer-workflow-experts`) with task description verbatim, plan artifact path (`swarm-report/<slug>-plan.md`) if it exists, and `git diff` of all branch changes. Returns PASS / WARN / FAIL with findings on the 0/25/50/75/100 confidence rubric (only above-threshold findings surface).
+Launch `code-reviewer` (from `developer-workflow-experts`) with task description verbatim, plan artifact path (`docs/plans/<slug>/plan.md`, else legacy `swarm-report/<slug>-plan.md`) if it exists, and `git diff` of all branch changes. Returns PASS / WARN / FAIL with findings on the 0/25/50/75/100 confidence rubric (only above-threshold findings surface).
 
 Non-negotiables violations from applicable `CLAUDE.md` `## Non-negotiables` are always BLOCK regardless of confidence — never moved to "acknowledged risks".
 

--- a/plugins/developer-workflow/skills/multiexpert-review/profiles/README.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/profiles/README.md
@@ -95,7 +95,7 @@ Profiles whose rubric is a **labeled checklist** with short IDs (e.g. test-plan 
 ## Receipt section semantics
 
 - **Present** — after Step 4 synthesis, engine updates the file matching `receipt.path_template` (with `<slug>` substituted) by setting each field in `fields_to_update` to the appropriate value from the verdict.
-- **Absent** — engine skips receipt writing entirely. Use for profiles whose artifact doesn't have a receipt contract (e.g., spec, implementation-plan).
+- **Absent** — engine skips receipt writing entirely. Use for profiles whose artifact doesn't have a receipt contract (e.g., spec, whose verdict is consumed inline by `write-spec`). `implementation-plan` declares a receipt: it writes its verdict back into the plan's own frontmatter at `docs/plans/<slug>/plan.md`.
 
 ## Error semantics (unified across engine)
 

--- a/plugins/developer-workflow/skills/multiexpert-review/profiles/implementation-plan.md
+++ b/plugins/developer-workflow/skills/multiexpert-review/profiles/implementation-plan.md
@@ -4,7 +4,8 @@ description: Default profile for implementation plans (Plan Mode output, plan.md
 
 detect:
   frontmatter_type: [implementation-plan, plan]
-  path_globs: []
+  path_globs:
+    - "docs/plans/**/plan.md"
   structural_signatures: []
 
 reviewer_roster:
@@ -19,6 +20,10 @@ source_routing:
   plan_mode: EnterPlanMode
   file: edit-in-place
   conversation: inline-revise
+
+receipt:
+  path_template: "docs/plans/<slug>/plan.md"
+  fields_to_update: [review_verdict, review_blockers]
 ---
 
 ## Rubric
@@ -37,7 +42,24 @@ No fixed severity mapping — reviewers judge severity from their expertise.
 
 ## Prompt augmentation
 
-(none — reviewers use the generic engine prompt)
+**Adversarial stance (strict but fair).** You are a red-team critic, not an approver. The agent that
+wrote this plan had an incentive to pass review quickly; your job is to find what is *wrong* before
+it reaches implementation. Do not reward plausible-looking prose. Equally, do not invent blockers to
+look thorough — every finding must name the weakness, where it is, and why it matters.
+
+**Anti-gaming rubric — flag these as blockers/majors:**
+
+- **Hand-waving verbs** — "handle errors appropriately", "wire it up", "update the relevant files",
+  "as needed" with no concrete file/contract/behaviour. Demand the specifics.
+- **Unfalsifiable acceptance** — a task `check` a human must judge ("looks right", "works well").
+  Demand a test name, grep, or build target.
+- **Missing failure modes** — happy-path-only design. Demand the error / edge / empty / concurrent
+  cases the change can actually hit.
+- **Invisible scope** — a one-line task hiding a subsystem. Demand it be split or sized honestly.
+- **Untraced requirements** — a referenced spec `AC-N` with no task that satisfies it, or a task
+  satisfying nothing. Demand the mapping be complete.
+
+This rubric is what converts "a plan that passes" into "a plan that is right".
 
 ## Agent pre-selection heuristic
 

--- a/plugins/developer-workflow/skills/plan/SKILL.md
+++ b/plugins/developer-workflow/skills/plan/SKILL.md
@@ -155,22 +155,21 @@ profile: implementation-plan
 docs/plans/<slug>/plan.md
 ```
 
-(The hint short-circuits detection deterministically — see
-[`references/review-loop.md`](references/review-loop.md) for why and for the full loop script.)
+(Why the hint and the full loop script: see
+[`references/review-loop.md`](references/review-loop.md).)
 
 The `implementation-plan` profile selects 2–3 reviewers by tech-match from the plan content
 (e.g. `security-expert` only when the plan touches auth / tokens / user data; `architecture-expert`
 only on new modules / dependency-direction / public-API changes). `--quick` permits a single
 reviewer.
 
-**Loop:** 3 review cycles total (1 initial + up to 2 re-reviews, same cap as `finalize`). PASS →
-proceed to Phase 4; CONDITIONAL/FAIL → the engine edits the plan and re-reviews until the cap. See
-[`references/review-loop.md`](references/review-loop.md) for the per-verdict action table and the
-residual-majors handling.
+**Loop:** run the review loop — the cap and per-verdict actions live in
+[`references/review-loop.md`](references/review-loop.md). PASS → proceed to Phase 4;
+CONDITIONAL/FAIL → the engine edits the plan and re-reviews until the cap.
 
-**Escalation (the only autonomous STOP):** if blockers remain after the 3rd cycle, set
-`review_verdict: escalate`, write the unresolved blockers into `## Open Questions` (tagged blocking),
-retire the state file, and surface them — only for genuine blockers, never for routine polish.
+**Escalation (the only autonomous STOP):** if blockers remain, set `review_verdict: escalate`, write
+the unresolved blockers into `## Open Questions` (tagged blocking), retire the state file (see Phase
+4.3), and surface them — only for genuine blockers, never for routine polish.
 
 ---
 
@@ -178,14 +177,10 @@ retire the state file, and surface them — only for genuine blockers, never for
 
 Reviewers grade against a rubric; an *implementer* discovers missing pieces — different failure
 modes. After the panel passes, run **one** Agent (general-purpose, sonnet) as a hostile implementer
-ordered to build from the plan with no questions allowed: it picks the riskiest task, mentally
-implements it end-to-end, and reports every detail it would have to guess, every unfalsifiable
-acceptance, every hand-waving verb, and every hidden-scope task. Strict but fair — only real gaps,
-no invented blockers. Feed its findings back: trivially fillable → edit inline; real design gap →
-fix the plan (or surface for a decision, subject to the **Headless mode** contract above);
-already-specified → no action.
+that tries to build from the plan and reports every gap it would hit; feeding findings back is
+subject to the **Headless mode** contract above. The full agent brief and per-item handling live in
+[`references/review-loop.md`](references/review-loop.md) §Phase 3.5.
 
-Full brief and item handling in [`references/review-loop.md`](references/review-loop.md) §Phase 3.5.
 Skip only with `--quick` on a small, well-bounded change with no risky tasks.
 
 ---
@@ -216,16 +211,13 @@ On `review_verdict: escalate`, do not flip to `approved`. Retire (delete) the st
 
 ## Phase 5: Hand Off
 
-Keep `progress.md` as the live execution ledger: as each `T-N` completes, check its box, append a
-one-line learning, and let the implementer commit plan + code together. Suggest the next step
-(implement the tasks; then `/write-tests`, `/check`, `/finalize`, `/acceptance`) — do not
-auto-invoke downstream skills; the user/agent drives the flow (toolbox model). The built-in
-exceptions are the mandatory Phase 3 inline `multiexpert-review` call and the Phase 3.5
-adversarial red-team Agent call: both are the review gate built into this skill, not downstream
-chains, and must always be invoked (unless `--quick` exempts Phase 3.5).
+Keep `progress.md` as the live execution ledger: as each `T-N` completes, check its box and append a
+one-line learning. Suggest the next step (implement the tasks; then `/write-tests`, `/check`,
+`/finalize`, `/acceptance`).
 
 See [`references/output-layout.md`](references/output-layout.md) for path conventions, the
-confirmation message, gitignore notes, and hand-off rules.
+confirmation message, gitignore notes, and the hand-off rules (do-not-auto-invoke, the toolbox model,
+and the Phase 3 / Phase 3.5 built-in exceptions).
 
 ---
 

--- a/plugins/developer-workflow/skills/plan/SKILL.md
+++ b/plugins/developer-workflow/skills/plan/SKILL.md
@@ -57,7 +57,10 @@ If the request is actually *undecided* ("should we use X or Y?", "is this feasib
 redirect to `research`. If it is a feature contract that has not been written ("what exactly are the
 requirements?"), redirect to `write-spec`. This skill plans execution; it does not decide scope.
 
-Generate a kebab-case slug (`offline-mode`, `push-notifications`).
+Generate a kebab-case slug (`offline-mode`, `push-notifications`). Strip common branch prefixes
+(`feature/`, `fix/`, `chore/`, `claude/`, `hotfix/`). If a spec exists under `docs/specs/` whose
+slug or title matches the candidate slug, adopt the spec's slug for all output paths (spec slug
+wins over the branch-derived one).
 
 ### 0.2 Artifacts
 
@@ -89,7 +92,10 @@ discarded. Launch investigation **in a single message** (parallel) sized to the 
 Write findings into `./swarm-report/plan-<slug>-state.md` as agents complete. Do not ask the user
 anything that investigation can answer. If a genuine design fork appears that investigation cannot
 resolve, surface it with `AskUserQuestion` (each option with a recommended pick) — never park
-questions in the plan file.
+questions in the plan file. **Headless / non-interactive default:** if `--interactive` was not
+passed and no user is present, do NOT block on `AskUserQuestion`; instead record the fork as a
+`[blocking]` Open Question, set `review_verdict: escalate`, and stop. `AskUserQuestion` is only
+used when `--interactive` or a user is actively present.
 
 `--quick`: skip the consortium; one inline Explore pass is enough.
 
@@ -150,15 +156,15 @@ The `implementation-plan` profile selects 2–3 reviewers by tech-match from the
 only on new modules / dependency-direction / public-API changes). `--quick` permits a single
 reviewer.
 
-**Loop** (initial + up to 2 re-reviews, same cap as `finalize`):
+**Loop** — 3 review cycles total: 1 initial review + up to 2 re-reviews (same cap as `finalize`):
 
 | Verdict | Action |
 |---|---|
 | **PASS** | Set `review_verdict: pass`, proceed to Phase 4. |
-| **CONDITIONAL** | Engine edits the plan to address majors; re-review. If still CONDITIONAL after the cap, record the residual majors in `## Open Questions` (non-blocking) and proceed. |
-| **FAIL** | Engine edits the plan to fix the blockers, then re-reviews. Repeat until PASS/CONDITIONAL or the cap. |
+| **CONDITIONAL** | Engine edits the plan to address majors; re-review. If still CONDITIONAL after the cap (cycle 3), set `review_verdict: conditional`, record the residual majors in `## Open Questions` (non-blocking), and proceed. |
+| **FAIL** | Engine edits the plan to fix the blockers, then re-reviews. On cycle 3 returning FAIL, go directly to escalate — no further re-review. |
 
-**Escalation:** if blockers remain after the cap (3 cycles), set `review_verdict: escalate`, write
+**Escalation:** if blockers remain after the 3rd cycle (cap), set `review_verdict: escalate`, write
 the unresolved blockers into `## Open Questions` (tagged blocking), and surface them. In an
 autonomous run this is the *only* stop — and only for genuine blockers, never for routine polish.
 
@@ -172,7 +178,9 @@ ordered to build from the plan with no questions allowed: it picks the riskiest 
 implements it end-to-end, and reports every detail it would have to guess, every unfalsifiable
 acceptance, every hand-waving verb, and every hidden-scope task. Strict but fair — only real gaps,
 no invented blockers. Feed its findings back: trivially fillable → edit inline; real design gap →
-fix the plan (or `AskUserQuestion` if it needs a decision); already-specified → no action.
+fix the plan (or `AskUserQuestion` if it needs a decision and `--interactive` / user is present;
+otherwise record as `[blocking]` Open Question and escalate as in Phase 1); already-specified →
+no action.
 
 Full brief and item handling in [`references/review-loop.md`](references/review-loop.md) §Phase 3.5.
 Skip only with `--quick` on a small, well-bounded change with no risky tasks.
@@ -197,8 +205,9 @@ the plan-mode approval gate — present only, never the default.
 
 ### 4.3 Escalate
 
-On `review_verdict: escalate`, do not flip to `approved`. Surface the blocking open questions and
-stop, exactly as `finalize` escalates on unresolved BLOCKs.
+On `review_verdict: escalate`, do not flip to `approved`. Retire (delete) the state file
+`./swarm-report/plan-<slug>-state.md`, surface the blocking open questions, and stop — exactly as
+`finalize` escalates on unresolved BLOCKs.
 
 ---
 
@@ -207,7 +216,9 @@ stop, exactly as `finalize` escalates on unresolved BLOCKs.
 Keep `progress.md` as the live execution ledger: as each `T-N` completes, check its box, append a
 one-line learning, and let the implementer commit plan + code together. Suggest the next step
 (implement the tasks; then `/write-tests`, `/check`, `/finalize`) — do not auto-invoke downstream
-skills; the user/agent drives the flow (toolbox model).
+skills; the user/agent drives the flow (toolbox model). The sole exception is the mandatory Phase 3
+inline `multiexpert-review` call: that is the review gate built into this skill, not a downstream
+chain, and must always be invoked.
 
 See [`references/output-layout.md`](references/output-layout.md) for path conventions, the
 confirmation message, gitignore notes, and hand-off rules.

--- a/plugins/developer-workflow/skills/plan/SKILL.md
+++ b/plugins/developer-workflow/skills/plan/SKILL.md
@@ -167,7 +167,7 @@ reviewer.
 [`references/review-loop.md`](references/review-loop.md). PASS → proceed to Phase 4;
 CONDITIONAL/FAIL → the engine edits the plan and re-reviews until the cap.
 
-**Escalation (the only autonomous STOP):** if blockers remain, set `review_verdict: escalate`, write
+**Escalation (the only autonomous STOP):** if blockers remain after the cap, set `review_verdict: escalate`, write
 the unresolved blockers into `## Open Questions` (tagged blocking), retire the state file (see Phase
 4.3), and surface them — only for genuine blockers, never for routine polish.
 

--- a/plugins/developer-workflow/skills/plan/SKILL.md
+++ b/plugins/developer-workflow/skills/plan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: "Plan-as-document implementation planning — the autonomous replacement for built-in plan mode. Investigates the codebase read-only, writes a persistent, reviewable plan (docs/plans/<slug>/plan.md + tasks.md) instead of an ephemeral approval prompt, then runs a MANDATORY multiexpert-review loop over the plan and revises until it passes. No human approval pause by default, so an agent can plan and execute end-to-end; opt into a checkpoint with --interactive. Use when: \"plan this\", \"make a plan\", \"how do I build this\", \"plan the implementation\", \"break this into tasks\", \"plan before coding\" for an ALREADY-DECIDED change. Prefer this over built-in plan mode whenever the plan should be saved, reviewed by experts, or executed autonomously. Do NOT use for: deciding WHAT to build or comparing options (use research), writing the feature contract / acceptance criteria (use write-spec), or trivial single-line edits (just do them)."
+description: "Produce a committed implementation plan document — the autonomous replacement for built-in plan mode. Investigates the codebase read-only, writes a persistent, reviewable plan (docs/plans/<slug>/plan.md + tasks.md) instead of an ephemeral approval prompt, then runs a MANDATORY multiexpert-review loop over the plan and revises until it passes. No human approval pause by default, so an agent can plan and execute end-to-end; opt into a checkpoint with --interactive. Use when: \"plan this\", \"make a plan\", \"how do I build this\", \"plan the implementation\", \"break this into tasks\", \"plan before coding\" for an ALREADY-DECIDED change. Prefer this over built-in plan mode whenever the plan should be saved, reviewed by experts, or executed autonomously. Do NOT use for: deciding WHAT to build or comparing options (use research), writing the feature contract / acceptance criteria (use write-spec), or trivial single-line edits (just do them)."
 ---
 
 # Plan
@@ -28,6 +28,14 @@ task description.
    human pause. The default flow is autonomous; a human checkpoint is opt-in (`--interactive`).
 3. **Every task has a verifiable done-condition.** Tasks carry explicit acceptance (Given/When/Then
    or "THE SYSTEM SHALL …"). Autonomy is only safe when "done" is checkable, not approved.
+
+### Headless mode (the autonomy contract)
+
+`AskUserQuestion` is used **only** when `--interactive` was passed or a user is actively present.
+In a headless / non-interactive run, never block on it: surface a genuine design fork to the caller
+instead. Before the plan file exists (Phase 1), surface it as a blocking hand-off; after the plan
+exists, record it as a `[blocking]` Open Question, set `review_verdict: escalate`, and stop. This
+single rule governs every later phase — phases below reference it rather than restating it.
 
 ---
 
@@ -68,16 +76,12 @@ finalize all resolve the same `docs/plans/<slug>/` path.
 
 ### 0.2 Artifacts
 
-| File | Lifetime | Purpose |
-|---|---|---|
-| `docs/plans/<slug>/plan.md` | Permanent (committed) | Technical approach, affected files, decisions, risks. Reviewed in PR. |
-| `docs/plans/<slug>/tasks.md` | Permanent (committed) | Ordered task checklist with dependencies + per-task acceptance. |
-| `docs/plans/<slug>/progress.md` | Permanent (committed) | Volatile status + learnings log. Split from the stable plan so execution churn never rewrites the design. |
-| `./swarm-report/plan-<slug>-state.md` | Operational (gitignored) | Investigation findings, review-cycle log. Deleted after. |
-
-> Naming: `docs/plans/` is deliberately alongside `docs/specs/` (spec = *what*, plan = *how*) and
-> distinct from the gitignored `swarm-report/` working area. Plans live in git because their value
-> is being reviewable in the PR and resumable later.
+Three committed files under `docs/plans/<slug>/` (`plan.md`, `tasks.md`, `progress.md`) plus the
+gitignored operational `./swarm-report/plan-<slug>-state.md` (deleted after). `docs/plans/` is
+deliberately alongside `docs/specs/` (spec = *what*, plan = *how*); plans live in git because their
+value is being reviewable in the PR and resumable later. See
+[`references/output-layout.md`](references/output-layout.md) for the full file/lifetime/purpose
+table.
 
 ---
 
@@ -96,10 +100,9 @@ discarded. Launch investigation **in a single message** (parallel) sized to the 
 Write findings into `./swarm-report/plan-<slug>-state.md` as agents complete. Do not ask the user
 anything that investigation can answer. If a genuine design fork appears that investigation cannot
 resolve, surface it with `AskUserQuestion` (each option with a recommended pick) — never park
-questions in the plan file. **Headless / non-interactive default:** if `--interactive` was not
-passed and no user is present, do NOT block on `AskUserQuestion` — stop and surface the blocking
-design fork to the caller (the plan is not yet written at this phase, so there is nothing to
-record in-file). `AskUserQuestion` is only used when `--interactive` or a user is actively present.
+questions in the plan file. The plan file does not exist yet at this phase, so per the **Headless
+mode** contract above, a headless run surfaces the blocking fork to the caller (nothing to record
+in-file).
 
 `--quick`: skip the consortium; one inline Explore pass is enough.
 
@@ -160,17 +163,14 @@ The `implementation-plan` profile selects 2–3 reviewers by tech-match from the
 only on new modules / dependency-direction / public-API changes). `--quick` permits a single
 reviewer.
 
-**Loop** — 3 review cycles total: 1 initial review + up to 2 re-reviews (same cap as `finalize`):
+**Loop:** 3 review cycles total (1 initial + up to 2 re-reviews, same cap as `finalize`). PASS →
+proceed to Phase 4; CONDITIONAL/FAIL → the engine edits the plan and re-reviews until the cap. See
+[`references/review-loop.md`](references/review-loop.md) for the per-verdict action table and the
+residual-majors handling.
 
-| Verdict | Action |
-|---|---|
-| **PASS** | Set `review_verdict: pass`, proceed to Phase 4. |
-| **CONDITIONAL** | Engine edits the plan to address majors; re-review. If still CONDITIONAL after the cap (cycle 3), record the residual majors in `## Open Questions` (non-blocking), and proceed. |
-| **FAIL** | Engine edits the plan to fix the blockers, then re-reviews. On cycle 3 returning FAIL, go directly to escalate — no further re-review. |
-
-**Escalation:** if blockers remain after the 3rd cycle (cap), set `review_verdict: escalate`, write
-the unresolved blockers into `## Open Questions` (tagged blocking), and surface them. In an
-autonomous run this is the *only* stop — and only for genuine blockers, never for routine polish.
+**Escalation (the only autonomous STOP):** if blockers remain after the 3rd cycle, set
+`review_verdict: escalate`, write the unresolved blockers into `## Open Questions` (tagged blocking),
+retire the state file, and surface them — only for genuine blockers, never for routine polish.
 
 ---
 
@@ -182,9 +182,8 @@ ordered to build from the plan with no questions allowed: it picks the riskiest 
 implements it end-to-end, and reports every detail it would have to guess, every unfalsifiable
 acceptance, every hand-waving verb, and every hidden-scope task. Strict but fair — only real gaps,
 no invented blockers. Feed its findings back: trivially fillable → edit inline; real design gap →
-fix the plan (or `AskUserQuestion` if it needs a decision and `--interactive` / user is present;
-in a non-interactive run do NOT block — record as `[blocking]` Open Question and set
-`review_verdict: escalate`, then stop); already-specified → no action.
+fix the plan (or surface for a decision, subject to the **Headless mode** contract above);
+already-specified → no action.
 
 Full brief and item handling in [`references/review-loop.md`](references/review-loop.md) §Phase 3.5.
 Skip only with `--quick` on a small, well-bounded change with no risky tasks.

--- a/plugins/developer-workflow/skills/plan/SKILL.md
+++ b/plugins/developer-workflow/skills/plan/SKILL.md
@@ -50,7 +50,10 @@ The *what* is assumed decided. Extract:
 
 - **The decided change** — what we are building (from the request, a spec, or research).
 - **Source of truth** — auto-discover a spec: newest `docs/specs/*-<slug>.md` whose slug or title
-  matches, or `--from-spec`. Record the path; the plan references it, never restates its AC.
+  matches the candidate slug. If `--from-spec <path>` was passed, use that path directly and skip
+  auto-discovery (verify the path exists; if not, stop and report). Record the path; the plan
+  references it, never restates its AC. The slug is always the branch/task-derived candidate — do
+  not parse a slug out of the `--from-spec` filename.
 - **Known constraints** — platform, libraries, "no new deps", deadlines.
 
 If the request is actually *undecided* ("should we use X or Y?", "is this feasible?"), STOP and
@@ -58,9 +61,10 @@ redirect to `research`. If it is a feature contract that has not been written ("
 requirements?"), redirect to `write-spec`. This skill plans execution; it does not decide scope.
 
 Generate a kebab-case slug (`offline-mode`, `push-notifications`). Strip common branch prefixes
-(`feature/`, `fix/`, `chore/`, `claude/`, `hotfix/`). If a spec exists under `docs/specs/` whose
-slug or title matches the candidate slug, adopt the spec's slug for all output paths (spec slug
-wins over the branch-derived one).
+(`feature/`, `fix/`, `chore/`, `claude/`, `hotfix/`). This candidate slug is used consistently
+for all output paths (`docs/plans/<slug>/`). If a spec exists under `docs/specs/` whose slug or
+title matches the candidate slug, reference it — but do not change the slug; plan, create-pr, and
+finalize all resolve the same `docs/plans/<slug>/` path.
 
 ### 0.2 Artifacts
 
@@ -93,9 +97,9 @@ Write findings into `./swarm-report/plan-<slug>-state.md` as agents complete. Do
 anything that investigation can answer. If a genuine design fork appears that investigation cannot
 resolve, surface it with `AskUserQuestion` (each option with a recommended pick) — never park
 questions in the plan file. **Headless / non-interactive default:** if `--interactive` was not
-passed and no user is present, do NOT block on `AskUserQuestion`; instead record the fork as a
-`[blocking]` Open Question, set `review_verdict: escalate`, and stop. `AskUserQuestion` is only
-used when `--interactive` or a user is actively present.
+passed and no user is present, do NOT block on `AskUserQuestion` — stop and surface the blocking
+design fork to the caller (the plan is not yet written at this phase, so there is nothing to
+record in-file). `AskUserQuestion` is only used when `--interactive` or a user is actively present.
 
 `--quick`: skip the consortium; one inline Explore pass is enough.
 
@@ -161,7 +165,7 @@ reviewer.
 | Verdict | Action |
 |---|---|
 | **PASS** | Set `review_verdict: pass`, proceed to Phase 4. |
-| **CONDITIONAL** | Engine edits the plan to address majors; re-review. If still CONDITIONAL after the cap (cycle 3), set `review_verdict: conditional`, record the residual majors in `## Open Questions` (non-blocking), and proceed. |
+| **CONDITIONAL** | Engine edits the plan to address majors; re-review. If still CONDITIONAL after the cap (cycle 3), record the residual majors in `## Open Questions` (non-blocking), and proceed. |
 | **FAIL** | Engine edits the plan to fix the blockers, then re-reviews. On cycle 3 returning FAIL, go directly to escalate — no further re-review. |
 
 **Escalation:** if blockers remain after the 3rd cycle (cap), set `review_verdict: escalate`, write
@@ -179,8 +183,8 @@ implements it end-to-end, and reports every detail it would have to guess, every
 acceptance, every hand-waving verb, and every hidden-scope task. Strict but fair — only real gaps,
 no invented blockers. Feed its findings back: trivially fillable → edit inline; real design gap →
 fix the plan (or `AskUserQuestion` if it needs a decision and `--interactive` / user is present;
-otherwise record as `[blocking]` Open Question and escalate as in Phase 1); already-specified →
-no action.
+in a non-interactive run do NOT block — record as `[blocking]` Open Question and set
+`review_verdict: escalate`, then stop); already-specified → no action.
 
 Full brief and item handling in [`references/review-loop.md`](references/review-loop.md) §Phase 3.5.
 Skip only with `--quick` on a small, well-bounded change with no risky tasks.
@@ -215,10 +219,11 @@ On `review_verdict: escalate`, do not flip to `approved`. Retire (delete) the st
 
 Keep `progress.md` as the live execution ledger: as each `T-N` completes, check its box, append a
 one-line learning, and let the implementer commit plan + code together. Suggest the next step
-(implement the tasks; then `/write-tests`, `/check`, `/finalize`) — do not auto-invoke downstream
-skills; the user/agent drives the flow (toolbox model). The sole exception is the mandatory Phase 3
-inline `multiexpert-review` call: that is the review gate built into this skill, not a downstream
-chain, and must always be invoked.
+(implement the tasks; then `/write-tests`, `/check`, `/finalize`, `/acceptance`) — do not
+auto-invoke downstream skills; the user/agent drives the flow (toolbox model). The built-in
+exceptions are the mandatory Phase 3 inline `multiexpert-review` call and the Phase 3.5
+adversarial red-team Agent call: both are the review gate built into this skill, not downstream
+chains, and must always be invoked (unless `--quick` exempts Phase 3.5).
 
 See [`references/output-layout.md`](references/output-layout.md) for path conventions, the
 confirmation message, gitignore notes, and hand-off rules.

--- a/plugins/developer-workflow/skills/plan/SKILL.md
+++ b/plugins/developer-workflow/skills/plan/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: plan
+description: "Plan-as-document implementation planning — the autonomous replacement for built-in plan mode. Investigates the codebase read-only, writes a persistent, reviewable plan (docs/plans/<slug>/plan.md + tasks.md) instead of an ephemeral approval prompt, then runs a MANDATORY multiexpert-review loop over the plan and revises until it passes. No human approval pause by default, so an agent can plan and execute end-to-end; opt into a checkpoint with --interactive. Use when: \"plan this\", \"make a plan\", \"how do I build this\", \"plan the implementation\", \"break this into tasks\", \"plan before coding\" for an ALREADY-DECIDED change. Prefer this over built-in plan mode whenever the plan should be saved, reviewed by experts, or executed autonomously. Do NOT use for: deciding WHAT to build or comparing options (use research), writing the feature contract / acceptance criteria (use write-spec), or trivial single-line edits (just do them)."
+---
+
+# Plan
+
+Turn an already-decided change into a **persistent, expert-reviewed implementation plan** that an
+agent can execute end-to-end without stopping for approval. This is the autonomous replacement for
+built-in plan mode: the plan is a file on disk (not an ephemeral `ExitPlanMode` prompt), so it can
+be version-controlled, reviewed by a multiexpert panel, referenced by `create-pr` / `finalize`, and
+resumed across sessions.
+
+**Role:** Tech Lead translating *what* into *how*. The decision is made (by the user, a spec, or
+prior research); this skill produces the technical approach, the ordered task list, and the
+per-task acceptance that makes autonomous execution safe.
+
+**Where it sits:** `write-spec` answers *what* we build (requirements + acceptance criteria). `plan`
+answers *how* (design + ordered tasks). If a spec exists, the plan **references** it and never
+duplicates its requirements. If no spec exists (smaller change), the plan works directly from the
+task description.
+
+**Core principles:**
+
+1. **The plan is a document, not a prompt.** Persist it before anything else needs it. Ephemeral
+   plans cannot be reviewed, diffed, or resumed — that is the limitation this skill removes.
+2. **Review replaces approval.** The quality gate is a mandatory multiexpert-review loop, not a
+   human pause. The default flow is autonomous; a human checkpoint is opt-in (`--interactive`).
+3. **Every task has a verifiable done-condition.** Tasks carry explicit acceptance (Given/When/Then
+   or "THE SYSTEM SHALL …"). Autonomy is only safe when "done" is checkable, not approved.
+
+---
+
+## Flags
+
+| Flag | Effect |
+|---|---|
+| (default) | Autonomous. Investigate → write plan → mandatory review loop → on PASS/CONDITIONAL, hand off to implementation with no human pause. |
+| `--interactive` | Add ONE human confirmation checkpoint after the review passes (Phase 4.2). The explicit, opt-in replacement for the `ExitPlanMode` gate. |
+| `--quick` | Trivial, well-bounded change: lighter investigation, single-reviewer review (`allow_single_reviewer`). Review is never skipped entirely — a plan without review is the failure mode this skill exists to prevent. |
+| `--from-spec <path>` | Anchor the plan to a specific spec instead of auto-discovering one. |
+
+---
+
+## Phase 0: Parse Input & Setup
+
+### 0.1 Separate decision from design
+
+The *what* is assumed decided. Extract:
+
+- **The decided change** — what we are building (from the request, a spec, or research).
+- **Source of truth** — auto-discover a spec: newest `docs/specs/*-<slug>.md` whose slug or title
+  matches, or `--from-spec`. Record the path; the plan references it, never restates its AC.
+- **Known constraints** — platform, libraries, "no new deps", deadlines.
+
+If the request is actually *undecided* ("should we use X or Y?", "is this feasible?"), STOP and
+redirect to `research`. If it is a feature contract that has not been written ("what exactly are the
+requirements?"), redirect to `write-spec`. This skill plans execution; it does not decide scope.
+
+Generate a kebab-case slug (`offline-mode`, `push-notifications`).
+
+### 0.2 Artifacts
+
+| File | Lifetime | Purpose |
+|---|---|---|
+| `docs/plans/<slug>/plan.md` | Permanent (committed) | Technical approach, affected files, decisions, risks. Reviewed in PR. |
+| `docs/plans/<slug>/tasks.md` | Permanent (committed) | Ordered task checklist with dependencies + per-task acceptance. |
+| `docs/plans/<slug>/progress.md` | Permanent (committed) | Volatile status + learnings log. Split from the stable plan so execution churn never rewrites the design. |
+| `./swarm-report/plan-<slug>-state.md` | Operational (gitignored) | Investigation findings, review-cycle log. Deleted after. |
+
+> Naming: `docs/plans/` is deliberately alongside `docs/specs/` (spec = *what*, plan = *how*) and
+> distinct from the gitignored `swarm-report/` working area. Plans live in git because their value
+> is being reviewable in the PR and resumable later.
+
+---
+
+## Phase 1: Investigate (read-only)
+
+Like plan mode, planning starts with read-only investigation — but the findings are persisted, not
+discarded. Launch investigation **in a single message** (parallel) sized to the change:
+
+- **Codebase (Explore)** — always. Existing code, patterns, module boundaries, the exact files and
+  symbols this change touches, test infrastructure, related TODOs.
+- **Architecture Expert** — when the change adds a module, shifts dependency direction, introduces
+  an abstraction, or crosses layers.
+- **Web / docs** — only for unfamiliar external APIs, protocols, or non-trivial algorithms the
+  codebase doesn't already demonstrate.
+
+Write findings into `./swarm-report/plan-<slug>-state.md` as agents complete. Do not ask the user
+anything that investigation can answer. If a genuine design fork appears that investigation cannot
+resolve, surface it with `AskUserQuestion` (each option with a recommended pick) — never park
+questions in the plan file.
+
+`--quick`: skip the consortium; one inline Explore pass is enough.
+
+---
+
+## Phase 2: Write the Plan
+
+Write `plan.md` and `tasks.md` for a reader who is an implementing agent with zero extra context.
+Every decision is explicit with rationale; every task has a checkable done-condition.
+
+Copy the templates from [`references/plan-template.md`](references/plan-template.md) verbatim and
+fill every placeholder. Shape:
+
+- **`plan.md`** — YAML frontmatter (`type: plan`, `slug`, `date`, `status: draft`, `spec:` link or
+  `none`, `risk_areas`, `review_verdict: pending`) + body: Context & Decision, Technical Approach,
+  Affected Modules & Files (table: path · change type · note), Decisions Made (with rationale),
+  Risks & Mitigations, Out of Scope, Open Questions (tagged blocking / non-blocking).
+- **`tasks.md`** — ordered list `T-N`, each with: short title, dependencies (`after: T-…`), the
+  files it touches, and **acceptance** in Given/When/Then or "THE SYSTEM SHALL …" form, plus the
+  check that proves it (test name, grep, build target). Tasks are small enough to implement and
+  verify in one focused pass.
+- **`progress.md`** — initialize with every `T-N` as an unchecked box and an empty Learnings log.
+
+The plan must reference, not restate, the spec's acceptance criteria (cite `AC-N` ids); `tasks.md`
+acceptance is the *implementation-level* check that each AC is met.
+
+---
+
+## Phase 3: Mandatory Review Loop
+
+The review is the gate that replaces human approval. It is **not optional** (this is the whole
+point — an unreviewed plan is low quality and must be sent back for rework until it meets the bar).
+
+**Writer vs. skeptic.** The agent that wrote the plan (Phase 2) has an incentive to pass the gate
+quickly; the critic is deliberately separate and adversarial. The reviewers act as a strict-but-fair
+red team applying an anti-gaming rubric (reject hand-waving, demand `file:line` evidence, demand
+checkable acceptance, hunt missing failure modes) — they look for what is *wrong*, not for reasons
+to approve. See [`references/review-loop.md`](references/review-loop.md) for the writer/critic
+rationale and the rubric.
+
+This mirrors `write-spec` Phase 4.3: invoke `multiexpert-review` **inline** with an explicit profile
+hint. The plan is already a file (`docs/plans/<slug>/plan.md`), so the engine classifies the source
+as `file` and edits the plan in place on FAIL/CONDITIONAL.
+
+Prepend to the review args:
+
+```
+profile: implementation-plan
+---
+docs/plans/<slug>/plan.md
+```
+
+(The hint short-circuits detection deterministically — see
+[`references/review-loop.md`](references/review-loop.md) for why and for the full loop script.)
+
+The `implementation-plan` profile selects 2–3 reviewers by tech-match from the plan content
+(e.g. `security-expert` only when the plan touches auth / tokens / user data; `architecture-expert`
+only on new modules / dependency-direction / public-API changes). `--quick` permits a single
+reviewer.
+
+**Loop** (initial + up to 2 re-reviews, same cap as `finalize`):
+
+| Verdict | Action |
+|---|---|
+| **PASS** | Set `review_verdict: pass`, proceed to Phase 4. |
+| **CONDITIONAL** | Engine edits the plan to address majors; re-review. If still CONDITIONAL after the cap, record the residual majors in `## Open Questions` (non-blocking) and proceed. |
+| **FAIL** | Engine edits the plan to fix the blockers, then re-reviews. Repeat until PASS/CONDITIONAL or the cap. |
+
+**Escalation:** if blockers remain after the cap (3 cycles), set `review_verdict: escalate`, write
+the unresolved blockers into `## Open Questions` (tagged blocking), and surface them. In an
+autonomous run this is the *only* stop — and only for genuine blockers, never for routine polish.
+
+---
+
+## Phase 3.5: Adversarial Red-Team Pass
+
+Reviewers grade against a rubric; an *implementer* discovers missing pieces — different failure
+modes. After the panel passes, run **one** Agent (general-purpose, sonnet) as a hostile implementer
+ordered to build from the plan with no questions allowed: it picks the riskiest task, mentally
+implements it end-to-end, and reports every detail it would have to guess, every unfalsifiable
+acceptance, every hand-waving verb, and every hidden-scope task. Strict but fair — only real gaps,
+no invented blockers. Feed its findings back: trivially fillable → edit inline; real design gap →
+fix the plan (or `AskUserQuestion` if it needs a decision); already-specified → no action.
+
+Full brief and item handling in [`references/review-loop.md`](references/review-loop.md) §Phase 3.5.
+Skip only with `--quick` on a small, well-bounded change with no risky tasks.
+
+---
+
+## Phase 4: Gate
+
+### 4.1 Default — autonomous
+
+On PASS/CONDITIONAL, flip `plan.md` `status` to `approved`, ensure `tasks.md` and `progress.md` are
+written, retire the state file, and hand off to implementation **without pausing**. Confirm in one
+sentence with the plan path and the first task. This is full autonomy: no `ExitPlanMode`, no
+approval prompt.
+
+### 4.2 `--interactive` — opt-in checkpoint
+
+Only when `--interactive` was passed: present a compact summary (plan path, the 3–5 key decisions,
+the task count, the review verdict, any non-blocking open questions) and ask for a single go / adjust
+confirmation before flipping to `approved`. This is the deliberate, user-requested replacement for
+the plan-mode approval gate — present only, never the default.
+
+### 4.3 Escalate
+
+On `review_verdict: escalate`, do not flip to `approved`. Surface the blocking open questions and
+stop, exactly as `finalize` escalates on unresolved BLOCKs.
+
+---
+
+## Phase 5: Hand Off
+
+Keep `progress.md` as the live execution ledger: as each `T-N` completes, check its box, append a
+one-line learning, and let the implementer commit plan + code together. Suggest the next step
+(implement the tasks; then `/write-tests`, `/check`, `/finalize`) — do not auto-invoke downstream
+skills; the user/agent drives the flow (toolbox model).
+
+See [`references/output-layout.md`](references/output-layout.md) for path conventions, the
+confirmation message, gitignore notes, and hand-off rules.
+
+---
+
+## Red Flags / STOP Conditions
+
+- **Undecided scope** — the request is "which approach?" or "is this feasible?". Redirect to
+  `research`; do not plan an undecided change.
+- **Missing contract** — a complex feature with no acceptance criteria anywhere. Recommend
+  `write-spec` first; a plan without a target is guesswork.
+- **Fundamental contradiction** — a constraint makes the change impossible, or two decided
+  requirements conflict. Surface it; do not invent a workaround.
+- **Missing critical access** — the change needs systems / APIs / credentials not available. List
+  what's needed and stop.

--- a/plugins/developer-workflow/skills/plan/references/output-layout.md
+++ b/plugins/developer-workflow/skills/plan/references/output-layout.md
@@ -2,22 +2,20 @@
 
 ## Paths
 
-| File | Lifetime | Committed? |
-|---|---|---|
-| `docs/plans/<slug>/plan.md` | Permanent | Yes — reviewed in the PR |
-| `docs/plans/<slug>/tasks.md` | Permanent | Yes |
-| `docs/plans/<slug>/progress.md` | Permanent (volatile content) | Yes — the execution ledger / audit trail |
-| `./swarm-report/plan-<slug>-state.md` | Operational | No (gitignored) — delete after |
+| File | Lifetime | Committed? | Purpose |
+|---|---|---|---|
+| `docs/plans/<slug>/plan.md` | Permanent | Yes — reviewed in the PR | Technical approach, affected files, decisions, risks. |
+| `docs/plans/<slug>/tasks.md` | Permanent | Yes | Ordered task checklist with dependencies + per-task acceptance. |
+| `docs/plans/<slug>/progress.md` | Permanent (volatile content) | Yes — the execution ledger / audit trail | Volatile status + learnings log. Split from the stable plan so execution churn never rewrites the design. |
+| `./swarm-report/plan-<slug>-state.md` | Operational | No (gitignored) — delete after | Investigation findings, review-cycle log. Deleted after. |
 
 `docs/plans/` is intentionally a sibling of `docs/specs/`: spec = *what* (requirements + AC), plan =
 *how* (design + tasks). Both live in git because their value is being reviewable in the PR and
 resumable later — the exact property built-in plan mode lacks.
 
-Slug rules match the rest of the toolbox: kebab-case, derived from the feature/task or branch name
-with common prefixes (`feature/`, `fix/`, `chore/`, `claude/`, `hotfix/`, …) stripped. This
-candidate slug is used consistently for all output paths. If a spec exists whose slug or title
-matches the candidate, reference it — but do not change the slug; plan, create-pr, and finalize
-all resolve the same `docs/plans/<slug>/` path.
+Slug rules are defined in `SKILL.md` Phase 0.1 (kebab-case, branch-prefixes stripped, one candidate
+slug for all output paths — plan, create-pr, and finalize all resolve the same `docs/plans/<slug>/`
+path). The slug never changes even when a matching spec is referenced.
 
 ## Status lifecycle
 

--- a/plugins/developer-workflow/skills/plan/references/output-layout.md
+++ b/plugins/developer-workflow/skills/plan/references/output-layout.md
@@ -13,9 +13,7 @@
 *how* (design + tasks). Both live in git because their value is being reviewable in the PR and
 resumable later — the exact property built-in plan mode lacks.
 
-Slug rules are defined in `SKILL.md` Phase 0.1 (kebab-case, branch-prefixes stripped, one candidate
-slug for all output paths — plan, create-pr, and finalize all resolve the same `docs/plans/<slug>/`
-path). The slug never changes even when a matching spec is referenced.
+Slug derivation: see `SKILL.md` Phase 0.1.
 
 ## Status lifecycle
 

--- a/plugins/developer-workflow/skills/plan/references/output-layout.md
+++ b/plugins/developer-workflow/skills/plan/references/output-layout.md
@@ -1,0 +1,47 @@
+# Output layout & hand-off
+
+## Paths
+
+| File | Lifetime | Committed? |
+|---|---|---|
+| `docs/plans/<slug>/plan.md` | Permanent | Yes — reviewed in the PR |
+| `docs/plans/<slug>/tasks.md` | Permanent | Yes |
+| `docs/plans/<slug>/progress.md` | Permanent (volatile content) | Yes — the execution ledger / audit trail |
+| `./swarm-report/plan-<slug>-state.md` | Operational | No (gitignored) — delete after |
+
+`docs/plans/` is intentionally a sibling of `docs/specs/`: spec = *what* (requirements + AC), plan =
+*how* (design + tasks). Both live in git because their value is being reviewable in the PR and
+resumable later — the exact property built-in plan mode lacks.
+
+Slug rules match the rest of the toolbox: kebab-case, derived from the feature/task or branch name
+with common prefixes (`feature/`, `fix/`, …) stripped.
+
+## Status lifecycle
+
+`plan.md` frontmatter `status`: `draft` → `approved` (Phase 4 on PASS/CONDITIONAL). On
+`review_verdict: escalate`, leave `status: draft` and stop with the blocking open questions
+surfaced.
+
+`review_verdict`: `pending` → `pass` | `conditional` | `escalate`, written by the Phase 3 loop (and
+by the profile receipt).
+
+## Confirmation message (default, autonomous)
+
+One sentence, e.g.:
+
+> Plan saved to `docs/plans/offline-mode/plan.md` (review: PASS, 7 tasks). Starting with T-1 —
+> add the offline cache layer.
+
+No approval prompt. With `--interactive`, present the compact summary and ask one go/adjust question
+before flipping to `approved`.
+
+## Hand-off rules
+
+- Do **not** auto-invoke downstream skills. Suggest the next step (implement the tasks; then
+  `/write-tests`, `/check`, `/finalize`, `/acceptance`) and let the user/agent drive — toolbox
+  model.
+- `progress.md` is the live ledger: as each `T-N` lands, check its box and append a one-line
+  learning. The implementer commits plan + code together so the PR shows the plan that produced the
+  change.
+- `create-pr` discovers `docs/plans/<slug>/plan.md` and references it in the PR body; `finalize`
+  anchors its `code-reviewer` pass on the same plan. No extra wiring needed beyond writing the file.

--- a/plugins/developer-workflow/skills/plan/references/output-layout.md
+++ b/plugins/developer-workflow/skills/plan/references/output-layout.md
@@ -14,8 +14,10 @@
 resumable later — the exact property built-in plan mode lacks.
 
 Slug rules match the rest of the toolbox: kebab-case, derived from the feature/task or branch name
-with common prefixes (`feature/`, `fix/`, `chore/`, `claude/`, `hotfix/`, …) stripped. If a spec
-exists whose slug matches the candidate, adopt the spec's slug (spec slug takes precedence).
+with common prefixes (`feature/`, `fix/`, `chore/`, `claude/`, `hotfix/`, …) stripped. This
+candidate slug is used consistently for all output paths. If a spec exists whose slug or title
+matches the candidate, reference it — but do not change the slug; plan, create-pr, and finalize
+all resolve the same `docs/plans/<slug>/` path.
 
 ## Status lifecycle
 
@@ -40,8 +42,9 @@ before flipping to `approved`.
 
 - Do **not** auto-invoke downstream skills. Suggest the next step (implement the tasks; then
   `/write-tests`, `/check`, `/finalize`, `/acceptance`) and let the user/agent drive — toolbox
-  model. (The mandatory Phase 3 inline `multiexpert-review` call is the review gate within this
-  skill, not a downstream chain — it is the single sanctioned in-skill invocation.)
+  model. (The mandatory Phase 3 inline `multiexpert-review` call and the Phase 3.5 adversarial
+  red-team Agent call are the review gate built into this skill, not downstream chains — these are
+  the sanctioned in-skill invocations.)
 - `progress.md` is the live ledger: as each `T-N` lands, check its box and append a one-line
   learning. The implementer commits plan + code together so the PR shows the plan that produced the
   change.

--- a/plugins/developer-workflow/skills/plan/references/output-layout.md
+++ b/plugins/developer-workflow/skills/plan/references/output-layout.md
@@ -14,7 +14,8 @@
 resumable later — the exact property built-in plan mode lacks.
 
 Slug rules match the rest of the toolbox: kebab-case, derived from the feature/task or branch name
-with common prefixes (`feature/`, `fix/`, …) stripped.
+with common prefixes (`feature/`, `fix/`, `chore/`, `claude/`, `hotfix/`, …) stripped. If a spec
+exists whose slug matches the candidate, adopt the spec's slug (spec slug takes precedence).
 
 ## Status lifecycle
 
@@ -39,7 +40,8 @@ before flipping to `approved`.
 
 - Do **not** auto-invoke downstream skills. Suggest the next step (implement the tasks; then
   `/write-tests`, `/check`, `/finalize`, `/acceptance`) and let the user/agent drive — toolbox
-  model.
+  model. (The mandatory Phase 3 inline `multiexpert-review` call is the review gate within this
+  skill, not a downstream chain — it is the single sanctioned in-skill invocation.)
 - `progress.md` is the live ledger: as each `T-N` lands, check its box and append a one-line
   learning. The implementer commits plan + code together so the PR shows the plan that produced the
   change.

--- a/plugins/developer-workflow/skills/plan/references/plan-template.md
+++ b/plugins/developer-workflow/skills/plan/references/plan-template.md
@@ -15,7 +15,7 @@ type: plan
 slug: <kebab-case>
 date: <YYYY-MM-DD>
 status: draft           # draft → approved (set by Phase 4 on PASS/CONDITIONAL); stays draft on escalate (review_verdict carries escalate, not this field)
-spec: docs/specs/YYYY-MM-DD-<slug>.md      # real path if a spec exists (date is the spec's own date, format matches write-spec output); if no spec exists, write: none — do NOT invent a path
+spec: docs/specs/<YYYY-MM-DD>-<slug>.md    # real path if a spec exists (date is the spec's own date, format matches write-spec output); if no spec exists, write: none — do NOT invent a path
 risk_areas: []          # subset of [auth, payment, pii, data-migration, perf-critical] — advisory only; reviewer selection is driven by the plan's prose (Technical Approach / Risks), so risks must also be described there for the matching expert (e.g. security-expert) to be triggered
 review_verdict: pending # pending → pass | conditional | escalate (set by Phase 3)
 review_blockers: []     # filled by the review loop when blockers remain

--- a/plugins/developer-workflow/skills/plan/references/plan-template.md
+++ b/plugins/developer-workflow/skills/plan/references/plan-template.md
@@ -1,0 +1,108 @@
+# Plan templates
+
+Copy each block verbatim into the matching file under `docs/plans/<slug>/` and fill every
+placeholder. Three files, split by lifetime: `plan.md` and `tasks.md` are the stable design;
+`progress.md` is the volatile execution ledger (Cline-style split — execution churn must never
+rewrite the design).
+
+---
+
+## `docs/plans/<slug>/plan.md`
+
+```markdown
+---
+type: plan
+slug: <kebab-case>
+date: <YYYY-MM-DD>
+status: draft           # draft → approved (set by Phase 4); escalate if blockers remain
+spec: docs/specs/<YYYY-MM-DD>-<slug>.md   # or: none
+risk_areas: []          # subset of [auth, payment, pii, data-migration, perf-critical]
+review_verdict: pending # pending → pass | conditional | escalate (set by Phase 3)
+review_blockers: []     # filled by the review loop when blockers remain
+---
+
+# Plan: <title>
+
+## Context & Decision
+<2–4 sentences: what is being built and why it is already decided. Link the spec / research /
+request that decided it. This plan is the HOW, not the WHAT — do not re-argue scope here.>
+
+## Technical Approach
+<The concrete design. Architecture, data flow, key types/interfaces, the integration points in the
+existing codebase (cite file:line from investigation). Enough that an implementing agent does not
+need to re-research.>
+
+## Affected Modules & Files
+| Path | Change | Note |
+|---|---|---|
+| `<path>` | New / Modified / Renamed / Deleted | <what changes and why> |
+
+## Decisions Made
+| Decision | Rationale | Alternatives rejected |
+|---|---|---|
+| <what we chose> | <because…> | <X because…> |
+
+## Risks & Mitigations
+| Risk | Severity | Mitigation |
+|---|---|---|
+| <risk> | critical / major / minor | <how the plan handles it> |
+
+## Out of Scope
+- <explicitly NOT done by this plan, with owner / deferral target if relevant>
+
+## Open Questions
+- [blocking] <question that must be answered before / during implementation>
+- [non-blocking] <question that can be resolved while implementing>
+```
+
+---
+
+## `docs/plans/<slug>/tasks.md`
+
+Ordered, dependency-aware checklist. Each task is small enough to implement AND verify in one
+focused pass, and carries an acceptance condition that is checkable without human judgement — this
+is what makes autonomous execution safe.
+
+```markdown
+# Tasks: <title>
+
+> Plan: ./plan.md · Spec AC referenced inline as AC-N
+
+## T-1 — <short title>
+- after: none
+- files: `<path>`, `<path>`
+- acceptance: GIVEN <precondition> WHEN <action> THEN <observable result>   (or: THE SYSTEM SHALL <…>)
+- check: <test name / grep / build target that proves acceptance>   (satisfies AC-1)
+
+## T-2 — <short title>
+- after: T-1
+- files: `<path>`
+- acceptance: <Given/When/Then or SHALL statement>
+- check: <how it is verified>   (satisfies AC-2, AC-3)
+```
+
+Acceptance phrasing: prefer Given/When/Then for behaviour, "THE SYSTEM SHALL …" (EARS) for
+invariants/constraints. Always pair acceptance with a concrete `check` — a test name, a grep, a
+build/lint target — never "looks right".
+
+---
+
+## `docs/plans/<slug>/progress.md`
+
+Initialize with one unchecked box per task and an empty learnings log. The implementer updates this
+as work proceeds; it carries state across sessions and fresh-context runs (so a stop/resume or an
+autonomous loop never loses its place).
+
+```markdown
+# Progress: <title>
+
+> Plan: ./plan.md · Tasks: ./tasks.md
+
+## Status
+- [ ] T-1 — <short title>
+- [ ] T-2 — <short title>
+
+## Learnings
+<!-- Append one line per completed task: surprises, gotchas, decisions taken during implementation.
+     This is the memory that survives context resets. -->
+```

--- a/plugins/developer-workflow/skills/plan/references/plan-template.md
+++ b/plugins/developer-workflow/skills/plan/references/plan-template.md
@@ -14,9 +14,9 @@ rewrite the design).
 type: plan
 slug: <kebab-case>
 date: <YYYY-MM-DD>
-status: draft           # draft → approved (set by Phase 4); escalate if blockers remain
-spec: docs/specs/<YYYY-MM-DD>-<slug>.md   # or: none
-risk_areas: []          # subset of [auth, payment, pii, data-migration, perf-critical]
+status: draft           # draft → approved (set by Phase 4 on PASS/CONDITIONAL); stays draft on escalate (review_verdict carries escalate, not this field)
+spec: docs/specs/YYYY-MM-DD-<slug>.md      # real path if a spec exists (date is the spec's own date, format matches write-spec output); if no spec exists, write: none — do NOT invent a path
+risk_areas: []          # subset of [auth, payment, pii, data-migration, perf-critical] — advisory only; reviewer selection is driven by the plan's prose (Technical Approach / Risks), so risks must also be described there for the matching expert (e.g. security-expert) to be triggered
 review_verdict: pending # pending → pass | conditional | escalate (set by Phase 3)
 review_blockers: []     # filled by the review loop when blockers remain
 ---

--- a/plugins/developer-workflow/skills/plan/references/review-loop.md
+++ b/plugins/developer-workflow/skills/plan/references/review-loop.md
@@ -25,7 +25,9 @@ matters.
 ## Phase 3 — multiexpert-review (the panel critic)
 
 Invoke `multiexpert-review` **inline** (the skill calls it directly, as `write-spec` Phase 4.3 calls
-it — skills do not chain through each other except this established inline use). Prepend the profile
+it — skills do not chain through each other except these established in-skill invocations: the Phase 3
+`multiexpert-review` call and the Phase 3.5 red-team Agent call are both part of the review gate, not
+forbidden downstream chaining). Prepend the profile
 hint so detection is deterministic for an inline file path:
 
 ```
@@ -47,11 +49,12 @@ drop a genuinely-triggered reviewer). `--quick` permits a single reviewer.
 | Verdict | Action |
 |---|---|
 | PASS | `review_verdict: pass` → Phase 4. |
-| CONDITIONAL | Engine edits the plan to address majors; re-review. Residual majors after the cap (cycle 3) → set `review_verdict: conditional`, record in `## Open Questions` (non-blocking), proceed. |
+| CONDITIONAL | Engine edits the plan to address majors; re-review. Residual majors after the cap (cycle 3) → record in `## Open Questions` (non-blocking), proceed. |
 | FAIL | Engine edits to fix blockers; re-review. On cycle 3 returning FAIL → go directly to escalate, no further re-review. |
 
 After the 3rd cycle with blockers remaining → `review_verdict: escalate`, write blockers into
-`## Open Questions` (tagged blocking) and surface. This is the only autonomous stop, and only for
+`## Open Questions` (tagged blocking), retire (delete) the state file
+`./swarm-report/plan-<slug>-state.md`, and surface. This is the only autonomous stop, and only for
 genuine blockers.
 
 ---
@@ -74,6 +77,8 @@ For each item:
 
 - **Trivially fillable** (one-line clarification) → edit the plan inline, move on.
 - **Real design gap** → fix the plan; if it needs a user decision, surface via `AskUserQuestion`.
+  In a non-interactive run do NOT block — record as `[blocking]` Open Question and set
+  `review_verdict: escalate`, then stop.
 - **Already specified, agent missed it** → no action.
 
 Skip only with `--quick` on a small, well-bounded change with no risky tasks.

--- a/plugins/developer-workflow/skills/plan/references/review-loop.md
+++ b/plugins/developer-workflow/skills/plan/references/review-loop.md
@@ -1,0 +1,99 @@
+# Review loop: writer vs. skeptic
+
+The single most important property of this skill is that **the agent that writes the plan is not the
+agent that approves it.** A planner has a built-in incentive to produce something that *passes the
+gate quickly* — to declare the plan "good enough" and move on. Left unchecked, that incentive yields
+plans full of hand-waving ("handle errors appropriately", "wire it up", "update the relevant
+files") that look complete and fall apart in implementation.
+
+The defence is a **separate, adversarial critic** whose only job is to find what is wrong. Two
+mechanisms provide it, and they compose:
+
+1. **multiexpert-review (`implementation-plan` profile)** — the panel critique (Phase 3). The
+   profile's prompt augmentation puts each reviewer in a strict-but-fair red-team stance with an
+   explicit anti-gaming rubric. This is the primary critic and is mandatory.
+2. **Adversarial red-team pass** (Phase 3.5) — one skeptic agent that does not *review* the plan but
+   tries to *use* it and break it, surfacing the holes an implementer would hit. Mirrors
+   `write-spec` Phase 4.5.
+
+"Strict but fair" cuts both ways: the critic must not wave through real weaknesses, and must not
+invent blockers to look thorough. A finding has to name the weakness, where it is, and why it
+matters.
+
+---
+
+## Phase 3 — multiexpert-review (the panel critic)
+
+Invoke `multiexpert-review` **inline** (the skill calls it directly, as `write-spec` Phase 4.3 calls
+it — skills do not chain through each other except this established inline use). Prepend the profile
+hint so detection is deterministic for an inline file path:
+
+```
+profile: implementation-plan
+---
+docs/plans/<slug>/plan.md
+```
+
+Why the hint: inline-arg callsites lack the frontmatter the detector classifies on; the prefix
+short-circuits detection. The plan is already on disk, so the engine classifies the source as
+`file` and edits the plan in place on FAIL/CONDITIONAL, and writes the verdict back into the plan's
+frontmatter via the profile's `receipt`.
+
+The profile selects 2–3 reviewers by tech-match from the plan content (do not pad the panel; do not
+drop a genuinely-triggered reviewer). `--quick` permits a single reviewer.
+
+**Loop** — initial + up to 2 re-reviews (cap 3, same as `finalize`):
+
+| Verdict | Action |
+|---|---|
+| PASS | `review_verdict: pass` → Phase 4. |
+| CONDITIONAL | Engine edits the plan to address majors; re-review. Residual majors after the cap → `## Open Questions` (non-blocking), proceed. |
+| FAIL | Engine edits to fix blockers; re-review until PASS/CONDITIONAL or cap. |
+
+After the cap with blockers remaining → `review_verdict: escalate`, write blockers into
+`## Open Questions` (tagged blocking) and surface. This is the only autonomous stop, and only for
+genuine blockers.
+
+---
+
+## Phase 3.5 — Adversarial red-team pass (the skeptic)
+
+Run **one** Agent (general-purpose, sonnet) as a hostile implementer. It does not grade the plan
+against a rubric — it tries to build from it and reports every place it would have to guess:
+
+> You are the engineer ordered to implement `docs/plans/<slug>/plan.md` exactly as written, with no
+> further questions allowed. Do not praise or summarize it. Pick the riskiest task in `tasks.md` and
+> mentally implement it end-to-end: inputs → state changes → outputs → error paths → cleanup. Every
+> time the plan forces you to GUESS a detail, invent a contract, or fill a gap, record it as:
+> "I'd have to guess X because the plan doesn't specify Y (file/section)". Also flag any acceptance
+> that is not actually checkable, any "handle/wire/update appropriately" hand-waving, any missing
+> failure mode, and any task that secretly hides two days of work. Be strict but fair: only real
+> gaps, no invented blockers. Cap 15 items, ordered by how badly each would derail implementation.
+
+For each item:
+
+- **Trivially fillable** (one-line clarification) → edit the plan inline, move on.
+- **Real design gap** → fix the plan; if it needs a user decision, surface via `AskUserQuestion`.
+- **Already specified, agent missed it** → no action.
+
+Skip only with `--quick` on a small, well-bounded change with no risky tasks.
+
+---
+
+## Anti-gaming rubric (shared by both critics)
+
+The critic rejects, as blockers or majors, plans that try to pass without substance:
+
+- **Hand-waving verbs** — "handle errors appropriately", "wire it up", "update the relevant files",
+  "as needed" with no concrete target. Demand the actual file, contract, or behaviour.
+- **Unfalsifiable acceptance** — any task `check` that a human has to judge ("looks right", "works
+  well"). Demand a test name, grep, or build target.
+- **Missing failure modes** — happy path only. Demand the error/edge/empty/concurrent cases the
+  change can hit.
+- **Invisible scope** — a one-line task that hides a subsystem. Demand it be split or sized
+  honestly.
+- **Untraced requirements** — a spec `AC-N` with no task that satisfies it, or a task that satisfies
+  nothing. Demand the mapping be complete.
+
+This rubric is what converts "a plan that passes" into "a plan that is right". It lives in the
+profile's prompt augmentation so the panel applies it automatically.

--- a/plugins/developer-workflow/skills/plan/references/review-loop.md
+++ b/plugins/developer-workflow/skills/plan/references/review-loop.md
@@ -76,9 +76,9 @@ against a rubric — it tries to build from it and reports every place it would 
 For each item:
 
 - **Trivially fillable** (one-line clarification) → edit the plan inline, move on.
-- **Real design gap** → fix the plan; if it needs a user decision, surface via `AskUserQuestion`.
-  In a non-interactive run do NOT block — record as `[blocking]` Open Question and set
-  `review_verdict: escalate`, then stop.
+- **Real design gap** → fix the plan; if it needs a user decision, surface it subject to the
+  **Headless mode** contract in `SKILL.md` (`AskUserQuestion` only when interactive / a user is
+  present; otherwise record as a `[blocking]` Open Question, set `review_verdict: escalate`, stop).
 - **Already specified, agent missed it** → no action.
 
 Skip only with `--quick` on a small, well-bounded change with no risky tasks.

--- a/plugins/developer-workflow/skills/plan/references/review-loop.md
+++ b/plugins/developer-workflow/skills/plan/references/review-loop.md
@@ -42,15 +42,15 @@ frontmatter via the profile's `receipt`.
 The profile selects 2–3 reviewers by tech-match from the plan content (do not pad the panel; do not
 drop a genuinely-triggered reviewer). `--quick` permits a single reviewer.
 
-**Loop** — initial + up to 2 re-reviews (cap 3, same as `finalize`):
+**Loop** — 3 review cycles total: 1 initial review + up to 2 re-reviews (same cap as `finalize`):
 
 | Verdict | Action |
 |---|---|
 | PASS | `review_verdict: pass` → Phase 4. |
-| CONDITIONAL | Engine edits the plan to address majors; re-review. Residual majors after the cap → `## Open Questions` (non-blocking), proceed. |
-| FAIL | Engine edits to fix blockers; re-review until PASS/CONDITIONAL or cap. |
+| CONDITIONAL | Engine edits the plan to address majors; re-review. Residual majors after the cap (cycle 3) → set `review_verdict: conditional`, record in `## Open Questions` (non-blocking), proceed. |
+| FAIL | Engine edits to fix blockers; re-review. On cycle 3 returning FAIL → go directly to escalate, no further re-review. |
 
-After the cap with blockers remaining → `review_verdict: escalate`, write blockers into
+After the 3rd cycle with blockers remaining → `review_verdict: escalate`, write blockers into
 `## Open Questions` (tagged blocking) and surface. This is the only autonomous stop, and only for
 genuine blockers.
 


### PR DESCRIPTION
## Why

Built-in plan mode has three limitations that block an autonomous agent flow (all confirmed in research):

1. **Ephemeral** — the plan from `ExitPlanMode` lives only in chat context, never on disk. It can't be version-controlled, diffed, or resumed.
2. **Not reviewable** — there is no plan *document* to point a multiexpert panel at, so the plan never gets a real critique pass.
3. **Forced approval pause** — `ExitPlanMode` is a hard interactive gate that conflates "exit plan mode" with "approve & execute". In a headless/autonomous run the agent just stalls on it.

This adds a `/plan` skill to `developer-workflow` that removes all three, mirroring the proven `spec → plan → tasks` patterns from GitHub Spec Kit, Kiro, BMAD, Cline Memory Bank, and the Ralph loop.

## What `/plan` does

- **Plan-as-document.** Investigates the codebase read-only (like plan mode) but **persists** the result to `docs/plans/<slug>/`:
  - `plan.md` — technical approach, affected files, decisions + rationale, risks
  - `tasks.md` — ordered tasks with dependencies and per-task **checkable acceptance** (Given/When/Then or EARS "THE SYSTEM SHALL …")
  - `progress.md` — volatile status + learnings ledger, split from the stable plan (Cline-style) so execution churn never rewrites the design
  - Sits alongside `docs/specs/` — **spec = what, plan = how**. A plan references a spec's `AC-N`, never restates it.
- **Review replaces approval (writer vs. skeptic).** The plan-writer has an incentive to pass the gate quickly, so the critic is deliberately separate and adversarial:
  - **Phase 3** — mandatory `multiexpert-review` (`implementation-plan` profile) loop with an **anti-gaming rubric**: reject hand-waving verbs, demand `file:line` evidence, demand checkable acceptance, hunt missing failure modes, flag hidden-scope tasks and untraced requirements. Strict but fair — no invented blockers. Loops (initial + up to 2 re-reviews) until PASS/CONDITIONAL.
  - **Phase 3.5** — a red-team pass: one agent acts as a hostile implementer that tries to *build* from the plan and reports every gap it would have to guess.
- **Autonomous by default.** On PASS/CONDITIONAL it proceeds with **no human pause** — full autonomy for headless runs. Flags: `--interactive` (opt back into a single checkpoint — the deliberate replacement for the plan-mode gate), `--quick` (single reviewer for trivial changes; review is never skipped entirely), `--from-spec`.

## Integration into the existing flow

- **multiexpert-review** `implementation-plan` profile: added `docs/plans/**/plan.md` glob, a `receipt` that writes the verdict back into the plan frontmatter, and the adversarial prompt augmentation.
- **create-pr** and **finalize** now discover/anchor on `docs/plans/<slug>/plan.md` (legacy `swarm-report/<slug>-plan.md` kept as fallback).
- Planning guidance in plugin + root `CLAUDE.md`/`README.md` updated to **prefer `/plan` over built-in plan mode**; skill roster 11 → 12.

## Verification

`bash scripts/validate.sh` — **all checks passed** (`developer-workflow/plan` frontmatter 932/1024 chars; references/ present so no length warning).

## Open for discussion

- The harsh skeptic is currently realized as (a) profile prompt augmentation + (b) a general-purpose red-team agent. If you'd prefer it as a **dedicated, reusable `plan-skeptic` expert agent** in `developer-workflow-experts` (so other skills can summon the same critic), that's an easy follow-up — I left it out to avoid expanding the shipped agent roster without your call.
- This is a docs/skill-only change (no version bump — that's a separate release step per the publishing checklist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAowhqvMbyfwGs6xZcZ4Ki

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAowhqvMbyfwGs6xZcZ4Ki)_