### PR TITLE
Enable skill/plugin authoring plugins via project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "enabledPlugins": {
+    "skill-creator@claude-plugins-official": true,
+    "claude-code-setup@claude-plugins-official": true,
+    "claude-md-management@claude-plugins-official": true,
+    "hookify@claude-plugins-official": true
+  },
+  "extraKnownMarketplaces": {
+    "claude-plugins-official": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-plugins-official"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds a committed `.claude/settings.json` that enables the Claude Code authoring toolkit for anyone working in this plugin monorepo, and declares the marketplace so the plugins resolve without manual setup.

**Enabled (`enabledPlugins`):**

| Plugin | Why it fits this repo |
|---|---|
| `skill-creator` | Create / improve / eval skills — the core activity here |
| `claude-code-setup` | Recommends tailored CC automations (hooks/skills/MCP/subagents) for a codebase |
| `claude-md-management` | Audit & maintain the repo's many `CLAUDE.md` files |
| `hookify` | Author hooks from conversation patterns (the repo ships hooks) |

**`extraKnownMarketplaces`:** declares `claude-plugins-official` (github `anthropics/claude-plugins-official`) so contributors get these plugins on trust without adding the marketplace by hand.

## Notes

- Project `enabledPlugins` override a user-level disable, so this turns the plugins on for the repo regardless of each contributor's global setting.
- Marketplace is *declared*, not force-installed — contributors confirm trust once on first load.
- Excluded as irrelevant to this repo: `swift-lsp` / `rust-analyzer-lsp` / `ruby-lsp` (no such source here — TS + shell + markdown only) and `lazyweb` (design research). `developer-workflow-swift` and `playwright` were considered but left off per the maintainer's selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)