### PR TITLE
developer-workflow: transient plans + mandatory spec/test-plan review

### DIFF
--- a/plugins/developer-workflow/skills/drive-to-merge/SKILL.md
+++ b/plugins/developer-workflow/skills/drive-to-merge/SKILL.md
@@ -181,7 +181,10 @@ In **`--auto` mode** the summary is shown for visibility and the merge executes 
 without waiting. If `isDraft == true` and everything else is merge-ready, promote the PR/MR
 first (`gh pr ready` / `glab mr update --remove-draft`) before running pre-merge checks.
 
-Procedure in [`references/merge.md`](references/merge.md).
+After a successful merge, tear down the transient implementation plan: delete
+`docs/plans/<slug>/` from the default branch and commit that removal (the plan is reviewable in the
+PR diff but must not survive into the merged history). `<slug>` is resolved the same way as
+`create-pr` / `plan`. Procedure in [`references/merge.md`](references/merge.md).
 
 ---
 
@@ -189,7 +192,7 @@ Procedure in [`references/merge.md`](references/merge.md).
 
 | State | When | What the skill writes |
 |---|---|---|
-| `merged` | Phase 5 succeeded | state file marked merged, success summary in session |
+| `merged` | Phase 5 succeeded | state file marked merged, transient `docs/plans/<slug>/` removed from the default branch, success summary in session |
 | `blocked` | A blocker was surfaced (failure-loop guard, integrity mismatch, unresolvable rebase, DISCUSSION requires user, polling exceeded cap, or user explicitly says "stop") | state file `Blockers raised` filled (including reason `"user stop"` when applicable), session message explains next action |
 
 ---

--- a/plugins/developer-workflow/skills/drive-to-merge/references/merge.md
+++ b/plugins/developer-workflow/skills/drive-to-merge/references/merge.md
@@ -92,8 +92,33 @@ On failure (e.g. GitHub repo has auto-merge disabled):
 ## After merge
 
 1. Mark state file `Status: merged`, timestamp the `Rounds` final entry.
-2. Report the merged URL + commit sha to the user.
-3. Stop. No further polling.
+2. **Plan cleanup (transient-plan teardown).** The implementation plan under
+   `docs/plans/<slug>/` is transient scaffolding — reviewable in the PR diff, but it must not
+   survive into the default branch after merge. If that directory exists, remove it from the base
+   branch and commit the removal:
+
+   Resolve `<slug>` consistently with `create-pr` / `plan`: prefer a slug passed as an argument,
+   else derive it from the (pre-merge) head branch name with common prefixes stripped (`feature/`,
+   `fix/`, `hotfix/`, `bug/`, `chore/`, `refactor/`, `docs/`, `claude/`).
+
+   ```bash
+   # Run against the freshly-updated default branch (the head branch was deleted on merge).
+   git fetch origin
+   git switch "$BASE"            # the PR base / default branch
+   git pull --ff-only origin "$BASE"
+   if [ -d "docs/plans/$SLUG" ]; then
+     git rm -r "docs/plans/$SLUG"
+     git commit -m "chore: remove transient plan docs/plans/$SLUG after merge"
+     git push origin "$BASE"
+   fi
+   ```
+
+   Honor the global "never commit/push directly to a protected default branch" rule: if direct
+   pushes to `$BASE` are blocked, open a tiny cleanup PR that deletes `docs/plans/$SLUG/` instead,
+   and note it in the final report rather than forcing a direct push.
+3. Report the merged URL + commit sha to the user, and note the plan-cleanup commit (or skip note if
+   no plan directory existed).
+4. Stop. No further polling.
 
 ## Rebase when base has advanced (Phase 2.6 companion)
 

--- a/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
+++ b/plugins/developer-workflow/skills/generate-test-plan/SKILL.md
@@ -97,6 +97,53 @@ the phase labels present.
 See [`references/format-templates.md`](references/format-templates.md) for the full standard and lightweight templates (verbatim
 markdown), the phase-segmentation worked example, and the rules for when each variant applies.
 
+## Review Loop — MANDATORY
+
+After the test plan is written, run a multiexpert-review over it. This review is **not optional** —
+an unreviewed test plan ships blind spots (missing edge cases, unfalsifiable expected results,
+untraced acceptance criteria), exactly the failure this skill exists to prevent. It mirrors the
+inline review-loop idiom used by `plan` (Phase 3) and `write-spec` (Phase 4.3): invoke
+`multiexpert-review` **inline** with an explicit profile hint, and let the engine drive the
+revise-loop until the plan passes.
+
+The test plan is already a file (`docs/testplans/<slug>-test-plan.md`), so prepend the profile hint
+and the file path to the review args:
+
+```
+profile: test-plan
+---
+docs/testplans/<slug>-test-plan.md
+```
+
+The hint is defense-in-depth: inline-arg callsites lack the frontmatter the detector classifies on,
+and the prefix short-circuits detection deterministically (same rationale as `plan` / `write-spec`).
+Because the plan is on disk, the engine classifies the source as `file` and edits it in place on
+FAIL/CONDITIONAL.
+
+The `test-plan` profile is panel-led by `business-analyst` and adds domain specialists
+(`security-expert`, `performance-expert`, `ux-expert`) only when the spec invokes their concerns; do
+not pad the panel and do not drop a genuinely-triggered reviewer. Its 7-item rubric checks AC
+coverage, negative/edge balance, priority-risk alignment, a valid `Type` field per TC, and the
+`Non-functional / Instrumentation` section (filled or carrying an explicit `N/A: <reason>`).
+
+**Loop** — run the review loop with the same cap as the sibling skills (1 initial review + up to 2
+re-reviews). The `test-plan` profile's verdict alphabet is PASS / WARN / FAIL:
+
+| Verdict | Action |
+|---|---|
+| PASS | Proceed. |
+| WARN | Proceed; the engine records the non-blocking items in `review_warnings`. |
+| FAIL | Engine edits the plan to fix the blockers, then re-reviews until PASS/WARN or the cap. On the final cycle still FAIL → surface the blockers and stop; do not mark the plan `Ready`. |
+
+When invoked with a `slug`, write the verdict back into the receipt's frontmatter
+(`review_verdict`, `review_warnings` / `review_blockers`) per
+[`references/receipt-format.md`](references/receipt-format.md), and flip the receipt `status` to
+`Ready` only on PASS/WARN. Standalone invocations (no slug, no receipt) still run the review — the
+permanent file is the artifact reviewed and edited in place.
+
+The mandatory `multiexpert-review` call here is the in-skill review gate (like `plan` Phase 3 and
+`write-spec` Phase 4.3), not forbidden downstream chaining. Do not auto-invoke any other skill.
+
 ## Field Definitions
 
 ### Type

--- a/plugins/developer-workflow/skills/plan/SKILL.md
+++ b/plugins/developer-workflow/skills/plan/SKILL.md
@@ -1,15 +1,19 @@
 ---
 name: plan
-description: "Produce a committed implementation plan document — the autonomous replacement for built-in plan mode. Investigates the codebase read-only, writes a persistent, reviewable plan (docs/plans/<slug>/plan.md + tasks.md) instead of an ephemeral approval prompt, then runs a MANDATORY multiexpert-review loop over the plan and revises until it passes. No human approval pause by default, so an agent can plan and execute end-to-end; opt into a checkpoint with --interactive. Use when: \"plan this\", \"make a plan\", \"how do I build this\", \"plan the implementation\", \"break this into tasks\", \"plan before coding\" for an ALREADY-DECIDED change. Prefer this over built-in plan mode whenever the plan should be saved, reviewed by experts, or executed autonomously. Do NOT use for: deciding WHAT to build or comparing options (use research), writing the feature contract / acceptance criteria (use write-spec), or trivial single-line edits (just do them)."
+description: "Produce a committed implementation plan document — the autonomous replacement for built-in plan mode. Investigates the codebase read-only, writes a reviewable plan (docs/plans/<slug>/plan.md + tasks.md) instead of an ephemeral approval prompt, then runs a MANDATORY multiexpert-review loop over the plan and revises until it passes. The plan is transient: kept through implementation and review, removed after merge. No approval pause by default, so an agent can plan and execute end-to-end; opt into a checkpoint with --interactive. Use when: \"plan this\", \"make a plan\", \"how do I build this\", \"plan the implementation\", \"break this into tasks\", \"plan before coding\" for an ALREADY-DECIDED change. Prefer this over built-in plan mode whenever the plan should be saved, reviewed by experts, or executed autonomously. Do NOT use for: deciding WHAT to build or comparing options (use research), writing the feature contract / acceptance criteria (use write-spec), or trivial single-line edits (just do them)."
 ---
 
 # Plan
 
-Turn an already-decided change into a **persistent, expert-reviewed implementation plan** that an
+Turn an already-decided change into an **expert-reviewed implementation plan** that an
 agent can execute end-to-end without stopping for approval. This is the autonomous replacement for
 built-in plan mode: the plan is a file on disk (not an ephemeral `ExitPlanMode` prompt), so it can
-be version-controlled, reviewed by a multiexpert panel, referenced by `create-pr` / `finalize`, and
-resumed across sessions.
+be reviewed by a multiexpert panel, diffed in the PR, referenced by `create-pr` / `finalize`, and
+resumed across sessions while the work is in progress. The plan is **transient implementation
+scaffolding**: it lives in `docs/plans/<slug>/` throughout implementation and PR review, then
+`drive-to-merge` deletes it after the change merges (and it should not survive an abandoned or
+rejected change either). The contrast with built-in plan mode is the *file*, not its permanence —
+an ephemeral approval prompt can be neither reviewed nor resumed.
 
 **Role:** Tech Lead translating *what* into *how*. The decision is made (by the user, a spec, or
 prior research); this skill produces the technical approach, the ordered task list, and the
@@ -78,8 +82,10 @@ finalize all resolve the same `docs/plans/<slug>/` path.
 
 Three committed files under `docs/plans/<slug>/` (`plan.md`, `tasks.md`, `progress.md`) plus the
 gitignored operational `./swarm-report/plan-<slug>-state.md` (deleted after). `docs/plans/` is
-deliberately alongside `docs/specs/` (spec = *what*, plan = *how*); plans live in git because their
-value is being reviewable in the PR and resumable later. See
+deliberately alongside `docs/specs/` (spec = *what*, plan = *how*), but their lifetimes differ: the
+spec is permanent, the plan is transient. Plans live in git only *while the work is in progress* —
+their value is being reviewable in the PR diff and resumable across sessions during implementation —
+and `drive-to-merge` deletes `docs/plans/<slug>/` after the change merges. See
 [`references/output-layout.md`](references/output-layout.md) for the full file/lifetime/purpose
 table.
 

--- a/plugins/developer-workflow/skills/plan/references/output-layout.md
+++ b/plugins/developer-workflow/skills/plan/references/output-layout.md
@@ -4,14 +4,18 @@
 
 | File | Lifetime | Committed? | Purpose |
 |---|---|---|---|
-| `docs/plans/<slug>/plan.md` | Permanent | Yes — reviewed in the PR | Technical approach, affected files, decisions, risks. |
-| `docs/plans/<slug>/tasks.md` | Permanent | Yes | Ordered task checklist with dependencies + per-task acceptance. |
-| `docs/plans/<slug>/progress.md` | Permanent (volatile content) | Yes — the execution ledger / audit trail | Volatile status + learnings log. Split from the stable plan so execution churn never rewrites the design. |
+| `docs/plans/<slug>/plan.md` | Transient — deleted after merge | Yes — reviewed in the PR | Technical approach, affected files, decisions, risks. |
+| `docs/plans/<slug>/tasks.md` | Transient — deleted after merge | Yes | Ordered task checklist with dependencies + per-task acceptance. |
+| `docs/plans/<slug>/progress.md` | Transient (volatile content) — deleted after merge | Yes — the execution ledger / audit trail | Volatile status + learnings log. Split from the stable plan so execution churn never rewrites the design. |
 | `./swarm-report/plan-<slug>-state.md` | Operational | No (gitignored) — delete after | Investigation findings, review-cycle log. Deleted after. |
 
 `docs/plans/` is intentionally a sibling of `docs/specs/`: spec = *what* (requirements + AC), plan =
-*how* (design + tasks). Both live in git because their value is being reviewable in the PR and
-resumable later — the exact property built-in plan mode lacks.
+*how* (design + tasks). Both live in git while the work is in progress because their value is being
+reviewable in the PR and resumable later — the exact property built-in plan mode lacks. Their
+lifetimes differ, though: the spec is **permanent**, the plan is **transient implementation
+scaffolding**. The whole `docs/plans/<slug>/` directory stays in git throughout implementation and
+PR review, then `drive-to-merge` deletes it once the change merges; it must not survive into the
+default branch after merge, nor outlive an abandoned / rejected change.
 
 Slug derivation: see `SKILL.md` Phase 0.1.
 
@@ -46,3 +50,6 @@ before flipping to `approved`.
   change.
 - `create-pr` discovers `docs/plans/<slug>/plan.md` and references it in the PR body; `finalize`
   anchors its `code-reviewer` pass on the same plan. No extra wiring needed beyond writing the file.
+- The plan is transient: `drive-to-merge` deletes the whole `docs/plans/<slug>/` directory after the
+  PR merges (a cleanup commit on the default branch), so the plan is reviewable in the PR diff but
+  never lingers in the merged history.

--- a/plugins/developer-workflow/skills/write-spec/SKILL.md
+++ b/plugins/developer-workflow/skills/write-spec/SKILL.md
@@ -193,7 +193,11 @@ While the user reviews, run a self-check:
 
 Fix any self-identified gaps.
 
-### 4.3 Run multiexpert-review (spec profile)
+### 4.3 Run multiexpert-review (spec profile) — MANDATORY
+
+This review is **not optional**. Every spec passes through a multiexpert-review loop before it can be
+approved — an unreviewed spec is the failure mode this skill exists to prevent. Run it even for small
+specs (the panel scales down, it is never skipped).
 
 Run `multiexpert-review` with explicit profile hint — prepend to args:
 


### PR DESCRIPTION
Aligns the `developer-workflow` skills with the updated autonomous, fully-reviewed workflow (companion to the global-settings rules change).

## Changes

### 1. Plan output is now transient scaffolding (not a permanent record)
- **`skills/plan/SKILL.md`** — reframed the plan as transient: it still lives in `docs/plans/<slug>/` throughout implementation and PR review (reviewable in the PR diff, resumable across sessions *while work is in progress*), but is removed after the change merges. Intro, Phase 0.2 "Artifacts", and the frontmatter `description` updated; the contrast with built-in plan mode is preserved. Spec lifecycle unchanged (specs stay permanent).
- **`skills/plan/references/output-layout.md`** — lifetime table `Permanent` → `Transient — deleted after merge` for `plan.md`/`tasks.md`/`progress.md`; sibling-of-specs paragraph and hand-off rules note the cleanup.

### 2. `/drive-to-merge` removes the plan after merge
- **`skills/drive-to-merge/SKILL.md`** — Phase 5 + the `merged` terminal-state row describe the post-merge plan teardown.
- **`skills/drive-to-merge/references/merge.md`** — new "Plan cleanup" step under "After merge": switch to base, `git rm -r docs/plans/$SLUG`, commit, push (with a protected-branch fallback to a tiny cleanup PR). Slug resolved consistently with `create-pr`/`plan`.

### 3. Mandatory multi-review of spec and test plan
- **`skills/write-spec/SKILL.md`** — Phase 4.3 marked explicitly **MANDATORY** (review was already invoked, now stated as not optional).
- **`skills/generate-test-plan/SKILL.md`** — added a **mandatory** "Review Loop" section: inline `multiexpert-review` with the existing `profile: test-plan`, PASS/WARN/FAIL handling, edit-in-place, verdict written to the receipt. Mirrors the `plan`/`write-spec` idiom; no MCP tool names hardcoded.

## Validation
`bash scripts/validate.sh` → **All checks passed** (green). All skill `description` frontmatter ≤1024 chars (plan at 1006).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013WfozqnE5CkpTrPUqtoExK

---
_Generated by [Claude Code](https://claude.ai/code/session_013WfozqnE5CkpTrPUqtoExK)_