### PR TITLE
feat(maven-mcp): remove NPM dependency, rewrite skills to use WebFetch

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "maven-mcp",
-      "description": "Maven dependency intelligence \u2014 auto-registers MCP server, provides /check-deps, /check-deps-vulnerabilities, /latest-version, /dependency-changes, and /dependency-health skills",
+      "description": "Maven dependency intelligence \u2014 provides /check-deps, /check-deps-vulnerabilities, /latest-version, /dependency-changes, and /dependency-health skills. Works in Claude cloud and local without any NPM setup.",
       "author": {
         "name": "kirich1409"
       },

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "maven-mcp",
   "version": "0.23.0",
-  "description": "Maven dependency intelligence — auto-registers MCP server, provides /check-deps, /check-deps-vulnerabilities, /latest-version, /dependency-changes, and /dependency-health skills",
+  "description": "Maven dependency intelligence — provides /check-deps, /check-deps-vulnerabilities, /latest-version, /dependency-changes, and /dependency-health skills. Works in Claude cloud and local without any NPM setup.",
   "author": {
     "name": "kirich1409"
   },
@@ -11,16 +11,6 @@
     "maven",
     "gradle",
     "dependencies",
-    "mcp",
     "android"
-  ],
-  "mcpServers": {
-    "maven-mcp": {
-      "command": "npx",
-      "args": [
-        "-y",
-        "@krozov/maven-central-mcp@^0.23.0"
-      ]
-    }
-  }
+  ]
 }

--- a/plugins/maven-mcp/plugin/skills/check-deps-vulnerabilities/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/check-deps-vulnerabilities/SKILL.md
@@ -11,155 +11,245 @@ description: >-
 
 # Check Dependency Vulnerabilities
 
-Scan the current Maven/Gradle project for known CVE/GHSA advisories on its
-declared dependencies (including submodules), grouped by severity, and offer
-remediation through targeted version updates.
+Scan the current Maven/Gradle project for known CVE/GHSA advisories on declared
+dependencies and offer remediation through targeted version updates.
 
-## Preflight
+## Step 1 — Discover build files
 
-Before doing anything else, confirm the `audit_project_dependencies` MCP tool
-is available. If it is not, stop and tell the user:
+Use Glob to find all build files in the project:
 
-> The maven-mcp plugin is required for this skill. Install it with
-> `claude plugin add maven-mcp`, then retry.
+```
+**/libs.versions.toml
+**/build.gradle.kts
+**/build.gradle
+**/pom.xml
+```
 
-Do not attempt to fall back to manual web searches — this skill requires the
-MCP server.
+Exclude files under `.gradle/`, `build/`, `.idea/`, `node_modules/`, and any path
+containing `/build/`.
 
-## Steps
+Read each found file with the Read tool.
 
-1. Call the MCP tool with the default flags:
+## Step 2 — Extract declared dependencies
 
-   ```json
-   {
-     "includeVulnerabilities": true,
-     "productionOnly": true
-   }
-   ```
+Parse each file to collect `groupId`, `artifactId`, and `version` for every production
+dependency. Default: exclude test-scoped entries (see Scopes section). If the user passes
+`productionOnly: false`, include them.
 
-   Do not pass any other parameters unless the user explicitly asks for
-   test/build configurations (then set `productionOnly: false`).
+### Version catalogs (`libs.versions.toml`)
 
-2. Filter the response to entries where `vulnerabilities` is non-empty. Drop
-   the rest from the report (still mention the total scanned count in the
-   summary).
+In the `[versions]` section, collect `key = "value"` pairs as a version map.
 
-3. Sort findings by severity desc, then by `groupId:artifactId` asc:
+In the `[libraries]` section, each entry has one of these forms:
+```toml
+alias = "group:artifact:version"
+alias = { group = "...", name = "...", version = "..." }
+alias = { group = "...", name = "...", version.ref = "key" }
+```
+Resolve `version.ref` entries using the version map.
 
-   - `CRITICAL` → `HIGH` → `MEDIUM` → `LOW` → unknown (`undefined`)
-   - Within a band: lexicographic order of `groupId:artifactId`.
+In the `[plugins]` section:
+```toml
+alias = { id = "...", version = "..." }
+alias = { id = "...", version.ref = "key" }
+```
+Convert plugin ID to Maven coordinates: `groupId = id`, `artifactId = "{id}.gradle.plugin"`.
 
-4. Render the findings as a markdown table. One row per `(module, finding)`:
+### Gradle build files (`build.gradle.kts` / `build.gradle`)
 
-   | Module | Artifact | Current | Severity | CVE/GHSA | Fixed in |
-   |--------|----------|---------|----------|----------|----------|
-   | `:app` | `org.apache.logging.log4j:log4j-core` | 2.14.1 | CRITICAL | GHSA-jfh8-c2jp-5v3q | 2.17.1 |
+Match patterns like:
+```
+implementation("group:artifact:version")
+api("group:artifact:version")
+compileOnly("group:artifact:version")
+runtimeOnly("group:artifact:version")
+```
+Also the Kotlin DSL map form:
+```
+implementation(group = "...", name = "...", version = "...")
+```
 
-   - `Module`: `dep.module` if set; otherwise `(root)`.
-   - `Artifact`: `groupId:artifactId`.
-   - `CVE/GHSA`: the OSV `id` (link it if the chat client renders Markdown links).
-   - `Fixed in`: `dep.vulnerabilities[*].fixedVersion`; if absent, write
-     `(no fixed version)`.
+Skip entries that reference version catalog variables (e.g. `libs.ktor.client.core`) —
+those versions are already captured from the catalog.
 
-5. Print a one-line summary after the table:
+**Production scopes** (include): `implementation`, `api`, `compileOnly`, `runtimeOnly`,
+`compile`, `runtime`, `provided`, `releaseImplementation`, `debugImplementation`.
 
-   `Total: N findings across M packages (X critical, Y high, Z medium, W low).`
+**Test scopes** (exclude by default): `testImplementation`, `testApi`,
+`androidTestImplementation`, `kaptTest`, `kaptAndroidTest`, `testCompileOnly`,
+`testRuntimeOnly`.
 
-   `M` counts distinct `groupId:artifactId` strings (a single package
-   accumulating multiple CVEs counts once).
+### Maven POM files (`pom.xml`)
 
-6. If `vulnerabilities` is empty for every dependency, print:
+Match entries inside `<dependencies>`:
+```xml
+<dependency>
+  <groupId>...</groupId>
+  <artifactId>...</artifactId>
+  <version>...</version>
+  <scope>...</scope>
+</dependency>
+```
 
-   `No known vulnerabilities found in production dependencies. (Test/build configurations were excluded.)`
+**Production scopes** (include): `compile` (default), `runtime`, `provided`.
+**Exclude**: `test`, `system`.
 
-   Then stop — no remediation prompt.
+### Plugins blocks
 
-7. Print this disclaimer verbatim once, immediately after the summary:
+Match `plugins { id("...") version "..." }` and `id("...") version "..."` lines.
+Convert the plugin ID to Maven coordinates as above.
 
-   > Note: OSV does not cover shaded/uber JARs. Dependencies bundled inside
-   > a fat JAR may carry CVEs that this scan will not surface.
+## Step 3 — Deduplicate
 
-## Remediation
+After parsing all files, deduplicate by `groupId:artifactId:version`. Keep track of
+which file each dependency came from for the report.
 
-When at least one finding exists, ask the user with `AskUserQuestion` — one
-question, exactly four options, in this order:
+## Step 4 — Query OSV.dev for vulnerabilities
 
-1. **Update all** — upgrade every vulnerable package to its recommended fixed
-   version.
+Send a batch request to OSV.dev for all unique `groupId:artifactId:version` combinations.
+
+**Request:**
+```
+POST https://api.osv.dev/v1/querybatch
+Content-Type: application/json
+
+{
+  "queries": [
+    {
+      "package": {
+        "name": "{groupId}:{artifactId}",
+        "ecosystem": "Maven"
+      },
+      "version": "{version}"
+    },
+    ...
+  ]
+}
+```
+
+OSV.dev accepts up to 1000 entries per batch. If there are more, split into multiple
+requests and merge results.
+
+**Response:**
+```json
+{
+  "results": [
+    {
+      "vulns": [
+        {
+          "id": "GHSA-xxxx-xxxx-xxxx",
+          "summary": "...",
+          "severity": [{"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/..."}],
+          "affected": [
+            {
+              "ranges": [
+                {
+                  "type": "ECOSYSTEM",
+                  "events": [
+                    {"introduced": "0"},
+                    {"fixed": "2.17.1"}
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+The `results` array corresponds 1:1 to the `queries` array. For each result:
+- If `vulns` is empty or missing, the dependency has no known advisories.
+- For each vuln, extract:
+  - `id` — advisory identifier (GHSA-... or CVE-...)
+  - `summary` — short description
+  - `severity` — derive from CVSS score: ≥9.0 CRITICAL, ≥7.0 HIGH, ≥4.0 MEDIUM,
+    <4.0 LOW; if no CVSS score is present use the `database_specific.severity` field
+    if available, otherwise "unknown"
+  - `fixedVersion` — the `fixed` event value from the first matching ECOSYSTEM range;
+    if absent, leave empty
+
+## Step 5 — Build the report
+
+Filter to dependencies where `vulns` is non-empty.
+
+Sort: CRITICAL → HIGH → MEDIUM → LOW → unknown, then lexicographic by
+`groupId:artifactId`.
+
+Render as a markdown table. One row per `(dependency, finding)`:
+
+| Source file | Artifact | Current | Severity | CVE/GHSA | Summary | Fixed in |
+|-------------|----------|---------|----------|----------|---------|----------|
+| `gradle/libs.versions.toml` | `org.apache.logging.log4j:log4j-core` | 2.14.1 | CRITICAL | [GHSA-jfh8-c2jp-5v3q](https://osv.dev/vulnerability/GHSA-jfh8-c2jp-5v3q) | Remote code execution in Log4Shell | 2.17.1 |
+
+**Summary line after the table:**
+`Total: N findings across M packages (X critical, Y high, Z medium, W low).`
+`Scanned: K dependencies total. Test configurations excluded.`
+
+**If no vulnerabilities found:**
+> No known vulnerabilities found in production dependencies. (Scanned K dependencies. Test configurations were excluded.)
+
+Then stop — no remediation prompt.
+
+**Disclaimer (always print once):**
+> Note: OSV does not cover shaded/uber JARs. Dependencies bundled inside a fat JAR may
+> carry CVEs that this scan will not surface.
+
+## Step 6 — Remediation
+
+When at least one finding exists, ask the user with `AskUserQuestion` — one question,
+exactly four options:
+
+1. **Update all** — upgrade every vulnerable package to its recommended fixed version.
 2. **Update CRITICAL + HIGH only** — leave MEDIUM/LOW for later.
-3. **Show details for a specific CVE/GHSA** — when chosen, ask which one,
-   then call `get_dependency_vulnerabilities` for that single GAV and present
-   the full advisory text + reference URL.
+3. **Show details for a specific CVE/GHSA** — ask which one, then fetch:
+   `https://api.osv.dev/v1/vulns/{id}` and present the full advisory text.
 4. **Report only** — make no changes.
 
-### Recommended fixed version per package
+**Recommended fixed version per package:** `max(fixedVersion)` across all findings for
+that `groupId:artifactId`. If a finding has no `fixedVersion`, exclude it from the max;
+if every finding lacks one, list under "Manual upgrade required".
 
-Per package, the recommended fixed version is `max(fixedVersion)` across all
-findings for that `groupId:artifactId` — a single bump must close every CVE
-the package carries. If a finding has no `fixedVersion`, exclude that finding
-from the max computation; if every finding for the package lacks a
-`fixedVersion`, the package cannot be auto-remediated — list it under a
-"Manual upgrade required" subsection instead of editing.
-
-## After updating versions
+## Step 7 — Apply updates
 
 When the user picks option 1 or 2:
 
-1. Edit the build files (`gradle/libs.versions.toml`, `build.gradle[.kts]`,
-   or `pom.xml`) to apply the recommended versions. Touch only the lines that
-   own the vulnerable dependency — do not reformat or reorder unrelated
-   entries.
+1. Edit the appropriate file:
+   - **Version catalog** (`libs.versions.toml`): update the `[versions]` entry or inline
+     version in `[libraries]`/`[plugins]`. Touch only the version value.
+   - **Gradle build file**: update the inline version string in the dependency declaration.
+   - **pom.xml**: update `<version>` inside the `<dependency>` block.
 
-2. **MANDATORY: Run the project build to verify compatibility.** Do NOT skip
-   this step.
+2. **MANDATORY: Run the project build to verify compatibility.** Do NOT skip this step.
+   - Gradle: `./gradlew build` (or `./gradlew assembleDebug` for Android)
+   - Maven: `mvn compile`
 
-   - Gradle: `./gradlew build` (or `./gradlew assembleDebug` for Android).
-   - Maven: `mvn compile`.
-   - Wait for the build to complete fully.
+3. If the build succeeds, report which dependencies were updated and which CVEs each
+   upgrade closes.
 
-3. **If the build succeeds:** report success, list which dependencies were
-   updated and which CVE/GHSA each upgrade closes.
+4. If the build fails, identify the incompatibility, attempt to fix it (API changes, import
+   updates). If non-trivial, revert that entry and mark it "manual upgrade required".
+   Re-run the build to confirm it passes. Report what was updated and what was reverted.
 
-4. **If the build fails:**
-   - Read the build error output carefully.
-   - Identify which upgraded dependency caused the incompatibility.
-   - Try to fix the incompatibility (API changes, import updates, deprecation
-     replacements).
-   - If the fix is non-trivial, revert that specific dependency to its
-     previous version and surface the CVE as "manual upgrade required".
-   - Re-run the build to confirm it passes.
-   - Report which packages were updated, which were reverted, and why.
-
-5. **Never report "vulnerabilities patched" without a passing build.** The
-   remediation is not complete until the project compiles successfully.
-
-## Language
-
-This SKILL.md is in English. The runtime output (tables, summary, prompts)
-should follow the user's chat language. CVE/GHSA identifiers, package
-coordinates, and version numbers stay in their original form regardless of
-language.
+**Never report "vulnerabilities patched" without a passing build.**
 
 ## Known limitations
 
-State these once at the top of the report when relevant:
+State these at the top of the report when relevant:
 
-- Test, build, and annotation-processor configurations (`testImplementation`,
-  `kapt`, `ksp`, `annotationProcessor`, etc.) are excluded by default. Pass
-  `productionOnly: false` to include them.
-- Submodule discovery uses default Gradle layout (`:foo:bar` →
-  `foo/bar/build.gradle[.kts]`). Modules with
-  `project(":foo").projectDir = file(...)` overrides and Gradle composite
-  builds (`includeBuild`) are not scanned.
-- Transitive dependencies are not enumerated — only direct declarations in
-  build files. A direct dependency that pulls a vulnerable transitive will
-  not appear in the report; investigate via `./gradlew dependencies` /
-  `mvn dependency:tree` when in doubt.
-- Android variant-prefixed configurations (`releaseImplementation`,
-  `debugImplementation`, `<flavor>ReleaseImplementation`, etc.) ship in the
-  final artifact but are not recognized by the underlying parser today, so
-  CVEs declared only on variant-specific configurations are silently
-  invisible to this scan. Workaround: declare security-critical deps on
-  plain `implementation` / `api`, or run `./gradlew dependencies` for the
-  target variant and audit the result manually.
-- OSV does not cover shaded/uber JARs.
+- Test, build, and annotation-processor configurations are excluded by default.
+- Version catalog entries referenced via `version.ref` are resolved; complex expressions
+  (e.g. multi-catalog from() form) may not be detected.
+- Transitive dependencies are not scanned — only direct declarations in build files.
+- Variant-specific configurations (`releaseImplementation`, `debugImplementation`, etc.)
+  are included in production scope but flavor-prefixed ones
+  (`<flavor>ReleaseImplementation`) may be missed.
+- OSV coverage for Gradle plugin marker artifacts is limited — plugin CVEs may not appear.
+- `buildSrc/` and composite builds (`includeBuild`) are not scanned.
+
+## Language
+
+This SKILL.md is in English. Runtime output follows the user's chat language. CVE/GHSA
+identifiers, package coordinates, and version numbers stay in their original form.

--- a/plugins/maven-mcp/plugin/skills/check-deps/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/check-deps/SKILL.md
@@ -13,39 +13,182 @@ Scan the current project — version catalogs, all submodules, plugin DSL blocks
 buildscript classpath — and report which dependencies have newer versions available, then
 apply the updates the user confirms.
 
-## Preflight
+## Step 1 — Discover build files
 
-Before doing anything else, confirm the `audit_project_dependencies` MCP tool is available.
-If it is not, stop and tell the user:
+Use Glob to find all build files:
 
-> The maven-mcp plugin is required for this skill. Install it with
-> `claude plugin add maven-mcp`, then retry.
+```
+**/libs.versions.toml
+**/build.gradle.kts
+**/build.gradle
+**/pom.xml
+**/settings.gradle.kts
+**/settings.gradle
+```
 
-Do not attempt to fall back to manual file parsing — this skill requires the MCP server.
+Exclude files under `.gradle/`, `build/`, `.idea/`, `node_modules/`, and any path
+containing `/build/`.
 
-## One-shot scan
+Read each found file with the Read tool.
 
-Call the tool once with both flags set:
+## Step 2 — Extract declared dependencies
 
-```json
+Parse each file to collect a list of dependency records. Each record has:
+- `groupId`, `artifactId`, `version` (resolved, not a variable reference)
+- `source.kind` — one of: `catalog-library`, `catalog-plugin`, `module-direct`,
+  `plugins-dsl`, `buildscript-classpath`
+- `source.file` — path to the file containing the declaration
+- `source.tomlPath` — for catalog entries, path to the .toml file
+- `source.alias` — for catalog entries, the alias key
+- `source.settingsBlock` — `true` for `pluginManagement { plugins {} }` entries
+- `usages` — list of `{ module, configuration }` for where the dependency is used
+
+### Version catalogs (`libs.versions.toml`) — `catalog-library` and `catalog-plugin`
+
+In the `[versions]` section, collect `key = "value"` pairs as a version map.
+
+In the `[libraries]` section:
+```toml
+alias = "group:artifact:version"
+alias = { group = "...", name = "...", version = "..." }
+alias = { group = "...", name = "...", version.ref = "key" }
+```
+Resolve `version.ref` using the version map.
+
+In the `[plugins]` section:
+```toml
+alias = { id = "...", version = "..." }
+alias = { id = "...", version.ref = "key" }
+```
+Convert plugin ID to Maven coordinates: `groupId = id`, `artifactId = "{id}.gradle.plugin"`.
+Set `source.kind = "catalog-plugin"`.
+
+To find which Gradle modules use a catalog alias, scan `build.gradle[.kts]` files for
+`libs.{alias-with-dots}` references. Record the module name (derived from the file path
+relative to the project root).
+
+### Gradle build files — `module-direct`
+
+Match dependency declarations with inline string versions:
+```
+implementation("group:artifact:version")
+api("group:artifact:version")
+implementation(group = "...", name = "...", version = "...")
+```
+
+**Include** (production scopes): `implementation`, `api`, `compileOnly`, `runtimeOnly`,
+`compile`, `runtime`, `provided`, `releaseImplementation`, `debugImplementation`,
+`ksp`, `kapt`, `annotationProcessor`.
+
+**Exclude** (test scopes): `testImplementation`, `testApi`, `androidTestImplementation`,
+`kaptTest`, `kaptAndroidTest`, `testCompileOnly`, `testRuntimeOnly`.
+
+Skip entries that reference catalog variables (no inline version string).
+
+Set `source.kind = "module-direct"`.
+
+### Plugin DSL blocks — `plugins-dsl`
+
+Match `plugins { }` blocks:
+```
+id("plugin.id") version "1.0.0"
+kotlin("jvm") version "2.0.0"
+```
+
+Also match `pluginManagement { plugins { } }` in `settings.gradle[.kts]` — set
+`source.settingsBlock = true`.
+
+Set `source.kind = "plugins-dsl"`.
+Convert plugin ID to Maven coordinates as described above.
+
+### Buildscript classpath — `buildscript-classpath`
+
+Match inside `buildscript { dependencies { ... } }` blocks:
+```
+classpath("group:artifact:version")
+classpath("group:artifact:version") { ... }
+```
+
+Set `source.kind = "buildscript-classpath"`.
+
+### Maven POM files — `module-direct`
+
+Match `<dependency>` blocks with `<version>` present and scope `compile` (default),
+`runtime`, or `provided`. Exclude `test` and `system` scope.
+
+## Step 3 — Deduplicate
+
+If the same `groupId:artifactId` appears both as a `catalog-library` entry and as a
+`module-direct` entry (same or different version), flag it as a drift case. Keep both
+records.
+
+## Step 4 — Check latest versions from Maven Central
+
+For each unique `groupId:artifactId`, fetch the Maven metadata. Build the group path by
+replacing `.` with `/` in the groupId.
+
+**Maven Central:**
+```
+https://repo1.maven.org/maven2/{group_path}/{artifactId}/maven-metadata.xml
+```
+
+**Google Maven** (for `androidx.*`, `com.google.android.*`, `com.android.*`,
+`com.google.firebase.*`, `com.google.gms.*`, `com.google.mlkit.*`):
+```
+https://dl.google.com/dl/android/maven2/{group_path}/{artifactId}/maven-metadata.xml
+```
+
+**Gradle Plugin Portal** (for plugin marker artifacts — `artifactId` ends in
+`.gradle.plugin`):
+```
+https://plugins.gradle.org/m2/{group_path}/{artifactId}/maven-metadata.xml
+```
+
+Extract all `<version>` entries from the XML.
+
+**Version classification** (same rules as `/latest-version` skill):
+- STABLE: no pre-release suffix
+- RC: contains `-rc`, `-RC`
+- BETA: contains `-beta`, `-b`
+- ALPHA: contains `-alpha`, `-dev`, `-SNAPSHOT`, `-milestone`, `-M`, `-preview`, `-eap`
+
+**Latest stable:** highest version classified as STABLE.
+If no stable version, use the highest RC, then BETA, then ALPHA.
+
+**Upgrade type** (comparing `currentVersion` to `latestVersion`):
+Split both versions into `[major, minor, patch]`. First differing segment:
+- Different `major` → `MAJOR`
+- Different `minor` → `MINOR`
+- Different `patch` or rest → `PATCH`
+
+Batch fetches: run up to 10 fetches in parallel. Process in batches of 10 to avoid
+overwhelming the network.
+
+## Step 5 — Check vulnerabilities (optional, enabled by default)
+
+Send the collected dependencies to OSV.dev:
+
+```
+POST https://api.osv.dev/v1/querybatch
+Content-Type: application/json
+
 {
-  "includeVulnerabilities": true,
-  "productionOnly": true
+  "queries": [
+    {
+      "package": {"name": "{groupId}:{artifactId}", "ecosystem": "Maven"},
+      "version": "{currentVersion}"
+    }
+  ]
 }
 ```
 
-`productionOnly: true` is the default. It excludes test-scoped usages but still includes
-unused catalog entries — the catalog is the single source of truth for declared versions
-and those entries still need to be kept current.
+For each result with non-empty `vulns`, derive severity from CVSS score and fixed version
+as described in the `/check-deps-vulnerabilities` skill.
 
-Keep the single tool call. Do not read build files manually before or after — the MCP
-server handles all file discovery and parsing.
+## Step 6 — Build the report
 
-## Grouping the result
-
-Group `dependencies[]` by `source.kind`. Only include entries where
-`latestVersion !== currentVersion` OR `vulnerabilities.length > 0`. If a group has nothing
-to show, omit that section entirely. If every group is empty, output:
+Only include entries where `latestVersion !== currentVersion` OR `vulnerabilities` is
+non-empty. If nothing to show in a group, omit that section. If all sections are empty:
 
 > All dependencies up to date.
 
@@ -57,16 +200,15 @@ Then skip to the Vulnerabilities section.
 
 Columns: alias | current → latest | upgrade type | catalog file | used by
 
-- `alias` — `source.alias`
-- `current → latest` — `currentVersion → latestVersion`
-- `upgrade type` — `upgradeType` (MAJOR / MINOR / PATCH)
-- `catalog file` — `source.tomlPath`
-- `used by` — count of `usages[]` entries; write `N modules` or `unused`
+- `alias` — catalog alias key
+- `current → latest` — e.g., `2.3.12 → 3.1.3`
+- `upgrade type` — MAJOR / MINOR / PATCH
+- `catalog file` — source.tomlPath
+- `used by` — count of usages (e.g. `4 modules`) or `unused`
 
-When the project has more than one catalog (`source.catalogName` differs across entries),
-prefix the alias with the catalog name: `libs.ktor-client-core` vs `bundles.okhttp`.
+When there are multiple catalogs, prefix alias with catalog name: `libs.alias`.
 
-Example row:
+Example:
 ```
 | ktor-client-core | 2.3.12 → 3.1.3 | MAJOR | gradle/libs.versions.toml | 4 modules |
 ```
@@ -77,37 +219,30 @@ Example row:
 
 Columns: alias | plugin ID | current → latest | upgrade type | catalog file | used by
 
-- `alias` — `source.alias`
-- `plugin ID` — `groupId` (plugin marker convention: `groupId` is the plugin ID)
-- remaining fields same as catalog libraries
-
 ---
 
 ### Module direct (`source.kind === "module-direct"`)
 
 Columns: module | file | artifact | current → latest | configuration
 
-- `module` — `usages[0].module` if set; otherwise `(root)`
-- `file` — `source.file`
+- `module` — relative path of the module (or `(root)`)
+- `file` — source file path
 - `artifact` — `groupId:artifactId`
-- `configuration` — `usages[0].configuration`
+- `configuration` — e.g. `implementation`
 
-Drift flag: if another entry in the result has the same `groupId:artifactId` with
-`source.kind === "catalog-library"`, append a note:
+Drift flag: if the same artifact is also a catalog entry, append:
 > ⚠ drift — same artifact declared in catalog and hardcoded here
 
 ---
 
 ### Plugin DSL (`source.kind === "plugins-dsl"`)
 
-Split into two sub-tables based on `source.settingsBlock`:
+Split by `source.settingsBlock`:
 
-**Root / module `plugins {}` block** (`settingsBlock` is `undefined` or `false`):
-
+**Root / module `plugins {}` block** (`settingsBlock` is false/undefined):
 Columns: plugin ID | current → latest | upgrade type | file
 
 **Settings `pluginManagement { plugins {} }` block** (`settingsBlock === true`):
-
 Same columns.
 
 ---
@@ -121,94 +256,66 @@ Columns: artifact | current → latest | file
 
 ---
 
-## Vulnerabilities
+## Step 7 — Vulnerabilities section
 
-After all upgrade tables, add a separate **Vulnerabilities** section listing every entry
-where `vulnerabilities` is non-empty, regardless of whether an upgrade is available.
+After all upgrade tables, add a **Vulnerabilities** section for every entry where
+vulnerabilities are non-empty (regardless of whether an upgrade is available).
 
 Columns: artifact | version | severity | advisory | fixed in | source | where to fix
 
-- `artifact` — `groupId:artifactId`
-- `version` — `currentVersion`
-- `severity` — `vulnerabilities[i].severity` (CRITICAL / HIGH / MEDIUM / LOW / unknown)
-- `advisory` — `vulnerabilities[i].id` (link it if the client renders Markdown)
-- `fixed in` — `vulnerabilities[i].fixedVersion`; if absent write `(no fixed version)`
-- `source` — `source.kind`
-- `where to fix` — `source.tomlPath` for catalog entries; `source.file` for all others
+Sort: CRITICAL → HIGH → MEDIUM → LOW → unknown, then lexicographic by artifact.
 
-Sort rows: CRITICAL → HIGH → MEDIUM → LOW → unknown, then lexicographic by
-`groupId:artifactId`.
+If no vulnerabilities: omit this section entirely.
 
-If no vulnerabilities exist, omit this section entirely.
+## Step 8 — Confirmation step
 
-## Confirmation step
-
-Present the full report to the user and **ask before making any edits**. Default
-proposal: update catalog entries first (they are the single source of truth and the
-safest edit).
+Present the full report and **ask before making any edits**. Default proposal: update
+catalog entries first (single source of truth, safest edit).
 
 Ask separately for each non-catalog group (Module direct, Plugin DSL, Buildscript
-classpath) — they require targeted edits in different files and carry more risk.
+classpath) — they require targeted edits in different files.
 
-Flag every entry with `upgradeType === "major"` explicitly — major version bumps may
-contain breaking changes and warrant individual confirmation.
+Flag every MAJOR upgrade explicitly — major version bumps may contain breaking changes and
+warrant individual confirmation.
 
-## Edit pass
+## Step 9 — Edit pass
 
 Apply only the groups the user confirms.
 
-**Catalog libraries / plugins** — `Edit` the `.toml` file at `source.tomlPath`.
-Update the `version` value or the referenced `[versions]` entry if a `version.ref` is
-used. Touch only the version value — do not reformat or reorder unrelated entries.
+**Catalog libraries / plugins** — Edit the `.toml` file. Update `[versions]` value or the
+inline version in `[libraries]`/`[plugins]`. If the entry uses `version.ref`, update the
+referenced `[versions]` key. Touch only the version value.
 
-**Module direct** — `Edit` the file at `source.file` inside the module directory
-indicated by `usages[0].module`. Update the inline version string only.
+**Module direct** — Edit the build file. Update only the inline version string.
 
-**Plugin DSL root / module** — `Edit` the root or module `build.gradle[.kts]` file
-(`source.file`). Update the version in the `plugins {}` block.
+**Plugin DSL root / module** — Edit the build file, update version in `plugins {}` block.
 
-**Plugin DSL settings** — `Edit` `settings.gradle[.kts]` (`source.file`). Update the
-version in the `pluginManagement { plugins {} }` block.
+**Plugin DSL settings** — Edit `settings.gradle[.kts]`, update version in
+`pluginManagement { plugins {} }` block.
 
-**Buildscript classpath** — `Edit` the root `build.gradle[.kts]` (`source.file`).
-Update the version in the `buildscript { dependencies { classpath … } }` block.
+**Buildscript classpath** — Edit the root build file, update version in
+`buildscript { dependencies { classpath … } }` block.
 
-## Build verification
+## Step 10 — Build verification
 
-After every edit pass, verify the project still builds.
+After every edit pass:
 
 - **Gradle:** `./gradlew build` — or `./gradlew :module:dependencies` for a fast
   dependency-resolve check when a full build is slow.
 - **Maven:** `mvn dependency:tree`.
 
-Do not invent flags. If the `/check` skill is available in the current environment,
-prefer it — it applies the project's own verification sequence.
+Surface any build failure immediately. Identify which updated dependency caused it.
+Attempt to fix incompatibilities. If non-trivial, revert that entry and note it as
+"manual upgrade required". Re-run the build to confirm it passes.
 
-Surface any build failure immediately. Read the error output, identify which updated
-dependency caused it, attempt to fix the incompatibility (API changes, import updates,
-deprecation replacements). If the fix is non-trivial, revert that specific entry to its
-previous version and note it as "manual upgrade required". Re-run the build to confirm it
-passes.
-
-**Never report "versions updated" without a passing build.** The update is not complete
-until the project resolves and compiles successfully.
+**Never report "versions updated" without a passing build.**
 
 ## Constraints and non-goals
 
-- **Major version bumps** are flagged in the report and require explicit per-entry
-  confirmation — do not batch-apply them silently.
-- **Multi-catalog `from("g:a:v")` form** (catalog declared as a Maven dependency) is not
-  supported; such entries are not scanned.
+- **Major version bumps** require explicit per-entry confirmation.
+- **Multi-catalog `from("g:a:v")` form** is not supported.
 - **`buildSrc/` and convention plugins** are not scanned.
-- **Transitive dependencies** are not enumerated — only direct declarations in build
-  files. Run `./gradlew dependencies` or `mvn dependency:tree` to inspect transitive
-  trees when needed.
-- This skill does not auto-select unstable/pre-release versions. The MCP server returns
-  the latest stable version by default.
-- **Vulnerabilities for plugin entries are typically not detected.** OSV currently indexes
-  implementation artifacts (e.g. `org.jetbrains.kotlin:kotlin-gradle-plugin`), not plugin
-  marker artifacts (e.g. the `.gradle.plugin` marker). Entries with `source.kind ===
-  "plugins-dsl"` or `"buildscript-classpath"` typically return no advisories today — OSV
-  still runs and will surface hits if OSV adds plugin-marker coverage later. For now treat
-  plugin CVEs as a known gap and check the implementation artifact's advisories manually if
-  concerned. v2 will resolve markers to implementation GAVs via POM.
+- **Transitive dependencies** are not enumerated — only direct declarations.
+- This skill does not auto-select unstable/pre-release versions.
+- **Vulnerabilities for plugin entries** may not be detected (OSV coverage gap for
+  `.gradle.plugin` marker artifacts).

--- a/plugins/maven-mcp/plugin/skills/dependency-changes/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/dependency-changes/SKILL.md
@@ -5,63 +5,131 @@ description: Show what changed between two versions of a Maven/Gradle dependency
 
 # Dependency Changes
 
-Show what changed between two versions of a Maven artifact — release notes, changelog entries, and links to GitHub releases.
+Show what changed between two versions of a Maven artifact by fetching release notes and
+changelog data from GitHub via HTTP.
 
 ## Input formats
 
 The user can provide versions in several ways:
 
 - **Explicit range:** "what changed in io.ktor:ktor-client-core from 2.3.0 to 3.1.3"
-- **After check-deps:** "show me the changelog for the ktor upgrade" — infer from the update table in the conversation
-- **Single artifact, one version:** "what's new in compose-bom 2025.01.00" — ask for the from-version, or assume the user's current version if visible in context
+- **After check-deps:** "show me the changelog for the ktor upgrade" — infer from the
+  update table in the conversation.
+- **Single artifact, one version:** "what's new in compose-bom 2025.01.00" — ask for the
+  from-version, or assume the user's current version if visible in context.
 
 ## Steps
 
-1. Parse `groupId`, `artifactId`, `fromVersion`, `toVersion` from the user's input or conversation context.
+### 1. Parse input
 
-   If `fromVersion` is missing and the current version is visible in context (e.g., from a check-deps table), use it. Otherwise ask.
+Extract `groupId`, `artifactId`, `fromVersion`, `toVersion` from the user's input or
+conversation context.
 
-2. Call the `get_dependency_changes` MCP tool:
-   ```json
-   {
-     "groupId": "io.ktor",
-     "artifactId": "ktor-client-core",
-     "fromVersion": "2.3.0",
-     "toVersion": "3.1.3"
-   }
-   ```
+If `fromVersion` is missing and the current version is visible in context (e.g., from a
+check-deps table), use it. Otherwise ask.
 
-3. Present the results:
+### 2. Discover GitHub repository
 
-   **If changes have release notes (`body`)** — render each version as a section:
-   ```
-   ## io.ktor:ktor-client-core — 2.3.0 → 3.1.3
+Find the GitHub owner/repo for this artifact using one of these strategies in order:
 
-   ### 3.1.3
-   <release notes body>
-   [Release](https://github.com/...)
+**a. Fetch the POM file** to extract the SCM URL:
+```
+https://repo1.maven.org/maven2/{group_path}/{artifactId}/{toVersion}/{artifactId}-{toVersion}.pom
+```
+(Convert groupId dots to slashes for `group_path`.)
 
-   ### 3.1.2
-   <release notes body>
-   ...
-   ```
+Look for `<scm><url>` or `<scm><connection>` in the POM XML. Extract the GitHub owner/repo
+from URLs like `https://github.com/owner/repo` or `scm:git:github.com/owner/repo.git`.
 
-   **If changes exist but have no body** — show versions as a list with links where available:
-   ```
-   ## io.ktor:ktor-client-core — 2.3.0 → 3.1.3
-   Versions in range: 3.1.3, 3.1.2, 3.1.1, 3.1.0, 3.0.3, ...
-   No release notes available. Changelog: <changelogUrl if present>
-   ```
+**b. Guess from groupId** if POM has no SCM info:
+- `io.github.{owner}.*` → `{owner}/{artifactId}`
+- `com.github.{owner}.*` → `{owner}/{artifactId}`
+- `org.{word}.*` → try `{word}/{artifactId}`
 
-   **If many versions in range (>6)** — collapse the middle:
-   > Showing notes for 3.1.3, 3.1.2, 3.1.1 ... (8 more) ... 3.0.0
+**c. Use Maven Central search** as fallback:
+```
+https://search.maven.org/solrsearch/select?q=g:{groupId}+AND+a:{artifactId}&rows=1&wt=json
+```
+The `response.docs[0]` may include a project URL field.
+
+### 3. Determine versions in range
+
+Fetch `maven-metadata.xml` from Maven Central:
+```
+https://repo1.maven.org/maven2/{group_path}/{artifactId}/maven-metadata.xml
+```
+
+Extract all `<version>` entries between `fromVersion` (exclusive) and `toVersion`
+(inclusive), sorted newest-first. If there are more than 20 versions in the range, note
+the count and show only the first and last 5.
+
+### 4. Fetch GitHub release notes
+
+If a GitHub repo was found:
+
+```
+https://api.github.com/repos/{owner}/{repo}/releases?per_page=100
+```
+
+If `GITHUB_TOKEN` is configured in the environment, add header `Authorization: Bearer {token}`
+to raise rate limits. Without a token, GitHub allows 60 unauthenticated requests/hour — this
+call counts as one.
+
+Match each version in the range to GitHub release tags. Common tag patterns:
+`v{version}`, `{version}`, `{artifactId}-{version}`, `release-{version}`.
+
+Collect matching releases and their `body` fields.
+
+### 5. Check for CHANGELOG.md
+
+If the GitHub repo is known, fetch the raw changelog file:
+```
+https://raw.githubusercontent.com/{owner}/{repo}/HEAD/CHANGELOG.md
+```
+(Also try `CHANGELOG.md`, `CHANGES.md`, `HISTORY.md`.)
+
+If found, extract sections for versions in the range. A section header typically looks like
+`## [3.1.3]`, `## 3.1.3`, or `### Version 3.1.3`.
+
+### 6. Present results
+
+**If release notes exist** — render each version as a section:
+```
+## io.ktor:ktor-client-core — 2.3.0 → 3.1.3
+
+### 3.1.3
+<release notes body>
+[Release](https://github.com/...)
+
+### 3.1.2
+<release notes body>
+```
+
+**If no release notes / CHANGELOG found** — show a version list and the project URL:
+```
+## io.ktor:ktor-client-core — 2.3.0 → 3.1.3
+
+Versions in range: 3.1.3, 3.1.2, 3.1.1, 3.1.0 (4 versions)
+No release notes found.
+GitHub: https://github.com/{owner}/{repo}/releases
+Maven: https://search.maven.org/artifact/{groupId}/{artifactId}
+```
+
+**If many versions in range (>6)** — collapse the middle:
+> Showing notes for 3.1.3, 3.1.2, 3.1.1 ... (8 more) ... 3.0.0
 
 ## Error handling
 
-- **`repositoryNotFound: true`** — the tool couldn't locate a GitHub repo or known changelog source. Tell the user: "Couldn't find a changelog for `groupId:artifactId`. You can check the project's GitHub or release page manually." Include the Maven Central artifact URL as a starting point.
-- **`error` field set** — surface the message and suggest checking the groupId/artifactId/version spelling.
-- **`fromVersion` equals `toVersion`** — tell the user the versions are the same, nothing to show.
+- **No GitHub repo found** — tell the user a GitHub repo could not be determined for the
+  artifact, and provide the Maven Central artifact URL as a starting point:
+  `https://search.maven.org/artifact/{groupId}/{artifactId}`
+- **GitHub API rate limited (HTTP 403/429)** — note that the limit is reached and suggest
+  setting `GITHUB_TOKEN` in the environment.
+- **fromVersion equals toVersion** — tell the user the versions are the same, nothing to show.
+- **Artifact not found in Maven Central** — suggest checking spelling.
 
 ## Context: used after check-deps
 
-When the user runs `check-deps` and sees an update table, they may then ask "show me what changed for X" without re-typing the artifact coordinates. In that case, pull `groupId`, `artifactId`, `currentVersion` (→ fromVersion), and the `Latest Stable` column (→ toVersion) from the table in context rather than asking the user to repeat them.
+When the user runs `check-deps` and sees an update table, they may ask "show me what changed
+for X" without re-typing coordinates. Pull `groupId`, `artifactId`, current version
+(→ fromVersion), and latest version (→ toVersion) from the table in context.

--- a/plugins/maven-mcp/plugin/skills/dependency-health/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/dependency-health/SKILL.md
@@ -11,7 +11,8 @@ description: >-
 
 # Dependency Health
 
-Assess the maintenance health of one or more Maven dependencies before adopting them.
+Assess the maintenance health of one or more Maven dependencies by querying Maven Central
+and GitHub directly via HTTP.
 
 ## Arguments
 
@@ -21,51 +22,128 @@ The user provides one or more `groupId:artifactId` coordinates, optionally with 
 
 ## Steps
 
-1. Parse each coordinate into `groupId`, `artifactId`, and optional `version`.
+For each dependency, execute steps 1–5 in parallel where possible.
 
-2. Call the `get_dependency_health` MCP tool (from maven-mcp server) with:
-   ```json
-   {
-     "dependencies": [
-       { "groupId": "...", "artifactId": "...", "version": "..." }
-     ]
-   }
-   ```
-   `version` is optional — omit it to assess the latest available version.
+### 1. Fetch Maven metadata
 
-3. For each result in `results[]`, present the signals in this order:
+Build the group path: replace `.` with `/` in the groupId.
 
-   **Identity & version**
-   - `groupId:artifactId` — `latestVersion` (`stability`)
-   - `versionCount` versions published; last Maven publish: `lastPublishedToMaven`
+Fetch from Maven Central:
+```
+https://repo1.maven.org/maven2/{group_path}/{artifactId}/maven-metadata.xml
+```
 
-   **Repository**
-   - GitHub URL from `repository.url`, or `scm.url` for non-GitHub forges.
-   - If `github` is null and `healthError` is set, note the error briefly and skip the GitHub section.
+For Android/Google artifacts (`androidx.*`, `com.google.android.*`, `com.android.*`,
+`com.google.firebase.*`), also try:
+```
+https://dl.google.com/dl/android/maven2/{group_path}/{artifactId}/maven-metadata.xml
+```
 
-   **Activity** (from `github`)
-   - Stars / forks / archived status
-   - Last commit: `lastCommit` — compute "N months ago" relative to today
-   - Last release: `lastRelease`; release cadence: `releaseCadenceDays` days
-   - License: `license`
+Extract:
+- All `<version>` entries → total version count
+- `<latest>` and `<release>` tags → determine current stable and latest versions
+- `<lastUpdated>` → last publish date (format: `YYYYMMDDHHMMSS`)
 
-   **Issues** (from `github.issues` — may be null if rate-limited)
-   - Open / closed, close ratio, median days to close
-   - If `issues` is null, note that issue stats were unavailable (rate limit or network).
+Classify the latest version for stability (STABLE / RC / BETA / ALPHA) using the same
+rules as the `/latest-version` skill.
 
-   **Signals**
-   - List every entry in `signals[]` as bullet points. These are the pre-computed red flags
-     (archived repo, no stable release, slow issue response, etc.).
+### 2. Fetch POM to find GitHub repo and license
 
-4. Do NOT interpret signals or issue an adopt/reject verdict in this skill. The raw signals
-   are the output. If the user wants an adopt/reject recommendation, suggest calling the
-   `dependency-evaluator` agent with the signals as input.
+Fetch the POM for the latest version:
+```
+https://repo1.maven.org/maven2/{group_path}/{artifactId}/{version}/{artifactId}-{version}.pom
+```
 
-## Error handling
+Extract:
+- `<scm><url>` or `<scm><connection>` → GitHub owner/repo
+- `<licenses><license><name>` → license name
 
-- `healthError` set with `github: null` — no public GitHub repo or rate-limited;
-  present the Maven data that was retrieved and note what is missing.
-- Tool unavailable — stop and tell the user:
+If no SCM URL in POM, guess from groupId:
+- `io.github.{owner}.*` → `github.com/{owner}/{artifactId}`
+- `com.github.{owner}.*` → `github.com/{owner}/{artifactId}`
 
-  > The `get_dependency_health` tool is not available in the current session.
-  > Check that the maven-mcp MCP server is running and registered, then retry.
+### 3. Fetch GitHub repository info
+
+If a GitHub repo was identified:
+
+```
+GET https://api.github.com/repos/{owner}/{repo}
+```
+
+If `GITHUB_TOKEN` is set in the environment, add header `Authorization: Bearer {token}`.
+
+Extract: `stargazers_count`, `forks_count`, `archived`, `pushed_at` (last commit date),
+`license.name` (use this if POM license was missing), `open_issues_count`.
+
+### 4. Fetch recent releases
+
+```
+GET https://api.github.com/repos/{owner}/{repo}/releases?per_page=20
+```
+
+From the releases list:
+- `published_at` of the most recent release → last release date
+- Compute release cadence: median days between the last 5 releases
+
+### 5. Assess issue health (optional — skip if rate-limited)
+
+GitHub's REST API does not expose closed issue counts directly. Use the Search API:
+
+```
+GET https://api.github.com/search/issues?q=repo:{owner}/{repo}+type:issue+state:closed&per_page=1
+```
+
+This returns `total_count` for closed issues. Combine with `open_issues_count` from step 3
+to compute a close ratio. **Note:** This endpoint is heavily rate-limited (30 req/min with
+token, 10 without). If it returns 403/429, skip this step and note issue stats as unavailable.
+
+### 6. Present results
+
+For each dependency, show signals in this order:
+
+**Identity & version**
+```
+## groupId:artifactId
+
+Latest stable: {version} ({stability})
+Versions published: {count}
+Last Maven publish: {date}
+```
+
+**Repository** (if found)
+```
+GitHub: https://github.com/{owner}/{repo}
+License: {license}
+Stars: {stars} | Forks: {forks} | Archived: yes/no
+Last commit: {date} ({N months ago})
+Last release: {date}
+Release cadence: ~{N} days between releases
+```
+
+**Issues** (if available)
+```
+Open issues: {N} | Closed: {M} | Close ratio: {X}%
+```
+
+**Signals** — list any red flags as bullet points:
+- Archived repository — no further development
+- No stable release available
+- Last commit more than 12 months ago
+- Last release more than 18 months ago
+- Release cadence slower than 365 days
+- Close ratio below 50% (more issues open than ever closed)
+- Only 1 version published (may indicate abandoned project)
+
+**No GitHub repo found:**
+- State what Maven data was retrieved
+- Note that GitHub signals are unavailable
+- Provide Maven Central URL: `https://search.maven.org/artifact/{groupId}/{artifactId}`
+
+## Important constraints
+
+- Do NOT issue an adopt/reject verdict — present raw signals only.
+- If the user wants a recommendation, suggest they weigh the signals themselves or use an
+  agent with evaluation criteria.
+- Degrade gracefully: if GitHub is unavailable or rate-limited, present Maven-only data
+  and note what is missing.
+- `GITHUB_TOKEN` in the environment raises the rate limit from 60 to 5000 req/h.

--- a/plugins/maven-mcp/plugin/skills/latest-version/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/latest-version/SKILL.md
@@ -8,7 +8,7 @@ description: >-
 
 # Latest Version
 
-Find the latest version of a specific Maven artifact.
+Find the latest version of a specific Maven artifact by querying Maven Central directly.
 
 ## Arguments
 
@@ -20,18 +20,67 @@ The user provides `groupId:artifactId`, for example:
 ## Steps
 
 1. Parse the user's input to extract `groupId` and `artifactId` (split by `:`).
+   If the input has no `:`, ask the user to provide it in `groupId:artifactId` form.
 
-2. Call the `get_latest_version` MCP tool (from maven-mcp server) with:
-   - `groupId`: extracted group ID
-   - `artifactId`: extracted artifact ID
-   - `stabilityFilter`: `PREFER_STABLE` (default)
+2. Convert `groupId` to a URL path by replacing every `.` with `/`.
+   Example: `io.ktor` → `io/ktor`.
 
-3. Display the result:
-   - Latest stable version
-   - Latest version (if different from stable)
-   - All available versions (abbreviated if more than 10)
+3. Fetch metadata from Maven repositories. Use WebFetch in order:
+
+   **a. Maven Central** (always try first):
+   ```
+   https://repo1.maven.org/maven2/{group_path}/{artifactId}/maven-metadata.xml
+   ```
+
+   **b. Google Maven** (try if the artifact looks Android-related — `groupId` starts with
+   `androidx.`, `com.google.android.`, `com.android.`, `com.google.firebase.`,
+   `com.google.gms.`, `com.google.mlkit.`):
+   ```
+   https://dl.google.com/dl/android/maven2/{group_path}/{artifactId}/maven-metadata.xml
+   ```
+
+   **c. Gradle Plugin Portal** (try if `artifactId` ends with `.gradle.plugin` or the
+   groupId matches known Gradle plugin patterns):
+   ```
+   https://plugins.gradle.org/m2/{group_path}/{artifactId}/maven-metadata.xml
+   ```
+
+4. From the XML response, extract all `<version>` entries inside `<versions>`.
+   Also note `<latest>` and `<release>` tags if present.
+
+5. Classify each version for stability:
+   - **STABLE** — no pre-release suffix (no alpha/beta/rc/dev/snapshot/milestone/preview,
+     case-insensitive)
+   - **RC** — contains `-rc`, `-RC`, `-RC.`, `-rc.`
+   - **BETA** — contains `-beta`, `-Beta`, `-b`
+   - **ALPHA** — contains `-alpha`, `-Alpha`, `-dev`, `-Dev`, `-SNAPSHOT`, `-snapshot`,
+     `-milestone`, `-M`, `-preview`, `-Preview`, `-eap`, `-EAP`
+
+6. Determine the latest versions to display:
+   - **Latest stable** — highest stable version (by semantic version ordering).
+     If no stable versions exist, note that.
+   - **Latest overall** — highest version across all stability levels (if different from
+     stable, show it too).
+
+7. Display the result:
+
+   ```
+   ## io.ktor:ktor-client-core
+
+   Latest stable:  3.1.3
+   Latest overall: 3.1.3
+
+   Recent versions: 3.1.3, 3.1.2, 3.1.1, 3.1.0, 3.0.3 ... (N total)
+   ```
+
+   If stable and overall are the same, show only "Latest: X".
+   If there are more than 10 versions total, show the 5 most recent and note "(N total)".
 
 ## Error Handling
 
-- If the artifact is not found, suggest checking the groupId and artifactId spelling.
-- If the format is wrong (no `:`), ask the user to provide `groupId:artifactId`.
+- If all repository fetches return 404 or fail, tell the user the artifact was not found
+  and suggest checking the `groupId` and `artifactId` spelling.
+- If only Google Maven succeeds (404 on Maven Central), present that result and note the
+  source.
+- If the XML response is empty or malformed, note the parse failure and surface the raw URL
+  so the user can check manually.


### PR DESCRIPTION
Closing in favour of a Python3 stdlib MCP server bundled with the plugin — no npm, no pip, works everywhere.