### PR TITLE
chore(release): remove npm publish, update release docs for Python server

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: NPM Publishing
     defaults:
       run:
         working-directory: plugins/maven-mcp
@@ -24,7 +23,6 @@ jobs:
           node-version: 22
           cache: npm
           cache-dependency-path: plugins/maven-mcp/package-lock.json
-          registry-url: https://registry.npmjs.org
 
       - name: Verify all versions match tag
         working-directory: .
@@ -34,20 +32,6 @@ jobs:
       - run: npm run lint
       - run: npm test
       - run: npm run build
-
-      - name: Publish to npm (idempotent)
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          TAG: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-          VERSION="${TAG#v}"
-          PKG=$(node -p "require('./package.json').name")
-          if npm view "${PKG}@${VERSION}" version >/dev/null 2>&1; then
-            echo "Version ${PKG}@${VERSION} already on npm — skipping publish."
-          else
-            npm publish --access public
-          fi
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,18 +44,17 @@ Always work on changes in a separate branch using a worktree (`.worktrees/`). Cr
 
 ## Publishing
 
-**Never run `npm publish` locally.** Publishing happens exclusively via GitHub Actions.
-
 All plugins use **unified versioning** — every release bumps all plugins to the same version.
 
 To release a new version:
-1. Bump `version` in all of these files to the new version:
-   - `plugins/maven-mcp/package.json`
+1. Bump `version` in both of these files to the new version:
    - `plugins/maven-mcp/plugin/.claude-plugin/plugin.json`
    - `.claude-plugin/marketplace.json`
 2. Merge to `main`.
 3. Push a git tag matching the version: `git tag v0.9.0 && git push origin v0.9.0`.
-4. GitHub Actions (`.github/workflows/release.yml`) triggers on `v*` tags: verifies all versions match, runs lint/tests/build, publishes to npm, **then creates one per-plugin tag `{plugin-name}--v{version}` for each plugin in `marketplace.json`**. These per-plugin tags are what Claude Code uses to resolve `dependencies` semver ranges.
+4. GitHub Actions (`.github/workflows/release.yml`) triggers on `v*` tags: verifies all versions match, runs lint/tests/build, **then creates one per-plugin tag `{plugin-name}--v{version}` for each plugin in `marketplace.json`**. These per-plugin tags are what Claude Code uses to resolve `dependencies` semver ranges.
+
+Note: `plugins/maven-mcp/package.json` is the TypeScript source package used for development (tests, lint, build) but is **not published to npm** and its version does not need to match the release tag.
 
 ## Worktrees
 

--- a/plugins/maven-mcp/CLAUDE.md
+++ b/plugins/maven-mcp/CLAUDE.md
@@ -10,9 +10,13 @@ Rules that are not open for discussion. Violating these is an error, not a judgm
 
 ## Project
 
-MCP server for Maven dependency intelligence. Provides tools to query artifact versions from Maven repositories (Maven Central, Google Maven, custom repos). Distributed as npm package, runs via `npx @krozov/maven-central-mcp`.
+MCP server for Maven dependency intelligence. Provides tools to query artifact versions from Maven repositories (Maven Central, Google Maven, custom repos).
 
-**Stack:** TypeScript, Node.js, `@modelcontextprotocol/sdk`, `zod/v4`, `vitest`
+**Plugin runtime:** `plugin/server/server.py` — a bundled Python 3 server (stdlib only, zero pip dependencies). Registered via `plugin/.claude-plugin/plugin.json` as `command: python3`. Works in Claude cloud and local environments without Node.js or npm.
+
+**TypeScript source** (`src/`): reference implementation and test suite. Used for development (lint, test, build) but not distributed or required at runtime.
+
+**Stack (TypeScript dev):** TypeScript, Node.js, `@modelcontextprotocol/sdk`, `zod/v4`, `vitest`
 
 ## Commands
 

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -154,17 +154,6 @@ check_tag_versions() {
     return
   fi
 
-  # maven-mcp: also check package.json (npm package)
-  PKG_JSON="plugins/maven-mcp/package.json"
-  if [ -f "$PKG_JSON" ]; then
-    pkg_version=$(jq -r '.version' "$PKG_JSON")
-    if [ "$pkg_version" != "$version" ]; then
-      fail "$PKG_JSON version \"$pkg_version\" does not match tag v${version}"
-    else
-      ok "$PKG_JSON version $pkg_version"
-    fi
-  fi
-
   # All plugin.json files — data-driven from marketplace.json
   while IFS=$'\t' read -r name source; do
     plugin_json="${source}/.claude-plugin/plugin.json"


### PR DESCRIPTION
## Summary

Follow-up to the Python server migration. The plugin no longer distributes via npm, so the release pipeline is simplified accordingly.

- **`release.yml`**: remove the `npm publish` step and the `NPM Publishing` environment; Node.js is still used to run TypeScript tests/lint/build
- **`scripts/validate.sh`**: remove the `package.json` version check from `--check-tag` — `package.json` is now a dev artifact, not a versioned release output
- **`CLAUDE.md`**: update Publishing section — only two files need version bumps at release time (`plugin.json` + `marketplace.json`); add a note that `package.json` is dev-only
- **`plugins/maven-mcp/CLAUDE.md`**: update Project section to describe the bundled Python3 server as the plugin runtime and TypeScript source as the dev/reference implementation

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJuw5e6dDEEMJLRsDZhgTS)_