### PR TITLE
Add routing disambiguator to dependency-health skill

### DIFF
--- a/plugins/maven-mcp/plugin/skills/dependency-health/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/dependency-health/SKILL.md
@@ -7,6 +7,8 @@ description: >-
   "dependency maintenance", "license of library", or when the dependency-evaluator
   agent needs raw maintenance signals for a library. Fetches latest version,
   stability, GitHub activity, issue dynamics, license, and archived status.
+  Do NOT use for: an adopt/avoid recommendation or new-dependency vetting (use
+  evaluate-dependency, which calls this skill for signals).
 ---
 
 # Dependency Health


### PR DESCRIPTION
Adds a `Do NOT use for` clause to the `dependency-health` SKILL.md description so adopt/avoid and new-dependency vetting questions route to `evaluate-dependency` (the verdict skill) instead of the lower-level raw-signal fetcher.

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYHYvucdrxsQ5Q9DesazRQ