### PR TITLE
Verify bundled server version in validate.sh --check-tag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Rules that are not open for discussion. Violating these is an error, not a judgment call.
 
 - **Never run `npm publish` locally.** Publishing is exclusively via GitHub Actions — prevents partial releases and version skew.
-- **All 3 version locations must stay in sync.** A version bump touches `plugin.json`, `package.json`, and `marketplace.json` simultaneously — see Publishing for the list.
+- **All 3 version locations must stay in sync.** A version bump touches `plugin.json`, `marketplace.json`, and the bundled server `server.py` (`SERVER_VERSION` + `USER_AGENT`) simultaneously — see Publishing for the list. (`package.json` is dev-only and intentionally excluded — see the Publishing note.)
 - **Critical or Major violations of PLUGIN-STANDARDS.md block the release.** Fix first, release later.
 - **All extension content is written in English.** Skills (`SKILL.md`, references, evals), agents (`agents/*.md`), hooks, MCP servers, plugin manifests (`plugin.json`, `marketplace.json`), and any prompt/instruction text shipped inside `plugins/` must be in English. User-facing chat in any language is fine; the shipped extension content itself targets an international audience and must not contain non-English prose. Code identifiers and external API field names keep their original form regardless of language. **Excluded:** repository documentation under `docs/` and top-level `README.md` — these are maintainer-facing and may be in any language. Do not "fix" them to English.
 
@@ -47,9 +47,10 @@ Always work on changes in a separate branch using a worktree (`.worktrees/`). Cr
 All plugins use **unified versioning** — every release bumps all plugins to the same version.
 
 To release a new version:
-1. Bump `version` in both of these files to the new version:
-   - `plugins/maven-mcp/plugin/.claude-plugin/plugin.json`
-   - `.claude-plugin/marketplace.json`
+1. Bump the version in all three of these locations to the new version:
+   - `plugins/maven-mcp/plugin/.claude-plugin/plugin.json` (`version`)
+   - `.claude-plugin/marketplace.json` (`version`)
+   - `plugins/maven-mcp/plugin/server/server.py` (`SERVER_VERSION` and `USER_AGENT`)
 2. Merge to `main`.
 3. Push a git tag matching the version: `git tag v0.9.0 && git push origin v0.9.0`.
 4. GitHub Actions (`.github/workflows/release.yml`) triggers on `v*` tags: verifies all versions match, runs lint/tests/build, **then creates one per-plugin tag `{plugin-name}--v{version}` for each plugin in `marketplace.json`**. These per-plugin tags are what Claude Code uses to resolve `dependencies` semver ranges.

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -177,6 +177,39 @@ check_tag_versions() {
       ok "marketplace.json '$name' version $mkt_version"
     fi
   done < <(jq -r '.plugins[] | [.name, .version] | @tsv' "$MARKETPLACE")
+
+  # Bundled MCP server scripts — version constants must track the tag.
+  # The script path is derived from each plugin.json mcpServers entry
+  # (${CLAUDE_PLUGIN_ROOT} resolves to the plugin source dir). This is the
+  # runtime that actually ships, so a stale SERVER_VERSION/USER_AGENT here is
+  # silent version skew that the manifest checks above cannot catch.
+  while IFS=$'\t' read -r name source; do
+    plugin_json="${source}/.claude-plugin/plugin.json"
+    [ -f "$plugin_json" ] || continue
+    while IFS= read -r arg; do
+      [ -n "$arg" ] || continue
+      script=$(printf '%s' "$arg" | sed "s|\${CLAUDE_PLUGIN_ROOT}|${source}|g")
+      [ -f "$script" ] || continue
+      found=0
+      while IFS= read -r sver; do
+        found=1
+        if [ "$sver" != "$version" ]; then
+          fail "'$name' $script version constant \"$sver\" does not match tag v${version}"
+        else
+          ok "'$name' $script version constant $sver"
+        fi
+      done < <(grep -oE '(SERVER_VERSION|USER_AGENT)[[:space:]]*=[[:space:]]*"[^"]*"' "$script" \
+                 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+      if [ "$found" -eq 0 ]; then
+        fail "'$name' $script has no SERVER_VERSION/USER_AGENT version constant to verify against tag v${version}"
+      fi
+    done < <(jq -r '
+      .mcpServers // {}
+      | to_entries[]
+      | select(.value.command | test("^python"))
+      | .value.args[]? | select(test("\\.py$"))
+    ' "$plugin_json")
+  done < <(jq -r '.plugins[] | [.name, .source] | @tsv' "$MARKETPLACE")
 }
 
 # ---------- L5: plugin.json component paths ----------


### PR DESCRIPTION
Closes #250

## Re-scope (read first)

#250 was filed 2026-05-31, before the maven-mcp Python-server migration (#302) and the removal of `npm publish` (#303). Re-scoped against current reality:

**Both literal #250 concerns are now obsolete — dropped, not implemented:**
- **(a) npx pin `@krozov/maven-central-mcp@^0.22.0` in `plugin.json` mcpServers args** — gone. The plugin now registers `command: python3`, `args: ["${CLAUDE_PLUGIN_ROOT}/server/server.py"]`. No version travels in the args anymore.
- **(b) five `^0.22.0` ranges in cross-plugin `dependencies[].version`** — gone. There is one plugin and no `dependencies` field in either `plugin.json` or `marketplace.json`.

**The skew class #250 describes is real but relocated.** The migration introduced a genuinely new runtime version-bearing location: `plugins/maven-mcp/plugin/server/server.py` carrying `SERVER_VERSION` and `USER_AGENT`. This is the server that actually ships and runs. A forgotten bump there ships a stale server while `validate.sh --check-tag` (the sole release gate in `release.yml`) stays green — exactly the silent skew the "all versions in sync" Non-negotiable claims to prevent.

A broad sweep of the shipped plugin dir (`grep -rnE '0\.[0-9]+\.[0-9]+|maven-central-mcp@' plugins/maven-mcp/plugin/`) confirms the only version-bearing shipped locations are `plugin.json`, `marketplace.json`, and `server.py` — no stale install snippets remain in skills/docs.

## Authoritative version locations (must track the release tag)

1. `.claude-plugin/marketplace.json` → `.plugins[].version` — already checked
2. `plugins/maven-mcp/plugin/.claude-plugin/plugin.json` → `.version` — already checked
3. `plugins/maven-mcp/plugin/server/server.py` → `SERVER_VERSION` + `USER_AGENT` — **the gap, now checked**

Excluded: `plugins/maven-mcp/package.json` (dev-only, not published — per the Publishing note).

## Changes

- **`scripts/validate.sh`** — in the `--check-tag` path, derive the server-script path data-driven from each `plugin.json` `mcpServers` entry (`${CLAUDE_PLUGIN_ROOT}` → plugin source) and assert every semver embedded in `SERVER_VERSION`/`USER_AGENT` equals the tag. Fails closed if a referenced python server has no recognizable version constant.
- **`CLAUDE.md`** — reconciled a documentation contradiction #250's Fix called out: the "3 version locations" Non-negotiable listed `package.json` (which Publishing excludes) and omitted `server.py`. Now: `{plugin.json, marketplace.json, server.py}`. Added `server.py` to the Publishing bump list.

## Verification (red-green)

```
$ bash scripts/validate.sh --check-tag 0.23.0          # baseline, clean
... OK: 'maven-mcp' .../server/server.py version constant 0.23.0   (x2)
=== All checks passed ===                              # EXIT 0

# inject skew: SERVER_VERSION = "0.24.0"
$ bash scripts/validate.sh --check-tag 0.23.0
ERROR: 'maven-mcp' .../server/server.py version constant "0.24.0" does not match tag v0.23.0
=== 1 error(s) found ===                               # EXIT 1

# revert
$ bash scripts/validate.sh --check-tag 0.23.0          # EXIT 0
```

`shellcheck scripts/validate.sh` clean; `bash -n` OK.

## Scope notes

- Tag-only check (not the always-on `check_version_consistency`): the release gate is `--check-tag`, so this catches the release-time skew #250 is about. Kept minimal.
- No runtime behaviour of the plugin changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MYHYvucdrxsQ5Q9DesazRQ