### PR TITLE
Add Python test suite + CI for maven-mcp (Python source-of-truth, PR A)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+# Least-privilege default for all jobs: they only read the repo (checkout +
+# build/test). No job writes contents, comments, or other resources.
+permissions:
+  contents: read
+
 jobs:
   validate-marketplace:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,60 @@ jobs:
       - if: steps.changes.outputs.maven_mcp == 'true'
         working-directory: plugins/maven-mcp
         run: npm run build
+
+  # Like build, this job is meant to become a required status check
+  # (python-tests (3.9), python-tests (3.13)). It must always run and report -
+  # so the JOB runs unconditionally and only the heavy STEPS are gated by the
+  # same path diff used by build. A job-level if:/paths skip would leave the
+  # required check "expected" forever and block merges.
+  python-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.13"]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect maven-mcp changes
+        id: changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "Push event - run all steps."
+            echo "maven_mcp=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Pull request: three-dot diff (merge-base..head) so we see only
+          # commits introduced by the PR, not unrelated changes that landed
+          # on main between fork-point and head.
+          CHANGED=$(git diff --name-only "$BASE_SHA...$HEAD_SHA" -- \
+            'plugins/maven-mcp/**' '.github/workflows/ci.yml')
+          if [ -n "$CHANGED" ]; then
+            echo "maven-mcp changed:"
+            echo "$CHANGED"
+            echo "maven_mcp=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No maven-mcp changes - skipping test steps."
+            echo "maven_mcp=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Setup Python ${{ matrix.python-version }}
+        if: steps.changes.outputs.maven_mcp == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - if: steps.changes.outputs.maven_mcp == 'true'
+        run: python3 -m unittest discover -s plugins/maven-mcp/tests -v
+
+      # Zero-dependency static gate (replaces the eslint gate the node build
+      # job provides; the node job is removed in PR B).
+      - if: steps.changes.outputs.maven_mcp == 'true'
+        run: python -m compileall plugins/maven-mcp/plugin/server

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ dist/
 .worktrees/
 *.tgz
 
+# Python
+__pycache__/
+*.pyc
+
 .DS_Store
 .claire/
 .remember/

--- a/docs/plans/maven-python-migration/coverage-map.md
+++ b/docs/plans/maven-python-migration/coverage-map.md
@@ -1,0 +1,151 @@
+# Coverage Map — TS test suite → Python parity (T-8)
+
+Maps each of the **47** TypeScript test files under `plugins/maven-mcp/src/**/__tests__/`
+to the shipped Python runtime (`plugin/server/server.py`) and its 6 test modules
+(`tests/test_{version,parsers,github,maven_search_osv,handlers,http}.py`).
+
+**This behavioral map is the AUTHORITATIVE parity bar.** It records what the Python
+suite actually asserts. `python3 -m trace --count` (see *Untested server.py functions*)
+is a **backstop only** — it proves a function executed, never that behavior was asserted.
+
+## The four buckets
+
+- **ported → `<py file>`** — the file's behavior is reproduced and asserted by the named Python module(s).
+- **partial → `<py file>` + `<diverged sub-cases → #n>`** — the core behavior is ported, but a specific sub-feature diverged (tracked as follow-up #n).
+- **diverged → `#n`** — the behavior does not exist in the shipped Python runtime; tracked as follow-up #n. Pre-existing gap from the #302 Python port — **not** a regression introduced here.
+- **N/A → `<reason>`** — intentionally not ported; no follow-up needed.
+
+**Follow-up divergences** (TS had it, shipped Python does not — all pre-existing #302 gaps):
+- **#1** HTTP retry/backoff (feature gap)
+- **#2** persistent file cache (feature gap)
+- **#3** AGP/AndroidX release-notes changelog providers + html-to-text + github CHANGELOG.md markdown fallback + `changelog/resolver` provider-selection — server.py has no agp/androidx/html parser and `_get_dependency_changes_impl` is GitHub-releases-only (feature gap)
+- **#4** HTTP/SSE transport — server.py is stdio-only (feature gap)
+- **#5** custom-repository discovery — **CORRECTNESS** regression (silently wrong version answers for projects with custom repos)
+- **#6** `resolveAll` parallel-merge vs first-hit — **CORRECTNESS** regression (multi-repo artifacts: first-hit drops versions present only in a later repo)
+
+## Map
+
+### version/ (3) — all ported
+| TS test file | Bucket | Python |
+|---|---|---|
+| `version/classify.test.ts` | ported | `test_version.py` (ClassifyVersion, FindLatestVersionForCurrent) |
+| `version/compare.test.ts` | ported | `test_version.py` (CompareVersions, GetUpgradeType) |
+| `version/range.test.ts` | ported | `test_version.py` (FilterVersionRange); also `test_github.py` (FilterVersionRange) |
+
+### dependencies/ (8) — all ported
+| TS test file | Bucket | Python |
+|---|---|---|
+| `dependencies/gradle-deps-parser.test.ts` | ported | `test_parsers.py` (TestParseGradleDeps) |
+| `dependencies/maven-deps-parser.test.ts` | ported | `test_parsers.py` (TestParseMavenDeps) |
+| `dependencies/maven-modules-parser.test.ts` | ported | `test_parsers.py` (TestParseMavenModules) |
+| `dependencies/plugins-block-parser.test.ts` | ported | `test_parsers.py` (TestParseGradlePluginsBlock) |
+| `dependencies/settings-catalogs-parser.test.ts` | ported | `test_parsers.py` (TestParseSettingsCatalogs) |
+| `dependencies/settings-gradle-parser.test.ts` | ported | `test_parsers.py` (TestParseSettingsModules) |
+| `dependencies/toml-parser.test.ts` | ported | `test_parsers.py` (TestParseTomlCatalog) |
+| `dependencies/scan.test.ts` | ported | `test_parsers.py` (TestDetectBuildSystem) + `test_handlers.py` (TestScanProjectDependencies) |
+
+### github/ (6) — 5 ported, 1 diverged
+| TS test file | Bucket | Python |
+|---|---|---|
+| `github/github-client.test.ts` | ported | `test_github.py` (GhRepoExists, GhFetchRepo, GhFetchReleases, GhFetchUser, GhFetchIssueStats, GitHubAuthHeader) |
+| `github/discover-repo.test.ts` | ported | `test_github.py` (DiscoverGithubRepo) |
+| `github/guess-repo.test.ts` | ported | `test_github.py` (DiscoverGithubRepo — falls-back-to-guess cases) |
+| `github/pom-scm.test.ts` | ported | `test_github.py` (DiscoverGithubRepo — returns-repo-from-pom-scm) |
+| `github/tag-matcher.test.ts` | ported | `test_github.py` (TagNormalization + DependencyChangesImpl tag-normalization) |
+| `github/changelog-parser.test.ts` | diverged → #3 | CHANGELOG.md markdown parser (`parseChangelogSections`) has no server.py equivalent; the Python github path uses release bodies only |
+
+### changelog/ (4) — 1 ported, 1 partial, 2 diverged
+| TS test file | Bucket | Python |
+|---|---|---|
+| `changelog/github-provider.test.ts` | ported | `test_github.py` (DependencyChangesImpl) + `test_handlers.py` (TestGetDependencyChanges) — github releases path |
+| `changelog/resolver.test.ts` | partial → `test_github.py` + provider-selection diverged → #3 | github branch ported; agp-vs-androidx-vs-github provider selection not in server.py |
+| `changelog/agp-provider.test.ts` | diverged → #3 | no AGP changelog provider in server.py |
+| `changelog/androidx-provider.test.ts` | diverged → #3 | no AndroidX changelog provider in server.py |
+
+### agp/ + androidx/ + html/ (5) — all diverged → #3
+| TS test file | Bucket | Python |
+|---|---|---|
+| `agp/release-notes-parser.test.ts` | diverged → #3 | no AGP release-notes parser in server.py |
+| `agp/url.test.ts` | diverged → #3 | no AGP URL mapping in server.py |
+| `androidx/release-notes-parser.test.ts` | diverged → #3 | no AndroidX release-notes parser in server.py |
+| `androidx/url.test.ts` | diverged → #3 | no AndroidX URL mapping in server.py |
+| `html/to-text.test.ts` | diverged → #3 | no htmlToText util in server.py (only used by agp/androidx providers) |
+
+### maven/ + search/ + vulnerabilities/ (4) — 3 ported, 1 partial
+| TS test file | Bucket | Python |
+|---|---|---|
+| `maven/repository.test.ts` | ported | `test_maven_search_osv.py` (TestReposFor + metadata/pom URL construction) |
+| `maven/resolver.test.ts` | partial → `test_maven_search_osv.py` + resolveAll-merge diverged → #6 | first-hit `fetch_metadata` exercised (incl. `test_first_hit_not_resolveall_merge`); parallel merge-across-repos semantics not ported |
+| `search/maven-search.test.ts` | ported | `test_maven_search_osv.py` (TestSearchMavenCentral) |
+| `vulnerabilities/osv-client.test.ts` | ported | `test_maven_search_osv.py` (TestQueryOsvBatch) |
+
+### http/ (1) — partial
+| TS test file | Bucket | Python |
+|---|---|---|
+| `http/client.test.ts` | partial → `test_http.py` + retry diverged → #1 | GET/POST + header builders ported (HttpGet, HttpPostJson, MakeHeaders, GithubHeaders); retry/backoff not in server.py |
+
+### cache/ (1) — diverged → #2
+| TS test file | Bucket | Python |
+|---|---|---|
+| `cache/file-cache.test.ts` | diverged → #2 | no persistent file cache in server.py (in-memory memoization only) |
+
+### discovery/ (3) — all diverged → #5
+| TS test file | Bucket | Python |
+|---|---|---|
+| `discovery/discover.test.ts` | diverged → #5 | server.py `_repos_for` is static group-prefix routing; no build-file custom-repo discovery |
+| `discovery/gradle-parser.test.ts` | diverged → #5 | no `maven {}` / `maven("url")` parsing in server.py |
+| `discovery/maven-parser.test.ts` | diverged → #5 | no `<repositories>` parsing in server.py |
+
+### tools/ (10) — all ported (`test_handlers.py`)
+| TS test file | Bucket | Python |
+|---|---|---|
+| `tools/get-latest-version.test.ts` | ported | `test_handlers.py` (TestGetLatestVersion) |
+| `tools/check-version-exists.test.ts` | ported | `test_handlers.py` (TestCheckVersionExists) |
+| `tools/check-multiple-dependencies.test.ts` | ported | `test_handlers.py` (TestCheckMultipleDependencies) |
+| `tools/compare-dependency-versions.test.ts` | ported | `test_handlers.py` (TestCompareDependencyVersions — incl. #263 regression) |
+| `tools/get-dependency-changes.test.ts` | ported | `test_handlers.py` (TestGetDependencyChanges) |
+| `tools/scan-project-dependencies.test.ts` | ported | `test_handlers.py` (TestScanProjectDependencies) |
+| `tools/get-dependency-vulnerabilities.test.ts` | ported | `test_handlers.py` (TestGetDependencyVulnerabilities) |
+| `tools/get-dependency-health.test.ts` | ported | `test_handlers.py` (TestGetDependencyHealth + TestDependencyHealthHelpers) |
+| `tools/search-artifacts.test.ts` | ported | `test_handlers.py` (TestSearchArtifacts) |
+| `tools/audit-project-dependencies.test.ts` | ported | `test_handlers.py` (TestAuditProjectDependencies) |
+
+### cli/ + project/ (2) — N/A
+| TS test file | Bucket | Reason |
+|---|---|---|
+| `cli/parse-port.test.ts` | N/A | stdio-only server — no `--port` / HTTP transport to parse |
+| `project/find-project-root.test.ts` | N/A | cwd-based — Python `scan_project` takes an explicit path (`projectPath or os.getcwd()`); no upward root-walk |
+
+## Tally
+
+| Bucket | Count |
+|---|---|
+| ported | 30 |
+| partial | 3 |
+| diverged | 12 |
+| N/A | 2 |
+| **Total** | **47** |
+
+partial files = `http/client.test.ts` (#1), `maven/resolver.test.ts` (#6), `changelog/resolver.test.ts` (#3) — the three required boundary files.
+
+## Untested server.py functions (trace backstop)
+
+Backstop: `python3 -m trace --count -C /tmp/cov --module unittest discover -s plugins/maven-mcp/tests`
+(the plan's literal `-m unittest` misparses — trace's `-m` is `--missing`, not module; `--module` is the correct flag). Zero-hit functions were derived by mapping the executed lines in `/tmp/cov/server.cover` onto each `def`'s body (excluding the signature line, which always shows count 1 from import-time definition).
+
+86 functions total; **8** have no executed body line:
+
+| Function (line) | Justification |
+|---|---|
+| `_handle_initialize` (:1805) | stdio JSON-RPC transport — exercised by the L5 stdio smoke (T-17, subprocess, not in-process trace), not unit tests. Belongs to divergence #4 scope (transport). |
+| `_handle_tools_list` (:1817) | transport — same as above. |
+| `_handle_tools_call` (:1825) | transport — same as above. |
+| `_handle_ping` (:1853) | transport — same as above. |
+| `dispatch` (:1857) | transport router — same as above. |
+| `main` (:1882) | stdin read loop — same as above. |
+| `_write_response` (:1800) | transport output helper, only called by the `_handle_*`/`dispatch` path above. |
+| `_is_excluded_path` (:756) | **dead code** — no caller anywhere in server.py (path exclusion in `scan_project` is implemented inline). Unused artifact of the #302 port; safe to drop in a later cleanup, out of scope here. |
+
+All 10 `handle_*` tool entrypoints and every pure/IO helper on the live request paths are exercised; the only gaps are the stdio transport layer (covered by the L5 smoke, divergence #4) and one dead helper.
+
+> Runtime note (not addressed here): `server.py:513` (`_months_since`) uses `datetime.utcnow()`, which emits a `DeprecationWarning` on Python 3.12+. This is runtime code and is out of scope for the test-migration work.

--- a/docs/plans/maven-python-migration/plan.md
+++ b/docs/plans/maven-python-migration/plan.md
@@ -1,0 +1,120 @@
+---
+type: plan
+slug: maven-python-migration
+date: 2026-06-29
+status: approved
+spec: none
+risk_areas: [data-migration]
+review_verdict: conditional
+review_blockers: []
+review_note: "2 cycles (architecture/devops/pr-test-analyzer). Cycle 1 FAIL → cycle 2 CONDITIONAL, all major/minor improvements folded in (6 divergences incl. 2 correctness regressions, release.yml/codeql/pr-template scope, ruleset two-step, coverage-map partial bucket). No remaining blockers."
+---
+
+# Plan: maven-mcp — Python as the single source of truth
+
+> Built on current `main` (includes #303 npm-publish removal, #304 routing, #305 server.py version-sync in `validate.sh --check-tag`). Branch `chore/maven-python-tests` is rebased onto it.
+
+## Context & Decision
+
+The shipped maven-mcp runtime is `plugins/maven-mcp/plugin/server/server.py` (Python 3, stdio-only, stdlib-only, 1910 lines) — but it has **zero automated tests**. The TypeScript `plugins/maven-mcp/src/` is fully tested (407 vitest cases / 47 files) yet is **not shipped** (reference only). The two implementations have diverged (e.g. `compare_dependency_versions` no-match: server.py handles it cleanly, TS has the issue #263 non-null-assertion bug). The user has decided: **Python is the source of truth.** This plan makes server.py the only implementation with real coverage, then retires the TS reference. It is a two-PR migration (PR A: Python tests + CI; PR B: remove TS + fix all TS-coupled pipelines) — the HOW of an already-decided change.
+
+## Technical Approach
+
+**Test framework: Python stdlib `unittest`** (no pip dependency). Tests live dev-only at `plugins/maven-mcp/tests/`, import `server` via a `sys.path` shim that resolves `plugin/server/` from `__file__` (not cwd) in a shared `tests/_helpers.py`. Run with `python3 -m unittest discover -s plugins/maven-mcp/tests`. `import server` is safe (tail `if __name__ == "__main__": main()` guard, verified :1908). Preserves the zero-runtime-dependency ethos; no install step in CI.
+
+**Network seam = `urllib.request.urlopen`** (server.py calls it as a module attribute at :92/:105 — verified, so `unittest.mock.patch("urllib.request.urlopen", ...)` is the correct target). server.py uses `with urllib.request.urlopen(...) as resp: resp.status / resp.read()` and maps `urllib.error.HTTPError → (code, b"")`. The `_helpers.mock_urlopen(responses)` helper therefore MUST return a **context-manager** object exposing `.status` + `.read()`, support a **sequence** of responses, and provide a helper to raise a correctly-constructed `HTTPError(url, code, msg, hdrs, fp)`. **Filesystem seam** (project scanning): tests write real build files into `tempfile.TemporaryDirectory()` and call `scan_project(path)` — exercises `_detect_build_system` + parsers end-to-end (better than patching `open`).
+
+**Testable surface in server.py (verified by direct `def` inventory — corrected from the first draft):**
+- Pure / parsing: `classify_version` (:204), `compare_versions` (:244), `_parse_segments`, `_extract_prerelease_numbers`, `_parse_metadata_xml` (:139), `_parse_toml_catalog` (:777), `_parse_gradle_deps` (:857), **`_parse_gradle_plugins_block` (:891 — TS plugins-block parser is 22 cases, the single largest parser test)**, `_parse_buildscript_classpath` (:910), `_parse_settings_modules` (:922), `_parse_settings_catalogs` (:930), `_parse_maven_deps` (:944), `_parse_maven_modules` (:965), `_detect_build_system` (:972), `_module_path_to_dir` (:1005), `scan_project` (:1011), `group_path`/`_metadata_url`/`_pom_url`/`_repos_for` (incl. the AndroidX/Google prefix routing constant at :30).
+- Network (mock urlopen): `http_get`/`http_post_json` (:88/:98), `fetch_metadata` (:154), `check_version_in_repos` (:170), `fetch_pom` (:187), `search_maven_central` (:731), `gh_*` (:422+), `discover_github_repo` (:557), OSV batch query, `_get_dependency_changes_impl` (:585, **GitHub-releases-only**) + `_filter_version_range` (:574) + tag normalization.
+- Handlers (mock urlopen + tempfile): all 10 `handle_*` (:1229–:1493), incl. the **#263 regression** for `handle_compare_dependency_versions` (:1293, guard at :1299).
+
+**Parity is auditable, not by count.** PR A produces a required **coverage-map deliverable** (`docs/plans/maven-python-migration/coverage-map.md`): each of the 47 TS test files → one of FOUR buckets `{ported → <py file>, partial → <py file> + <diverged sub-cases → issue #>, diverged → <follow-up issue #>, N/A → <reason>}`. The `partial` bucket is mandatory for files where only some cases port — `http/client.test.ts` (GET/POST ported, retry diverged #1), `maven/resolver.test.ts` (symbol exercised but first-hit vs merge semantics diverged #6), `changelog/resolver.test.ts` (github branch ported, provider-selection diverged #3) — so coverage cannot leak silently at the divergence boundaries. The **behavioral coverage-map is the authoritative parity bar**; `python3 -m trace --count` over server.py is a *backstop* only (it proves a function was executed, not asserted) — derive zero-hit functions by mapping the `.cover` hit-lines onto the `def`-line inventory, and justify any unexercised function in the map. This makes parity falsifiable before PR B deletes the baseline.
+
+**Confirmed divergences — TS had it, the shipped Python runtime does NOT. All are PRE-EXISTING gaps from the #302 Python port (grep/source-verified), NOT regressions this plan introduces. Per "test actual behavior + file follow-ups", each gets a tracked issue; none is fixed here. Two (#5, #6) are CORRECTNESS regressions (wrong answers), not mere feature gaps — flagged at higher priority and cross-linked to epic #293:**
+1. **HTTP retry/backoff** — TS `fetchWithRetry` retries 5xx/429; Python does a single `urlopen`. (9 TS cases) — feature gap.
+2. **Persistent file cache** — TS `file-cache` `~/.cache/...`; Python has only in-memory per-call memoization (`metadata_cache` :1526). The `plugin/CLAUDE.md` "Persistent cache" line is stale → corrected in PR B. (17 TS cases) — feature gap.
+3. **AGP/AndroidX release-notes changelog providers + html-to-text + changelog/resolver provider-selection** — server.py has NO agp/androidx/html parser (`def` inventory = 0); `_get_dependency_changes_impl` (:585) is GitHub-releases-only and does NOT do the agp-vs-androidx-vs-github provider selection TS `changelog/resolver` tests. (TS `agp/` 15 + `androidx/` 17 + `html/` 7 + `changelog` resolver+providers ≈ 58 cases — largest divergence.) Note: AndroidX *version-metadata routing* IS present (:30 → `_repos_for`) and is tested under T-3/T-5. — feature gap.
+4. **HTTP/SSE transport (#230/#231)** — exists only in the retired TS; server.py is stdio-only (no `--port`/HTTP server). Closing #230 assumed #231 delivered it, but #231's transport lives in the non-shipped TS. Follow-up (revisit Claude-Cloud compatibility). — feature gap, pre-existing from #302.
+5. **Custom-repository discovery (CORRECTNESS)** — TS `discovery/{discover,gradle-parser,maven-parser}` parses build files for declared custom repos (`maven("url")`, `maven { url = uri(...) }`, JitPack/Nexus/Artifactory); server.py `_repos_for` (:128) is purely static group-prefix routing (Central/Google/Plugin-Portal) with NO `maven {`/`maven(` parsing. Consequence: for any project using a private/custom repo, version answers are **silently wrong**. Cross-links epic #293 (#295/#299). 3 TS discovery files → `diverged`.
+6. **`resolveAll` merge vs first-hit metadata (CORRECTNESS)** — `fetch_metadata` (:154) returns the FIRST successful repo's metadata; TS `resolveAll` merges version sets across ALL repos (plugin CLAUDE.md line 86) for get_latest/check_multiple/compare. Consequence: an artifact mirrored across Google Maven + Central with divergent version sets gets a **different "latest"** answer. `maven/resolver.test.ts` → `partial`/`diverged` with a behavioral note, never silently `ported`.
+
+**Intentional non-ports (accounted for in the 47→N delta, no follow-up needed):** `cli/parse-port` (no transport port in stdio-only server), `project/find-project-root` (Python `handle_scan` uses `projectPath or os.getcwd()`, no upward root-walk).
+
+**Version-sync is ALREADY correct on current main** (do not re-solve): `validate.sh --check-tag` checks `server.py` `SERVER_VERSION`/`USER_AGENT` against the tag (#305, :184–204), and root `CLAUDE.md` already enumerates the 3 locations as `{plugin.json, marketplace.json, server.py}` with `package.json` excluded. PR B must PRESERVE this check and only drop the now-dead `package.json` dev-note from docs.
+
+**CI strategy.** `.github/workflows/ci.yml` runs the `build` **job unconditionally** and gates only its heavy *steps* on a `Detect maven-mcp changes` output, so `build (20)/(22)` always REPORT (a required check that is job-level-skipped becomes "expected but missing" → BLOCKED-while-mergeable forever). PR A's new `python-tests` job MUST mirror this exactly: job always runs, replicate the detect step, condition only the `unittest` step. PR A keeps the node jobs so required checks stay green through the transition. PR B removes the node jobs and fixes every TS-coupled pipeline (`ci.yml`, `release.yml`, `codeql.yml`) plus the branch ruleset.
+
+## Affected Modules & Files
+
+| Path | Change | Note |
+|---|---|---|
+| `plugins/maven-mcp/tests/_helpers.py` | New (PR A) | `__file__`-based sys.path shim; `mock_urlopen` (ctx-mgr `.status`/`.read()`, sequence, HTTPError helper); `temp_project(files)` |
+| `plugins/maven-mcp/tests/test_version.py` | New (PR A) | classify/compare/range |
+| `plugins/maven-mcp/tests/test_parsers.py` | New (PR A) | gradle deps + **plugins-block + buildscript-classpath + settings-modules/catalogs**, maven deps + maven-modules, toml catalog (dedup+source), metadata-xml, detect-build-system, `scan_project` via tempfile |
+| `plugins/maven-mcp/tests/test_github.py` | New (PR A) | gh_*, discover_github_repo, changelog (`_get_dependency_changes_impl`, `_filter_version_range`, tag normalization, repositoryNotFound/empty branches) |
+| `plugins/maven-mcp/tests/test_maven_search_osv.py` | New (PR A) | fetch_metadata/check_version/fetch_pom across repo list, search, OSV batch |
+| `plugins/maven-mcp/tests/test_handlers.py` | New (PR A) | all 10 handle_*; **#263 regression** |
+| `plugins/maven-mcp/tests/test_http.py` | New (PR A) | http_get/http_post_json: (status,bytes), HTTPError→(code,b""), headers/User-Agent, POST JSON body; no-retry documented |
+| `docs/plans/maven-python-migration/coverage-map.md` | New (PR A) | 47 TS files → ported/diverged/N/A audit artifact |
+| `.github/workflows/ci.yml` | Modified (PR A add python job; PR B remove node job) | python-tests = always-run job (`fetch-depth: 0`) + step-gated, mirrors build; includes zero-dep `python -m compileall` static gate; matrix quoted `["3.9","3.13"]` |
+| `.github/pull_request_template.md` | Modified (PR B) | replace npm `build/test/lint` checklist + `package.json` version item with `unittest` + 3 version locations |
+| `plugins/maven-mcp/src/` (+ `package.json`, `package-lock.json`, `tsconfig.json`, `vitest.config.ts`, `eslint.config.js`, `node_modules/`) | Deleted (PR B) | retire TS reference |
+| `.github/workflows/release.yml` | Modified (PR B) | remove setup-node + `npm ci/lint/test/build`; KEEP `validate.sh --check-tag`; add `python3 -m unittest discover` |
+| `.github/workflows/codeql.yml` | Modified (PR B) | drop `javascript-typescript` matrix leg (keep `python` + `actions`); correct the stale "ruleset requires CodeQL" comment (it does not). CodeQL is not a required check — no ruleset reconcile |
+| `plugins/maven-mcp/CLAUDE.md` | Modified (PR B) | Python is the documented impl + `unittest` commands; FIX stale "Persistent cache" claim; drop TS dev sections |
+| `CLAUDE.md` (root) | Modified (PR B) | drop the `package.json` dev-note + any npm/TS references (version-locations non-negotiable already correct, leave it) |
+| `plugins/maven-mcp/plugin/server/server.py` | Modified (PR B, doc only) | correct docstring "3.6+" → "3.9+" (matrix floor); NO runtime-logic change |
+| branch ruleset (repo settings) | Modified (PR B, two steps) | required checks: +python-tests(3.9)/(3.13) [+validate-marketplace], −build(20)/(22); preserve all other rules |
+
+## Decisions Made
+
+| Decision | Rationale | Alternatives rejected |
+|---|---|---|
+| stdlib `unittest` | zero new deps, no CI install, matches stdlib-only ethos | pytest (adds dev dep + install for marginal gain) |
+| Tests at `plugins/maven-mcp/tests/` (outside `plugin/`) | keep test code out of the shipped plugin tree | `plugin/server/tests/` (ships tests to users) |
+| Mock `urllib.request.urlopen`; tempfile for FS | single network seam; real temp files exercise parsers+detection honestly | patching `open` (brittle); fake HTTP server (overkill) |
+| Test Python's actual behavior; flag 4 divergences as follow-ups | user decided Python = truth; constraint forbids runtime changes except real bugs; divergences are pre-existing #302 gaps | porting retry/cache/agp/sse into Python now (scope creep — feature work, not a test migration) |
+| Coverage-map.md + `trace --count` as PR-A deliverable | makes "parity by behavior" falsifiable before deleting 407 tested cases | manual human-judgment parity claim (unauditable) |
+| Two PRs; PR B fixes ci+release+codeql+ruleset together | keep a green required gate at all times; never delete the tested reference before its replacement is proven and every TS-coupled pipeline is migrated | one big-bang PR (removes coverage+gate at once); PR B touching only ci.yml (breaks release.yml/codeql.yml) |
+| python matrix [3.9, 3.13] + docstring→3.9+ | 3.6–3.8 awkward on current runners; don't claim a floor we don't test | matrix floor 3.6 (runner friction); keeping false "3.6+" docstring |
+
+## Risks & Mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| PR B breaks `release.yml` (npm ci with no lockfile) — every future release fails | critical | Dedicated PR-B task gutting npm from release.yml, keeping `validate.sh --check-tag`, adding python unittest; verify the release path logic before done |
+| `codeql.yml` `javascript-typescript` leg finds no code after PR B (cosmetic red run) | minor | CodeQL is NOT a required check (verified: ruleset 13632214 has no code_scanning rule) — cannot block merge. T-13c drops the JS/TS leg + corrects the now-false codeql.yml "ruleset requires CodeQL" comment. No ruleset reconcile needed. |
+| Required-check rename deadlocks (build(20)/(22) never report on PR B → BLOCKED-while-mergeable) | critical | T-16 split: (a) after PR A merge ADD python-tests required; (b) while PR B open with green python-tests, DROP build(20)/(22); validate via `gh api` ruleset diff, not a probe PR |
+| `python-tests` job-level path-skip → required check never reports on non-maven PRs | critical | T-9 mandates always-run job + replicate detect step (incl. `fetch-depth: 0` for the three-dot diff) + step-gate only the unittest step (mirror build); never job-level `if:`/`paths` |
+| `release.yml` new unittest step double-paths (`defaults.run.working-directory: plugins/maven-mcp`) → release fails | major | T-13b sets `working-directory: .` on the unittest step (consistent with the surviving `validate.sh`/tag steps) |
+| Contributor-facing `.github/pull_request_template.md` still references npm + `package.json` after PR B | major | T-14 updates it to `python3 -m unittest discover` + the 3 version locations {plugin.json, marketplace.json, server.py} |
+| Dropping required `npm run lint` (eslint) leaves no L1-static gate | minor | T-9 adds zero-dep `python -m compileall plugins/maven-mcp/plugin/server` to the python-tests job (syntax gate; accepted tradeoff vs adding ruff/mypy deps) |
+| Divergences #5/#6 are silent CORRECTNESS regressions (wrong version answers for custom-repo / multi-repo artifacts) | major | Documented as divergences #5/#6 + dedicated follow-up issues (T-10) cross-linked to epic #293; coverage-map marks the affected TS files diverged/partial; not fixed here (feature/bugfix work for #293) |
+| `gh api` ruleset PUT wipes other rules (squash-only, review-thread-resolution, linear-history, copilot, deletion/non-ff) | major | Read-modify-write the full ruleset doc; replace ONLY `required_status_checks.required_status_checks` contexts (each new context carries `integration_id: 15368`); verify all rules survive |
+| Hidden coverage loss across the 4 divergences | major | coverage-map.md accounts for every one of the 47 TS files; 4 follow-up issues filed; stale cache doc fixed; nothing silent |
+| Deleting 407 tested cases on a human-judgment parity bar | major | coverage-map + `trace --count` make it auditable while TS still exists; deletion reversible via git history |
+| server.py runtime accidentally changed | minor | Migration touches tests/CI/docs only; the one server.py edit (PR B) is a docstring; L5 smoke confirms the server still responds |
+
+## Verification & Sources
+
+Migration / "shouldn't change behavior" task → the **before-state baseline** is the source of truth.
+
+| Source of truth | Type | Status | Sufficient for verification? |
+|---|---|---|---|
+| `plugins/maven-mcp/src/**/__tests__` (vitest, 407 green) | before-state baseline | present (green now) | yes — coverage-map.md maps each of the 47 files to ported/diverged/N/A; a reviewer diffs coverage behavior-by-behavior |
+| `docs/plans/maven-python-migration/coverage-map.md` | parity audit artifact (produced in PR A) | to-produce (PR A) | yes — the falsifiable parity record + `trace --count` of untested server.py functions |
+| GitHub issue #263 | debug-repro | present | yes — defines the compare-no-match regression to lock |
+| server.py actual behavior | before-state baseline (runtime) | present | yes — for the 4 divergences the runtime is the truth by the user's decision |
+
+**Testing strategy (pyramid levels):** L0 build (python imports cleanly) + L1 static (`bash scripts/validate.sh`, the tests themselves) + L2 unit (the deliverable: `python3 -m unittest discover`) + **L5 manual mandatory** (infra/migration: smoke the actual MCP server over stdio — send a JSON-RPC `initialize`+`tools/list` and one real `get_latest_version` call — to confirm the runtime is intact after PR B touches CI/docs/docstring). L3/L4 N/A (no UI/E2E surface).
+
+## Out of Scope
+
+- Adding HTTP retry/backoff, persistent file cache, AGP/AndroidX release-notes providers + html-to-text, or HTTP/SSE transport to the Python runtime → **four follow-up issues** (T-10).
+- Any new maven-mcp feature (epics #281/#293) — built on this foundation afterward.
+- Changing server.py runtime behavior beyond the PR-B docstring fix (a test-revealed real bug would be a separate tracked change).
+
+## Open Questions
+
+- [non-blocking] File the 4 follow-up issues standalone (`enhancement`) and cross-link from epics #281/#293, or nest under an epic? Default: standalone, cross-linked. Resolvable while implementing.

--- a/docs/plans/maven-python-migration/progress.md
+++ b/docs/plans/maven-python-migration/progress.md
@@ -1,0 +1,29 @@
+# Progress: maven-mcp — Python as the single source of truth
+
+> Plan: ./plan.md · Tasks: ./tasks.md
+
+## Status
+### PR A — chore/maven-python-tests (rebased on current main: #303/#304/#305)
+- [ ] T-1 — Test harness scaffold
+- [ ] T-2 — version domain tests
+- [ ] T-3 — parser & scan tests
+- [ ] T-4 — github + changelog tests
+- [ ] T-5 — maven/search/OSV network tests
+- [ ] T-6 — tool handler integration tests (+ #263 regression)
+- [ ] T-7 — http_get / http_post_json tests
+- [ ] T-8 — coverage-map deliverable + trace
+- [ ] T-9 — CI: add python-tests job (mirror build gating)
+- [ ] T-10 — file 4 divergence follow-up issues
+- [ ] T-11 — open PR A
+
+### PR B — chore/maven-remove-ts (after PR A merged)
+- [ ] T-12 — remove TS reference
+- [ ] T-13 — CI/release/codeql: remove node, python becomes gate
+- [ ] T-14 — docs: Python-first
+- [ ] T-15 — server.py docstring 3.6+ → 3.9+
+- [ ] T-16 — branch ruleset required-check transition (2 steps)
+- [ ] T-17 — L5 runtime smoke + open PR B
+
+## Learnings
+<!-- Append one line per completed task: surprises, gotchas, decisions taken during implementation. -->
+- Cycle-1 review (architecture/devops/pr-test-analyzer) → FAIL. Revised: added release.yml + codeql.yml to PR B (both would break), split ruleset transition (T-16 a/b) to avoid BLOCKED-while-mergeable, python-tests job must mirror build's always-run+step-gate, removed invalid T-4 (agp/androidx/html absent in server.py), named big parsers (plugins-block 22 cases), added coverage-map deliverable, pinned #263 observable, 4 divergences (retry/cache/agp-androidx-html/http-sse). Version-sync already correct on main (#305).

--- a/docs/plans/maven-python-migration/progress.md
+++ b/docs/plans/maven-python-migration/progress.md
@@ -4,17 +4,17 @@
 
 ## Status
 ### PR A — chore/maven-python-tests (rebased on current main: #303/#304/#305)
-- [ ] T-1 — Test harness scaffold
-- [ ] T-2 — version domain tests
-- [ ] T-3 — parser & scan tests
-- [ ] T-4 — github + changelog tests
-- [ ] T-5 — maven/search/OSV network tests
-- [ ] T-6 — tool handler integration tests (+ #263 regression)
-- [ ] T-7 — http_get / http_post_json tests
-- [ ] T-8 — coverage-map deliverable + trace
-- [ ] T-9 — CI: add python-tests job (mirror build gating)
-- [ ] T-10 — file 4 divergence follow-up issues
-- [ ] T-11 — open PR A
+- [x] T-1 — Test harness scaffold (_helpers.py: __file__ shim, mock_urlopen, http_error, temp_project)
+- [x] T-2 — version domain tests (30)
+- [x] T-3 — parser & scan tests (81)
+- [x] T-4 — github + changelog tests (27)
+- [x] T-5 — maven/search/OSV network tests (33, incl. #6 first-hit)
+- [x] T-6 — tool handler tests + #263 regression (24, incl. health P3 helpers)
+- [x] T-7 — http tests (11) — 209 total, all green
+- [x] T-8 — coverage-map.md (47: 30 ported/3 partial/12 diverged/2 N/A) + harness ResourceWarning fixed
+- [x] T-9 — CI python-tests job (3.9/3.13, always-run + step-gate, actionlint clean)
+- [x] T-10 — follow-up issues filed: #306 retry, #307 cache, #308 agp/androidx/html, #309 http-sse, #310 custom-repo (bug,→#293), #311 first-hit (bug,→#293), #312 version-selection (bug), #313 parser-gaps+utcnow
+- [ ] T-11 — open PR A (in progress)
 
 ### PR B — chore/maven-remove-ts (after PR A merged)
 - [ ] T-12 — remove TS reference

--- a/docs/plans/maven-python-migration/tasks.md
+++ b/docs/plans/maven-python-migration/tasks.md
@@ -1,0 +1,108 @@
+# Tasks: maven-mcp — Python as the single source of truth
+
+> Plan: ./plan.md · No spec (works from task description)
+> PR A = T-1…T-11 (branch `chore/maven-python-tests`, rebased on current main). PR B = T-12…T-17 (branch `chore/maven-remove-ts`, after PR A merged).
+
+## T-1 — Test harness scaffold
+- after: none
+- files: `plugins/maven-mcp/tests/_helpers.py`, `plugins/maven-mcp/tests/test_smoke.py`
+- acceptance: GIVEN a fresh checkout WHEN running `python3 -m unittest discover -s plugins/maven-mcp/tests` from ANY cwd THEN it imports `server` via a `__file__`-resolved sys.path shim and a smoke test passes. `_helpers` exposes: `mock_urlopen(responses)` returning a **context-manager** with `.status` + `.read()`, supporting a **sequence** of responses; `http_error(url, code, msg="", hdrs=None, body=b"")` building a valid 5-arg `urllib.error.HTTPError`; `temp_project(files: dict)` writing files into a `TemporaryDirectory` and returning the path
+- check: `python3 -m unittest discover -s plugins/maven-mcp/tests` exits 0 from repo root AND from `/tmp`
+
+## T-2 — version domain tests
+- after: T-1
+- files: `plugins/maven-mcp/tests/test_version.py`
+- acceptance: THE SYSTEM SHALL cover `classify_version` (stable/rc/beta/alpha/milestone/snapshot + edge: empty/garbage), `compare_versions` (semantic order, prerelease ordering, equality), `_parse_segments`/`_extract_prerelease_numbers`, and the `find_latest_version*`/range selection used by compare+audit — mirroring `src/version/__tests__/{classify,compare,range}.test.ts` (33 cases)
+- check: tests pass; each comments the TS test it mirrors
+
+## T-3 — parser & scan tests
+- after: T-1
+- files: `plugins/maven-mcp/tests/test_parsers.py`
+- acceptance: THE SYSTEM SHALL cover, each named explicitly: `_parse_gradle_deps`, **`_parse_gradle_plugins_block`** (incl. settings variant; mirrors TS plugins-block 22 cases), `_parse_buildscript_classpath`, `_parse_settings_modules`, `_parse_settings_catalogs`, `_parse_maven_deps`, `_parse_maven_modules`, `_parse_toml_catalog` (catalog dedup + source tracking), `_parse_metadata_xml`, `_detect_build_system`, and `scan_project` end-to-end via `temp_project` (gradle/kts single + multi-module, maven pom + modules, toml catalog) — mirroring `src/dependencies/**`, `src/maven/__tests__/repository.test.ts`. NOTE: do NOT claim to mirror `src/discovery/**` — custom-repo discovery (`maven{}`/`maven()` parsing) is divergence #5 (server.py `_repos_for` is static group-prefix only); those 3 discovery files go to the coverage-map `diverged` bucket
+- check: tests pass; plugins-block and multi-module cases present and named; no test asserts custom-repo parsing
+
+## T-4 — github + changelog tests
+- after: T-1
+- files: `plugins/maven-mcp/tests/test_github.py`
+- acceptance: THE SYSTEM SHALL cover `gh_repo_exists`/`gh_fetch_repo`/`gh_fetch_releases`/`gh_fetch_user`/`gh_fetch_issue_stats` (mock urlopen; assert URL + headers incl. token header when `GITHUB_TOKEN` set), `discover_github_repo` (POM-SCM → guess fallback), AND the GitHub-only changelog path: `_get_dependency_changes_impl`, `_filter_version_range`, tag normalization (`re.sub(r"^[^0-9]*", "", tag)`), and the `repositoryNotFound` / no-releases / empty-range branches — mirroring `src/github/**` + `src/changelog/__tests__/github-provider`
+- check: tests pass; named cases for version-range filter, tag normalization, and the no-repo/empty branches
+
+## T-5 — maven/search/OSV network tests
+- after: T-1
+- files: `plugins/maven-mcp/tests/test_maven_search_osv.py`
+- acceptance: THE SYSTEM SHALL cover `fetch_metadata`/`check_version_in_repos`/`fetch_pom` (mock urlopen across `_repos_for`, most-specific-first incl. AndroidX/Google prefix routing :30), `search_maven_central`, and the OSV batch query (POST body shape, CVSS/severity extraction) — mirroring `src/maven`, `src/search`, `src/vulnerabilities`. Test `fetch_metadata`'s ACTUAL first-hit semantics (returns the first successful repo's metadata, no cross-repo merge) and document it as divergence #6 (TS used `resolveAll` merge); `maven/resolver.test.ts` → coverage-map `partial`/`diverged` with a behavioral note, never plain `ported`
+- check: tests pass; a test asserts first-hit (not merged) behavior of fetch_metadata
+
+## T-6 — tool handler integration tests (+ #263 regression)
+- after: T-2, T-3, T-4, T-5
+- files: `plugins/maven-mcp/tests/test_handlers.py`
+- acceptance: THE SYSTEM SHALL cover all 10 `handle_*` (mock urlopen + temp_project), AND the #263 regression: GIVEN `compare_dependency_versions` with one dependency whose `currentVersion` has no matching newer version AND a sibling dependency that resolves WHEN the handler runs THEN the no-match dependency's result has `error == "No matching version found"`, `upgradeAvailable is False`, `latestVersion == ""`, AND the sibling still resolves successfully (so removing the `if not latest` guard changes the output). ALSO add P3 edge cases for the dependency-health stat/date helpers (`median_days_to_close` :452 empty/single-element, `_months_since` :507, `_parse_iso` :496 naive-vs-aware ISO, `_summarize_releases` :523 release-cadence) — exercise the boundaries directly, not only transitively through the handler
+- check: tests pass; #263 asserts the exact observable above (not merely "an error field exists"); health helper P3 boundaries asserted
+
+## T-7 — http_get / http_post_json tests
+- after: T-1
+- files: `plugins/maven-mcp/tests/test_http.py`
+- acceptance: THE SYSTEM SHALL cover `http_get`/`http_post_json` actual behavior: returns `(status, bytes)`; maps `HTTPError → (code, b"")` using the `http_error` helper; sets User-Agent + extra headers; POST encodes JSON body + Content-Type. A module-level comment documents that retry/backoff is intentionally absent (divergence #1, tracked in T-10) — no retry test
+- check: tests pass; `HTTPError → (code, b"")` mapping asserted
+
+## T-8 — coverage-map deliverable + trace
+- after: T-2…T-7
+- files: `docs/plans/maven-python-migration/coverage-map.md`
+- acceptance: THE SYSTEM SHALL produce a table mapping EACH of the 47 TS test files to one of FOUR buckets: `ported → <py file>` / `partial → <py file> + <diverged sub-cases → issue #>` / `diverged → <follow-up issue #>` / `N/A → <reason>`. The `partial` bucket is REQUIRED for `http/client.test.ts` (GET/POST ported, retry diverged #1), `maven/resolver.test.ts` (symbol exercised, first-hit-vs-merge diverged #6), `changelog/resolver.test.ts` (github ported, provider-selection diverged #3). The 3 `discovery/*` files → `diverged` (#5). `cli/parse-port`, `find-project-root` → `N/A`. The behavioral map is the AUTHORITATIVE parity bar; `python3 -m trace --count -C /tmp/cov -m unittest discover -s plugins/maven-mcp/tests` is a BACKSTOP only — derive zero-hit functions by mapping `.cover` hit-lines onto the server.py `def`-line inventory; justify any unexercised function
+- check: coverage-map.md exists, all 47 files classified into the 4 buckets (tally = 47); partial rows present for the 3 named files; no unexplained zero-hit server.py function
+
+## T-9 — CI: add python-tests job (mirror build's gating)
+- after: T-1
+- files: `.github/workflows/ci.yml`
+- acceptance: THE SYSTEM SHALL add a `python-tests` job (matrix `python-version: ["3.9", "3.13"]` — QUOTED, so the rendered required-check contexts `python-tests (3.9)`/`python-tests (3.13)` are stable) using `actions/setup-python`, that — like `build` — checks out with `fetch-depth: 0` (the three-dot detect diff needs the merge-base), runs the JOB unconditionally, replicates the `Detect maven-mcp changes` step, and gates ONLY the test steps on `steps.changes.outputs.maven_mcp == 'true'`: `python3 -m unittest discover -s plugins/maven-mcp/tests -v` AND a zero-dep static gate `python -m compileall plugins/maven-mcp/plugin/server` (replaces the eslint gate lost when the node job is removed in PR B). Existing `build (20)/(22)` + `validate-marketplace` unchanged. NO job-level `if:`/`paths` skip
+- check: on the PR, `python-tests (3.9)` + `python-tests (3.13)` REPORT and pass; contexts match the strings T-16 will require; compileall step present
+
+## T-10 — file divergence follow-up issues
+- after: T-7
+- files: (GitHub issues — no repo files)
+- acceptance: THE SYSTEM SHALL open SIX issues for the Python runtime's pre-existing gaps vs the retired TS. Feature gaps (`enhancement`): (1) HTTP retry/backoff on 5xx/429; (2) persistent file cache; (3) AGP/AndroidX release-notes changelog providers + html-to-text + changelog provider-selection; (4) HTTP/SSE transport (revisit #230 Claude-Cloud compat). CORRECTNESS regressions (`bug`, cross-link epic #293 / #295 / #299): (5) custom-repository discovery missing → wrong version answers for private/custom-repo projects; (6) `fetch_metadata` first-hit vs `resolveAll` merge → wrong "latest" for multi-repo artifacts. Each describes the gap + retired TS reference + user impact; all six linked from the PR A description
+- check: six issue URLs recorded in progress.md and the PR body; #5/#6 labeled `bug` and reference #293
+
+## T-11 — open PR A
+- after: T-8, T-9, T-10
+- files: (PR)
+- acceptance: THE SYSTEM SHALL open PR A from `chore/maven-python-tests` as ready-for-review, body linking the plan + coverage-map + the four follow-up issues; node build(20)/(22) + new python-tests(3.9)/(3.13) + validate-marketplace all green
+- check: PR open, all checks green
+
+---
+
+## T-12 — remove TS reference (PR B)
+- after: T-11 (PR A merged)
+- files: delete `plugins/maven-mcp/src/`, `package.json`, `package-lock.json`, `tsconfig.json`, `vitest.config.ts`, `eslint.config.js`, `node_modules/`
+- acceptance: GIVEN PR A merged (Python coverage live) WHEN the TS reference is deleted THEN no `*.ts` remains under `plugins/maven-mcp/`, and `python3 -m unittest discover` still passes
+- check: `find plugins/maven-mcp -name '*.ts' -not -path '*/node_modules/*'` empty; python tests green
+
+## T-13 — CI/release/codeql: remove node, python becomes gate (PR B)
+- after: T-12
+- files: `.github/workflows/ci.yml`, `.github/workflows/release.yml`, `.github/workflows/codeql.yml`, `scripts/validate.sh`
+- acceptance: THE SYSTEM SHALL (a) remove the node `build` matrix job + its package.json↔plugin.json step from ci.yml, keep `python-tests` + `validate-marketplace`; (b) in release.yml remove setup-node + `npm ci/lint/test/build`, KEEP the `validate.sh --check-tag` step (already guards server.py version, #305), add `python3 -m unittest discover -s plugins/maven-mcp/tests` WITH `working-directory: .` on that step (release.yml `defaults.run.working-directory` is `plugins/maven-mcp` → without the override the path double-resolves and the release fails); (c) in codeql.yml drop the `javascript-typescript` matrix leg (keep `python` + `actions`) AND correct the stale comment claiming the ruleset requires a CodeQL analysis (it does not); (d) ensure validate.sh has no npm/TS assumption and its server.py version-sync check stays intact
+- check: no `setup-node`/`npm` in any workflow; `bash scripts/validate.sh` passes; release.yml still calls `validate.sh --check-tag` and its unittest step has `working-directory: .`; codeql matrix has no js/ts and the stale comment is gone
+
+## T-14 — docs: Python-first (PR B)
+- after: T-12
+- files: `plugins/maven-mcp/CLAUDE.md`, `CLAUDE.md` (root), `.github/pull_request_template.md`
+- acceptance: THE SYSTEM SHALL update plugin CLAUDE.md to document Python as the implementation with `python3 -m unittest discover` commands, remove TS dev sections, and FIX the stale "Persistent cache: ~/.cache/maven-central-mcp/" claim (server.py has only in-memory memoization); root CLAUDE.md SHALL drop the `package.json` dev-note and any npm/TS references (the 3-version-locations non-negotiable is already correct — leave it); `.github/pull_request_template.md` SHALL replace the `npm run build/test/lint` checklist items + the "Version bumped (package.json and plugin.json)" line with `python3 -m unittest discover` + the 3 version locations {plugin.json, marketplace.json, server.py}. All content English
+- check: grep `npm`/`vitest`/`Persistent cache`/`package.json` in the three files returns none/intentional; `bash scripts/validate.sh` passes
+
+## T-15 — server.py docstring fix (PR B)
+- after: T-12
+- files: `plugins/maven-mcp/plugin/server/server.py`
+- acceptance: THE SYSTEM SHALL correct the module docstring "Python 3.6+" to "Python 3.9+" (matching the tested matrix floor). NO runtime-logic change
+- check: `git diff` shows only the docstring line changed in server.py
+
+## T-16 — branch ruleset: required-check transition (PR B)
+- after: substep (a) after T-11 (PR A merged); substep (b) after T-13 (PR B open, green python-tests)
+- files: (repo settings via `gh api`)
+- acceptance: THE SYSTEM SHALL update the `main` branch ruleset (id 13632214) via read-modify-write: GET the full ruleset, replace ONLY `required_status_checks.required_status_checks` contexts, PUT the full doc back — preserving all six original rules (squash-only merge, required-review-thread-resolution, linear-history, copilot review, deletion, non-fast-forward). New required contexts: `python-tests (3.9)` + `python-tests (3.13)` (ADD) + `validate-marketplace` (ADD — this is an INTENTIONAL NEW requirement, not currently required; it always runs so it's zero-risk), REMOVE `build (20)`/`build (22)`. Each context carries `integration_id: 15368` (GitHub Actions). Two safe steps: (a) right after PR A merges, ADD python-tests + validate-marketplace (open PRs need a rebase to show them); (b) while PR B is open with green python-tests, DROP build(20)/(22) before merging PR B. CodeQL is NOT required → no codeql context to add. Validate via the `gh api` ruleset diff, NOT a probe PR
+- check: `gh api repos/:owner/:repo/rulesets/13632214` shows required contexts = {python-tests (3.9), python-tests (3.13), validate-marketplace}, build(20)/(22) gone, and all six original rules still present
+
+## T-17 — L5 runtime smoke + open PR B
+- after: T-13, T-14, T-15
+- files: (PR)
+- acceptance: THE SYSTEM SHALL smoke the stdio server (`echo` JSON-RPC `initialize`+`tools/list`, then one `get_latest_version` call, piped into `python3 server.py`) and confirm valid responses; THEN open PR B ready-for-review linking the plan; checks python-tests + validate-marketplace green
+- check: smoke transcript recorded in progress.md; PR B open, gating checks green

--- a/plugins/maven-mcp/tests/_helpers.py
+++ b/plugins/maven-mcp/tests/_helpers.py
@@ -107,7 +107,12 @@ def http_error(
         with mock.patch("urllib.request.urlopen", side_effect=mock_urlopen([err])):
             status, body = server.http_get(url)  # -> (404, b"")
     """
-    return urllib.error.HTTPError(url, code, msg, hdrs or {}, io.BytesIO(body))
+    err = urllib.error.HTTPError(url, code, msg, hdrs or {}, io.BytesIO(body))
+    # server.py maps HTTPError -> (e.code, b"") without ever reading the body, so
+    # the wrapped BytesIO is never consumed. Close it now to avoid a
+    # ResourceWarning when the unread stream is later garbage-collected.
+    err.close()
+    return err
 
 
 @contextlib.contextmanager

--- a/plugins/maven-mcp/tests/_helpers.py
+++ b/plugins/maven-mcp/tests/_helpers.py
@@ -1,0 +1,131 @@
+"""Shared test harness for the maven-mcp Python server.
+
+Imports the shipped ``server`` module and provides HTTP / filesystem mocking
+helpers. Stdlib only (zero third-party dependencies), matching the server's
+zero-pip-dependency ethos.
+
+Test modules should do ``from _helpers import server, mock_urlopen, ...`` so the
+sys.path shim below is installed before ``server`` is first imported.
+"""
+
+import contextlib
+import io
+import os
+import sys
+import tempfile
+import urllib.error
+from typing import Any, Callable, Dict, List, Union
+
+# --- sys.path shim ----------------------------------------------------------
+# Resolve plugin/server/ relative to THIS file, never the process cwd, so the
+# suite imports the same `server` whether run from the repo root, /tmp, or
+# anywhere else. server.py is import-safe (tail `if __name__ == "__main__"`).
+_SERVER_DIR = os.path.normpath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "plugin", "server")
+)
+if _SERVER_DIR not in sys.path:
+    sys.path.insert(0, _SERVER_DIR)
+
+import server  # noqa: E402  (must follow the sys.path shim above)
+
+# A single response spec: (status, body) tuple, or an Exception to raise.
+ResponseSpec = Union["_MockResponse", BaseException, Any]
+
+
+class _MockResponse:
+    """Stand-in for the object returned by urllib.request.urlopen.
+
+    server.py uses it as ``with urllib.request.urlopen(...) as resp:`` and reads
+    ``resp.status`` / ``resp.read()`` — so this is both a context manager and
+    exposes those two members.
+    """
+
+    def __init__(self, status: int, body: bytes) -> None:
+        self.status = status
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "_MockResponse":
+        return self
+
+    def __exit__(self, *exc: Any) -> bool:
+        return False
+
+
+def mock_urlopen(responses: Union[ResponseSpec, List[ResponseSpec]]) -> Callable:
+    """Build a ``side_effect`` callable for patching ``urllib.request.urlopen``.
+
+    ``responses`` is a single response or a list of them consumed in order
+    across consecutive urlopen calls. Each item is one of:
+      - ``(status: int, body: bytes)`` -> returned as a context manager exposing
+        ``.status`` and ``.read()``
+      - an ``Exception`` instance (e.g. ``http_error(...)``) -> raised
+      - a ``_MockResponse`` -> returned as-is
+
+    Pass a ``list`` for a sequence; anything else is treated as a single
+    response. Usage::
+
+        with mock.patch("urllib.request.urlopen",
+                        side_effect=mock_urlopen([(200, b"<xml/>")])):
+            status, body = server.http_get(url)
+    """
+    queue = list(responses) if isinstance(responses, list) else [responses]
+    iterator = iter(queue)
+
+    def _side_effect(*_args: Any, **_kwargs: Any) -> _MockResponse:
+        try:
+            spec = next(iterator)
+        except StopIteration:
+            raise AssertionError(
+                "mock_urlopen: more urlopen calls than configured responses"
+            )
+        if isinstance(spec, BaseException):
+            raise spec
+        if isinstance(spec, _MockResponse):
+            return spec
+        status, body = spec
+        return _MockResponse(status, body)
+
+    return _side_effect
+
+
+def http_error(
+    url: str,
+    code: int,
+    msg: str = "",
+    hdrs: Any = None,
+    body: bytes = b"",
+) -> urllib.error.HTTPError:
+    """Build a correctly-constructed 5-arg ``urllib.error.HTTPError``.
+
+    server.py maps ``HTTPError -> (e.code, b"")``. Feed the result to
+    ``mock_urlopen`` to make the patched urlopen raise it. Usage::
+
+        err = http_error(url, 404, "Not Found")
+        with mock.patch("urllib.request.urlopen", side_effect=mock_urlopen([err])):
+            status, body = server.http_get(url)  # -> (404, b"")
+    """
+    return urllib.error.HTTPError(url, code, msg, hdrs or {}, io.BytesIO(body))
+
+
+@contextlib.contextmanager
+def temp_project(files: Dict[str, str]):
+    """Write ``{relative_path: content}`` into a fresh TemporaryDirectory and
+    yield its path; the directory is removed on exit.
+
+    Drives ``server.scan_project(path)`` against real build files. Usage::
+
+        with temp_project({"pom.xml": "<project>...</project>"}) as root:
+            result = server.scan_project(root)
+    """
+    with tempfile.TemporaryDirectory() as root:
+        for rel, content in files.items():
+            path = os.path.join(root, rel)
+            parent = os.path.dirname(path)
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(content)
+        yield root

--- a/plugins/maven-mcp/tests/_helpers.py
+++ b/plugins/maven-mcp/tests/_helpers.py
@@ -28,6 +28,11 @@ if _SERVER_DIR not in sys.path:
 
 import server  # noqa: E402  (must follow the sys.path shim above)
 
+# Public test API re-exported for ``from _helpers import ...``. Listing
+# ``server`` makes the shimmed import above an intentional re-export rather
+# than an unused import.
+__all__ = ["server", "mock_urlopen", "http_error", "temp_project"]
+
 # A single response spec: (status, body) tuple, or an Exception to raise.
 ResponseSpec = Union["_MockResponse", BaseException, Any]
 

--- a/plugins/maven-mcp/tests/test_github.py
+++ b/plugins/maven-mcp/tests/test_github.py
@@ -1,0 +1,428 @@
+"""GitHub client + GitHub-only changelog path tests for the Python server.
+
+Mirrors the TypeScript reference suites:
+  - src/github/__tests__/github-client.test.ts   (gh_repo_exists / gh_fetch_*)
+  - src/github/__tests__/discover-repo.test.ts    (discover_github_repo)
+  - src/changelog/__tests__/github-provider.test.ts (the GitHub releases path)
+
+Each test class cites the TS test it mirrors. Network is faked by patching
+urllib.request.urlopen with the _helpers.mock_urlopen sequence builder; the
+patched mock object records the urllib Request objects so URL + header
+assertions read the exact bytes the server sent.
+
+Divergence guardrail (#3): server.py's changelog path is GitHub-releases-ONLY.
+There is no AGP/AndroidX provider and no provider-selection (the TS
+changelog/resolver + agp/androidx providers do not exist in Python), and the
+GitHub path does NOT fall back to a CHANGELOG.md file when no releases match
+(the TS github-provider does). Those behaviours are intentionally NOT tested
+here — only the github-releases path is exercised.
+"""
+
+import json
+import re
+import unittest
+from unittest import mock
+
+from _helpers import server, mock_urlopen, http_error
+
+
+# POM fixtures mirror discover-repo.test.ts / github-provider.test.ts.
+POM_WITH_SCM_KTOR = (
+    '<?xml version="1.0" encoding="UTF-8"?>'
+    "<project><scm><url>https://github.com/ktorio/ktor</url></scm></project>"
+)
+POM_WITH_SCM_OKHTTP = (
+    '<?xml version="1.0" encoding="UTF-8"?>'
+    "<project><scm><url>https://github.com/square/okhttp</url></scm></project>"
+)
+POM_WITHOUT_SCM = (
+    '<?xml version="1.0" encoding="UTF-8"?>'
+    "<project><groupId>com.example</groupId><artifactId>lib</artifactId></project>"
+)
+
+
+def _metadata_xml(versions):
+    body = "".join(f"<version>{v}</version>" for v in versions)
+    return f"<metadata><versioning><versions>{body}</versions></versioning></metadata>".encode()
+
+
+def _captured_request(mock_obj, index=0):
+    """Return the urllib Request object from the Nth recorded urlopen call."""
+    return mock_obj.call_args_list[index].args[0]
+
+
+# ---------------------------------------------------------------------------
+# gh_repo_exists — mirrors github-client.test.ts "repoExists"
+# ---------------------------------------------------------------------------
+class GhRepoExistsTest(unittest.TestCase):
+    def test_true_when_repo_exists(self):
+        # repoExists "returns true when repo exists" + asserts URL.
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen([(200, b"{}")])
+        ) as m:
+            self.assertTrue(server.gh_repo_exists("owner", "repo"))
+        req = _captured_request(m)
+        self.assertEqual(req.full_url, "https://api.github.com/repos/owner/repo")
+        self.assertEqual(req.get_header("Accept"), "application/vnd.github.v3+json")
+
+    def test_false_when_repo_missing(self):
+        # repoExists "returns false when repo does not exist" (404).
+        err = http_error("https://api.github.com/repos/owner/repo", 404, "Not Found")
+        with mock.patch("urllib.request.urlopen", side_effect=mock_urlopen([err])):
+            self.assertFalse(server.gh_repo_exists("owner", "repo"))
+
+    def test_false_on_network_error(self):
+        # repoExists "returns false on fetch error".
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([server.urllib.error.URLError("boom")]),
+        ):
+            self.assertFalse(server.gh_repo_exists("owner", "repo"))
+
+
+# ---------------------------------------------------------------------------
+# gh_fetch_repo — mirrors github-client.test.ts (repo JSON via _gh_get)
+# ---------------------------------------------------------------------------
+class GhFetchRepoTest(unittest.TestCase):
+    def test_returns_repo_json(self):
+        payload = {"full_name": "owner/repo", "stargazers_count": 42}
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, json.dumps(payload).encode())]),
+        ) as m:
+            result = server.gh_fetch_repo("owner", "repo")
+        self.assertEqual(result, payload)
+        self.assertEqual(
+            _captured_request(m).full_url, "https://api.github.com/repos/owner/repo"
+        )
+
+    def test_returns_none_on_404(self):
+        err = http_error("https://api.github.com/repos/owner/repo", 404)
+        with mock.patch("urllib.request.urlopen", side_effect=mock_urlopen([err])):
+            self.assertIsNone(server.gh_fetch_repo("owner", "repo"))
+
+
+# ---------------------------------------------------------------------------
+# gh_fetch_releases — mirrors github-client.test.ts "fetchReleases"
+# ---------------------------------------------------------------------------
+class GhFetchReleasesTest(unittest.TestCase):
+    def test_returns_releases_and_sends_headers(self):
+        # fetchReleases "returns releases on success" + URL/header assertions.
+        releases = [
+            {"tag_name": "v1.0.0", "body": "First", "html_url": "u1"},
+            {"tag_name": "v2.0.0", "body": "Second", "html_url": "u2"},
+        ]
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, json.dumps(releases).encode())]),
+        ) as m:
+            result = server.gh_fetch_releases("owner", "repo")
+        self.assertEqual(result, releases)
+        req = _captured_request(m)
+        self.assertEqual(
+            req.full_url,
+            "https://api.github.com/repos/owner/repo/releases?per_page=100",
+        )
+        self.assertEqual(req.get_header("Accept"), "application/vnd.github.v3+json")
+        # User-Agent is stored capitalized as "User-agent" by urllib.request.Request.
+        self.assertEqual(req.get_header("User-agent"), "maven-mcp/0.23.0")
+
+    def test_returns_empty_list_on_404(self):
+        # fetchReleases "returns empty array on non-ok response".
+        err = http_error("https://api.github.com/x", 404)
+        with mock.patch("urllib.request.urlopen", side_effect=mock_urlopen([err])):
+            self.assertEqual(server.gh_fetch_releases("owner", "repo"), [])
+
+    def test_returns_empty_list_on_network_error(self):
+        # fetchReleases "returns empty array on fetch error".
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([server.urllib.error.URLError("net")]),
+        ):
+            self.assertEqual(server.gh_fetch_releases("owner", "repo"), [])
+
+
+# ---------------------------------------------------------------------------
+# gh_fetch_user — _gh_get("/users/<login>")
+# ---------------------------------------------------------------------------
+class GhFetchUserTest(unittest.TestCase):
+    def test_returns_user_json(self):
+        payload = {"login": "square", "public_repos": 120}
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, json.dumps(payload).encode())]),
+        ) as m:
+            result = server.gh_fetch_user("square")
+        self.assertEqual(result, payload)
+        self.assertEqual(
+            _captured_request(m).full_url, "https://api.github.com/users/square"
+        )
+
+    def test_returns_none_on_404(self):
+        err = http_error("https://api.github.com/users/nobody", 404)
+        with mock.patch("urllib.request.urlopen", side_effect=mock_urlopen([err])):
+            self.assertIsNone(server.gh_fetch_user("nobody"))
+
+
+# ---------------------------------------------------------------------------
+# gh_fetch_issue_stats — three sequential search calls (open, closed, median)
+# ---------------------------------------------------------------------------
+class GhFetchIssueStatsTest(unittest.TestCase):
+    def test_aggregates_open_closed_ratio_and_median(self):
+        open_resp = (200, json.dumps({"total_count": 5}).encode())
+        closed_resp = (200, json.dumps({"total_count": 15}).encode())
+        # Two closed issues: 2-day and 4-day durations -> even median = 3 days.
+        median_resp = (
+            200,
+            json.dumps(
+                {
+                    "items": [
+                        {
+                            "created_at": "2024-01-01T00:00:00Z",
+                            "closed_at": "2024-01-03T00:00:00Z",
+                        },
+                        {
+                            "created_at": "2024-01-01T00:00:00Z",
+                            "closed_at": "2024-01-05T00:00:00Z",
+                        },
+                    ]
+                }
+            ).encode(),
+        )
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([open_resp, closed_resp, median_resp]),
+        ) as m:
+            stats = server.gh_fetch_issue_stats("owner", "repo")
+        self.assertEqual(stats["open"], 5)
+        self.assertEqual(stats["closed"], 15)
+        self.assertEqual(stats["closeRatio"], 15 / 20)
+        self.assertEqual(stats["medianDaysToClose"], 3)
+        self.assertEqual(len(m.call_args_list), 3)
+        self.assertIn("/search/issues", _captured_request(m).full_url)
+
+    def test_returns_none_when_both_counts_unavailable(self):
+        # Both search calls non-200 -> early return None before the median call.
+        err = http_error("https://api.github.com/search/issues", 403, "rate limited")
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen([err, err])
+        ) as m:
+            self.assertIsNone(server.gh_fetch_issue_stats("owner", "repo"))
+        # Only 2 calls: median_days_to_close is skipped when both counts are None.
+        self.assertEqual(len(m.call_args_list), 2)
+
+
+# ---------------------------------------------------------------------------
+# GITHUB_TOKEN auth header — mirrors github-client.test.ts token tests
+# ---------------------------------------------------------------------------
+class GitHubAuthHeaderTest(unittest.TestCase):
+    def test_authorization_header_sent_when_token_set(self):
+        # "sends Authorization header when token is provided".
+        with mock.patch.dict("os.environ", {"GITHUB_TOKEN": "secret-token"}):
+            with mock.patch(
+                "urllib.request.urlopen", side_effect=mock_urlopen([(200, b"{}")])
+            ) as m:
+                server.gh_fetch_repo("owner", "repo")
+        self.assertEqual(
+            _captured_request(m).get_header("Authorization"), "Bearer secret-token"
+        )
+
+    def test_no_authorization_header_without_token(self):
+        # "does not send Authorization header when no token" (env cleared).
+        with mock.patch.dict("os.environ", {}, clear=True):
+            with mock.patch(
+                "urllib.request.urlopen", side_effect=mock_urlopen([(200, b"{}")])
+            ) as m:
+                server.gh_fetch_repo("owner", "repo")
+        self.assertIsNone(_captured_request(m).get_header("Authorization"))
+
+
+# ---------------------------------------------------------------------------
+# discover_github_repo — mirrors discover-repo.test.ts (POM SCM -> guess)
+# ---------------------------------------------------------------------------
+class DiscoverGithubRepoTest(unittest.TestCase):
+    def test_returns_repo_from_pom_scm(self):
+        # "returns GitHub repo from POM SCM". One urlopen (POM, Maven Central only).
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, POM_WITH_SCM_OKHTTP.encode())]),
+        ) as m:
+            result = server.discover_github_repo(
+                "com.squareup.okhttp3", "okhttp", "4.12.0"
+            )
+        self.assertEqual(result, {"owner": "square", "repo": "okhttp"})
+        self.assertEqual(len(m.call_args_list), 1)
+        self.assertTrue(_captured_request(m).full_url.endswith("okhttp-4.12.0.pom"))
+
+    def test_falls_back_to_guess_when_no_scm(self):
+        # "falls back to guess when POM has no GitHub SCM" (io.github.* groupId).
+        responses = [
+            (200, POM_WITHOUT_SCM.encode()),  # POM has no github SCM
+            (200, b"{}"),  # gh_repo_exists for the guessed repo -> 200
+        ]
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen(responses)
+        ) as m:
+            result = server.discover_github_repo("io.github.javalin", "javalin", "5.0.0")
+        self.assertEqual(result, {"owner": "javalin", "repo": "javalin"})
+        self.assertEqual(len(m.call_args_list), 2)
+
+    def test_returns_none_when_guessed_repo_missing(self):
+        # "returns null when guess repo does not exist on GitHub".
+        err = http_error("https://api.github.com/repos/someuser/nonexistent-lib", 404)
+        responses = [(200, POM_WITHOUT_SCM.encode()), err]
+        with mock.patch("urllib.request.urlopen", side_effect=mock_urlopen(responses)):
+            result = server.discover_github_repo(
+                "io.github.someuser", "nonexistent-lib", "1.0.0"
+            )
+        self.assertIsNone(result)
+
+    def test_returns_none_when_no_pom_and_not_guessable(self):
+        # "returns null when no POM found and groupId is not guessable".
+        err = http_error("https://repo1.maven.org/maven2/x.pom", 404)
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen([err])
+        ) as m:
+            result = server.discover_github_repo(
+                "org.apache.commons", "commons-lang3", "3.14.0"
+            )
+        self.assertIsNone(result)
+        # POM fetch only (1 call); no guess possible -> no gh_repo_exists call.
+        self.assertEqual(len(m.call_args_list), 1)
+
+
+# ---------------------------------------------------------------------------
+# _filter_version_range — from exclusive, to inclusive
+# ---------------------------------------------------------------------------
+class FilterVersionRangeTest(unittest.TestCase):
+    def test_from_exclusive_to_inclusive(self):
+        versions = ["1.0.0", "1.5.0", "2.0.0", "2.1.0"]
+        result = server._filter_version_range(versions, "1.0.0", "2.0.0")
+        # 1.0.0 excluded (from is exclusive); 2.0.0 included (to is inclusive);
+        # 2.1.0 excluded (above to).
+        self.assertEqual(result, ["1.5.0", "2.0.0"])
+
+    def test_empty_when_nothing_in_range(self):
+        versions = ["1.0.0"]
+        self.assertEqual(server._filter_version_range(versions, "2.0.0", "3.0.0"), [])
+
+
+# ---------------------------------------------------------------------------
+# Tag normalization — re.sub(r"^[^0-9]*", "", tag)
+# ---------------------------------------------------------------------------
+class TagNormalizationTest(unittest.TestCase):
+    def test_strips_leading_non_digits(self):
+        # Mirrors tag-matcher.test.ts: leading prefix removed up to first digit.
+        norm = lambda tag: re.sub(r"^[^0-9]*", "", tag)
+        self.assertEqual(norm("v2.0.0"), "2.0.0")
+        self.assertEqual(norm("release-1.5.0"), "1.5.0")
+        self.assertEqual(norm("ktor-2.0.0"), "2.0.0")
+        self.assertEqual(norm("1.0.0"), "1.0.0")
+
+
+# ---------------------------------------------------------------------------
+# _get_dependency_changes_impl — GitHub-releases-only changelog path
+# mirrors changelog/__tests__/github-provider.test.ts (github path only)
+# ---------------------------------------------------------------------------
+class DependencyChangesImplTest(unittest.TestCase):
+    def test_returns_changes_from_github_releases(self):
+        # github-provider "returns entries from GitHub releases".
+        releases = [
+            {
+                "tag_name": "v2.0.0",
+                "body": "New features",
+                "html_url": "https://github.com/ktorio/ktor/releases/tag/2.0.0",
+            }
+        ]
+        responses = [
+            (200, _metadata_xml(["1.0.0", "1.5.0", "2.0.0"])),  # fetch_metadata
+            (200, POM_WITH_SCM_KTOR.encode()),  # discover_github_repo (POM SCM)
+            (200, json.dumps(releases).encode()),  # gh_fetch_releases
+        ]
+        with mock.patch("urllib.request.urlopen", side_effect=mock_urlopen(responses)):
+            result = server._get_dependency_changes_impl(
+                "io.ktor", "ktor-core", "1.0.0", "2.0.0"
+            )
+        self.assertNotIn("error", result)
+        self.assertNotIn("repositoryNotFound", result)
+        self.assertEqual(result["repositoryUrl"], "https://github.com/ktorio/ktor")
+        by_version = {c["version"]: c for c in result["changes"]}
+        # Range is (1.0.0, 2.0.0] -> 1.5.0 (no release) and 2.0.0 (matched).
+        self.assertEqual(set(by_version), {"1.5.0", "2.0.0"})
+        self.assertNotIn("body", by_version["1.5.0"])
+        self.assertEqual(by_version["2.0.0"]["body"], "New features")
+        self.assertEqual(
+            by_version["2.0.0"]["releaseUrl"],
+            "https://github.com/ktorio/ktor/releases/tag/2.0.0",
+        )
+
+    def test_tag_normalization_matches_prefixed_release(self):
+        # A "ktor-1.5.0" tag is normalized to "1.5.0" and matched to the range.
+        releases = [{"tag_name": "ktor-1.5.0", "body": "mid", "html_url": "u"}]
+        responses = [
+            (200, _metadata_xml(["1.0.0", "1.5.0"])),
+            (200, POM_WITH_SCM_KTOR.encode()),
+            (200, json.dumps(releases).encode()),
+        ]
+        with mock.patch("urllib.request.urlopen", side_effect=mock_urlopen(responses)):
+            result = server._get_dependency_changes_impl(
+                "io.ktor", "ktor-core", "1.0.0", "1.5.0"
+            )
+        by_version = {c["version"]: c for c in result["changes"]}
+        self.assertEqual(by_version["1.5.0"]["body"], "mid")
+
+    def test_repository_not_found_branch(self):
+        # discover_github_repo returns None (no SCM, groupId not guessable).
+        responses = [
+            (200, _metadata_xml(["1.0.0", "2.0.0"])),  # fetch_metadata
+            (200, POM_WITHOUT_SCM.encode()),  # POM has no github SCM
+        ]
+        with mock.patch("urllib.request.urlopen", side_effect=mock_urlopen(responses)):
+            result = server._get_dependency_changes_impl(
+                "com.example", "lib", "1.0.0", "2.0.0"
+            )
+        self.assertTrue(result["repositoryNotFound"])
+        self.assertNotIn("repositoryUrl", result)
+
+    def test_no_releases_branch(self):
+        # Repo discovered but it has zero releases: every change is bare {version}.
+        # Python divergence: unlike the TS github-provider, there is NO CHANGELOG.md
+        # file fallback here — an empty releases list yields version-only entries.
+        responses = [
+            (200, _metadata_xml(["1.0.0", "2.0.0"])),
+            (200, POM_WITH_SCM_KTOR.encode()),
+            (200, b"[]"),  # gh_fetch_releases -> []
+        ]
+        with mock.patch("urllib.request.urlopen", side_effect=mock_urlopen(responses)):
+            result = server._get_dependency_changes_impl(
+                "io.ktor", "ktor-core", "1.0.0", "2.0.0"
+            )
+        self.assertNotIn("error", result)
+        self.assertEqual(result["repositoryUrl"], "https://github.com/ktorio/ktor")
+        self.assertEqual(result["changes"], [{"version": "2.0.0"}])
+
+    def test_empty_range_branch(self):
+        # Filter yields nothing -> "No versions found" error, no network past metadata.
+        responses = [(200, _metadata_xml(["1.0.0"]))]
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen(responses)
+        ) as m:
+            result = server._get_dependency_changes_impl(
+                "io.ktor", "ktor-core", "2.0.0", "3.0.0"
+            )
+        self.assertEqual(result["error"], "No versions found between 2.0.0 and 3.0.0")
+        self.assertEqual(len(m.call_args_list), 1)  # only the metadata fetch
+
+    def test_metadata_unavailable_branch(self):
+        # fetch_metadata raising (all repos 404) surfaces as an "error" field.
+        err = http_error("https://repo1.maven.org/maven2/x/maven-metadata.xml", 404)
+        with mock.patch("urllib.request.urlopen", side_effect=mock_urlopen([err])):
+            result = server._get_dependency_changes_impl(
+                "io.ktor", "ktor-core", "1.0.0", "2.0.0"
+            )
+        self.assertIn("error", result)
+        self.assertEqual(result["changes"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/maven-mcp/tests/test_github.py
+++ b/plugins/maven-mcp/tests/test_github.py
@@ -21,7 +21,7 @@ here — only the github-releases path is exercised.
 import json
 import re
 import unittest
-from unittest import mock
+import unittest.mock
 
 from _helpers import server, mock_urlopen, http_error
 
@@ -57,7 +57,7 @@ def _captured_request(mock_obj, index=0):
 class GhRepoExistsTest(unittest.TestCase):
     def test_true_when_repo_exists(self):
         # repoExists "returns true when repo exists" + asserts URL.
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen", side_effect=mock_urlopen([(200, b"{}")])
         ) as m:
             self.assertTrue(server.gh_repo_exists("owner", "repo"))
@@ -68,12 +68,12 @@ class GhRepoExistsTest(unittest.TestCase):
     def test_false_when_repo_missing(self):
         # repoExists "returns false when repo does not exist" (404).
         err = http_error("https://api.github.com/repos/owner/repo", 404, "Not Found")
-        with mock.patch("urllib.request.urlopen", side_effect=mock_urlopen([err])):
+        with unittest.mock.patch("urllib.request.urlopen", side_effect=mock_urlopen([err])):
             self.assertFalse(server.gh_repo_exists("owner", "repo"))
 
     def test_false_on_network_error(self):
         # repoExists "returns false on fetch error".
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([server.urllib.error.URLError("boom")]),
         ):
@@ -86,7 +86,7 @@ class GhRepoExistsTest(unittest.TestCase):
 class GhFetchRepoTest(unittest.TestCase):
     def test_returns_repo_json(self):
         payload = {"full_name": "owner/repo", "stargazers_count": 42}
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([(200, json.dumps(payload).encode())]),
         ) as m:
@@ -98,7 +98,7 @@ class GhFetchRepoTest(unittest.TestCase):
 
     def test_returns_none_on_404(self):
         err = http_error("https://api.github.com/repos/owner/repo", 404)
-        with mock.patch("urllib.request.urlopen", side_effect=mock_urlopen([err])):
+        with unittest.mock.patch("urllib.request.urlopen", side_effect=mock_urlopen([err])):
             self.assertIsNone(server.gh_fetch_repo("owner", "repo"))
 
 
@@ -112,7 +112,7 @@ class GhFetchReleasesTest(unittest.TestCase):
             {"tag_name": "v1.0.0", "body": "First", "html_url": "u1"},
             {"tag_name": "v2.0.0", "body": "Second", "html_url": "u2"},
         ]
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([(200, json.dumps(releases).encode())]),
         ) as m:
@@ -130,12 +130,12 @@ class GhFetchReleasesTest(unittest.TestCase):
     def test_returns_empty_list_on_404(self):
         # fetchReleases "returns empty array on non-ok response".
         err = http_error("https://api.github.com/x", 404)
-        with mock.patch("urllib.request.urlopen", side_effect=mock_urlopen([err])):
+        with unittest.mock.patch("urllib.request.urlopen", side_effect=mock_urlopen([err])):
             self.assertEqual(server.gh_fetch_releases("owner", "repo"), [])
 
     def test_returns_empty_list_on_network_error(self):
         # fetchReleases "returns empty array on fetch error".
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([server.urllib.error.URLError("net")]),
         ):
@@ -148,7 +148,7 @@ class GhFetchReleasesTest(unittest.TestCase):
 class GhFetchUserTest(unittest.TestCase):
     def test_returns_user_json(self):
         payload = {"login": "square", "public_repos": 120}
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([(200, json.dumps(payload).encode())]),
         ) as m:
@@ -160,7 +160,7 @@ class GhFetchUserTest(unittest.TestCase):
 
     def test_returns_none_on_404(self):
         err = http_error("https://api.github.com/users/nobody", 404)
-        with mock.patch("urllib.request.urlopen", side_effect=mock_urlopen([err])):
+        with unittest.mock.patch("urllib.request.urlopen", side_effect=mock_urlopen([err])):
             self.assertIsNone(server.gh_fetch_user("nobody"))
 
 
@@ -189,7 +189,7 @@ class GhFetchIssueStatsTest(unittest.TestCase):
                 }
             ).encode(),
         )
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([open_resp, closed_resp, median_resp]),
         ) as m:
@@ -204,7 +204,7 @@ class GhFetchIssueStatsTest(unittest.TestCase):
     def test_returns_none_when_both_counts_unavailable(self):
         # Both search calls non-200 -> early return None before the median call.
         err = http_error("https://api.github.com/search/issues", 403, "rate limited")
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen", side_effect=mock_urlopen([err, err])
         ) as m:
             self.assertIsNone(server.gh_fetch_issue_stats("owner", "repo"))
@@ -218,8 +218,8 @@ class GhFetchIssueStatsTest(unittest.TestCase):
 class GitHubAuthHeaderTest(unittest.TestCase):
     def test_authorization_header_sent_when_token_set(self):
         # "sends Authorization header when token is provided".
-        with mock.patch.dict("os.environ", {"GITHUB_TOKEN": "secret-token"}):
-            with mock.patch(
+        with unittest.mock.patch.dict("os.environ", {"GITHUB_TOKEN": "secret-token"}):
+            with unittest.mock.patch(
                 "urllib.request.urlopen", side_effect=mock_urlopen([(200, b"{}")])
             ) as m:
                 server.gh_fetch_repo("owner", "repo")
@@ -229,8 +229,8 @@ class GitHubAuthHeaderTest(unittest.TestCase):
 
     def test_no_authorization_header_without_token(self):
         # "does not send Authorization header when no token" (env cleared).
-        with mock.patch.dict("os.environ", {}, clear=True):
-            with mock.patch(
+        with unittest.mock.patch.dict("os.environ", {}, clear=True):
+            with unittest.mock.patch(
                 "urllib.request.urlopen", side_effect=mock_urlopen([(200, b"{}")])
             ) as m:
                 server.gh_fetch_repo("owner", "repo")
@@ -243,7 +243,7 @@ class GitHubAuthHeaderTest(unittest.TestCase):
 class DiscoverGithubRepoTest(unittest.TestCase):
     def test_returns_repo_from_pom_scm(self):
         # "returns GitHub repo from POM SCM". One urlopen (POM, Maven Central only).
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([(200, POM_WITH_SCM_OKHTTP.encode())]),
         ) as m:
@@ -260,7 +260,7 @@ class DiscoverGithubRepoTest(unittest.TestCase):
             (200, POM_WITHOUT_SCM.encode()),  # POM has no github SCM
             (200, b"{}"),  # gh_repo_exists for the guessed repo -> 200
         ]
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen", side_effect=mock_urlopen(responses)
         ) as m:
             result = server.discover_github_repo("io.github.javalin", "javalin", "5.0.0")
@@ -271,7 +271,7 @@ class DiscoverGithubRepoTest(unittest.TestCase):
         # "returns null when guess repo does not exist on GitHub".
         err = http_error("https://api.github.com/repos/someuser/nonexistent-lib", 404)
         responses = [(200, POM_WITHOUT_SCM.encode()), err]
-        with mock.patch("urllib.request.urlopen", side_effect=mock_urlopen(responses)):
+        with unittest.mock.patch("urllib.request.urlopen", side_effect=mock_urlopen(responses)):
             result = server.discover_github_repo(
                 "io.github.someuser", "nonexistent-lib", "1.0.0"
             )
@@ -280,7 +280,7 @@ class DiscoverGithubRepoTest(unittest.TestCase):
     def test_returns_none_when_no_pom_and_not_guessable(self):
         # "returns null when no POM found and groupId is not guessable".
         err = http_error("https://repo1.maven.org/maven2/x.pom", 404)
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen", side_effect=mock_urlopen([err])
         ) as m:
             result = server.discover_github_repo(
@@ -339,7 +339,7 @@ class DependencyChangesImplTest(unittest.TestCase):
             (200, POM_WITH_SCM_KTOR.encode()),  # discover_github_repo (POM SCM)
             (200, json.dumps(releases).encode()),  # gh_fetch_releases
         ]
-        with mock.patch("urllib.request.urlopen", side_effect=mock_urlopen(responses)):
+        with unittest.mock.patch("urllib.request.urlopen", side_effect=mock_urlopen(responses)):
             result = server._get_dependency_changes_impl(
                 "io.ktor", "ktor-core", "1.0.0", "2.0.0"
             )
@@ -364,7 +364,7 @@ class DependencyChangesImplTest(unittest.TestCase):
             (200, POM_WITH_SCM_KTOR.encode()),
             (200, json.dumps(releases).encode()),
         ]
-        with mock.patch("urllib.request.urlopen", side_effect=mock_urlopen(responses)):
+        with unittest.mock.patch("urllib.request.urlopen", side_effect=mock_urlopen(responses)):
             result = server._get_dependency_changes_impl(
                 "io.ktor", "ktor-core", "1.0.0", "1.5.0"
             )
@@ -377,7 +377,7 @@ class DependencyChangesImplTest(unittest.TestCase):
             (200, _metadata_xml(["1.0.0", "2.0.0"])),  # fetch_metadata
             (200, POM_WITHOUT_SCM.encode()),  # POM has no github SCM
         ]
-        with mock.patch("urllib.request.urlopen", side_effect=mock_urlopen(responses)):
+        with unittest.mock.patch("urllib.request.urlopen", side_effect=mock_urlopen(responses)):
             result = server._get_dependency_changes_impl(
                 "com.example", "lib", "1.0.0", "2.0.0"
             )
@@ -393,7 +393,7 @@ class DependencyChangesImplTest(unittest.TestCase):
             (200, POM_WITH_SCM_KTOR.encode()),
             (200, b"[]"),  # gh_fetch_releases -> []
         ]
-        with mock.patch("urllib.request.urlopen", side_effect=mock_urlopen(responses)):
+        with unittest.mock.patch("urllib.request.urlopen", side_effect=mock_urlopen(responses)):
             result = server._get_dependency_changes_impl(
                 "io.ktor", "ktor-core", "1.0.0", "2.0.0"
             )
@@ -404,7 +404,7 @@ class DependencyChangesImplTest(unittest.TestCase):
     def test_empty_range_branch(self):
         # Filter yields nothing -> "No versions found" error, no network past metadata.
         responses = [(200, _metadata_xml(["1.0.0"]))]
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen", side_effect=mock_urlopen(responses)
         ) as m:
             result = server._get_dependency_changes_impl(
@@ -416,7 +416,7 @@ class DependencyChangesImplTest(unittest.TestCase):
     def test_metadata_unavailable_branch(self):
         # fetch_metadata raising (all repos 404) surfaces as an "error" field.
         err = http_error("https://repo1.maven.org/maven2/x/maven-metadata.xml", 404)
-        with mock.patch("urllib.request.urlopen", side_effect=mock_urlopen([err])):
+        with unittest.mock.patch("urllib.request.urlopen", side_effect=mock_urlopen([err])):
             result = server._get_dependency_changes_impl(
                 "io.ktor", "ktor-core", "1.0.0", "2.0.0"
             )

--- a/plugins/maven-mcp/tests/test_handlers.py
+++ b/plugins/maven-mcp/tests/test_handlers.py
@@ -1,0 +1,479 @@
+"""Tool-handler integration tests for the maven-mcp Python server (T-6).
+
+Covers all 10 ``handle_*`` entry points (server.py :1229-:1607) by patching
+``urllib.request.urlopen`` with ``mock_urlopen`` and driving the local-scan
+handlers through ``temp_project``. Each handler test cites the TypeScript test
+it mirrors under ``src/tools/__tests__/``.
+
+Two extra requirements live here:
+  * the #263 regression for ``handle_compare_dependency_versions`` — asserts the
+    EXACT observable produced by the ``if not latest`` guard (server.py :1299),
+    so deleting that guard changes the output, and
+  * P3 boundary tests for the dependency-health stat/date helpers
+    (``median_days_to_close`` :452, ``_months_since`` :507, ``_parse_iso`` :496,
+    ``_summarize_releases`` :523) exercised directly, not only via the handler.
+"""
+
+import datetime
+import json
+import unittest
+from unittest import mock
+
+from _helpers import server, mock_urlopen, http_error, temp_project
+
+
+# --- response builders ------------------------------------------------------
+
+def _meta(versions, last_updated="20240101000000"):
+    """maven-metadata.xml bytes; the parser only reads <version>/<lastUpdated>."""
+    vers = "".join(f"<version>{v}</version>" for v in versions)
+    xml = (
+        "<metadata><versioning>"
+        f"<lastUpdated>{last_updated}</lastUpdated>"
+        f"<versions>{vers}</versions>"
+        "</versioning></metadata>"
+    )
+    return xml.encode("utf-8")
+
+
+def _json(obj):
+    return json.dumps(obj).encode("utf-8")
+
+
+def _patch_urlopen(responses):
+    return mock.patch("urllib.request.urlopen", side_effect=mock_urlopen(responses))
+
+
+# --- handle_get_latest_version ----------------------------------------------
+
+class TestGetLatestVersion(unittest.TestCase):
+    """mirrors src/tools/__tests__/get-latest-version.test.ts"""
+
+    def test_returns_latest_stable(self):
+        with _patch_urlopen([(200, _meta(["1.0.0", "2.0.0"]))]):
+            out = server.handle_get_latest_version(
+                {"groupId": "com.example", "artifactId": "lib"}
+            )
+        self.assertEqual(out["latestVersion"], "2.0.0")
+        self.assertEqual(out["stability"], "stable")
+        self.assertEqual(out["allVersionsCount"], 2)
+
+    def test_no_stable_version_raises(self):
+        # STABLE_ONLY over a prerelease-only metadata -> find_latest_version None
+        # -> handler raises ValueError (server.py :1235-:1236).
+        with _patch_urlopen([(200, _meta(["1.0.0-alpha01"]))]):
+            with self.assertRaises(ValueError):
+                server.handle_get_latest_version({
+                    "groupId": "com.example",
+                    "artifactId": "lib",
+                    "stabilityFilter": "STABLE_ONLY",
+                })
+
+
+# --- handle_check_version_exists --------------------------------------------
+
+class TestCheckVersionExists(unittest.TestCase):
+    """mirrors src/tools/__tests__/check-version-exists.test.ts"""
+
+    def test_version_present(self):
+        with _patch_urlopen([(200, _meta(["1.0.0", "1.1.0"]))]):
+            out = server.handle_check_version_exists({
+                "groupId": "com.example", "artifactId": "lib", "version": "1.1.0",
+            })
+        self.assertTrue(out["exists"])
+        self.assertEqual(out["repository"], "Maven Central")
+
+    def test_version_absent(self):
+        with _patch_urlopen([(200, _meta(["1.0.0", "1.1.0"]))]):
+            out = server.handle_check_version_exists({
+                "groupId": "com.example", "artifactId": "lib", "version": "9.9.9",
+            })
+        self.assertFalse(out["exists"])
+        self.assertNotIn("repository", out)
+
+
+# --- handle_check_multiple_dependencies -------------------------------------
+
+class TestCheckMultipleDependencies(unittest.TestCase):
+    """mirrors src/tools/__tests__/check-multiple-dependencies.test.ts"""
+
+    def test_resolves_latest(self):
+        with _patch_urlopen([(200, _meta(["1.0.0", "1.1.0"]))]):
+            out = server.handle_check_multiple_dependencies({
+                "dependencies": [{"groupId": "com.example", "artifactId": "lib"}],
+            })
+        self.assertEqual(out["results"][0]["latestVersion"], "1.1.0")
+
+    def test_failed_fetch_records_error(self):
+        # First dep resolves, second 404s -> fetch_metadata raises -> error entry.
+        responses = [
+            (200, _meta(["1.0.0", "1.1.0"])),
+            http_error("https://repo.example/x", 404, "Not Found"),
+        ]
+        with _patch_urlopen(responses):
+            out = server.handle_check_multiple_dependencies({
+                "dependencies": [
+                    {"groupId": "com.example", "artifactId": "good"},
+                    {"groupId": "com.example", "artifactId": "bad"},
+                ],
+            })
+        self.assertEqual(out["results"][0]["latestVersion"], "1.1.0")
+        self.assertEqual(out["results"][1]["latestVersion"], "")
+        self.assertIn("error", out["results"][1])
+
+
+# --- handle_compare_dependency_versions (+ #263 regression) -----------------
+
+class TestCompareDependencyVersions(unittest.TestCase):
+    """mirrors src/tools/__tests__/compare-dependency-versions.test.ts"""
+
+    def test_263_no_match_guard_exact_observables(self):
+        # #263 regression. dep[0] is alpha-current with only a STABLE candidate
+        # newer: find_latest_version_for_current returns None (no version is as
+        # unstable-or-more than alpha), so the `if not latest` guard (server.py
+        # :1299) raises "No matching version found". dep[1] resolves normally.
+        # Asserting the EXACT error string + upgradeAvailable/latestVersion makes
+        # this fail if the guard is removed: without it, get_upgrade_type(current,
+        # None) raises a TypeError whose message would replace the error text.
+        responses = [
+            (200, _meta(["2.0.0"])),            # dep[0] no-match metadata
+            (200, _meta(["1.0.0", "1.1.0"])),   # dep[1] sibling metadata
+        ]
+        with _patch_urlopen(responses):
+            out = server.handle_compare_dependency_versions({
+                "dependencies": [
+                    {"groupId": "com.example", "artifactId": "nomatch",
+                     "currentVersion": "1.0.0-alpha01"},
+                    {"groupId": "com.example", "artifactId": "sibling",
+                     "currentVersion": "1.0.0"},
+                ],
+            })
+        no_match, sibling = out["results"]
+
+        # Exact observables of the guard:
+        self.assertEqual(no_match["error"], "No matching version found")
+        self.assertIs(no_match["upgradeAvailable"], False)
+        self.assertEqual(no_match["latestVersion"], "")
+
+        # Sibling still resolves successfully alongside the failed one:
+        self.assertEqual(sibling["latestVersion"], "1.1.0")
+        self.assertIs(sibling["upgradeAvailable"], True)
+        self.assertEqual(sibling["upgradeType"], "minor")
+
+
+# --- handle_get_dependency_changes ------------------------------------------
+
+class TestGetDependencyChanges(unittest.TestCase):
+    """mirrors src/tools/__tests__/get-dependency-changes.test.ts"""
+
+    def test_happy_path_github_releases(self):
+        # fetch_metadata(1) + fetch_pom(1, github SCM) + gh_fetch_releases(1) = 3.
+        pom = (
+            "<project><scm><url>https://github.com/acme/widget</url></scm>"
+            "</project>"
+        )
+        releases = [{
+            "tag_name": "v1.2.0",
+            "html_url": "https://github.com/acme/widget/releases/v1.2.0",
+            "body": "release notes",
+        }]
+        responses = [
+            (200, _meta(["1.0.0", "1.1.0", "1.2.0"])),
+            (200, pom.encode("utf-8")),
+            (200, _json(releases)),
+        ]
+        with _patch_urlopen(responses):
+            out = server.handle_get_dependency_changes({
+                "groupId": "com.example", "artifactId": "widget",
+                "fromVersion": "1.0.0", "toVersion": "1.2.0",
+            })
+        self.assertEqual(out["repositoryUrl"], "https://github.com/acme/widget")
+        by_version = {c["version"]: c for c in out["changes"]}
+        self.assertEqual(set(by_version), {"1.1.0", "1.2.0"})
+        # v1.2.0 tag normalized to 1.2.0 and matched -> carries releaseUrl/body.
+        self.assertEqual(
+            by_version["1.2.0"]["releaseUrl"],
+            "https://github.com/acme/widget/releases/v1.2.0",
+        )
+
+    def test_repository_not_found(self):
+        # POM 404 -> no SCM repo; com.example is not io.github/com.github so the
+        # guess path yields nothing -> repositoryNotFound (server.py :603-:604).
+        responses = [
+            (200, _meta(["1.0.0", "1.1.0", "1.2.0"])),
+            http_error("https://repo.example/pom", 404, "Not Found"),
+        ]
+        with _patch_urlopen(responses):
+            out = server.handle_get_dependency_changes({
+                "groupId": "com.example", "artifactId": "widget",
+                "fromVersion": "1.0.0", "toVersion": "1.2.0",
+            })
+        self.assertIs(out["repositoryNotFound"], True)
+
+
+# --- handle_scan_project_dependencies ---------------------------------------
+
+class TestScanProjectDependencies(unittest.TestCase):
+    """mirrors src/tools/__tests__/scan-project-dependencies.test.ts"""
+
+    def test_maven_pom_scan(self):
+        pom = (
+            "<project><dependencies><dependency>"
+            "<groupId>com.example</groupId>"
+            "<artifactId>lib</artifactId>"
+            "<version>1.2.3</version>"
+            "</dependency></dependencies></project>"
+        )
+        with temp_project({"pom.xml": pom}) as root:
+            out = server.handle_scan_project_dependencies({"projectPath": root})
+        self.assertEqual(out["buildSystem"], "maven")
+        deps = {(d["groupId"], d["artifactId"]): d for d in out["dependencies"]}
+        self.assertIn(("com.example", "lib"), deps)
+        self.assertEqual(deps[("com.example", "lib")]["version"], "1.2.3")
+
+    def test_unknown_build_system(self):
+        with temp_project({"README.md": "no build files here"}) as root:
+            out = server.handle_scan_project_dependencies({"projectPath": root})
+        self.assertEqual(out["buildSystem"], "unknown")
+        self.assertEqual(out["dependencies"], [])
+
+
+# --- handle_get_dependency_vulnerabilities ----------------------------------
+
+class TestGetDependencyVulnerabilities(unittest.TestCase):
+    """mirrors src/tools/__tests__/get-dependency-vulnerabilities.test.ts"""
+
+    def test_reports_vulnerability(self):
+        osv = {"results": [{"vulns": [{
+            "id": "GHSA-xxxx",
+            "summary": "bad bug",
+            "severity": [{"type": "CVSS_V3", "score": "9.8"}],
+            "affected": [{"ranges": [{"type": "ECOSYSTEM", "events": [
+                {"introduced": "0"}, {"fixed": "1.2.3"},
+            ]}]}],
+            "references": [{"type": "ADVISORY", "url": "https://advisory/x"}],
+        }]}]}
+        with _patch_urlopen([(200, _json(osv))]):
+            out = server.handle_get_dependency_vulnerabilities({
+                "dependencies": [
+                    {"groupId": "com.example", "artifactId": "lib", "version": "1.0.0"},
+                ],
+            })
+        result = out["results"][0]
+        self.assertEqual(result["vulnerabilityCount"], 1)
+        self.assertEqual(result["vulnerabilities"][0]["severity"], "CRITICAL")
+        self.assertEqual(result["vulnerabilities"][0]["fixedVersion"], "1.2.3")
+
+    def test_osv_non_200_yields_no_vulns(self):
+        with _patch_urlopen([(500, b"")]):
+            out = server.handle_get_dependency_vulnerabilities({
+                "dependencies": [
+                    {"groupId": "com.example", "artifactId": "lib", "version": "1.0.0"},
+                ],
+            })
+        self.assertEqual(out["results"][0]["vulnerabilityCount"], 0)
+
+
+# --- handle_get_dependency_health -------------------------------------------
+
+class TestGetDependencyHealth(unittest.TestCase):
+    """mirrors src/tools/__tests__/get-dependency-health.test.ts"""
+
+    def test_full_github_signals(self):
+        # Call sequence (all must be 200 + valid JSON or the chain short-circuits):
+        # metadata(1) + pom(1) + gh_fetch_repo(1) + gh_fetch_releases(1)
+        # + gh_fetch_issue_stats(3) + gh_fetch_user(1) = 8.
+        pom = (
+            "<project><scm><url>https://github.com/acme/widget</url></scm>"
+            "<licenses><license><name>Apache-2.0</name></license></licenses>"
+            "</project>"
+        )
+        repo = {
+            "stargazers_count": 100, "forks_count": 10, "open_issues_count": 5,
+            "archived": False,
+            "owner": {"login": "acme", "type": "Organization"},
+            "pushed_at": "2024-06-01T00:00:00Z",
+            "license": {"spdx_id": "Apache-2.0"},
+            "created_at": "2020-01-01T00:00:00Z",
+        }
+        responses = [
+            (200, _meta(["1.0.0"])),
+            (200, pom.encode("utf-8")),
+            (200, _json(repo)),
+            (200, _json([])),                       # releases
+            (200, _json({"total_count": 5})),       # issues open
+            (200, _json({"total_count": 20})),      # issues closed
+            (200, _json({"items": []})),            # median items
+            (200, _json({"public_repos": 50, "created_at": "2015-01-01T00:00:00Z"})),
+        ]
+        with _patch_urlopen(responses):
+            out = server.handle_get_dependency_health({
+                "dependencies": [{"groupId": "com.example", "artifactId": "widget"}],
+            })
+        result = out["results"][0]
+        self.assertEqual(result["repository"]["owner"], "acme")
+        self.assertIsNotNone(result["github"])
+        self.assertEqual(result["github"]["stars"], 100)
+        self.assertEqual(result["github"]["license"], "Apache-2.0")
+
+    def test_no_github_repo_health_error(self):
+        # metadata(1) + pom 404 -> None(1); guess fails for com.example -> no repo.
+        responses = [
+            (200, _meta(["1.0.0"])),
+            http_error("https://repo.example/pom", 404, "Not Found"),
+        ]
+        with _patch_urlopen(responses):
+            out = server.handle_get_dependency_health({
+                "dependencies": [{"groupId": "com.example", "artifactId": "widget"}],
+            })
+        result = out["results"][0]
+        self.assertIsNone(result["github"])
+        self.assertIn("healthError", result)
+
+
+# --- handle_search_artifacts ------------------------------------------------
+
+class TestSearchArtifacts(unittest.TestCase):
+    """mirrors src/tools/__tests__/search-artifacts.test.ts"""
+
+    def test_returns_results(self):
+        body = {"response": {"docs": [
+            {"g": "com.example", "a": "lib", "latestVersion": "1.0.0", "versionCount": 3},
+        ]}}
+        with _patch_urlopen([(200, _json(body))]):
+            out = server.handle_search_artifacts({"query": "lib"})
+        self.assertEqual(out["results"][0]["groupId"], "com.example")
+        self.assertEqual(out["results"][0]["latestVersion"], "1.0.0")
+
+    def test_non_200_yields_empty(self):
+        with _patch_urlopen([(503, b"")]):
+            out = server.handle_search_artifacts({"query": "lib"})
+        self.assertEqual(out["results"], [])
+
+
+# --- handle_audit_project_dependencies --------------------------------------
+
+class TestAuditProjectDependencies(unittest.TestCase):
+    """mirrors src/tools/__tests__/audit-project-dependencies.test.ts"""
+
+    def test_maven_audit_with_upgrade(self):
+        pom = (
+            "<project><dependencies><dependency>"
+            "<groupId>com.example</groupId>"
+            "<artifactId>lib</artifactId>"
+            "<version>1.0.0</version>"
+            "</dependency></dependencies></project>"
+        )
+        # scan (local) -> fetch_metadata(1) -> query_osv_batch POST(1).
+        responses = [
+            (200, _meta(["1.0.0", "1.1.0"])),
+            (200, _json({"results": [{"vulns": []}]})),
+        ]
+        with temp_project({"pom.xml": pom}) as root:
+            with _patch_urlopen(responses):
+                out = server.handle_audit_project_dependencies({"projectPath": root})
+        self.assertEqual(out["buildSystem"], "maven")
+        dep = out["dependencies"][0]
+        self.assertEqual(dep["latestVersion"], "1.1.0")
+        self.assertEqual(dep["upgradeType"], "minor")
+        self.assertGreaterEqual(out["summary"]["upgradeable"], 1)
+
+    def test_empty_project_no_network(self):
+        # Unknown build system -> no deps, no network calls (mock would assert if
+        # any urlopen happened). Exercises the empty-scan edge of the orchestrator.
+        with temp_project({"README.md": "nothing"}) as root:
+            with _patch_urlopen([]):
+                out = server.handle_audit_project_dependencies({"projectPath": root})
+        self.assertEqual(out["buildSystem"], "unknown")
+        self.assertEqual(out["dependencies"], [])
+        self.assertEqual(out["summary"]["total"], 0)
+
+
+# --- dependency-health stat/date helpers (P3 boundaries, direct) ------------
+
+class TestDependencyHealthHelpers(unittest.TestCase):
+    """P3 edges for the health stat/date helpers, exercised directly.
+
+    ``median_days_to_close`` (server.py :452) is a closure inside
+    ``gh_fetch_issue_stats``; "directly" therefore means driving that function
+    one level below ``handle_get_dependency_health`` with mocked urlopen, not
+    through the handler.
+    """
+
+    def test_median_days_to_close_empty_durations(self):
+        # gh_fetch_issue_stats issues 3 _gh_get calls: open, closed, median items.
+        # Empty items -> empty durations -> median returns None (:471-:472).
+        responses = [
+            (200, _json({"total_count": 3})),   # open
+            (200, _json({"total_count": 2})),   # closed
+            (200, _json({"items": []})),        # median items (empty)
+        ]
+        with _patch_urlopen(responses):
+            stats = server.gh_fetch_issue_stats("acme", "widget")
+        self.assertIsNone(stats["medianDaysToClose"])
+
+    def test_median_days_to_close_single_element(self):
+        # One closed issue 4 days wide -> single-element durations -> odd branch
+        # returns that value, rounded to days (:475-:479).
+        responses = [
+            (200, _json({"total_count": 1})),
+            (200, _json({"total_count": 1})),
+            (200, _json({"items": [
+                {"created_at": "2024-01-01T00:00:00Z",
+                 "closed_at": "2024-01-05T00:00:00Z"},
+            ]})),
+        ]
+        with _patch_urlopen(responses):
+            stats = server.gh_fetch_issue_stats("acme", "widget")
+        self.assertEqual(stats["medianDaysToClose"], 4)
+
+    def test_months_since(self):
+        self.assertIsNone(server._months_since(None))  # :508-:509
+        # Naive UTC "now" (matches _months_since's internal utcnow baseline)
+        # without the deprecated utcnow() call.
+        now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        recent = (now - datetime.timedelta(days=15)).isoformat()
+        self.assertEqual(server._months_since(recent), 0)  # int(15/30)
+        old = (now - datetime.timedelta(days=400)).isoformat()
+        self.assertEqual(server._months_since(old), 13)    # int(400/30)
+        # Aware ISO (offset present): :515-:516 strips tzinfo before subtracting.
+        aware = (datetime.datetime.now(datetime.timezone.utc)
+                 - datetime.timedelta(days=400)).isoformat()
+        self.assertTrue(aware.endswith("+00:00"))
+        self.assertEqual(server._months_since(aware), 13)
+
+    def test_parse_iso_naive_and_aware(self):
+        naive = server._parse_iso("2020-01-02T03:04:05")  # :496
+        self.assertEqual((naive.year, naive.month, naive.day), (2020, 1, 2))
+        self.assertIsNone(naive.utcoffset())  # naive timestamp -> no offset
+        aware = server._parse_iso("2020-01-02T03:04:05Z")  # Z -> +00:00 (:499)
+        self.assertEqual(aware.utcoffset(), datetime.timedelta(0))
+
+    def test_summarize_releases(self):
+        # Empty -> all-None (:539-:540).
+        empty = server._summarize_releases([])
+        self.assertEqual(empty, {"last": None, "cadenceDays": None, "count": 0})
+
+        # Single -> last set, cadence None (:542-:543).
+        single = server._summarize_releases([{"published_at": "2024-03-21T00:00:00Z"}])
+        self.assertEqual(single["count"], 1)
+        self.assertEqual(single["last"], "2024-03-21T00:00:00Z")
+        self.assertIsNone(single["cadenceDays"])
+
+        # Cadence math: gaps of 10 and 30 days -> even-length median = 20 days.
+        # draft/prerelease entries are filtered out before the math (:527).
+        releases = [
+            {"published_at": "2024-03-21T00:00:00Z"},
+            {"published_at": "2024-03-11T00:00:00Z"},   # 10 days before
+            {"published_at": "2024-02-10T00:00:00Z"},   # 30 days before 03-11
+            {"published_at": "2024-04-01T00:00:00Z", "prerelease": True},
+            {"published_at": "2024-04-02T00:00:00Z", "draft": True},
+        ]
+        summary = server._summarize_releases(releases)
+        self.assertEqual(summary["count"], 3)
+        self.assertEqual(summary["last"], "2024-03-21T00:00:00Z")
+        self.assertEqual(summary["cadenceDays"], 20)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/maven-mcp/tests/test_handlers.py
+++ b/plugins/maven-mcp/tests/test_handlers.py
@@ -17,7 +17,7 @@ Two extra requirements live here:
 import datetime
 import json
 import unittest
-from unittest import mock
+import unittest.mock
 
 from _helpers import server, mock_urlopen, http_error, temp_project
 
@@ -41,7 +41,7 @@ def _json(obj):
 
 
 def _patch_urlopen(responses):
-    return mock.patch("urllib.request.urlopen", side_effect=mock_urlopen(responses))
+    return unittest.mock.patch("urllib.request.urlopen", side_effect=mock_urlopen(responses))
 
 
 # --- handle_get_latest_version ----------------------------------------------

--- a/plugins/maven-mcp/tests/test_http.py
+++ b/plugins/maven-mcp/tests/test_http.py
@@ -1,0 +1,143 @@
+"""HTTP utility tests: ``http_get`` / ``http_post_json`` plus the header builders
+``_make_headers`` / ``_github_headers`` (server.py:73-108).
+
+Mirrors the NON-retry assertions of ``src/http/__tests__/client.test.ts``:
+default User-Agent, caller-header pass-through, status pass-through, and error
+mapping.
+
+DIVERGENCE #1 (tracked as a T-10 follow-up issue): the retired TS
+``fetchWithRetry`` retried once on 5xx / 429 responses and on network errors
+with backoff. The Python runtime's ``http_get`` / ``http_post_json`` perform a
+SINGLE request and map ``urllib.error.HTTPError`` straight to ``(code, b"")``
+with no retry, backoff, or rate-limit handling. This absence is intentional for
+the current runtime, so there is deliberately NO retry test here — the TS retry
+cases (5xx retry, 429 retry, network-error retry, "stops after retries") have no
+Python counterpart by design.
+"""
+
+import json
+import unittest
+from unittest import mock
+
+from _helpers import server, mock_urlopen, http_error
+
+
+def _headers_ci(req):
+    """Case-insensitive {name: value} view of a urllib Request's headers.
+
+    urllib.request.Request capitalizes header names on insertion
+    (``User-Agent`` -> ``User-agent``), so assertions go through this helper
+    rather than guessing the stored casing.
+    """
+    return {name.lower(): value for name, value in req.header_items()}
+
+
+class MakeHeadersTest(unittest.TestCase):
+    def test_sets_default_user_agent(self):
+        headers = server._make_headers()
+        self.assertEqual(headers["User-Agent"], server.USER_AGENT)
+        # Mirrors client.test.ts: USER_AGENT matches maven-*-mcp/<semver>.
+        self.assertRegex(server.USER_AGENT, r"^maven-.*mcp/\d+\.\d+\.\d+")
+
+    def test_passes_through_extra_headers(self):
+        headers = server._make_headers({"Accept": "application/json"})
+        self.assertEqual(headers["Accept"], "application/json")
+        self.assertEqual(headers["User-Agent"], server.USER_AGENT)
+
+
+class GithubHeadersTest(unittest.TestCase):
+    def test_includes_user_agent_and_accept_without_token(self):
+        with mock.patch.dict("os.environ", {}, clear=False):
+            server.os.environ.pop("GITHUB_TOKEN", None)
+            headers = server._github_headers()
+        self.assertEqual(headers["User-Agent"], server.USER_AGENT)
+        self.assertEqual(headers["Accept"], "application/vnd.github.v3+json")
+        self.assertNotIn("Authorization", headers)
+
+    def test_injects_bearer_authorization_when_token_set(self):
+        with mock.patch.dict("os.environ", {"GITHUB_TOKEN": "tok123"}):
+            headers = server._github_headers()
+        self.assertEqual(headers["Authorization"], "Bearer tok123")
+        self.assertEqual(headers["User-Agent"], server.USER_AGENT)
+
+
+class HttpGetTest(unittest.TestCase):
+    def test_returns_status_and_bytes(self):
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, b"<xml/>")]),
+        ):
+            status, body = server.http_get("https://example.test/x")
+        self.assertEqual(status, 200)
+        self.assertEqual(body, b"<xml/>")
+
+    def test_maps_httperror_to_code_and_empty_bytes(self):
+        err = http_error("https://example.test/x", 500)
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([err]),
+        ):
+            status, body = server.http_get("https://example.test/x")
+        self.assertEqual(status, 500)
+        self.assertEqual(body, b"")
+
+    def test_attaches_default_user_agent(self):
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, b"ok")]),
+        ) as urlopen:
+            server.http_get("https://example.test/x")
+        req = urlopen.call_args.args[0]
+        self.assertEqual(_headers_ci(req)["user-agent"], server.USER_AGENT)
+
+    def test_passes_through_caller_headers(self):
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, b"ok")]),
+        ) as urlopen:
+            server.http_get(
+                "https://example.test/x",
+                headers={"User-Agent": server.USER_AGENT, "Accept": "application/json"},
+            )
+        headers = _headers_ci(urlopen.call_args.args[0])
+        self.assertEqual(headers["accept"], "application/json")
+        self.assertEqual(headers["user-agent"], server.USER_AGENT)
+
+
+class HttpPostJsonTest(unittest.TestCase):
+    def test_encodes_json_body_and_sets_content_type(self):
+        payload = {"queries": [{"package": {"name": "g:a"}}]}
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, b"{}")]),
+        ) as urlopen:
+            server.http_post_json("https://example.test/osv", payload)
+        req = urlopen.call_args.args[0]
+        self.assertEqual(req.get_method(), "POST")
+        self.assertEqual(json.loads(req.data), payload)
+        headers = _headers_ci(req)
+        self.assertEqual(headers["content-type"], "application/json")
+        self.assertEqual(headers["user-agent"], server.USER_AGENT)
+
+    def test_returns_status_and_bytes(self):
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, b'{"ok":true}')]),
+        ):
+            status, body = server.http_post_json("https://example.test/osv", {})
+        self.assertEqual(status, 200)
+        self.assertEqual(body, b'{"ok":true}')
+
+    def test_maps_httperror_to_code_and_empty_bytes(self):
+        err = http_error("https://example.test/osv", 500)
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([err]),
+        ):
+            status, body = server.http_post_json("https://example.test/osv", {})
+        self.assertEqual(status, 500)
+        self.assertEqual(body, b"")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/maven-mcp/tests/test_http.py
+++ b/plugins/maven-mcp/tests/test_http.py
@@ -17,7 +17,7 @@ Python counterpart by design.
 
 import json
 import unittest
-from unittest import mock
+import unittest.mock
 
 from _helpers import server, mock_urlopen, http_error
 
@@ -47,7 +47,7 @@ class MakeHeadersTest(unittest.TestCase):
 
 class GithubHeadersTest(unittest.TestCase):
     def test_includes_user_agent_and_accept_without_token(self):
-        with mock.patch.dict("os.environ", {}, clear=False):
+        with unittest.mock.patch.dict("os.environ", {}, clear=False):
             server.os.environ.pop("GITHUB_TOKEN", None)
             headers = server._github_headers()
         self.assertEqual(headers["User-Agent"], server.USER_AGENT)
@@ -55,7 +55,7 @@ class GithubHeadersTest(unittest.TestCase):
         self.assertNotIn("Authorization", headers)
 
     def test_injects_bearer_authorization_when_token_set(self):
-        with mock.patch.dict("os.environ", {"GITHUB_TOKEN": "tok123"}):
+        with unittest.mock.patch.dict("os.environ", {"GITHUB_TOKEN": "tok123"}):
             headers = server._github_headers()
         self.assertEqual(headers["Authorization"], "Bearer tok123")
         self.assertEqual(headers["User-Agent"], server.USER_AGENT)
@@ -63,7 +63,7 @@ class GithubHeadersTest(unittest.TestCase):
 
 class HttpGetTest(unittest.TestCase):
     def test_returns_status_and_bytes(self):
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([(200, b"<xml/>")]),
         ):
@@ -73,7 +73,7 @@ class HttpGetTest(unittest.TestCase):
 
     def test_maps_httperror_to_code_and_empty_bytes(self):
         err = http_error("https://example.test/x", 500)
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([err]),
         ):
@@ -82,7 +82,7 @@ class HttpGetTest(unittest.TestCase):
         self.assertEqual(body, b"")
 
     def test_attaches_default_user_agent(self):
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([(200, b"ok")]),
         ) as urlopen:
@@ -91,7 +91,7 @@ class HttpGetTest(unittest.TestCase):
         self.assertEqual(_headers_ci(req)["user-agent"], server.USER_AGENT)
 
     def test_passes_through_caller_headers(self):
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([(200, b"ok")]),
         ) as urlopen:
@@ -107,7 +107,7 @@ class HttpGetTest(unittest.TestCase):
 class HttpPostJsonTest(unittest.TestCase):
     def test_encodes_json_body_and_sets_content_type(self):
         payload = {"queries": [{"package": {"name": "g:a"}}]}
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([(200, b"{}")]),
         ) as urlopen:
@@ -120,7 +120,7 @@ class HttpPostJsonTest(unittest.TestCase):
         self.assertEqual(headers["user-agent"], server.USER_AGENT)
 
     def test_returns_status_and_bytes(self):
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([(200, b'{"ok":true}')]),
         ):
@@ -130,7 +130,7 @@ class HttpPostJsonTest(unittest.TestCase):
 
     def test_maps_httperror_to_code_and_empty_bytes(self):
         err = http_error("https://example.test/osv", 500)
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([err]),
         ):

--- a/plugins/maven-mcp/tests/test_maven_search_osv.py
+++ b/plugins/maven-mcp/tests/test_maven_search_osv.py
@@ -1,0 +1,504 @@
+"""Maven repository resolution, Maven Central search, and OSV batch tests.
+
+Mirrors the retired TypeScript suite:
+  - src/maven/__tests__/repository.test.ts  -> TestReposFor / TestParseMetadataXml
+  - src/maven/__tests__/resolver.test.ts    -> TestFetchMetadata
+        NOTE: Python semantics DIFFER from resolver.test.ts. The TS layer had two
+        strategies, `resolveFirst` (sequential, stop at first hit) and `resolveAll`
+        (parallel fetch + cross-repo version-set MERGE). server.py kept only the
+        first-hit behavior: `fetch_metadata` returns the FIRST successful repo's
+        metadata and never merges across repos. The resolver.test.ts merge cases
+        therefore have NO Python equivalent (divergence #6); only the first-hit
+        contract is portable and is asserted here.
+  - src/search/__tests__/maven-search.test.ts     -> TestSearchMavenCentral
+  - src/vulnerabilities/__tests__/osv-client.test.ts -> TestQueryOsvBatch
+
+Network is mocked by patching urllib.request.urlopen with mock_urlopen([...]);
+the list is the sequence of responses across consecutive urlopen calls. Request
+shape (URL / POST body / headers) is inspected via the patched mock's
+call_args_list, since the server builds a urllib.request.Request per call.
+"""
+
+import json
+import unittest
+import urllib.error
+from unittest import mock
+
+from _helpers import server, mock_urlopen, http_error
+
+
+def _metadata_xml(versions, latest=None, release=None, last_updated=None):
+    """Build a maven-metadata.xml body (bytes) with the given version list."""
+    vtags = "".join("<version>%s</version>" % v for v in versions)
+    parts = ["<metadata><versioning>"]
+    if latest is not None:
+        parts.append("<latest>%s</latest>" % latest)
+    if release is not None:
+        parts.append("<release>%s</release>" % release)
+    parts.append("<versions>%s</versions>" % vtags)
+    if last_updated is not None:
+        parts.append("<lastUpdated>%s</lastUpdated>" % last_updated)
+    parts.append("</versioning></metadata>")
+    return "".join(parts).encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# _repos_for routing + URL builders + XML parse
+# Mirrors src/maven/__tests__/repository.test.ts (URL construction, parse,
+# well-known repo constants). server.py's repo selection is the static
+# group-prefix router `_repos_for` (server.py:128), not a configurable repo
+# object; the AndroidX/Google prefix constant lives at server.py:29-32.
+# ---------------------------------------------------------------------------
+class TestReposFor(unittest.TestCase):
+    def test_plain_artifact_uses_central_only(self):
+        # A non-Google, non-plugin artifact resolves to Maven Central only.
+        repos = server._repos_for("io.ktor", "ktor-server-core")
+        self.assertEqual(repos, [("Maven Central", server.MAVEN_CENTRAL_URL)])
+
+    def test_androidx_routes_google_first_then_central(self):
+        # AndroidX prefix routing (server.py:30): Google Maven is tried first,
+        # Maven Central second -> most-specific-first.
+        repos = server._repos_for("androidx.core", "core-ktx")
+        self.assertEqual(
+            repos,
+            [
+                ("Google Maven", server.GOOGLE_MAVEN_URL),
+                ("Maven Central", server.MAVEN_CENTRAL_URL),
+            ],
+        )
+
+    def test_google_firebase_group_routes_to_google(self):
+        # Another entry of the GOOGLE_MAVEN_GROUPS prefix constant (server.py:30);
+        # the prefix carries a trailing dot, so the group must be a sub-group.
+        repos = server._repos_for("com.google.firebase.crashlytics", "firebase-crashlytics")
+        self.assertEqual(repos[0], ("Google Maven", server.GOOGLE_MAVEN_URL))
+        self.assertEqual(repos[-1], ("Maven Central", server.MAVEN_CENTRAL_URL))
+
+    def test_gradle_plugin_marker_routes_to_plugin_portal_first(self):
+        repos = server._repos_for(
+            "org.jetbrains.kotlin.jvm", "org.jetbrains.kotlin.jvm.gradle.plugin"
+        )
+        self.assertEqual(
+            repos,
+            [
+                ("Gradle Plugin Portal", server.GRADLE_PLUGIN_PORTAL_URL),
+                ("Maven Central", server.MAVEN_CENTRAL_URL),
+            ],
+        )
+
+    def test_most_specific_first_ordering_plugin_then_google_then_central(self):
+        # Plugin marker AND a Google group: portal, then Google, then Central.
+        repos = server._repos_for("androidx.tooling", "x.gradle.plugin")
+        self.assertEqual(
+            [name for name, _ in repos],
+            ["Gradle Plugin Portal", "Google Maven", "Maven Central"],
+        )
+
+    def test_metadata_url_construction(self):
+        # Mirrors repository.test.ts "builds correct metadata URL".
+        url = server._metadata_url(
+            "https://repo.example.com/maven2", "io.ktor", "ktor-server-core"
+        )
+        self.assertEqual(
+            url,
+            "https://repo.example.com/maven2/io/ktor/ktor-server-core/maven-metadata.xml",
+        )
+
+    def test_metadata_url_strips_trailing_slash(self):
+        # Mirrors repository.test.ts "builds metadata URL with trailing slash".
+        url = server._metadata_url(
+            "https://repo.example.com/maven2/", "io.ktor", "ktor-server-core"
+        )
+        self.assertEqual(
+            url,
+            "https://repo.example.com/maven2/io/ktor/ktor-server-core/maven-metadata.xml",
+        )
+
+    def test_pom_url_construction(self):
+        url = server._pom_url(
+            "https://repo.example.com/maven2", "io.ktor", "ktor-core", "3.1.1"
+        )
+        self.assertEqual(
+            url,
+            "https://repo.example.com/maven2/io/ktor/ktor-core/3.1.1/ktor-core-3.1.1.pom",
+        )
+
+
+class TestParseMetadataXml(unittest.TestCase):
+    def test_parses_versions_latest_release(self):
+        # Mirrors repository.test.ts "parses metadata XML correctly".
+        xml = _metadata_xml(
+            ["2.0.0", "3.0.0", "3.1.1"], latest="3.1.1", release="3.1.1",
+            last_updated="20250301",
+        ).decode("utf-8")
+        result = server._parse_metadata_xml(xml, "io.ktor", "ktor-server-core")
+        self.assertEqual(result["groupId"], "io.ktor")
+        self.assertEqual(result["artifactId"], "ktor-server-core")
+        self.assertEqual(result["versions"], ["2.0.0", "3.0.0", "3.1.1"])
+        self.assertEqual(result["latest"], "3.1.1")
+        self.assertEqual(result["release"], "3.1.1")
+        self.assertEqual(result["lastUpdated"], "20250301")
+
+    def test_missing_optional_tags_are_none(self):
+        result = server._parse_metadata_xml(
+            _metadata_xml(["1.0.0"]).decode("utf-8"), "g", "a"
+        )
+        self.assertEqual(result["versions"], ["1.0.0"])
+        self.assertIsNone(result["latest"])
+        self.assertIsNone(result["release"])
+        self.assertIsNone(result["lastUpdated"])
+
+
+# ---------------------------------------------------------------------------
+# fetch_metadata (server.py:154)
+# Mirrors src/maven/__tests__/resolver.test.ts, but only the first-hit contract
+# is portable. The resolveAll MERGE cases have NO Python equivalent -> see the
+# divergence #6 test below.
+# ---------------------------------------------------------------------------
+class TestFetchMetadata(unittest.TestCase):
+    def test_returns_first_successful_repo_metadata(self):
+        # Mirrors resolver.test.ts "returns metadata from first repo that has it".
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, _metadata_xml(["1.0.0", "2.0.0"]))]),
+        ):
+            result = server.fetch_metadata("io.ktor", "ktor-core")
+        self.assertEqual(result["versions"], ["1.0.0", "2.0.0"])
+
+    def test_first_hit_not_resolveall_merge(self):
+        # DIVERGENCE #6: fetch_metadata returns the FIRST successful repo's set,
+        # it does NOT merge version sets across repos like the retired TS
+        # resolveAll. androidx.* routes Google Maven (#1) then Maven Central (#2).
+        # Google returns [1.0.0, 2.0.0]; Central would return [3.0.0]. First-hit
+        # means only Google's set is returned (no 3.0.0) AND Central is never
+        # queried -- urlopen is called exactly once.
+        responses = [
+            (200, _metadata_xml(["1.0.0", "2.0.0"])),  # Google Maven (#1)
+            (200, _metadata_xml(["3.0.0"])),           # Maven Central (#2) -- never reached
+        ]
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen(responses)
+        ) as m:
+            result = server.fetch_metadata("androidx.core", "core-ktx")
+        self.assertEqual(result["versions"], ["1.0.0", "2.0.0"])
+        self.assertNotIn("3.0.0", result["versions"])  # NOT merged with Central
+        self.assertEqual(m.call_count, 1)  # Central (#2) never queried
+        first_url = m.call_args_list[0].args[0].full_url
+        self.assertTrue(first_url.startswith(server.GOOGLE_MAVEN_URL))
+
+    def test_skips_non_200_repo_and_continues_to_next(self):
+        # Google Maven 404 -> falls through to Maven Central, which returns 200.
+        responses = [
+            http_error(server.GOOGLE_MAVEN_URL, 404, "Not Found"),
+            (200, _metadata_xml(["9.9.9"])),
+        ]
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen(responses)
+        ) as m:
+            result = server.fetch_metadata("androidx.core", "core-ktx")
+        self.assertEqual(result["versions"], ["9.9.9"])
+        self.assertEqual(m.call_count, 2)
+
+    def test_network_error_on_first_repo_is_caught_and_continues(self):
+        # http_get does NOT catch URLError (only HTTPError) -> it propagates and
+        # fetch_metadata's broad `except Exception` swallows it, then continues.
+        responses = [
+            urllib.error.URLError("dns down"),
+            (200, _metadata_xml(["4.5.6"])),
+        ]
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen(responses)
+        ):
+            result = server.fetch_metadata("androidx.core", "core-ktx")
+        self.assertEqual(result["versions"], ["4.5.6"])
+
+    def test_raises_when_all_repos_fail(self):
+        # Mirrors resolver.test.ts "throws when all repos fail".
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([http_error("u", 500, "boom")]),
+        ):
+            with self.assertRaises(ValueError):
+                server.fetch_metadata("io.ktor", "ktor-core")
+
+
+# ---------------------------------------------------------------------------
+# check_version_in_repos (server.py:170)
+# ---------------------------------------------------------------------------
+class TestCheckVersionInRepos(unittest.TestCase):
+    def test_returns_repo_name_when_version_present(self):
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, _metadata_xml(["1.0.0", "2.0.0"]))]),
+        ):
+            name = server.check_version_in_repos("io.ktor", "ktor-core", "2.0.0")
+        self.assertEqual(name, "Maven Central")
+
+    def test_returns_none_when_version_absent(self):
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, _metadata_xml(["1.0.0"]))]),
+        ):
+            name = server.check_version_in_repos("io.ktor", "ktor-core", "9.9.9")
+        self.assertIsNone(name)
+
+    def test_checks_google_then_central_when_only_central_has_version(self):
+        # Unlike fetch_metadata, this iterates ALL repos until the version is
+        # found: Google Maven (200, lacks version) -> Maven Central (200, has it).
+        responses = [
+            (200, _metadata_xml(["1.0.0"])),          # Google Maven, no 2.0.0
+            (200, _metadata_xml(["1.0.0", "2.0.0"])),  # Maven Central, has 2.0.0
+        ]
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen(responses)
+        ) as m:
+            name = server.check_version_in_repos("androidx.core", "core-ktx", "2.0.0")
+        self.assertEqual(name, "Maven Central")
+        self.assertEqual(m.call_count, 2)
+
+
+# ---------------------------------------------------------------------------
+# fetch_pom (server.py:187)
+# ---------------------------------------------------------------------------
+class TestFetchPom(unittest.TestCase):
+    def test_returns_pom_text_on_200(self):
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, b"<project><scm/></project>")]),
+        ) as m:
+            pom = server.fetch_pom("io.ktor", "ktor-core", "3.1.1")
+        self.assertEqual(pom, "<project><scm/></project>")
+        # POM URL shape includes the version directory and the -version.pom file.
+        self.assertTrue(m.call_args_list[0].args[0].full_url.endswith("ktor-core-3.1.1.pom"))
+
+    def test_returns_none_when_no_repo_has_pom(self):
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([http_error("u", 404, "Not Found")]),
+        ):
+            self.assertIsNone(server.fetch_pom("io.ktor", "ktor-core", "3.1.1"))
+
+
+# ---------------------------------------------------------------------------
+# search_maven_central (server.py:731)
+# Mirrors src/search/__tests__/maven-search.test.ts
+# ---------------------------------------------------------------------------
+class TestSearchMavenCentral(unittest.TestCase):
+    def test_returns_parsed_results(self):
+        # Mirrors maven-search.test.ts "returns parsed search results".
+        body = json.dumps({
+            "response": {
+                "numFound": 2,
+                "docs": [
+                    {"g": "io.ktor", "a": "ktor-client-core",
+                     "latestVersion": "3.1.1", "versionCount": 50},
+                    {"g": "io.ktor", "a": "ktor-server-core",
+                     "latestVersion": "3.1.1", "versionCount": 48},
+                ],
+            }
+        }).encode()
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen([(200, body)])
+        ):
+            result = server.search_maven_central("ktor")
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0]["groupId"], "io.ktor")
+        self.assertEqual(result[0]["artifactId"], "ktor-client-core")
+        self.assertEqual(result[0]["latestVersion"], "3.1.1")
+        self.assertEqual(result[0]["versionCount"], 50)
+
+    def test_respects_limit_and_url_encodes_query(self):
+        # Mirrors maven-search.test.ts "respects limit parameter"; also asserts
+        # the query is URL-encoded (a Python-side detail: urllib.parse.quote).
+        body = json.dumps({"response": {"numFound": 0, "docs": []}}).encode()
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen([(200, body)])
+        ) as m:
+            server.search_maven_central("g:io ktor", 5)
+        url = m.call_args_list[0].args[0].full_url
+        self.assertIn("rows=5", url)
+        self.assertIn("g%3Aio%20ktor", url)  # ':' and ' ' percent-encoded
+
+    def test_returns_empty_on_http_error(self):
+        # Mirrors maven-search.test.ts "returns empty array on error" (500).
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([http_error("u", 500, "boom")]),
+        ):
+            self.assertEqual(server.search_maven_central("fail"), [])
+
+    def test_returns_empty_when_request_raises(self):
+        # Mirrors maven-search.test.ts "returns empty array when fetch rejects".
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([urllib.error.URLError("network error")]),
+        ):
+            self.assertEqual(server.search_maven_central("network-fail"), [])
+
+
+# ---------------------------------------------------------------------------
+# query_osv_batch (server.py:689) + severity/fixed-version extraction
+# Mirrors src/vulnerabilities/__tests__/osv-client.test.ts
+# OSV uses http_post_json semantics (POST + JSON body + Content-Type).
+# ---------------------------------------------------------------------------
+class TestQueryOsvBatch(unittest.TestCase):
+    def test_returns_vulnerabilities_for_affected_packages(self):
+        # Mirrors osv-client.test.ts "returns vulnerabilities for affected packages".
+        body = json.dumps({
+            "results": [
+                {"vulns": [{
+                    "id": "GHSA-1234-abcd",
+                    "summary": "Remote code execution",
+                    "severity": [{"type": "CVSS_V3",
+                                  "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}],
+                    "database_specific": {"severity": "CRITICAL"},
+                    "affected": [{"ranges": [{"type": "ECOSYSTEM",
+                                  "events": [{"introduced": "0"}, {"fixed": "2.0.1"}]}]}],
+                    "references": [{"type": "ADVISORY",
+                                   "url": "https://github.com/advisories/GHSA-1234-abcd"}],
+                }]},
+                {"vulns": []},
+            ]
+        }).encode()
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen([(200, body)])
+        ):
+            results = server.query_osv_batch([
+                {"groupId": "com.example", "artifactId": "lib", "version": "2.0.0"},
+                {"groupId": "io.safe", "artifactId": "safe-lib", "version": "1.0.0"},
+            ])
+        self.assertEqual(len(results), 2)
+        self.assertEqual(len(results[0]["vulnerabilities"]), 1)
+        v = results[0]["vulnerabilities"][0]
+        self.assertEqual(v["id"], "GHSA-1234-abcd")
+        self.assertEqual(v["severity"], "CRITICAL")
+        self.assertEqual(v["fixedVersion"], "2.0.1")
+        self.assertEqual(v["url"], "https://github.com/advisories/GHSA-1234-abcd")
+        self.assertEqual(len(results[1]["vulnerabilities"]), 0)
+
+    def test_post_body_shape_and_content_type(self):
+        # Mirrors osv-client.test.ts "sends correct request format". Asserts the
+        # POST URL, JSON body shape, and Content-Type header (http_post_json).
+        body = json.dumps({"results": [{"vulns": []}]}).encode()
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen([(200, body)])
+        ) as m:
+            server.query_osv_batch([
+                {"groupId": "io.ktor", "artifactId": "ktor-core", "version": "2.3.0"},
+            ])
+        req = m.call_args_list[0].args[0]
+        self.assertEqual(req.full_url, server.OSV_API)
+        self.assertEqual(req.get_method(), "POST")
+        self.assertEqual(req.get_header("Content-type"), "application/json")
+        payload = json.loads(req.data)
+        self.assertEqual(payload["queries"][0]["package"]["name"], "io.ktor:ktor-core")
+        self.assertEqual(payload["queries"][0]["package"]["ecosystem"], "Maven")
+        self.assertEqual(payload["queries"][0]["version"], "2.3.0")
+
+    def test_empty_deps_short_circuits_without_request(self):
+        # No deps -> [] and no network call at all (server.py:691).
+        with mock.patch("urllib.request.urlopen") as m:
+            self.assertEqual(server.query_osv_batch([]), [])
+        m.assert_not_called()
+
+    def test_empty_vulnerabilities_on_api_error(self):
+        # Mirrors osv-client.test.ts "returns empty vulnerabilities on API error".
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([http_error("u", 500, "boom")]),
+        ):
+            results = server.query_osv_batch([
+                {"groupId": "com.example", "artifactId": "lib", "version": "1.0.0"},
+            ])
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["vulnerabilities"], [])
+
+    def test_normalizes_moderate_severity_to_medium(self):
+        # Mirrors osv-client.test.ts "normalizes MODERATE severity to MEDIUM".
+        body = json.dumps({"results": [{"vulns": [{
+            "id": "GHSA-mod-erat-eeee", "summary": "moderate",
+            "database_specific": {"severity": "MODERATE"},
+            "affected": [], "references": [],
+        }]}]}).encode()
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen([(200, body)])
+        ):
+            results = server.query_osv_batch([
+                {"groupId": "com.example", "artifactId": "lib", "version": "1.0.0"},
+            ])
+        self.assertEqual(results[0]["vulnerabilities"][0]["severity"], "MEDIUM")
+
+    def test_rejects_unknown_severity_string(self):
+        # Mirrors osv-client.test.ts "rejects unknown severity strings".
+        # In Python an unrecognized database_specific severity falls through to
+        # the CVSS array (none here) -> the "severity" key is omitted entirely.
+        body = json.dumps({"results": [{"vulns": [{
+            "id": "GHSA-unkn-own1", "summary": "unknown",
+            "database_specific": {"severity": "BOGUS"},
+            "affected": [], "references": [],
+        }]}]}).encode()
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen([(200, body)])
+        ):
+            results = server.query_osv_batch([
+                {"groupId": "com.example", "artifactId": "lib", "version": "1.0.0"},
+            ])
+        self.assertNotIn("severity", results[0]["vulnerabilities"][0])
+
+    def test_cvss_numeric_score_maps_to_severity_bucket(self):
+        # CVSS fallback path: no database_specific, severity=[{CVSS_V3, score}].
+        # _extract_severity does float(score) -> _cvss_to_severity. NOTE: real
+        # OSV puts a CVSS *vector string* in `score`, which float() cannot parse,
+        # so this numeric-score branch only fires on numeric data -- exercised
+        # here directly to cover _cvss_to_severity (9.8 -> CRITICAL).
+        body = json.dumps({"results": [{"vulns": [{
+            "id": "GHSA-cvss-only0", "summary": "cvss only",
+            "severity": [{"type": "CVSS_V3", "score": "9.8"}],
+            "affected": [], "references": [],
+        }]}]}).encode()
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen([(200, body)])
+        ):
+            results = server.query_osv_batch([
+                {"groupId": "com.example", "artifactId": "lib", "version": "1.0.0"},
+            ])
+        self.assertEqual(results[0]["vulnerabilities"][0]["severity"], "CRITICAL")
+
+    def test_filters_out_withdrawn_vulnerabilities(self):
+        # Mirrors osv-client.test.ts "filters out withdrawn vulnerabilities".
+        body = json.dumps({"results": [{"vulns": [
+            {"id": "GHSA-active-active", "summary": "active",
+             "database_specific": {"severity": "HIGH"}, "affected": [], "references": []},
+            {"id": "GHSA-with-drawn", "summary": "withdrawn",
+             "database_specific": {"severity": "CRITICAL"},
+             "withdrawn": "2024-01-01T00:00:00Z", "affected": [], "references": []},
+        ]}]}).encode()
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen([(200, body)])
+        ):
+            results = server.query_osv_batch([
+                {"groupId": "com.example", "artifactId": "lib", "version": "1.0.0"},
+            ])
+        self.assertEqual(len(results[0]["vulnerabilities"]), 1)
+        self.assertEqual(results[0]["vulnerabilities"][0]["id"], "GHSA-active-active")
+
+    def test_advisory_url_fallback_to_osv_dev(self):
+        # No ADVISORY reference -> _extract_url falls back to the osv.dev URL.
+        body = json.dumps({"results": [{"vulns": [{
+            "id": "OSV-NO-ADVISORY", "summary": "no advisory ref",
+            "database_specific": {"severity": "LOW"}, "affected": [], "references": [],
+        }]}]}).encode()
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen([(200, body)])
+        ):
+            results = server.query_osv_batch([
+                {"groupId": "com.example", "artifactId": "lib", "version": "1.0.0"},
+            ])
+        self.assertEqual(
+            results[0]["vulnerabilities"][0]["url"],
+            "https://osv.dev/vulnerability/OSV-NO-ADVISORY",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/maven-mcp/tests/test_maven_search_osv.py
+++ b/plugins/maven-mcp/tests/test_maven_search_osv.py
@@ -22,7 +22,7 @@ call_args_list, since the server builds a urllib.request.Request per call.
 import json
 import unittest
 import urllib.error
-from unittest import mock
+import unittest.mock
 
 from _helpers import server, mock_urlopen, http_error
 
@@ -158,7 +158,7 @@ class TestParseMetadataXml(unittest.TestCase):
 class TestFetchMetadata(unittest.TestCase):
     def test_returns_first_successful_repo_metadata(self):
         # Mirrors resolver.test.ts "returns metadata from first repo that has it".
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([(200, _metadata_xml(["1.0.0", "2.0.0"]))]),
         ):
@@ -176,7 +176,7 @@ class TestFetchMetadata(unittest.TestCase):
             (200, _metadata_xml(["1.0.0", "2.0.0"])),  # Google Maven (#1)
             (200, _metadata_xml(["3.0.0"])),           # Maven Central (#2) -- never reached
         ]
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen", side_effect=mock_urlopen(responses)
         ) as m:
             result = server.fetch_metadata("androidx.core", "core-ktx")
@@ -192,7 +192,7 @@ class TestFetchMetadata(unittest.TestCase):
             http_error(server.GOOGLE_MAVEN_URL, 404, "Not Found"),
             (200, _metadata_xml(["9.9.9"])),
         ]
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen", side_effect=mock_urlopen(responses)
         ) as m:
             result = server.fetch_metadata("androidx.core", "core-ktx")
@@ -206,7 +206,7 @@ class TestFetchMetadata(unittest.TestCase):
             urllib.error.URLError("dns down"),
             (200, _metadata_xml(["4.5.6"])),
         ]
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen", side_effect=mock_urlopen(responses)
         ):
             result = server.fetch_metadata("androidx.core", "core-ktx")
@@ -214,7 +214,7 @@ class TestFetchMetadata(unittest.TestCase):
 
     def test_raises_when_all_repos_fail(self):
         # Mirrors resolver.test.ts "throws when all repos fail".
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([http_error("u", 500, "boom")]),
         ):
@@ -227,7 +227,7 @@ class TestFetchMetadata(unittest.TestCase):
 # ---------------------------------------------------------------------------
 class TestCheckVersionInRepos(unittest.TestCase):
     def test_returns_repo_name_when_version_present(self):
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([(200, _metadata_xml(["1.0.0", "2.0.0"]))]),
         ):
@@ -235,7 +235,7 @@ class TestCheckVersionInRepos(unittest.TestCase):
         self.assertEqual(name, "Maven Central")
 
     def test_returns_none_when_version_absent(self):
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([(200, _metadata_xml(["1.0.0"]))]),
         ):
@@ -249,7 +249,7 @@ class TestCheckVersionInRepos(unittest.TestCase):
             (200, _metadata_xml(["1.0.0"])),          # Google Maven, no 2.0.0
             (200, _metadata_xml(["1.0.0", "2.0.0"])),  # Maven Central, has 2.0.0
         ]
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen", side_effect=mock_urlopen(responses)
         ) as m:
             name = server.check_version_in_repos("androidx.core", "core-ktx", "2.0.0")
@@ -262,7 +262,7 @@ class TestCheckVersionInRepos(unittest.TestCase):
 # ---------------------------------------------------------------------------
 class TestFetchPom(unittest.TestCase):
     def test_returns_pom_text_on_200(self):
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([(200, b"<project><scm/></project>")]),
         ) as m:
@@ -272,7 +272,7 @@ class TestFetchPom(unittest.TestCase):
         self.assertTrue(m.call_args_list[0].args[0].full_url.endswith("ktor-core-3.1.1.pom"))
 
     def test_returns_none_when_no_repo_has_pom(self):
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([http_error("u", 404, "Not Found")]),
         ):
@@ -297,7 +297,7 @@ class TestSearchMavenCentral(unittest.TestCase):
                 ],
             }
         }).encode()
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen", side_effect=mock_urlopen([(200, body)])
         ):
             result = server.search_maven_central("ktor")
@@ -311,7 +311,7 @@ class TestSearchMavenCentral(unittest.TestCase):
         # Mirrors maven-search.test.ts "respects limit parameter"; also asserts
         # the query is URL-encoded (a Python-side detail: urllib.parse.quote).
         body = json.dumps({"response": {"numFound": 0, "docs": []}}).encode()
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen", side_effect=mock_urlopen([(200, body)])
         ) as m:
             server.search_maven_central("g:io ktor", 5)
@@ -321,7 +321,7 @@ class TestSearchMavenCentral(unittest.TestCase):
 
     def test_returns_empty_on_http_error(self):
         # Mirrors maven-search.test.ts "returns empty array on error" (500).
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([http_error("u", 500, "boom")]),
         ):
@@ -329,7 +329,7 @@ class TestSearchMavenCentral(unittest.TestCase):
 
     def test_returns_empty_when_request_raises(self):
         # Mirrors maven-search.test.ts "returns empty array when fetch rejects".
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([urllib.error.URLError("network error")]),
         ):
@@ -360,7 +360,7 @@ class TestQueryOsvBatch(unittest.TestCase):
                 {"vulns": []},
             ]
         }).encode()
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen", side_effect=mock_urlopen([(200, body)])
         ):
             results = server.query_osv_batch([
@@ -380,7 +380,7 @@ class TestQueryOsvBatch(unittest.TestCase):
         # Mirrors osv-client.test.ts "sends correct request format". Asserts the
         # POST URL, JSON body shape, and Content-Type header (http_post_json).
         body = json.dumps({"results": [{"vulns": []}]}).encode()
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen", side_effect=mock_urlopen([(200, body)])
         ) as m:
             server.query_osv_batch([
@@ -397,13 +397,13 @@ class TestQueryOsvBatch(unittest.TestCase):
 
     def test_empty_deps_short_circuits_without_request(self):
         # No deps -> [] and no network call at all (server.py:691).
-        with mock.patch("urllib.request.urlopen") as m:
+        with unittest.mock.patch("urllib.request.urlopen") as m:
             self.assertEqual(server.query_osv_batch([]), [])
         m.assert_not_called()
 
     def test_empty_vulnerabilities_on_api_error(self):
         # Mirrors osv-client.test.ts "returns empty vulnerabilities on API error".
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([http_error("u", 500, "boom")]),
         ):
@@ -420,7 +420,7 @@ class TestQueryOsvBatch(unittest.TestCase):
             "database_specific": {"severity": "MODERATE"},
             "affected": [], "references": [],
         }]}]}).encode()
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen", side_effect=mock_urlopen([(200, body)])
         ):
             results = server.query_osv_batch([
@@ -437,7 +437,7 @@ class TestQueryOsvBatch(unittest.TestCase):
             "database_specific": {"severity": "BOGUS"},
             "affected": [], "references": [],
         }]}]}).encode()
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen", side_effect=mock_urlopen([(200, body)])
         ):
             results = server.query_osv_batch([
@@ -456,7 +456,7 @@ class TestQueryOsvBatch(unittest.TestCase):
             "severity": [{"type": "CVSS_V3", "score": "9.8"}],
             "affected": [], "references": [],
         }]}]}).encode()
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen", side_effect=mock_urlopen([(200, body)])
         ):
             results = server.query_osv_batch([
@@ -473,7 +473,7 @@ class TestQueryOsvBatch(unittest.TestCase):
              "database_specific": {"severity": "CRITICAL"},
              "withdrawn": "2024-01-01T00:00:00Z", "affected": [], "references": []},
         ]}]}).encode()
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen", side_effect=mock_urlopen([(200, body)])
         ):
             results = server.query_osv_batch([
@@ -488,7 +488,7 @@ class TestQueryOsvBatch(unittest.TestCase):
             "id": "OSV-NO-ADVISORY", "summary": "no advisory ref",
             "database_specific": {"severity": "LOW"}, "affected": [], "references": [],
         }]}]}).encode()
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen", side_effect=mock_urlopen([(200, body)])
         ):
             results = server.query_osv_batch([

--- a/plugins/maven-mcp/tests/test_parsers.py
+++ b/plugins/maven-mcp/tests/test_parsers.py
@@ -1,0 +1,1173 @@
+"""Parser unit tests for server.py.
+
+Mirrors TypeScript tests in:
+  src/dependencies/__tests__/gradle-deps-parser.test.ts
+  src/dependencies/__tests__/plugins-block-parser.test.ts
+  src/dependencies/__tests__/maven-deps-parser.test.ts
+  src/dependencies/__tests__/maven-modules-parser.test.ts
+  src/dependencies/__tests__/settings-catalogs-parser.test.ts
+  src/dependencies/__tests__/toml-parser.test.ts
+  src/dependencies/__tests__/scan.test.ts
+  src/maven/__tests__/repository.test.ts
+
+Python-vs-TS behavioral differences (documented inline and in test comments):
+  1. _parse_settings_catalogs returns [] for absent/empty versionCatalogs block;
+     the TS parseSettingsCatalogs returns a default libs descriptor. The fallback
+     is handled in scan_project(), not in the parser function itself.
+  2. _parse_settings_catalogs uses old-style Groovy block syntax
+     `name { from(files("...")) }` and does NOT parse Kotlin DSL
+     `create("name") { from(files("...")) }`.
+  3. _parse_gradle_plugins_block has no kotlin("shorthand") support
+     (TS plugins-block-parser handles kotlin("jvm") etc.; Python does not).
+  4. _parse_gradle_deps return dicts have no "source" key; the source is
+     attached by scan_project(). TS parseGradleDependencies includes source
+     directly.
+  5. parseGradleRepositories (src/discovery/gradle-parser.ts) — custom-repo
+     URL discovery — has no Python equivalent. All test cases covering that
+     TS module are skipped (divergence guardrail #5).
+"""
+
+import os
+import unittest
+
+from _helpers import server, temp_project
+
+
+# ---------------------------------------------------------------------------
+# _parse_metadata_xml
+# Mirrors: src/maven/__tests__/repository.test.ts > "parses metadata XML correctly"
+# ---------------------------------------------------------------------------
+
+class TestParseMetadataXml(unittest.TestCase):
+    """Tests for server._parse_metadata_xml."""
+
+    # Mirrors: repository.test.ts > "parses metadata XML correctly"
+    def test_parses_versions_latest_release(self):
+        xml = (
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            "<metadata>\n"
+            "  <groupId>io.ktor</groupId>\n"
+            "  <artifactId>ktor-server-core</artifactId>\n"
+            "  <versioning>\n"
+            "    <latest>3.1.1</latest>\n"
+            "    <release>3.1.1</release>\n"
+            "    <versions>\n"
+            "      <version>2.0.0</version>\n"
+            "      <version>3.0.0</version>\n"
+            "      <version>3.1.1</version>\n"
+            "    </versions>\n"
+            "    <lastUpdated>20250301</lastUpdated>\n"
+            "  </versioning>\n"
+            "</metadata>"
+        )
+        result = server._parse_metadata_xml(xml, "io.ktor", "ktor-server-core")
+        self.assertEqual(result["groupId"], "io.ktor")
+        self.assertEqual(result["artifactId"], "ktor-server-core")
+        self.assertEqual(result["versions"], ["2.0.0", "3.0.0", "3.1.1"])
+        self.assertEqual(result["latest"], "3.1.1")
+        self.assertEqual(result["release"], "3.1.1")
+        self.assertEqual(result["lastUpdated"], "20250301")
+
+    # Mirrors: repository.test.ts > "parses metadata XML correctly" (absent fields)
+    def test_missing_latest_release_returns_none(self):
+        xml = (
+            "<metadata>\n"
+            "  <versioning>\n"
+            "    <versions><version>1.0.0</version></versions>\n"
+            "  </versioning>\n"
+            "</metadata>"
+        )
+        result = server._parse_metadata_xml(xml, "com.example", "lib")
+        self.assertEqual(result["versions"], ["1.0.0"])
+        self.assertIsNone(result["latest"])
+        self.assertIsNone(result["release"])
+        self.assertIsNone(result["lastUpdated"])
+
+    # Mirrors: repository.test.ts > "parses metadata XML correctly" (empty)
+    def test_empty_xml_returns_empty_fields(self):
+        result = server._parse_metadata_xml("<metadata/>", "g", "a")
+        self.assertEqual(result["groupId"], "g")
+        self.assertEqual(result["artifactId"], "a")
+        self.assertEqual(result["versions"], [])
+        self.assertIsNone(result["latest"])
+
+
+# ---------------------------------------------------------------------------
+# _parse_gradle_deps
+# Mirrors: src/dependencies/__tests__/gradle-deps-parser.test.ts
+# NOTE: Python return dicts have no "source" key (TS includes it).
+# ---------------------------------------------------------------------------
+
+class TestParseGradleDeps(unittest.TestCase):
+    """Tests for server._parse_gradle_deps."""
+
+    # Mirrors: gradle-deps-parser.test.ts > "parses string notation with version"
+    def test_string_notation_with_version(self):
+        content = (
+            'dependencies {\n'
+            '    implementation("io.ktor:ktor-client-core:3.1.1")\n'
+            '    testImplementation("org.junit:junit:5.10.0")\n'
+            '}'
+        )
+        deps = server._parse_gradle_deps(content, "build.gradle.kts")
+        groups = {(d["groupId"], d["artifactId"]): d for d in deps}
+        ktor = groups[("io.ktor", "ktor-client-core")]
+        self.assertEqual(ktor["version"], "3.1.1")
+        self.assertEqual(ktor["configuration"], "implementation")
+        self.assertIsNone(ktor["catalogRef"])
+        junit = groups[("org.junit", "junit")]
+        self.assertEqual(junit["configuration"], "testImplementation")
+
+    # Mirrors: gradle-deps-parser.test.ts > "parses string notation without version (BOM)"
+    def test_string_notation_without_version_returns_none(self):
+        deps = server._parse_gradle_deps('implementation("io.ktor:ktor-client-core")', "build.gradle.kts")
+        self.assertEqual(len(deps), 1)
+        self.assertIsNone(deps[0]["version"])
+
+    # Mirrors: gradle-deps-parser.test.ts > "parses Groovy single-quote notation"
+    def test_groovy_single_quote_notation(self):
+        deps = server._parse_gradle_deps("implementation 'io.ktor:ktor-client-core:3.1.1'", "build.gradle")
+        self.assertEqual(len(deps), 1)
+        self.assertEqual(deps[0]["groupId"], "io.ktor")
+        self.assertEqual(deps[0]["version"], "3.1.1")
+
+    # Mirrors: gradle-deps-parser.test.ts > "parses version catalog references"
+    def test_catalog_ref_libs_prefix(self):
+        deps = server._parse_gradle_deps("implementation(libs.ktor.client.core)", "build.gradle.kts")
+        self.assertEqual(len(deps), 1)
+        self.assertIsNone(deps[0]["groupId"])
+        self.assertIsNone(deps[0]["artifactId"])
+        self.assertIsNone(deps[0]["version"])
+        self.assertEqual(deps[0]["configuration"], "implementation")
+        self.assertEqual(deps[0]["catalogRef"], "libs.ktor.client.core")
+
+    # Mirrors: gradle-deps-parser.test.ts > "parses non-libs catalog references"
+    def test_catalog_ref_non_libs_prefix(self):
+        deps = server._parse_gradle_deps("testImplementation(testLibs.mockk.core)", "build.gradle.kts")
+        self.assertEqual(len(deps), 1)
+        self.assertEqual(deps[0]["catalogRef"], "testLibs.mockk.core")
+        self.assertEqual(deps[0]["configuration"], "testImplementation")
+
+    # Mirrors: gradle-deps-parser.test.ts > "extracts various configurations"
+    def test_various_configurations(self):
+        content = (
+            'api("com.example:api-lib:1.0")\n'
+            'compileOnly("com.example:compile-lib:1.0")\n'
+            'runtimeOnly("com.example:runtime-lib:1.0")\n'
+        )
+        deps = server._parse_gradle_deps(content, "build.gradle.kts")
+        configs = [d["configuration"] for d in deps]
+        self.assertIn("api", configs)
+        self.assertIn("compileOnly", configs)
+        self.assertIn("runtimeOnly", configs)
+
+    # Mirrors: gradle-deps-parser.test.ts > "returns empty for no dependencies"
+    def test_no_dependencies_returns_empty(self):
+        result = server._parse_gradle_deps("plugins { }", "build.gradle.kts")
+        self.assertEqual(result, [])
+
+    # Mirrors: gradle-deps-parser.test.ts > "catalog name with underscore: test_libs.foo.bar"
+    def test_catalog_name_with_underscore(self):
+        deps = server._parse_gradle_deps("testImplementation(test_libs.foo.bar)", "build.gradle.kts")
+        self.assertEqual(len(deps), 1)
+        self.assertEqual(deps[0]["catalogRef"], "test_libs.foo.bar")
+
+    # Additional: kapt/ksp/annotationProcessor configurations
+    def test_annotation_processor_configurations(self):
+        content = (
+            'kapt("com.example:kapt-lib:1.0")\n'
+            'ksp("com.example:ksp-lib:1.0")\n'
+            'annotationProcessor("com.example:ap-lib:1.0")\n'
+        )
+        deps = server._parse_gradle_deps(content, "build.gradle.kts")
+        configs = {d["configuration"] for d in deps}
+        self.assertIn("kapt", configs)
+        self.assertIn("ksp", configs)
+        self.assertIn("annotationProcessor", configs)
+
+
+# ---------------------------------------------------------------------------
+# _parse_gradle_plugins_block
+# Mirrors: src/dependencies/__tests__/plugins-block-parser.test.ts
+# NOTE: Python does NOT support kotlin("shorthand") syntax.
+# ---------------------------------------------------------------------------
+
+class TestParseGradlePluginsBlock(unittest.TestCase):
+    """Tests for server._parse_gradle_plugins_block."""
+
+    # Mirrors: plugins-block-parser.test.ts > id + version
+    def test_id_with_version(self):
+        content = 'plugins {\n    id("org.jetbrains.kotlin.jvm") version "2.1.0"\n}'
+        result = server._parse_gradle_plugins_block(content)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["pluginId"], "org.jetbrains.kotlin.jvm")
+        self.assertEqual(result[0]["version"], "2.1.0")
+        self.assertIsNone(result[0]["catalogRef"])
+        self.assertFalse(result[0]["settingsBlock"])
+
+    # Mirrors: plugins-block-parser.test.ts > id without version
+    def test_id_without_version(self):
+        content = 'plugins {\n    id("com.android.application")\n}'
+        result = server._parse_gradle_plugins_block(content)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["pluginId"], "com.android.application")
+        self.assertIsNone(result[0]["version"])
+        self.assertIsNone(result[0]["catalogRef"])
+
+    # Mirrors: plugins-block-parser.test.ts > alias reference
+    def test_alias_plugins_reference(self):
+        content = 'plugins {\n    alias(libs.plugins.kotlin.android)\n}'
+        result = server._parse_gradle_plugins_block(content)
+        self.assertEqual(len(result), 1)
+        self.assertIsNone(result[0]["pluginId"])
+        self.assertIsNone(result[0]["version"])
+        self.assertEqual(result[0]["catalogRef"], "libs.plugins.kotlin.android")
+
+    # Mirrors: plugins-block-parser.test.ts > alias with non-libs catalog
+    def test_alias_non_libs_catalog(self):
+        content = 'plugins {\n    alias(testLibs.plugins.android.lint)\n}'
+        result = server._parse_gradle_plugins_block(content)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["catalogRef"], "testLibs.plugins.android.lint")
+
+    # Mirrors: plugins-block-parser.test.ts > settingsBlock flag true
+    def test_settings_block_flag_true(self):
+        content = 'plugins {\n    id("com.gradle.plugin") version "1.0"\n}'
+        result = server._parse_gradle_plugins_block(content, is_settings=True)
+        self.assertEqual(len(result), 1)
+        self.assertTrue(result[0]["settingsBlock"])
+
+    # Mirrors: plugins-block-parser.test.ts > settingsBlock flag false by default
+    def test_settings_block_flag_false_by_default(self):
+        content = 'plugins {\n    id("x") version "1"\n}'
+        result = server._parse_gradle_plugins_block(content)
+        self.assertFalse(result[0]["settingsBlock"])
+
+    # Mirrors: plugins-block-parser.test.ts > multiple plugins in one block
+    def test_multiple_plugins_in_block(self):
+        content = (
+            'plugins {\n'
+            '    id("com.android.application") version "8.5.0"\n'
+            '    id("org.jetbrains.kotlin.android") version "2.1.0"\n'
+            '    alias(libs.plugins.compose)\n'
+            '}'
+        )
+        result = server._parse_gradle_plugins_block(content)
+        self.assertEqual(len(result), 3)
+        plugin_ids = [r["pluginId"] for r in result]
+        self.assertIn("com.android.application", plugin_ids)
+        self.assertIn("org.jetbrains.kotlin.android", plugin_ids)
+
+    # Mirrors: plugins-block-parser.test.ts > apply false is parsed (version captured, apply ignored)
+    def test_apply_false_still_parses_plugin(self):
+        content = 'plugins {\n    id("com.android.library") version "8.0.0" apply false\n}'
+        result = server._parse_gradle_plugins_block(content)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["pluginId"], "com.android.library")
+        self.assertEqual(result[0]["version"], "8.0.0")
+
+    # Mirrors: plugins-block-parser.test.ts > empty plugins block
+    def test_empty_plugins_block(self):
+        result = server._parse_gradle_plugins_block("plugins {}")
+        self.assertEqual(result, [])
+
+    # Mirrors: plugins-block-parser.test.ts > no plugins block
+    def test_no_plugins_block(self):
+        result = server._parse_gradle_plugins_block("dependencies { implementation('x:y:1') }")
+        self.assertEqual(result, [])
+
+    # Mirrors: plugins-block-parser.test.ts > Groovy single-quote with parentheses
+    # NOTE: Python requires parentheses: id('x') works, but id 'x' (no parens) does not.
+    def test_groovy_single_quote_id_with_parens(self):
+        content = "plugins {\n    id('com.example.plugin') version '1.0'\n}"
+        result = server._parse_gradle_plugins_block(content)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["pluginId"], "com.example.plugin")
+        self.assertEqual(result[0]["version"], "1.0")
+
+    # Python-specific: Groovy space-style `id 'plugin' version '1.0'` (no parens) is NOT parsed.
+    # TS plugins-block-parser handles both Groovy and Kotlin DSL id() forms.
+    def test_groovy_space_style_without_parens_not_parsed(self):
+        content = "plugins {\n    id 'com.example.plugin' version '1.0'\n}"
+        result = server._parse_gradle_plugins_block(content)
+        # Python does not parse id without parentheses — result is empty.
+        self.assertEqual(result, [])
+
+    # NOTE: Python does NOT support kotlin("jvm") shorthand notation.
+    # TS plugins-block-parser handles kotlin("jvm") version "2.0.0"
+    # -> { pluginId: "org.jetbrains.kotlin.jvm", version: "2.0.0" }.
+    # Python returns no entry for kotlin("jvm") in the plugins block.
+    def test_kotlin_shorthand_not_supported_in_python(self):
+        content = 'plugins {\n    kotlin("jvm") version "2.0.0"\n}'
+        result = server._parse_gradle_plugins_block(content)
+        # Python does not parse kotlin() shorthand — result is empty.
+        self.assertEqual(result, [])
+
+
+# ---------------------------------------------------------------------------
+# _parse_buildscript_classpath
+# Mirrors: src/dependencies/__tests__/scan.test.ts > "buildscript classpath"
+# ---------------------------------------------------------------------------
+
+class TestParseBuildscriptClasspath(unittest.TestCase):
+    """Tests for server._parse_buildscript_classpath."""
+
+    # Mirrors: scan.test.ts > "buildscript classpath → kind buildscript-classpath"
+    def test_simple_classpath_with_version(self):
+        content = (
+            'buildscript {\n'
+            '    dependencies {\n'
+            '        classpath("com.android.tools.build:gradle:8.0.0")\n'
+            '    }\n'
+            '}'
+        )
+        result = server._parse_buildscript_classpath(content)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["groupId"], "com.android.tools.build")
+        self.assertEqual(result[0]["artifactId"], "gradle")
+        self.assertEqual(result[0]["version"], "8.0.0")
+
+    # Mirrors: scan.test.ts > buildscript without version
+    def test_classpath_without_version_returns_none(self):
+        content = (
+            'buildscript {\n'
+            '    dependencies {\n'
+            '        classpath("com.example:lib")\n'
+            '    }\n'
+            '}'
+        )
+        result = server._parse_buildscript_classpath(content)
+        self.assertEqual(len(result), 1)
+        self.assertIsNone(result[0]["version"])
+
+    # Mirrors: scan.test.ts > no buildscript block
+    def test_no_buildscript_block_returns_empty(self):
+        result = server._parse_buildscript_classpath('dependencies { implementation("x:y:1") }')
+        self.assertEqual(result, [])
+
+    # Mirrors: scan.test.ts > multiple classpath entries
+    def test_multiple_classpath_entries(self):
+        content = (
+            'buildscript {\n'
+            '    dependencies {\n'
+            '        classpath("com.android.tools.build:gradle:8.0.0")\n'
+            '        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.0")\n'
+            '    }\n'
+            '}'
+        )
+        result = server._parse_buildscript_classpath(content)
+        self.assertEqual(len(result), 2)
+        artifacts = {r["artifactId"] for r in result}
+        self.assertIn("gradle", artifacts)
+        self.assertIn("kotlin-gradle-plugin", artifacts)
+
+
+# ---------------------------------------------------------------------------
+# _parse_settings_modules
+# Mirrors: src/dependencies/__tests__/settings-gradle-parser.test.ts
+# ---------------------------------------------------------------------------
+
+class TestParseSettingsModules(unittest.TestCase):
+    """Tests for server._parse_settings_modules."""
+
+    # Mirrors: settings-gradle-parser.test.ts > single include
+    def test_single_module(self):
+        result = server._parse_settings_modules('include(":app")')
+        self.assertEqual(result, [":app"])
+
+    # Mirrors: settings-gradle-parser.test.ts > multiple includes on one line
+    def test_multiple_modules_separate_calls(self):
+        content = 'include(":app")\ninclude(":lib")\ninclude(":core")'
+        result = server._parse_settings_modules(content)
+        self.assertEqual(set(result), {":app", ":lib", ":core"})
+
+    # Mirrors: settings-gradle-parser.test.ts > no include declarations
+    def test_no_includes_returns_empty(self):
+        result = server._parse_settings_modules('rootProject.name = "demo"')
+        self.assertEqual(result, [])
+
+    # Mirrors: settings-gradle-parser.test.ts > single-quote variant
+    def test_single_quote_include(self):
+        result = server._parse_settings_modules("include(':feature')")
+        self.assertEqual(result, [":feature"])
+
+
+# ---------------------------------------------------------------------------
+# _parse_settings_catalogs
+# Mirrors: src/dependencies/__tests__/settings-catalogs-parser.test.ts
+# KEY DIFFERENCE: Python returns [] for absent/empty block; TS returns default.
+# Python only parses old-style `name { from(files("...")) }`, not Kotlin DSL
+# `create("name") { from(files("...")) }`.
+# ---------------------------------------------------------------------------
+
+class TestParseSettingsCatalogs(unittest.TestCase):
+    """Tests for server._parse_settings_catalogs.
+
+    Python behavioral difference vs TS parseSettingsCatalogs:
+      - No versionCatalogs block  → returns []  (TS returns default libs descriptor)
+      - Empty versionCatalogs {}  → returns []  (TS returns default libs descriptor)
+      - Kotlin DSL create("name") → returns []  (TS parses it correctly)
+      The scan_project() function adds the fallback default descriptor when
+      _parse_settings_catalogs returns [].
+    """
+
+    # Python-specific: function returns [] for absent block (TS returns default).
+    def test_no_version_catalogs_block_returns_empty(self):
+        content = 'rootProject.name = "demo"\ninclude(":app")'
+        result = server._parse_settings_catalogs(content)
+        # Python diverges from TS here: [] not [{name:"libs",...}]
+        self.assertEqual(result, [])
+
+    # Python-specific: empty block also returns [] (TS returns default).
+    def test_empty_version_catalogs_block_returns_empty(self):
+        content = (
+            'dependencyResolutionManagement {\n'
+            '  versionCatalogs {\n'
+            '  }\n'
+            '}'
+        )
+        result = server._parse_settings_catalogs(content)
+        # Python diverges from TS here: [] not [{name:"libs",...}]
+        self.assertEqual(result, [])
+
+    # Groovy-style `name { from(files("...")) }` is what Python actually parses.
+    # This corresponds to old Groovy DSL syntax or Groovy inside versionCatalogs.
+    def test_groovy_style_catalog_block(self):
+        content = (
+            'dependencyResolutionManagement {\n'
+            '  versionCatalogs {\n'
+            '    testLibs {\n'
+            '      from(files("gradle/test.versions.toml"))\n'
+            '    }\n'
+            '  }\n'
+            '}'
+        )
+        result = server._parse_settings_catalogs(content)
+        self.assertEqual(result, [{"name": "testLibs", "tomlPath": "gradle/test.versions.toml"}])
+
+    # Groovy-style multiple catalogs.
+    def test_groovy_style_multiple_catalogs(self):
+        content = (
+            'versionCatalogs {\n'
+            '  libs {\n'
+            '    from(files("gradle/libs.versions.toml"))\n'
+            '  }\n'
+            '  testLibs {\n'
+            '    from(files("gradle/test.versions.toml"))\n'
+            '  }\n'
+            '}'
+        )
+        result = server._parse_settings_catalogs(content)
+        names = {r["name"]: r["tomlPath"] for r in result}
+        self.assertEqual(names["libs"], "gradle/libs.versions.toml")
+        self.assertEqual(names["testLibs"], "gradle/test.versions.toml")
+
+    # NOTE: Python does NOT parse Kotlin DSL create("name") syntax.
+    # Mirrors: settings-catalogs-parser.test.ts > "parses Kotlin DSL versionCatalogs with create block"
+    # but asserts the ACTUAL Python behavior (empty), not TS behavior.
+    def test_kotlin_dsl_create_syntax_not_parsed_by_python(self):
+        content = (
+            'dependencyResolutionManagement {\n'
+            '  versionCatalogs {\n'
+            '    create("testLibs") {\n'
+            '      from(files("gradle/test.versions.toml"))\n'
+            '    }\n'
+            '  }\n'
+            '}'
+        )
+        result = server._parse_settings_catalogs(content)
+        # Python does not parse create("name") DSL — returns [].
+        # TS would return [{name:"libs",...}, {name:"testLibs",...}].
+        self.assertEqual(result, [])
+
+
+# ---------------------------------------------------------------------------
+# _parse_maven_deps
+# Mirrors: src/dependencies/__tests__/maven-deps-parser.test.ts
+# ---------------------------------------------------------------------------
+
+class TestParseMavenDeps(unittest.TestCase):
+    """Tests for server._parse_maven_deps."""
+
+    # Mirrors: maven-deps-parser.test.ts > "parses dependencies with version and scope"
+    def test_with_version_no_scope_defaults_to_implementation(self):
+        pom = (
+            "<dependencies>\n"
+            "  <dependency>\n"
+            "    <groupId>io.ktor</groupId>\n"
+            "    <artifactId>ktor-client-core</artifactId>\n"
+            "    <version>3.1.1</version>\n"
+            "  </dependency>\n"
+            "</dependencies>"
+        )
+        deps = server._parse_maven_deps(pom)
+        self.assertEqual(len(deps), 1)
+        self.assertEqual(deps[0]["groupId"], "io.ktor")
+        self.assertEqual(deps[0]["artifactId"], "ktor-client-core")
+        self.assertEqual(deps[0]["version"], "3.1.1")
+        self.assertEqual(deps[0]["configuration"], "implementation")
+
+    # Mirrors: maven-deps-parser.test.ts > test scope maps to testImplementation
+    def test_test_scope_maps_to_test_implementation(self):
+        pom = (
+            "<dependency>\n"
+            "  <groupId>junit</groupId>\n"
+            "  <artifactId>junit</artifactId>\n"
+            "  <version>4.13.2</version>\n"
+            "  <scope>test</scope>\n"
+            "</dependency>"
+        )
+        deps = server._parse_maven_deps(pom)
+        self.assertEqual(deps[0]["configuration"], "testImplementation")
+
+    # Mirrors: maven-deps-parser.test.ts > "parses dependencies without version (BOM)"
+    def test_without_version_returns_none(self):
+        pom = (
+            "<dependency>\n"
+            "  <groupId>io.ktor</groupId>\n"
+            "  <artifactId>ktor-client-core</artifactId>\n"
+            "</dependency>"
+        )
+        deps = server._parse_maven_deps(pom)
+        self.assertIsNone(deps[0]["version"])
+
+    # Mirrors: maven-deps-parser.test.ts > "handles property references as null version"
+    def test_property_reference_returns_none(self):
+        pom = (
+            "<dependency>\n"
+            "  <groupId>io.ktor</groupId>\n"
+            "  <artifactId>ktor-core</artifactId>\n"
+            "  <version>${ktor.version}</version>\n"
+            "</dependency>"
+        )
+        deps = server._parse_maven_deps(pom)
+        self.assertIsNone(deps[0]["version"])
+
+    # Mirrors: maven-deps-parser.test.ts > "returns empty for no dependencies"
+    def test_empty_project_returns_empty(self):
+        result = server._parse_maven_deps("<project></project>")
+        self.assertEqual(result, [])
+
+    # Scope mapping: provided → compileOnly
+    def test_provided_scope_maps_to_compile_only(self):
+        pom = (
+            "<dependency>\n"
+            "  <groupId>javax.servlet</groupId>\n"
+            "  <artifactId>servlet-api</artifactId>\n"
+            "  <version>2.5</version>\n"
+            "  <scope>provided</scope>\n"
+            "</dependency>"
+        )
+        deps = server._parse_maven_deps(pom)
+        self.assertEqual(deps[0]["configuration"], "compileOnly")
+
+    # Scope mapping: runtime → runtimeOnly
+    def test_runtime_scope_maps_to_runtime_only(self):
+        pom = (
+            "<dependency>\n"
+            "  <groupId>com.example</groupId>\n"
+            "  <artifactId>runtime-lib</artifactId>\n"
+            "  <version>1.0</version>\n"
+            "  <scope>runtime</scope>\n"
+            "</dependency>"
+        )
+        deps = server._parse_maven_deps(pom)
+        self.assertEqual(deps[0]["configuration"], "runtimeOnly")
+
+
+# ---------------------------------------------------------------------------
+# _parse_maven_modules
+# Mirrors: src/dependencies/__tests__/maven-modules-parser.test.ts
+# ---------------------------------------------------------------------------
+
+class TestParseMavenModules(unittest.TestCase):
+    """Tests for server._parse_maven_modules."""
+
+    # Mirrors: maven-modules-parser.test.ts > single module
+    def test_single_module(self):
+        pom = "<project><modules><module>core</module></modules></project>"
+        result = server._parse_maven_modules(pom)
+        self.assertEqual(result, ["core"])
+
+    # Mirrors: maven-modules-parser.test.ts > multiple modules
+    def test_multiple_modules(self):
+        pom = (
+            "<modules>\n"
+            "  <module>core</module>\n"
+            "  <module>api</module>\n"
+            "  <module>web</module>\n"
+            "</modules>"
+        )
+        result = server._parse_maven_modules(pom)
+        self.assertEqual(result, ["core", "api", "web"])
+
+    # Mirrors: maven-modules-parser.test.ts > no modules
+    def test_no_modules_returns_empty(self):
+        result = server._parse_maven_modules("<project></project>")
+        self.assertEqual(result, [])
+
+
+# ---------------------------------------------------------------------------
+# _parse_toml_catalog
+# Mirrors: src/dependencies/__tests__/toml-parser.test.ts
+# NOTE: Python returns plain dicts, TS returns Maps.
+# ---------------------------------------------------------------------------
+
+class TestParseTomlCatalog(unittest.TestCase):
+    """Tests for server._parse_toml_catalog."""
+
+    # Mirrors: toml-parser.test.ts > "parses libraries with version.ref"
+    def test_libraries_with_version_ref(self):
+        toml = (
+            "[versions]\n"
+            'ktor = "3.1.1"\n'
+            'kotlin = "2.1.0"\n'
+            "\n"
+            "[libraries]\n"
+            'ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }\n'
+            'kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }\n'
+        )
+        result = server._parse_toml_catalog(toml)
+        libs = result["libraries"]
+        self.assertIn("ktor-client-core", libs)
+        self.assertEqual(libs["ktor-client-core"]["groupId"], "io.ktor")
+        self.assertEqual(libs["ktor-client-core"]["artifactId"], "ktor-client-core")
+        self.assertEqual(libs["ktor-client-core"]["version"], "3.1.1")
+        self.assertEqual(libs["kotlin-stdlib"]["version"], "2.1.0")
+
+    # Mirrors: toml-parser.test.ts > "parses libraries with inline version"
+    def test_libraries_with_inline_version(self):
+        toml = (
+            "[libraries]\n"
+            'gson = { module = "com.google.code.gson:gson", version = "2.11.0" }\n'
+        )
+        result = server._parse_toml_catalog(toml)
+        lib = result["libraries"]["gson"]
+        self.assertEqual(lib["groupId"], "com.google.code.gson")
+        self.assertEqual(lib["artifactId"], "gson")
+        self.assertEqual(lib["version"], "2.11.0")
+
+    # Mirrors: toml-parser.test.ts > "parses libraries with group/name syntax"
+    def test_libraries_with_group_name_syntax(self):
+        toml = (
+            "[versions]\n"
+            'ktor = "3.1.1"\n'
+            "\n"
+            "[libraries]\n"
+            'ktor-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }\n'
+        )
+        result = server._parse_toml_catalog(toml)
+        lib = result["libraries"]["ktor-core"]
+        self.assertEqual(lib["groupId"], "io.ktor")
+        self.assertEqual(lib["artifactId"], "ktor-client-core")
+        self.assertEqual(lib["version"], "3.1.1")
+
+    # Mirrors: toml-parser.test.ts > "returns null version for libraries without version"
+    def test_library_without_version_returns_none(self):
+        toml = (
+            "[libraries]\n"
+            'bom-lib = { module = "io.ktor:ktor-bom" }\n'
+        )
+        result = server._parse_toml_catalog(toml)
+        self.assertIsNone(result["libraries"]["bom-lib"]["version"])
+
+    # Mirrors: toml-parser.test.ts > "returns empty maps for empty content"
+    def test_empty_content_returns_empty_dicts(self):
+        result = server._parse_toml_catalog("")
+        self.assertEqual(result["libraries"], {})
+        self.assertEqual(result["plugins"], {})
+
+    # Mirrors: toml-parser.test.ts > "parses [plugins] with version.ref"
+    def test_plugins_with_version_ref(self):
+        toml = (
+            "[versions]\n"
+            'kotlin = "2.1.0"\n'
+            "\n"
+            "[plugins]\n"
+            'kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }\n'
+        )
+        result = server._parse_toml_catalog(toml)
+        plugin = result["plugins"]["kotlin-jvm"]
+        self.assertEqual(plugin["id"], "org.jetbrains.kotlin.jvm")
+        self.assertEqual(plugin["version"], "2.1.0")
+
+    # Mirrors: toml-parser.test.ts > "parses [plugins] with inline version"
+    def test_plugins_with_inline_version(self):
+        toml = (
+            "[plugins]\n"
+            'android-app = { id = "com.android.application", version = "8.5.0" }\n'
+        )
+        result = server._parse_toml_catalog(toml)
+        plugin = result["plugins"]["android-app"]
+        self.assertEqual(plugin["id"], "com.android.application")
+        self.assertEqual(plugin["version"], "8.5.0")
+
+    # Mirrors: toml-parser.test.ts > "parses [plugins] with no version returns null"
+    def test_plugins_without_version_returns_none(self):
+        toml = (
+            "[plugins]\n"
+            'my-plugin = { id = "com.example.plugin" }\n'
+        )
+        result = server._parse_toml_catalog(toml)
+        self.assertIsNone(result["plugins"]["my-plugin"]["version"])
+
+    # Source tracking: catalog returns plain dicts (no source tracking at this layer).
+    # Source info (catalogName, tomlPath, alias) is added by scan_project().
+    def test_multiple_libraries_dedup_by_alias(self):
+        toml = (
+            "[libraries]\n"
+            'ktor-core = { module = "io.ktor:ktor-client-core", version = "3.1.1" }\n'
+            'ktor-json = { module = "io.ktor:ktor-serialization-json", version = "3.1.1" }\n'
+        )
+        result = server._parse_toml_catalog(toml)
+        self.assertEqual(len(result["libraries"]), 2)
+        self.assertIn("ktor-core", result["libraries"])
+        self.assertIn("ktor-json", result["libraries"])
+
+
+# ---------------------------------------------------------------------------
+# _detect_build_system
+# Mirrors: src/dependencies/__tests__/scan.test.ts (build system detection)
+# ---------------------------------------------------------------------------
+
+class TestDetectBuildSystem(unittest.TestCase):
+    """Tests for server._detect_build_system via temp_project."""
+
+    # Mirrors: scan.test.ts > buildSystem is "gradle" when build.gradle.kts present
+    def test_gradle_from_build_gradle_kts(self):
+        with temp_project({"build.gradle.kts": ""}) as root:
+            self.assertEqual(server._detect_build_system(root), "gradle")
+
+    # Mirrors: scan.test.ts > buildSystem is "gradle" when build.gradle present
+    def test_gradle_from_build_gradle(self):
+        with temp_project({"build.gradle": ""}) as root:
+            self.assertEqual(server._detect_build_system(root), "gradle")
+
+    # Mirrors: scan.test.ts > buildSystem is "gradle" when settings.gradle.kts present
+    def test_gradle_from_settings_gradle_kts(self):
+        with temp_project({"settings.gradle.kts": ""}) as root:
+            self.assertEqual(server._detect_build_system(root), "gradle")
+
+    # Mirrors: scan.test.ts > buildSystem is "gradle" via toml only
+    def test_gradle_from_toml_only(self):
+        with temp_project({"gradle/libs.versions.toml": ""}) as root:
+            self.assertEqual(server._detect_build_system(root), "gradle")
+
+    # Mirrors: scan.test.ts > buildSystem is "maven" when pom.xml present
+    def test_maven_from_pom_xml(self):
+        with temp_project({"pom.xml": "<project/>"}) as root:
+            self.assertEqual(server._detect_build_system(root), "maven")
+
+    # Mirrors: scan.test.ts > "returns empty for unknown project"
+    def test_unknown_for_empty_directory(self):
+        with temp_project({}) as root:
+            self.assertEqual(server._detect_build_system(root), "unknown")
+
+
+# ---------------------------------------------------------------------------
+# scan_project — Gradle (end-to-end via temp_project)
+# Mirrors: src/dependencies/__tests__/scan.test.ts (Gradle sections)
+# ---------------------------------------------------------------------------
+
+class TestScanProjectGradle(unittest.TestCase):
+    """End-to-end tests for server.scan_project() on Gradle projects."""
+
+    # Mirrors: scan.test.ts > "unused catalog library emitted once with kind catalog-library and empty usages"
+    def test_unused_catalog_library_emitted_once_with_empty_usages(self):
+        files = {
+            "gradle/libs.versions.toml": (
+                "[libraries]\n"
+                'ktor-core = { module = "io.ktor:ktor-client-core", version = "3.1.1" }\n'
+            ),
+        }
+        with temp_project(files) as root:
+            result = server.scan_project(root)
+        self.assertEqual(result["buildSystem"], "gradle")
+        deps = [d for d in result["dependencies"]
+                if d["groupId"] == "io.ktor" and d["artifactId"] == "ktor-client-core"]
+        self.assertEqual(len(deps), 1)
+        dep = deps[0]
+        self.assertEqual(dep["source"]["kind"], "catalog-library")
+        self.assertEqual(dep["source"]["catalogName"], "libs")
+        self.assertEqual(dep["source"]["tomlPath"], "gradle/libs.versions.toml")
+        self.assertEqual(dep["source"]["alias"], "ktor-core")
+        self.assertEqual(dep["usages"], [])
+
+    # Mirrors: scan.test.ts > "used catalog library: usages populated, single entry (no duplicate)"
+    def test_used_catalog_library_has_usage_and_no_duplicate(self):
+        files = {
+            "gradle/libs.versions.toml": (
+                "[libraries]\n"
+                'ktor-core = { module = "io.ktor:ktor-client-core", version = "3.1.1" }\n'
+            ),
+            "build.gradle.kts": (
+                "dependencies {\n"
+                "    implementation(libs.ktor.core)\n"
+                "}"
+            ),
+        }
+        with temp_project(files) as root:
+            result = server.scan_project(root)
+        deps = [d for d in result["dependencies"] if d.get("groupId") == "io.ktor"]
+        # Only one entry — catalog entry populated with usage, no duplicate module-direct
+        self.assertEqual(len(deps), 1)
+        self.assertEqual(deps[0]["source"]["kind"], "catalog-library")
+        self.assertEqual(len(deps[0]["usages"]), 1)
+        self.assertEqual(deps[0]["usages"][0]["module"], None)
+        self.assertEqual(deps[0]["usages"][0]["configuration"], "implementation")
+
+    # Mirrors: scan.test.ts > "catalog library used by two modules: one entry, two usages"
+    def test_catalog_library_two_modules_two_usages(self):
+        files = {
+            "settings.gradle.kts": 'include(":app")\ninclude(":lib")',
+            "gradle/libs.versions.toml": (
+                "[libraries]\n"
+                'ktor-core = { module = "io.ktor:ktor-client-core", version = "3.1.1" }\n'
+            ),
+            "app/build.gradle.kts": (
+                "dependencies {\n"
+                "    implementation(libs.ktor.core)\n"
+                "}"
+            ),
+            "lib/build.gradle.kts": (
+                "dependencies {\n"
+                "    api(libs.ktor.core)\n"
+                "}"
+            ),
+        }
+        with temp_project(files) as root:
+            result = server.scan_project(root)
+        deps = [d for d in result["dependencies"]
+                if d.get("groupId") == "io.ktor" and d["source"]["kind"] == "catalog-library"]
+        self.assertEqual(len(deps), 1)
+        self.assertEqual(len(deps[0]["usages"]), 2)
+        configurations = {u["configuration"] for u in deps[0]["usages"]}
+        self.assertIn("implementation", configurations)
+        self.assertIn("api", configurations)
+
+    # Mirrors: scan.test.ts > "catalog version drift: catalog says 1.0, module hardcodes 2.0"
+    def test_catalog_version_drift_both_reported_separately(self):
+        files = {
+            "gradle/libs.versions.toml": (
+                "[libraries]\n"
+                'ktor-core = { module = "io.ktor:ktor-client-core", version = "1.0.0" }\n'
+            ),
+            "build.gradle.kts": (
+                "dependencies {\n"
+                "    implementation(libs.ktor.core)\n"
+                '    implementation("io.ktor:ktor-client-core:2.0.0")\n'
+                "}"
+            ),
+        }
+        with temp_project(files) as root:
+            result = server.scan_project(root)
+        deps = [d for d in result["dependencies"]
+                if d.get("groupId") == "io.ktor" and d.get("artifactId") == "ktor-client-core"]
+        self.assertEqual(len(deps), 2)
+        catalog_dep = next(d for d in deps if d["source"]["kind"] == "catalog-library")
+        direct_dep = next(d for d in deps if d["source"]["kind"] == "module-direct")
+        self.assertEqual(catalog_dep["version"], "1.0.0")
+        self.assertEqual(direct_dep["version"], "2.0.0")
+
+    # Mirrors: scan.test.ts > "unused catalog plugin emitted with kind catalog-plugin and plugin marker artifactId"
+    def test_unused_catalog_plugin_emitted(self):
+        files = {
+            "gradle/libs.versions.toml": (
+                "[plugins]\n"
+                'android-application = { id = "com.android.application", version = "8.5.0" }\n'
+            ),
+        }
+        with temp_project(files) as root:
+            result = server.scan_project(root)
+        dep = next((d for d in result["dependencies"]
+                    if d.get("groupId") == "com.android.application"), None)
+        self.assertIsNotNone(dep)
+        self.assertEqual(dep["artifactId"], "com.android.application.gradle.plugin")
+        self.assertEqual(dep["source"]["kind"], "catalog-plugin")
+        self.assertEqual(dep["usages"], [])
+
+    # Mirrors: scan.test.ts > "root plugins {} block: id("x") version "1.0" → kind plugins-dsl"
+    def test_root_plugins_block_kind_plugins_dsl(self):
+        files = {
+            "build.gradle.kts": (
+                'plugins {\n'
+                '    id("com.android.application") version "8.5.0"\n'
+                '}'
+            ),
+        }
+        with temp_project(files) as root:
+            result = server.scan_project(root)
+        dep = next((d for d in result["dependencies"]
+                    if d.get("groupId") == "com.android.application"), None)
+        self.assertIsNotNone(dep)
+        self.assertEqual(dep["artifactId"], "com.android.application.gradle.plugin")
+        self.assertEqual(dep["version"], "8.5.0")
+        self.assertEqual(dep["source"]["kind"], "plugins-dsl")
+        self.assertIsNone(dep["source"]["module"])
+        self.assertNotIn("settingsBlock", dep["source"])
+        self.assertEqual(len(dep["usages"]), 1)
+        self.assertEqual(dep["usages"][0]["configuration"], "plugin-dsl")
+
+    # Mirrors: scan.test.ts > "module-level plugins {} block → source.module :app"
+    def test_module_level_plugins_block_has_module_label(self):
+        files = {
+            "settings.gradle.kts": 'include(":app")',
+            "app/build.gradle.kts": (
+                'plugins {\n'
+                '    id("com.android.application") version "8.0.0"\n'
+                '}'
+            ),
+        }
+        with temp_project(files) as root:
+            result = server.scan_project(root)
+        dep = next((d for d in result["dependencies"]
+                    if d.get("groupId") == "com.android.application"), None)
+        self.assertIsNotNone(dep)
+        self.assertEqual(dep["source"]["kind"], "plugins-dsl")
+        self.assertEqual(dep["source"]["module"], ":app")
+        self.assertNotIn("settingsBlock", dep["source"])
+
+    # Mirrors: scan.test.ts > "buildscript classpath → kind buildscript-classpath"
+    def test_buildscript_classpath_kind(self):
+        files = {
+            "build.gradle.kts": (
+                'buildscript {\n'
+                '    dependencies {\n'
+                '        classpath("com.android.tools.build:gradle:8.0.0")\n'
+                '    }\n'
+                '}'
+            ),
+        }
+        with temp_project(files) as root:
+            result = server.scan_project(root)
+        dep = next((d for d in result["dependencies"]
+                    if d.get("artifactId") == "gradle"
+                    and d.get("groupId") == "com.android.tools.build"), None)
+        self.assertIsNotNone(dep)
+        self.assertEqual(dep["source"]["kind"], "buildscript-classpath")
+        self.assertEqual(len(dep["usages"]), 1)
+        self.assertEqual(dep["usages"][0]["configuration"], "classpath")
+        self.assertIsNone(dep["usages"][0]["module"])
+
+    # Mirrors: scan.test.ts > "buildscript classpath in submodule is not scanned"
+    def test_buildscript_classpath_in_submodule_not_scanned(self):
+        files = {
+            "settings.gradle.kts": 'include(":app")',
+            "app/build.gradle.kts": (
+                'buildscript {\n'
+                '    dependencies {\n'
+                '        classpath("com.example:submodule-classpath:1.0")\n'
+                '    }\n'
+                '}'
+            ),
+        }
+        with temp_project(files) as root:
+            result = server.scan_project(root)
+        dep = next((d for d in result["dependencies"]
+                    if d.get("artifactId") == "submodule-classpath"), None)
+        self.assertIsNone(dep)
+
+    # Mirrors: scan.test.ts > "settings plugins block → settingsBlock: true in source"
+    def test_settings_plugins_block_has_settings_block_flag(self):
+        files = {
+            "settings.gradle.kts": (
+                'pluginManagement {\n'
+                '    plugins {\n'
+                '        id("com.gradle.plugin") version "1.0"\n'
+                '    }\n'
+                '}'
+            ),
+        }
+        with temp_project(files) as root:
+            result = server.scan_project(root)
+        dep = next((d for d in result["dependencies"]
+                    if d.get("groupId") == "com.gradle.plugin"), None)
+        self.assertIsNotNone(dep)
+        self.assertEqual(dep["source"]["kind"], "plugins-dsl")
+        self.assertTrue(dep["source"].get("settingsBlock"))
+
+    # Mirrors: scan.test.ts > "no Gradle settings, only gradle/libs.versions.toml → default libs descriptor"
+    def test_no_settings_file_default_catalog_used(self):
+        files = {
+            "gradle/libs.versions.toml": (
+                "[libraries]\n"
+                'gson = { module = "com.google.code.gson:gson", version = "2.11.0" }\n'
+            ),
+            "build.gradle.kts": (
+                "dependencies {\n"
+                "    implementation(libs.gson)\n"
+                "}"
+            ),
+        }
+        with temp_project(files) as root:
+            result = server.scan_project(root)
+        self.assertEqual(result["buildSystem"], "gradle")
+        dep = next((d for d in result["dependencies"]
+                    if d.get("artifactId") == "gson"), None)
+        self.assertIsNotNone(dep)
+        self.assertEqual(len(dep["usages"]), 1)
+
+    # Mirrors: scan.test.ts > "alias(libs.plugins.x) in module resolves through catalog [plugins]"
+    def test_alias_plugins_ref_in_module_resolves_catalog_plugin(self):
+        files = {
+            "settings.gradle.kts": 'include(":app")',
+            "gradle/libs.versions.toml": (
+                "[plugins]\n"
+                'kotlin-android = { id = "org.jetbrains.kotlin.android", version = "2.0.0" }\n'
+            ),
+            "app/build.gradle.kts": (
+                "plugins {\n"
+                "    alias(libs.plugins.kotlin.android)\n"
+                "}"
+            ),
+        }
+        with temp_project(files) as root:
+            result = server.scan_project(root)
+        deps = [d for d in result["dependencies"]
+                if d.get("groupId") == "org.jetbrains.kotlin.android"]
+        # Only one entry — the catalog plugin entry, no extra plugins-dsl dep
+        self.assertEqual(len(deps), 1)
+        self.assertEqual(deps[0]["source"]["kind"], "catalog-plugin")
+        self.assertEqual(len(deps[0]["usages"]), 1)
+        self.assertEqual(deps[0]["usages"][0]["module"], ":app")
+        self.assertEqual(deps[0]["usages"][0]["configuration"], "plugin-dsl")
+
+    # Mirrors: scan.test.ts > "module-level plugin with apply false still emits"
+    def test_module_level_plugin_apply_false_still_emits(self):
+        files = {
+            "settings.gradle.kts": 'include(":lib")',
+            "lib/build.gradle.kts": (
+                "plugins {\n"
+                '    id("com.android.library") version "8.0.0" apply false\n'
+                "}"
+            ),
+        }
+        with temp_project(files) as root:
+            result = server.scan_project(root)
+        dep = next((d for d in result["dependencies"]
+                    if d.get("groupId") == "com.android.library"), None)
+        self.assertIsNotNone(dep)
+        self.assertEqual(dep["source"]["kind"], "plugins-dsl")
+        self.assertEqual(dep["source"]["module"], ":lib")
+
+    # Gradle .gradle (Groovy) single-module end-to-end
+    def test_gradle_groovy_single_module(self):
+        files = {
+            "build.gradle": (
+                "dependencies {\n"
+                "    implementation 'io.ktor:ktor-client-core:3.1.1'\n"
+                "}"
+            ),
+        }
+        with temp_project(files) as root:
+            result = server.scan_project(root)
+        self.assertEqual(result["buildSystem"], "gradle")
+        dep = next((d for d in result["dependencies"]
+                    if d.get("artifactId") == "ktor-client-core"), None)
+        self.assertIsNotNone(dep)
+        self.assertEqual(dep["version"], "3.1.1")
+        self.assertEqual(dep["source"]["kind"], "module-direct")
+
+    # Gradle.kts multi-module end-to-end
+    def test_gradle_kts_multi_module_submodule_deps(self):
+        files = {
+            "settings.gradle.kts": 'include(":core")\ninclude(":feature")',
+            "core/build.gradle.kts": (
+                "dependencies {\n"
+                '    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")\n'
+                "}"
+            ),
+            "feature/build.gradle.kts": (
+                "dependencies {\n"
+                '    implementation("com.squareup.retrofit2:retrofit:2.11.0")\n'
+                "}"
+            ),
+        }
+        with temp_project(files) as root:
+            result = server.scan_project(root)
+        self.assertEqual(result["buildSystem"], "gradle")
+        core_dep = next(
+            (d for d in result["dependencies"] if d.get("artifactId") == "kotlinx-coroutines-core"),
+            None,
+        )
+        feature_dep = next(
+            (d for d in result["dependencies"] if d.get("artifactId") == "retrofit"),
+            None,
+        )
+        self.assertIsNotNone(core_dep)
+        self.assertEqual(core_dep["usages"][0]["module"], ":core")
+        self.assertIsNotNone(feature_dep)
+        self.assertEqual(feature_dep["usages"][0]["module"], ":feature")
+
+
+# ---------------------------------------------------------------------------
+# scan_project — Maven (end-to-end via temp_project)
+# Mirrors: src/dependencies/__tests__/scan.test.ts (Maven sections)
+# ---------------------------------------------------------------------------
+
+class TestScanProjectMaven(unittest.TestCase):
+    """End-to-end tests for server.scan_project() on Maven projects."""
+
+    # Mirrors: scan.test.ts > "Maven project: each pom dep → kind module-direct, usages populated"
+    def test_single_pom_dep_kind_module_direct(self):
+        pom = (
+            "<project>\n"
+            "  <dependencies>\n"
+            "    <dependency>\n"
+            "      <groupId>io.ktor</groupId>\n"
+            "      <artifactId>ktor-core</artifactId>\n"
+            "      <version>3.1.1</version>\n"
+            "    </dependency>\n"
+            "  </dependencies>\n"
+            "</project>"
+        )
+        with temp_project({"pom.xml": pom}) as root:
+            result = server.scan_project(root)
+        self.assertEqual(result["buildSystem"], "maven")
+        self.assertEqual(len(result["dependencies"]), 1)
+        dep = result["dependencies"][0]
+        self.assertEqual(dep["groupId"], "io.ktor")
+        self.assertEqual(dep["artifactId"], "ktor-core")
+        self.assertEqual(dep["source"]["kind"], "module-direct")
+        self.assertIsNone(dep["source"]["module"])
+        self.assertEqual(len(dep["usages"]), 1)
+        self.assertIsNone(dep["usages"][0]["module"])
+
+    # Mirrors: scan.test.ts > "Maven submodule recursion preserved"
+    def test_maven_multi_module_recursion(self):
+        root_pom = (
+            "<project>\n"
+            "  <modules>\n"
+            "    <module>core</module>\n"
+            "  </modules>\n"
+            "</project>"
+        )
+        core_pom = (
+            "<project>\n"
+            "  <dependencies>\n"
+            "    <dependency>\n"
+            "      <groupId>io.ktor</groupId>\n"
+            "      <artifactId>ktor-core</artifactId>\n"
+            "      <version>3.1.1</version>\n"
+            "    </dependency>\n"
+            "  </dependencies>\n"
+            "</project>"
+        )
+        with temp_project({"pom.xml": root_pom, "core/pom.xml": core_pom}) as root:
+            result = server.scan_project(root)
+        self.assertEqual(result["buildSystem"], "maven")
+        self.assertEqual(len(result["dependencies"]), 1)
+        dep = result["dependencies"][0]
+        self.assertEqual(dep["source"]["file"], "pom.xml")
+        self.assertEqual(dep["usages"][0]["module"], "core")
+
+    # Mirrors: scan.test.ts > "returns empty for unknown project"
+    def test_unknown_project_returns_empty(self):
+        with temp_project({}) as root:
+            result = server.scan_project(root)
+        self.assertEqual(result["buildSystem"], "unknown")
+        self.assertEqual(result["dependencies"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/maven-mcp/tests/test_parsers.py
+++ b/plugins/maven-mcp/tests/test_parsers.py
@@ -27,7 +27,6 @@ Python-vs-TS behavioral differences (documented inline and in test comments):
      TS module are skipped (divergence guardrail #5).
 """
 
-import os
 import unittest
 
 from _helpers import server, temp_project

--- a/plugins/maven-mcp/tests/test_smoke.py
+++ b/plugins/maven-mcp/tests/test_smoke.py
@@ -1,7 +1,7 @@
 """Smoke tests: the harness imports `server` and the HTTP mocking works."""
 
 import unittest
-from unittest import mock
+import unittest.mock
 
 from _helpers import server, mock_urlopen, http_error
 
@@ -12,7 +12,7 @@ class SmokeTest(unittest.TestCase):
         self.assertEqual(server.classify_version("1.2.3"), "stable")
 
     def test_http_get_returns_mocked_status_and_bytes(self):
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([(200, b"hello")]),
         ):
@@ -22,7 +22,7 @@ class SmokeTest(unittest.TestCase):
 
     def test_http_error_maps_to_code_and_empty_bytes(self):
         err = http_error("https://example.test/x", 404, "Not Found")
-        with mock.patch(
+        with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([err]),
         ):

--- a/plugins/maven-mcp/tests/test_smoke.py
+++ b/plugins/maven-mcp/tests/test_smoke.py
@@ -1,0 +1,35 @@
+"""Smoke tests: the harness imports `server` and the HTTP mocking works."""
+
+import unittest
+from unittest import mock
+
+from _helpers import server, mock_urlopen, http_error
+
+
+class SmokeTest(unittest.TestCase):
+    def test_import_and_pure_function(self):
+        # classify_version falls through to "stable" for a plain semver (server.py:208).
+        self.assertEqual(server.classify_version("1.2.3"), "stable")
+
+    def test_http_get_returns_mocked_status_and_bytes(self):
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, b"hello")]),
+        ):
+            status, body = server.http_get("https://example.test/x")
+        self.assertEqual(status, 200)
+        self.assertEqual(body, b"hello")
+
+    def test_http_error_maps_to_code_and_empty_bytes(self):
+        err = http_error("https://example.test/x", 404, "Not Found")
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([err]),
+        ):
+            status, body = server.http_get("https://example.test/x")
+        self.assertEqual(status, 404)
+        self.assertEqual(body, b"")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/maven-mcp/tests/test_version.py
+++ b/plugins/maven-mcp/tests/test_version.py
@@ -1,0 +1,241 @@
+"""Tests for version classification and comparison functions in server.py.
+
+Mirrors assertions from:
+  - src/version/__tests__/classify.test.ts
+  - src/version/__tests__/compare.test.ts
+  - src/version/__tests__/range.test.ts
+
+All test methods call pure functions only — no network, no mocking required.
+"""
+
+import unittest
+
+from _helpers import server
+
+
+# ---------------------------------------------------------------------------
+# classify_version
+# ---------------------------------------------------------------------------
+
+class ClassifyVersionTest(unittest.TestCase):
+
+    def test_classifies_stable(self):
+        # mirrors classify.test.ts: "classifies stable versions"
+        self.assertEqual(server.classify_version("3.5.11"), "stable")
+        self.assertEqual(server.classify_version("1.0"), "stable")
+        self.assertEqual(server.classify_version("2.0.0"), "stable")
+
+    def test_classifies_snapshot(self):
+        # mirrors classify.test.ts: "classifies snapshot versions"
+        self.assertEqual(server.classify_version("1.0-SNAPSHOT"), "snapshot")
+        self.assertEqual(server.classify_version("2.0.0-SNAPSHOT"), "snapshot")
+
+    def test_classifies_alpha(self):
+        # mirrors classify.test.ts: "classifies alpha versions"
+        self.assertEqual(server.classify_version("1.0-alpha-1"), "alpha")
+        self.assertEqual(server.classify_version("1.0.0-alpha1"), "alpha")
+        self.assertEqual(server.classify_version("1.0-a1"), "alpha")
+
+    def test_classifies_beta(self):
+        # mirrors classify.test.ts: "classifies beta versions"
+        self.assertEqual(server.classify_version("1.0-beta-1"), "beta")
+        self.assertEqual(server.classify_version("1.0.0-beta1"), "beta")
+        self.assertEqual(server.classify_version("1.0-b1"), "beta")
+
+    def test_classifies_rc(self):
+        # mirrors classify.test.ts: "classifies RC versions"
+        self.assertEqual(server.classify_version("1.0-RC1"), "rc")
+        self.assertEqual(server.classify_version("1.0-rc-2"), "rc")
+        self.assertEqual(server.classify_version("1.0-CR1"), "rc")
+
+    def test_no_false_positive_on_short_form_patterns(self):
+        # mirrors classify.test.ts: "does not false-positive on short-form patterns"
+        self.assertEqual(server.classify_version("1.0-bar"), "stable")
+        self.assertEqual(server.classify_version("1.0-ace"), "stable")
+
+    def test_classifies_milestone(self):
+        # mirrors classify.test.ts: "classifies milestone versions"
+        self.assertEqual(server.classify_version("1.0-M1"), "milestone")
+        self.assertEqual(server.classify_version("1.0-milestone-2"), "milestone")
+
+    def test_edge_case_empty_string(self):
+        # edge case: empty string matches no pattern — falls through to "stable"
+        self.assertEqual(server.classify_version(""), "stable")
+
+    def test_edge_case_garbage_input(self):
+        # edge case: unrecognised string matches no pattern — falls through to "stable"
+        self.assertEqual(server.classify_version("garbage"), "stable")
+
+
+# ---------------------------------------------------------------------------
+# find_latest_version_for_current
+# ---------------------------------------------------------------------------
+
+_MIXED_VERSIONS = ["1.0.0", "2.0.0-alpha1", "2.0.0-beta1", "2.0.0-RC1", "2.0.0"]
+
+
+class FindLatestVersionForCurrentTest(unittest.TestCase):
+
+    def test_returns_stable_when_current_is_stable(self):
+        # mirrors classify.test.ts: "returns the stable when current is stable"
+        self.assertEqual(
+            server.find_latest_version_for_current(_MIXED_VERSIONS, "1.0.0"),
+            "2.0.0",
+        )
+
+    def test_current_rc_returns_rc_not_stable(self):
+        # mirrors classify.test.ts: "returns the stable when current is rc"
+        # Python difference: TS returns "2.0.0" (picks highest-versioned entry
+        # whose stability >= rc).  Python scans in reverse and returns the first
+        # entry whose PRERELEASE_WEIGHT <= rc weight (4); stable weight (5) > 4
+        # so "2.0.0" is skipped and "2.0.0-RC1" is returned instead.
+        self.assertEqual(
+            server.find_latest_version_for_current(_MIXED_VERSIONS, "1.0.0-RC1"),
+            "2.0.0-RC1",
+        )
+
+    def test_skips_versions_less_stable_than_current_beta(self):
+        # mirrors classify.test.ts: "skips less stable versions"
+        v = ["1.0.0", "2.0.0-alpha1", "2.0.0-beta1"]
+        self.assertEqual(
+            server.find_latest_version_for_current(v, "1.0.0-beta1"),
+            "2.0.0-beta1",
+        )
+
+    def test_returns_snapshot_when_stable_not_available(self):
+        # mirrors classify.test.ts: "returns undefined when no matching version exists"
+        # Python difference: TS returns undefined because snapshot stability is
+        # below the stable threshold.  Python returns "1.0.0-SNAPSHOT" because
+        # snapshot PRERELEASE_WEIGHT (0) <= stable max_rank (5).
+        v = ["1.0.0-SNAPSHOT"]
+        self.assertEqual(
+            server.find_latest_version_for_current(v, "1.0.0"),
+            "1.0.0-SNAPSHOT",
+        )
+
+
+# ---------------------------------------------------------------------------
+# compare_versions
+# ---------------------------------------------------------------------------
+
+class CompareVersionsTest(unittest.TestCase):
+
+    def test_compares_numeric_cores(self):
+        # mirrors compare.test.ts: "compares numeric cores"
+        self.assertLess(server.compare_versions("1.0.0", "2.0.0"), 0)
+        self.assertGreater(server.compare_versions("2.0.0", "1.9.9"), 0)
+        self.assertEqual(server.compare_versions("1.0.0", "1.0.0"), 0)
+
+    def test_orders_stable_above_prerelease_of_same_core(self):
+        # mirrors compare.test.ts: "orders stable above pre-release of same core"
+        self.assertGreater(server.compare_versions("2.0.0", "2.0.0-RC1"), 0)
+
+    def test_orders_prereleases_relative_to_each_other(self):
+        # mirrors compare.test.ts: "orders pre-releases relative to each other"
+        self.assertGreater(server.compare_versions("2.0.0-RC1", "2.0.0-beta1"), 0)
+        self.assertLess(server.compare_versions("2.0.0-alpha1", "2.0.0-beta1"), 0)
+
+
+# ---------------------------------------------------------------------------
+# get_upgrade_type
+# ---------------------------------------------------------------------------
+
+class GetUpgradeTypeTest(unittest.TestCase):
+
+    def test_detects_major_upgrade(self):
+        # mirrors compare.test.ts: "detects major upgrade"
+        self.assertEqual(server.get_upgrade_type("1.0.0", "2.0.0"), "major")
+
+    def test_detects_minor_upgrade(self):
+        # mirrors compare.test.ts: "detects minor upgrade"
+        self.assertEqual(server.get_upgrade_type("1.0.0", "1.1.0"), "minor")
+
+    def test_detects_patch_upgrade(self):
+        # mirrors compare.test.ts: "detects patch upgrade"
+        self.assertEqual(server.get_upgrade_type("1.0.0", "1.0.1"), "patch")
+
+    def test_returns_none_for_downgrade(self):
+        # mirrors compare.test.ts: "returns none for downgrade"
+        self.assertEqual(server.get_upgrade_type("2.0.0", "1.5.0"), "none")
+        self.assertEqual(server.get_upgrade_type("1.5.0", "1.3.9"), "none")
+
+    def test_handles_two_segment_versions(self):
+        # mirrors compare.test.ts: "handles two-segment versions"
+        self.assertEqual(server.get_upgrade_type("1.0", "2.0"), "major")
+        self.assertEqual(server.get_upgrade_type("1.0", "1.1"), "minor")
+
+    def test_prerelease_to_stable_is_patch(self):
+        # mirrors compare.test.ts: "classifies pre-release → stable as patch"
+        self.assertEqual(server.get_upgrade_type("2.0.0-beta-1", "2.0.0"), "patch")
+        self.assertEqual(server.get_upgrade_type("2.0.0-rc-1", "2.0.0"), "patch")
+
+    def test_prerelease_to_higher_prerelease_is_patch(self):
+        # mirrors compare.test.ts: "classifies pre-release → higher pre-release as patch"
+        self.assertEqual(server.get_upgrade_type("2.0.0-beta-1", "2.0.0-beta-2"), "patch")
+        self.assertEqual(server.get_upgrade_type("2.0.0-beta-1", "2.0.0-rc-1"), "patch")
+        self.assertEqual(server.get_upgrade_type("2.0.0-alpha", "2.0.0-beta"), "patch")
+
+    def test_returns_none_for_stable_to_prerelease_same_core(self):
+        # mirrors compare.test.ts: "returns none for stable → pre-release of same core (downgrade)"
+        self.assertEqual(server.get_upgrade_type("2.0.0", "2.0.0-beta-1"), "none")
+        self.assertEqual(server.get_upgrade_type("2.0.0-rc-1", "2.0.0-beta-1"), "none")
+
+    def test_core_level_upgrades_across_prerelease_suffixes(self):
+        # mirrors compare.test.ts: "still classifies core-level upgrades across pre-release suffixes"
+        self.assertEqual(server.get_upgrade_type("1.9.0", "2.0.0-beta-1"), "major")
+        self.assertEqual(server.get_upgrade_type("1.3.2-1.4.0-rc", "1.3.2"), "patch")
+
+
+# ---------------------------------------------------------------------------
+# _filter_version_range  (mirrors TS filterVersionRange)
+# ---------------------------------------------------------------------------
+
+_RANGE_VERSIONS = ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "2.0.0-beta1", "2.0.0"]
+
+
+class FilterVersionRangeTest(unittest.TestCase):
+
+    def test_returns_versions_exclusive_from_inclusive_to(self):
+        # mirrors range.test.ts: "returns versions between from (exclusive) and to (inclusive)"
+        self.assertEqual(
+            server._filter_version_range(_RANGE_VERSIONS, "1.0.0", "1.3.0"),
+            ["1.1.0", "1.2.0", "1.3.0"],
+        )
+
+    def test_includes_prerelease_versions_in_range(self):
+        # mirrors range.test.ts: "includes pre-release versions in range"
+        self.assertEqual(
+            server._filter_version_range(_RANGE_VERSIONS, "1.2.0", "2.0.0"),
+            ["1.3.0", "2.0.0-beta1", "2.0.0"],
+        )
+
+    def test_empty_when_from_equals_to(self):
+        # mirrors range.test.ts: "returns empty array when from and to are the same"
+        self.assertEqual(
+            server._filter_version_range(_RANGE_VERSIONS, "1.0.0", "1.0.0"),
+            [],
+        )
+
+    def test_from_not_found_falls_back_to_numeric_comparison(self):
+        # mirrors range.test.ts: "returns empty array when fromVersion is not found"
+        # Python difference: TS returns [] when fromVersion is absent from the list.
+        # Python uses compare_versions, so "0.9.0" acts as a numeric lower bound
+        # and all versions between 0.9.0 (exclusive) and 1.3.0 (inclusive) are returned.
+        self.assertEqual(
+            server._filter_version_range(_RANGE_VERSIONS, "0.9.0", "1.3.0"),
+            ["1.0.0", "1.1.0", "1.2.0", "1.3.0"],
+        )
+
+    def test_to_not_found_falls_back_to_numeric_comparison(self):
+        # mirrors range.test.ts: "returns empty array when toVersion is not found"
+        # Python difference: TS returns [] when toVersion is absent from the list.
+        # Python uses compare_versions, so "9.9.9" acts as a numeric upper bound
+        # and all versions between 1.0.0 (exclusive) and 9.9.9 (inclusive) are returned.
+        self.assertEqual(
+            server._filter_version_range(_RANGE_VERSIONS, "1.0.0", "9.9.9"),
+            ["1.1.0", "1.2.0", "1.3.0", "2.0.0-beta1", "2.0.0"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

PR **A** of the two-PR migration making the shipped Python runtime (`plugin/server/server.py`) the single source of truth for maven-mcp. This PR adds real test coverage to the runtime (which had **zero** tests) while the TS reference still exists. PR **B** (follow-up) removes `src/` and migrates the TS-coupled pipelines.

Plan: `docs/plans/maven-python-migration/plan.md` · Tasks: `tasks.md` · Parity audit: `coverage-map.md`.

## Changes
- **209 stdlib `unittest` tests** against `server.py` (zero pip deps): version, parsers (incl. plugins-block/multi-module), github+changelog, maven/search/OSV, all 10 handlers, http. Network mocked via `urllib.request.urlopen`; project scans via `tempfile`.
- **#263 regression** locked: `compare_dependency_versions` no-match → clean per-dep `error` (exact observable; fails if the guard is removed).
- **`coverage-map.md`**: all 47 TS test files classified — 30 ported / 3 partial / 12 diverged / 2 N/A — the auditable parity bar before PR B deletes the baseline.
- **CI `python-tests` job** (matrix 3.9/3.13), always-run + step-gated like `build` so the check always reports; runs unittest + zero-dep `compileall`. Node jobs untouched here (removed in PR B).

## Reviewed
Plan went through 2 cycles of multiexpert-review (architecture / devops / pr-test-analyzer); all blockers resolved before implementation.

## Divergences found (pre-existing gaps from the #302 Python port — filed, not fixed here)
Feature gaps: #306 retry, #307 file cache, #308 AGP/AndroidX changelog+html, #309 HTTP/SSE transport.
**Correctness regressions** (cross-linked to epic #293): #310 custom-repo discovery → wrong answers for private repos, #311 first-hit vs resolveAll-merge → wrong latest, #312 version-selection may suggest prerelease/snapshot over stable. Plus #313 parser gaps + `utcnow()` deprecation.

Tests assert the **actual** Python behavior and comment each divergence; the runtime is unchanged in this PR.

## Verification
`python3 -m unittest discover -s plugins/maven-mcp/tests` → 209 passed. `actionlint` clean. No ResourceWarning under `-W error::ResourceWarning`.