### PR TITLE
Fix find_latest_version_for_current to not offer less-stable upgrades (#312)

### DIFF
--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -273,11 +273,17 @@ def find_latest_version(versions: List[str], filter_mode: str = "PREFER_STABLE")
 
 
 def find_latest_version_for_current(versions: List[str], current_version: str) -> Optional[str]:
-    """Latest version at least as stable as current (mirrors TS findLatestVersionForCurrent)."""
-    current_stability = classify_version(current_version)
-    max_rank = PRERELEASE_WEIGHT.get(current_stability, 5)
+    """Highest version newer-or-equal to current at acceptable stability, else None.
+
+    A candidate qualifies iff it is newer-than-or-equal to current AND ranks at
+    least as stable on snapshot < alpha < beta < milestone < rc < stable; an
+    up-to-date dependency thus returns current itself (upgradeType "none"),
+    never a less-stable SNAPSHOT/RC as an upgrade from a more stable current
+    (#312). None only when nothing at acceptable stability is >= current.
+    """
+    current_rank = PRERELEASE_WEIGHT.get(classify_version(current_version), 5)
     for v in reversed(versions):
-        if PRERELEASE_WEIGHT.get(classify_version(v), 5) <= max_rank:
+        if compare_versions(v, current_version) >= 0 and PRERELEASE_WEIGHT.get(classify_version(v), 5) >= current_rank:
             return v
     return None
 

--- a/plugins/maven-mcp/tests/test_handlers.py
+++ b/plugins/maven-mcp/tests/test_handlers.py
@@ -128,22 +128,25 @@ class TestCompareDependencyVersions(unittest.TestCase):
     """mirrors src/tools/__tests__/compare-dependency-versions.test.ts"""
 
     def test_263_no_match_guard_exact_observables(self):
-        # #263 regression. dep[0] is alpha-current with only a STABLE candidate
-        # newer: find_latest_version_for_current returns None (no version is as
-        # unstable-or-more than alpha), so the `if not latest` guard (server.py
-        # :1299) raises "No matching version found". dep[1] resolves normally.
+        # #263 regression. dep[0]'s published versions are a single SNAPSHOT and
+        # current 1.0.0 is absent from the list: the only candidate is less
+        # stable than current, so find_latest_version_for_current returns None
+        # (a SNAPSHOT is never offered as an upgrade, #312), and — because
+        # current itself is not published — nothing newer-or-equal qualifies
+        # either (#312 correction). The `if not latest` guard (server.py :1299)
+        # therefore raises "No matching version found". dep[1] resolves normally.
         # Asserting the EXACT error string + upgradeAvailable/latestVersion makes
         # this fail if the guard is removed: without it, get_upgrade_type(current,
         # None) raises a TypeError whose message would replace the error text.
         responses = [
-            (200, _meta(["2.0.0"])),            # dep[0] no-match metadata
-            (200, _meta(["1.0.0", "1.1.0"])),   # dep[1] sibling metadata
+            (200, _meta(["2.0.0-SNAPSHOT"])),  # dep[0] only less-stable, current absent
+            (200, _meta(["1.0.0", "1.1.0"])),  # dep[1] sibling metadata
         ]
         with _patch_urlopen(responses):
             out = server.handle_compare_dependency_versions({
                 "dependencies": [
                     {"groupId": "com.example", "artifactId": "nomatch",
-                     "currentVersion": "1.0.0-alpha01"},
+                     "currentVersion": "1.0.0"},
                     {"groupId": "com.example", "artifactId": "sibling",
                      "currentVersion": "1.0.0"},
                 ],
@@ -159,6 +162,27 @@ class TestCompareDependencyVersions(unittest.TestCase):
         self.assertEqual(sibling["latestVersion"], "1.1.0")
         self.assertIs(sibling["upgradeAvailable"], True)
         self.assertEqual(sibling["upgradeType"], "minor")
+
+    def test_up_to_date_reports_no_upgrade_without_error(self):
+        # #312 correction: an already-up-to-date dependency (current == latest
+        # published stable) must NOT trip the `if not latest` guard. With the
+        # newer-OR-equal rule find_latest_version_for_current returns the
+        # current 2.0.0 itself, so the handler reports latestVersion 2.0.0,
+        # upgradeAvailable False (upgradeType "none") and emits NO error — where
+        # the prior strict-newer check returned None and raised a spurious
+        # "No matching version found".
+        with _patch_urlopen([(200, _meta(["1.0.0", "2.0.0"]))]):
+            out = server.handle_compare_dependency_versions({
+                "dependencies": [
+                    {"groupId": "com.example", "artifactId": "uptodate",
+                     "currentVersion": "2.0.0"},
+                ],
+            })
+        result = out["results"][0]
+        self.assertEqual(result["latestVersion"], "2.0.0")
+        self.assertIs(result["upgradeAvailable"], False)
+        self.assertEqual(result["upgradeType"], "none")
+        self.assertNotIn("error", result)
 
 
 # --- handle_get_dependency_changes ------------------------------------------

--- a/plugins/maven-mcp/tests/test_version.py
+++ b/plugins/maven-mcp/tests/test_version.py
@@ -83,15 +83,13 @@ class FindLatestVersionForCurrentTest(unittest.TestCase):
             "2.0.0",
         )
 
-    def test_current_rc_returns_rc_not_stable(self):
-        # mirrors classify.test.ts: "returns the stable when current is rc"
-        # Python difference: TS returns "2.0.0" (picks highest-versioned entry
-        # whose stability >= rc).  Python scans in reverse and returns the first
-        # entry whose PRERELEASE_WEIGHT <= rc weight (4); stable weight (5) > 4
-        # so "2.0.0" is skipped and "2.0.0-RC1" is returned instead.
+    def test_current_rc_returns_stable_upgrade(self):
+        # #312: a more-stable upgrade must win. From an RC current, the stable
+        # 2.0.0 qualifies (stable >= rc) and is the highest candidate, so it is
+        # returned in preference to the same-core 2.0.0-RC1.
         self.assertEqual(
             server.find_latest_version_for_current(_MIXED_VERSIONS, "1.0.0-RC1"),
-            "2.0.0-RC1",
+            "2.0.0",
         )
 
     def test_skips_versions_less_stable_than_current_beta(self):
@@ -102,15 +100,24 @@ class FindLatestVersionForCurrentTest(unittest.TestCase):
             "2.0.0-beta1",
         )
 
-    def test_returns_snapshot_when_stable_not_available(self):
-        # mirrors classify.test.ts: "returns undefined when no matching version exists"
-        # Python difference: TS returns undefined because snapshot stability is
-        # below the stable threshold.  Python returns "1.0.0-SNAPSHOT" because
-        # snapshot PRERELEASE_WEIGHT (0) <= stable max_rank (5).
+    def test_returns_none_when_only_less_stable_available(self):
+        # #312: a SNAPSHOT must never be offered as an upgrade from a stable
+        # current. Snapshot rank (0) is below stable rank (5), so nothing
+        # qualifies and None is returned.
         v = ["1.0.0-SNAPSHOT"]
-        self.assertEqual(
+        self.assertIsNone(
             server.find_latest_version_for_current(v, "1.0.0"),
-            "1.0.0-SNAPSHOT",
+        )
+
+    def test_up_to_date_current_returns_current_not_none(self):
+        # #312 correction: when current is already the highest acceptable
+        # version it is present in the list, qualifies (compare == 0, same
+        # stability) and is returned. The newer-OR-equal rule avoids the
+        # spurious "no matching version" the strict-newer check produced for
+        # already-up-to-date dependencies.
+        self.assertEqual(
+            server.find_latest_version_for_current(["1.0.0", "2.0.0"], "2.0.0"),
+            "2.0.0",
         )
 
 


### PR DESCRIPTION
## Bug (#312)

`find_latest_version_for_current` had an inverted stability gate (`weight(v) <= max_rank`): it offered a SNAPSHOT/RC as an "upgrade" from a stable current and gave an RC current another RC instead of the available stable. Found during the TS→Python migration (the retired TS had the correct behavior). This drives `compare_dependency_versions` and `audit_project_dependencies`, so it produced wrong upgrade recommendations.

## Fix

A candidate qualifies iff it is **newer-or-equal** (`compare_versions(v, current) >= 0`) AND **at least as stable** as current (rank snapshot < alpha < beta < milestone < rc < stable). Returns the highest qualifying version; None only when nothing >= current at acceptable stability. Up-to-date deps return current itself → `upgradeAvailable: false` (no false "no version" error). Only `find_latest_version_for_current` changed; `find_latest_version` untouched.

## Verification (red-green)
- current `1.0.0-RC1` → stable `2.0.0` (was `2.0.0-RC1`)
- current stable `1.0.0`, only `1.0.0-SNAPSHOT` → None (was SNAPSHOT)
- up-to-date current `2.0.0` → `2.0.0`, `upgradeAvailable: false`, no error (new regression test)
- 211 Python tests pass; `validate.sh` rc=0. #263 no-match regression preserved (re-targeted to a genuine None case).

Closes #312