### PR TITLE
Project-first repository resolution + cross-repo merge (#310, #311; core of #299)

### DIFF
--- a/docs/plans/maven-python-migration/coverage-map.md
+++ b/docs/plans/maven-python-migration/coverage-map.md
@@ -1,8 +1,13 @@
 # Coverage Map — TS test suite → Python parity (T-8)
 
 Maps each of the **47** TypeScript test files under `plugins/maven-mcp/src/**/__tests__/`
-to the shipped Python runtime (`plugin/server/server.py`) and its 6 test modules
-(`tests/test_{version,parsers,github,maven_search_osv,handlers,http}.py`).
+to the shipped Python runtime (`plugin/server/server.py`) and its 8 test modules
+(`tests/test_{version,parsers,github,maven_search_osv,handlers,http,repo_discovery,resolution}.py`).
+
+> Update (`fix/maven-repo-resolution`): the repository-resolution layer (#310/#311,
+> core of #299) added project-repo discovery + cross-repo metadata merge, so the
+> 3 `discovery/*` files and `maven/resolver.test.ts` move from diverged/partial to
+> **ported** (covered by `test_repo_discovery.py` + `test_resolution.py`).
 
 **This behavioral map is the AUTHORITATIVE parity bar.** It records what the Python
 suite actually asserts. `python3 -m trace --count` (see *Untested server.py functions*)
@@ -20,8 +25,10 @@ is a **backstop only** — it proves a function executed, never that behavior wa
 - **#2** persistent file cache (feature gap)
 - **#3** AGP/AndroidX release-notes changelog providers + html-to-text + github CHANGELOG.md markdown fallback + `changelog/resolver` provider-selection — server.py has no agp/androidx/html parser and `_get_dependency_changes_impl` is GitHub-releases-only (feature gap)
 - **#4** HTTP/SSE transport — server.py is stdio-only (feature gap)
-- **#5** custom-repository discovery — **CORRECTNESS** regression (silently wrong version answers for projects with custom repos)
-- **#6** `resolveAll` parallel-merge vs first-hit — **CORRECTNESS** regression (multi-repo artifacts: first-hit drops versions present only in a later repo)
+
+**Resolved by this PR** (`fix/maven-repo-resolution`) — both former CORRECTNESS regressions are now **ported**:
+- **#5** custom-repository discovery — `discover_repositories` + project-first `_repos_for` parse declared Gradle/Maven repos (covered by `test_repo_discovery.py` + `test_resolution.py`).
+- **#6** `resolveAll` parallel-merge vs first-hit — `fetch_metadata` now merges versions across all answering repos (covered by `test_resolution.py` `TestMetadataMerge`).
 
 ## Map
 
@@ -71,11 +78,11 @@ is a **backstop only** — it proves a function executed, never that behavior wa
 | `androidx/url.test.ts` | diverged → #3 | no AndroidX URL mapping in server.py |
 | `html/to-text.test.ts` | diverged → #3 | no htmlToText util in server.py (only used by agp/androidx providers) |
 
-### maven/ + search/ + vulnerabilities/ (4) — 3 ported, 1 partial
+### maven/ + search/ + vulnerabilities/ (4) — all ported
 | TS test file | Bucket | Python |
 |---|---|---|
 | `maven/repository.test.ts` | ported | `test_maven_search_osv.py` (TestReposFor + metadata/pom URL construction) |
-| `maven/resolver.test.ts` | partial → `test_maven_search_osv.py` + resolveAll-merge diverged → #6 | first-hit `fetch_metadata` exercised (incl. `test_first_hit_not_resolveall_merge`); parallel merge-across-repos semantics not ported |
+| `maven/resolver.test.ts` | ported | `test_resolution.py` (TestMetadataMerge — cross-repo union/dedup/sort, `lastUpdated` max, all-404 raise; TestProjectFirstRouting) + `test_maven_search_osv.py`. Cross-repo merge now ported (#6); the former `test_first_hit_not_resolveall_merge` was rewritten to assert the merge |
 | `search/maven-search.test.ts` | ported | `test_maven_search_osv.py` (TestSearchMavenCentral) |
 | `vulnerabilities/osv-client.test.ts` | ported | `test_maven_search_osv.py` (TestQueryOsvBatch) |
 
@@ -89,12 +96,12 @@ is a **backstop only** — it proves a function executed, never that behavior wa
 |---|---|---|
 | `cache/file-cache.test.ts` | diverged → #2 | no persistent file cache in server.py (in-memory memoization only) |
 
-### discovery/ (3) — all diverged → #5
+### discovery/ (3) — all ported
 | TS test file | Bucket | Python |
 |---|---|---|
-| `discovery/discover.test.ts` | diverged → #5 | server.py `_repos_for` is static group-prefix routing; no build-file custom-repo discovery |
-| `discovery/gradle-parser.test.ts` | diverged → #5 | no `maven {}` / `maven("url")` parsing in server.py |
-| `discovery/maven-parser.test.ts` | diverged → #5 | no `<repositories>` parsing in server.py |
+| `discovery/discover.test.ts` | ported | `test_repo_discovery.py` (TestDiscoverRepositories — plugin/dependency scoping, gradle-wins-over-pom, 2x2 no-leak, buildscript-vs-bare) + `test_resolution.py` (TestProjectFirstRouting) |
+| `discovery/gradle-parser.test.ts` | ported | `test_repo_discovery.py` (TestParseGradleRepos — shorthands, `maven("url")`, `maven { url }` incl. url-after-credentials; TestExtractBlock — brace scanner) |
+| `discovery/maven-parser.test.ts` | ported | `test_repo_discovery.py` (TestParseMavenRepos — `<repositories>` / `<pluginRepositories>` dual-container separation) |
 
 ### tools/ (10) — all ported (`test_handlers.py`)
 | TS test file | Bucket | Python |
@@ -120,13 +127,13 @@ is a **backstop only** — it proves a function executed, never that behavior wa
 
 | Bucket | Count |
 |---|---|
-| ported | 30 |
-| partial | 3 |
-| diverged | 12 |
+| ported | 34 |
+| partial | 2 |
+| diverged | 9 |
 | N/A | 2 |
 | **Total** | **47** |
 
-partial files = `http/client.test.ts` (#1), `maven/resolver.test.ts` (#6), `changelog/resolver.test.ts` (#3) — the three required boundary files.
+partial files = `http/client.test.ts` (#1), `changelog/resolver.test.ts` (#3). (`maven/resolver.test.ts` graduated partial → ported with the cross-repo merge; the 3 `discovery/*` files graduated diverged → ported with project-repo discovery — both via `fix/maven-repo-resolution`.)
 
 ## Untested server.py functions (trace backstop)
 

--- a/docs/plans/maven-repo-resolution/plan.md
+++ b/docs/plans/maven-repo-resolution/plan.md
@@ -1,0 +1,116 @@
+---
+type: plan
+slug: maven-repo-resolution
+date: 2026-06-29
+status: approved
+spec: none
+risk_areas: [data-migration]
+review_verdict: conditional
+review_blockers: []
+review_note: "2 cycles (build-engineer/architecture/pr-test-analyzer). Cycle 1 FAIL (~25 findings) → cycle 2 CONDITIONAL. All folded: descoped #299→core (deferred #317-#320), brace scanner incl. inner maven{} via _extract_block, ctx REQUIRED + threaded all resolvers, merge keeps raise + carries lastUpdated, Google-heuristic-in-fallback, baseline-test contract edits (TestReposFor dict-shape + rewrite first-hit→merge test), 2x2 no-leak + buildscript-excision tests. No criticals remain; descope coherent."
+---
+
+# Plan: maven-mcp repository resolution layer (#310 + #311; core of #299)
+
+> Branch `fix/maven-repo-resolution` off main (034e522). Epic #293 foundation. server.py = Python 3.9+ stdlib-only stdio runtime. **Closes #310, #311. Partially addresses #299** (discovery + project-first scoping + cross-repo merge); the remaining #299 acceptance criteria are split into follow-ups #317 (provenance reporting), #318 (repositoriesMode), #319 (parent-POM/profile inheritance), #320 (content/group filtering).
+
+## Context & Decision
+
+Epic #293 (closed-perimeter) builds on project-first repository resolution. In the current Python runtime three issues are interdependent:
+- **#310 (correctness bug, CLOSE):** the #302 port dropped build-file repository discovery; `_repos_for` (server.py:128) is static group-prefix routing only → custom/private repos (`maven { url … }`, Maven `<repositories>`, JitPack/Nexus/Artifactory) are invisible → wrong answers.
+- **#311 (correctness bug, CLOSE):** `fetch_metadata` (server.py:154) returns the FIRST repo's metadata; it must MERGE across all resolved repos so a multi-repo artifact gets the union → correct "latest".
+- **#299 (foundational, PARTIAL):** resolution must be project-first + coordinate-kind-scoped. This PR delivers the resolution mechanics (discover declared repos, scope plugin vs dependency, prefer them, demote public to fallback). #299's *reporting* AC and the deeper Gradle/Maven resolution semantics (repositoriesMode, parent-POM/profile inheritance, content filtering) are larger than this PR and are tracked as #317–#320 — so #299 is NOT auto-closed.
+
+## Technical Approach
+
+**Brace-depth scanner (THE risky core — regex cannot balance nested blocks).** Add a hand-written `_extract_block(content, header)` that, given a block header (`pluginManagement`, `dependencyResolutionManagement`, `buildscript`, `repositories`), finds the header then walks a `{`/`}` depth counter (string-literal aware: skip braces inside `"`/`'` and line comments) to return the balanced block body. This — not the ported regexes — is the load-bearing mechanism for scoping; it gets dedicated tests (nested `maven{}` in `repositories{}` in `pluginManagement{}`; sibling `pluginManagement{}`+`dependencyResolutionManagement{}`; a `}` inside a URL string).
+
+**Repository parsers (regex, inside an already-extracted block — stdlib-only, "No XML parser" non-negotiable holds).** Port the retired TS regexes (git `c438680~1:.../discovery/gradle-parser.ts`): shorthands `mavenCentral/google/gradlePluginPortal/mavenLocal()` (`\b<fn>\s*\(\s*\)`), explicit `maven(...)`/`maven { url … }` (the 5 forms). Maven: `<repositories>` and `<pluginRepositories>` blocks → per-repo `<url>` (NOTE: the retired TS had NO `<pluginRepositories>` and NO scoping — the scoping layer is NET-NEW, its tests are authored fresh, not "mirrored").
+
+**`discover_repositories(project_root)` → scoped result** `{"dependency":[RepoEntry], "plugin":[RepoEntry]}`, `RepoEntry = {"name":str, "url":str, "scope":str}`:
+- Gradle scopes: `pluginManagement{repositories{}}` + `buildscript{repositories{}}` → **plugin** (buildscript backs legacy plugin/classpath resolution); `dependencyResolutionManagement{repositories{}}` + project `build.gradle* repositories{}` → **dependency**.
+- Maven scopes: `<repositories>` → dependency; `<pluginRepositories>` → plugin.
+- Shorthands mapped via `_SHORTHAND_URLS`. `mavenLocal()` recorded with a non-HTTP marker (`url=file://…`) — it does NOT count toward scope non-emptiness (see fallback policy) and is never HTTP-queried.
+- Dedup by URL within scope, declaration order. Gradle-first / pom-exclusive (match TS).
+- Memoized **per tool invocation** (a cache dict created at the handler boundary and passed down, like the existing `metadata_cache` in `audit_project_dependencies`:1532) — NOT process-global, so editing a build file between calls is never stale.
+
+**Resolution policy resolved ONCE at the handler boundary (no env/cwd sniffing in leaf functions).** Each resolution handler computes a `ResolutionContext` = `{project_path, scoped_repos (from discover), public_fallback: bool}` and threads it down. `_repos_for(group_id, artifact_id, ctx)` then:
+- coordinate kind: `.gradle.plugin` suffix → plugin scope, else dependency (NOTE: marker-suffix only; resolved plugin impl-GAVs classify as library — deferred to #290; documented, not a defect).
+- if the relevant scope has ≥1 HTTP-queryable repo → return EXACTLY those (no implicit public append) — the #299/#310 core.
+- else (scope has no queryable repo: no build file, empty block, or mavenLocal-only) → public fallback: the current static well-known routing **including the Google-Maven group-prefix heuristic** (`GOOGLE_MAVEN_GROUPS` → Google Maven) preserved here, so androidx/google coordinates still resolve in the no-declaration case.
+- `MAVEN_MCP_PUBLIC_FALLBACK=on` (read once at the boundary into `ctx.public_fallback`) forces appending public even when the scope is declared (escape hatch for implicit/inherited-repo builds; #294/closed-mode wants it OFF).
+- `_repos_for` returns rich entries `{name,url,scope,is_public_fallback}` (carries provenance for #317 later; this PR does not surface it in output).
+
+**Threading (ALL resolvers, not just handlers).** `project_path`/`ctx` must reach every `_repos_for` call: `fetch_metadata`(:154), `check_version_in_repos`(:172), `fetch_pom`(:188), `discover_github_repo`(:565), `_get_dependency_changes_impl`(:585), and the 7 handlers (get_latest_version, check_version_exists, check_multiple_dependencies, compare_dependency_versions, get_dependency_changes, get_dependency_health, audit_project_dependencies). Handlers default `project_path = args.get("projectPath") or os.getcwd()`; add optional `projectPath` to each tool schema. (Without threading the intermediates, `check_version_exists`/`health`/`changes` silently ignore the project — the #310 core would stay unfixed for those paths.)
+
+**`fetch_metadata` → merge, PRESERVING the no-match contract.** Current `fetch_metadata` ends in `raise ValueError("Could not fetch metadata…")` on no-match; callers (e.g. `handle_get_latest_version`:1239) call it UNWRAPPED. Keep that contract: query all `ctx` repos, parse each returning 200, MERGE versions (union, dedup, sort by `compare_versions`); if ≥1 repo answered → return merged metadata; if NONE answered (all 404/error) → `raise ValueError` with the same message as today (so every unwrapped caller keeps working). Post-merge "latest"/"release" selection uses the existing stability-aware `find_latest_version*` (PREFER_STABLE / STABLE_ONLY) over the merged set — so a SNAPSHOT-only repo merged with a release repo does not surface `-SNAPSHOT` as `release`. The merged dict MUST also carry **`lastUpdated`** = the MAX (most recent) across answering repos — `handle_get_dependency_health`:1387 reads `metadata.get("lastUpdated")` into `lastPublishedToMaven`, so dropping it would silently regress health even single-repo. This **intentionally diverges from the retired TS `resolveAll`**: no proxy-target dedup (naive union is closer to Gradle's dynamic-version union across repos) — a conscious choice, not "matching TS". **Single-repo result is identical to today** because the merge of one repo's metadata = that metadata (versions union of one set = itself; lastUpdated max of one = itself); the *runtime answer* (versions[] + lastUpdated) is the invariant, not any test count.
+
+**ctx is REQUIRED, not optional-defaulted, on the leaf resolvers** (`_repos_for`, `fetch_metadata`, `check_version_in_repos`, `fetch_pom`, `discover_github_repo`, `_get_dependency_changes_impl`). An optional ctx defaulting to public routing would reintroduce the silent-global anti-pattern this design rejects — a future caller that forgets ctx would get public-only routing and silently resurrect #310. Required ctx makes project-awareness enforced at every call site. The signature-update cost on existing baseline tests is paid explicitly (see Affected Files).
+
+**Inner `maven{}` body parsing also uses `_extract_block`, not brace-naive regex.** Per-`maven{}` block: extract the balanced body via the scanner, THEN regex `url`/`uri(...)` within it. The retired TS `maven\s*\{[^}]*url…` regex silently skips `maven { credentials { … }; url = uri("…") }` (url after a nested `credentials{}`) — and `credentials{}` is characteristic of exactly the private Nexus/Artifactory repos #310 targets, so brace-naive inner parsing would miss the highest-value case.
+
+## Affected Modules & Files
+
+| Path | Change | Note |
+|---|---|---|
+| `plugins/maven-mcp/plugin/server/server.py` | Modified | `_extract_block` (brace scanner), `_parse_gradle_repos`, `_parse_maven_repos`, `discover_repositories`, `_SHORTHAND_URLS`, `ResolutionContext` builder; rework `_repos_for(..., ctx)` (rich entries, project-first, fallback incl. Google heuristic); `fetch_metadata` first-hit→merge (keep `raise`); thread ctx through `check_version_in_repos`, `fetch_pom`, `discover_github_repo`, `_get_dependency_changes_impl` + 7 handlers; add `projectPath` to those tool schemas |
+| `plugins/maven-mcp/tests/test_repo_discovery.py` | New | brace scanner (nested/sibling/string-brace), gradle/maven parsers, scoping, shorthand mapping, dedup, buildscript→plugin, mavenLocal-not-queryable |
+| `plugins/maven-mcp/tests/test_resolution.py` | New | project-first + Central-NOT-queried (#310 negative), public-project-no-regression (mavenCentral() still → Central), Google-group heuristic in fallback, plugin vs dependency scope (both directions), scope-empty-with-build-file → fallback, toggle on, mavenLocal-only → fallback, merge: A[1,2]+B[3]→3, 404+200 tolerant, overlapping-version dedup, SNAPSHOT+release → release stable, all-404 → raise |
+| `plugins/maven-mcp/tests/test_handlers.py` | Modified | resolution handlers honor `projectPath` (explicit tempdir for isolation); `check_version_exists` against custom-repo-only artifact; `get_dependency_health.lastPublishedToMaven` preserved |
+| `plugins/maven-mcp/tests/test_maven_search_osv.py` | Modified | `TestReposFor` assertions updated for rich-dict return shape; old-arity calls updated for required ctx; **`test_first_hit_not_resolveall_merge` REWRITTEN** to assert the cross-repo MERGE (it deliberately encoded the now-fixed #311 first-hit bug — it must invert, not "stay green") |
+| `plugins/maven-mcp/tests/test_github.py` | Modified | `discover_github_repo`/`_get_dependency_changes_impl` calls updated for required ctx arity |
+| `docs/plans/maven-python-migration/coverage-map.md` | Modified | discovery/* + maven/resolver: diverged/partial → ported |
+| `plugins/maven-mcp/CLAUDE.md` | Modified | project-first resolution, scoping, `MAVEN_MCP_PUBLIC_FALLBACK`, documented limitations (#317–#320, #290, mavenLocal, variable URLs) |
+
+## Decisions Made
+
+| Decision | Rationale | Alternatives rejected |
+|---|---|---|
+| Hand-written brace-depth scanner for block extraction | regex cannot balance nested `{}`; scoping correctness depends on it | non-greedy/greedy regex (truncates/over-captures — the #299-defeating bug) |
+| Close #310/#311 fully; #299 PARTIAL (defer #317–#320) | #299's 5 ACs + Gradle/Maven edge semantics exceed one PR; auto-closing it with ACs unmet is the anti-pattern reviewers flagged | "Closes #299" (dishonest); doing all of #299 now (huge, blocks the correctness fixes) |
+| `fetch_metadata` keeps `raise`-on-no-match | unwrapped callers + #263 depend on it; switching to None breaks them | return None (NoneType subscript / degraded error) |
+| Google-group heuristic preserved in the FALLBACK path only | no-declaration androidx lookups must still reach Google Maven; declared-repo projects use exactly their repos | drop heuristic (regresses androidx); keep it always (re-introduces the #299 false-positive) |
+| buildscript{} repos → plugin scope | buildscript backs legacy plugin/classpath resolution | ignore (custom buildscript repo invisible — #310 persists there) |
+| mavenLocal() recorded, non-queryable, doesn't count for non-emptiness | it's `file://`; HTTP can't read it; mavenLocal-only must still fall back to public | count it (mavenLocal-only project → everything reported missing) |
+| Merge = naive union, no proxy-dedup; stability-aware selection | closer to Gradle dynamic-version union; proxy-dedup was a TS hack | claim "matches resolveAll" (false); first-hit (the bug) |
+| Policy/repos resolved once at handler boundary (ctx), threaded down | env/cwd in leaf = hidden global that #294/#295 would compound | env-sniff inside `_repos_for` (untestable, surprises #294) |
+| Per-invocation memoization (ctx-carried) | long-lived stdio server; per-process serves stale repo sets during editing | per-process global keyed by project_root (stale) |
+| Rich `_repos_for` entries {name,url,scope,is_public_fallback} | carries provenance for #317 without surfacing it now; clean seam | flat tuples (can't carry scope/fallback for #294/#317) |
+
+## Risks & Mitigations
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Brace scanner mis-extracts nested/sibling blocks → plugin repos leak into dependency scope | critical | First-class scanner with depth counter + string-awareness; dedicated tests for nested, sibling, and brace-in-string before any scoping test |
+| Normal public project (declares mavenCentral()) regresses | critical | shorthand→URL means Central IS queried; explicit no-regression test (gson-style coord resolves via Central); Google-group heuristic kept in fallback |
+| Threading gap leaves check_version_exists/health/changes project-blind | critical | thread ctx through ALL intermediates (check_version_in_repos, fetch_pom, discover_github_repo, _get_dependency_changes_impl); test check_version_exists routes to a custom repo |
+| Merge changes existing answers | major | invariant is the single-repo RUNTIME answer (versions[] + lastUpdated), NOT a test count: the contract change (tuple→dict, first-hit→merge, +ctx arity) intentionally edits `TestReposFor` + rewrites `test_first_hit_not_resolveall_merge` + updates arity in test_maven_search_osv/test_github — so the suite total moves by design. Gate = "all tests green after those intentional edits" + new partial-failure (404+200) + dedup + lastUpdated-preserved tests |
+| `fetch_metadata` contract change breaks unwrapped callers | major | keep `raise`-on-no-match; explicit get_latest_version all-404 → clean #263 error test (not NoneType) |
+| Silent #299 over-claim (repositoriesMode, parent-POM, content-filter) | major | descoped to #317–#320 + documented limitations; not claimed closed |
+| Handler tests implicitly discover against runner cwd | minor | resolution-handler tests pass an explicit repo-less tempdir projectPath |
+
+## Verification & Sources
+
+Correctness-fix (#310/#311) + foundational feature (#299 core). Before-state baseline = current behavior (211 tests) + the retired TS parsing reference + the issue specs.
+
+| Source of truth | Type | Status | Sufficient? |
+|---|---|---|---|
+| Issues #310, #311, #299 | requirements | present | yes — define correct behavior + bugs (with #317–#320 carving the deferred #299 ACs) |
+| Retired TS `discovery/*` + tests (git `c438680~1`) | parsing reference | present in history | yes — for the regex parsers ONLY; scoping is net-new (fresh tests) |
+| Current server.py (211 tests on main) | before-state baseline | present | yes — single-repo resolution must stay identical; new tests assert deltas |
+
+**Testing strategy:** L0 build + L1 (validate.sh, tests) + L2 unit (brace scanner, parsers, scoped resolution, merge, fallback matrix — mock urlopen + tempfile) + **L5 manual** (stdio smoke: public `get_latest_version` still works; tempfile project with custom `maven{url}` repo → assert that URL queried and Central NOT queried). No UI → no L3/L4.
+
+## Out of Scope (documented limitations, with trackers)
+
+- #299 provenance reporting (`resolvedFrom`/`viaPublicFallback`) → **#317**.
+- Gradle `repositoriesMode` (PREFER_PROJECT vs union) → **#318**.
+- Maven parent-POM `<parent>` + `<profiles>` repo inheritance → **#319**.
+- Repository content/group filtering (`includeGroup`/`exclusiveContent`) → **#320**.
+- settings.xml `mirrorOf` / offline (#294), repo-manager search backends (#295), degradation (#296), TLS/proxy (#298), auth (#291) — consume this layer.
+- `mavenLocal()` file:// reads; variable-interpolated repo URLs; resolved plugin impl-GAV scoping (#290) — documented, deferred.
+- Per-submodule `build.gradle*` repos (discovery reads root build/settings only); `maven { credentials{} }` body is parsed via `_extract_block` but auth itself is #291. Multi-module per-module repo discovery → documented limitation (fallback-to-public mitigates). The #318 settings∪project union OVER-reports vs strict `repositoriesMode` (safe direction for an advisory tool — may query a repo Gradle wouldn't; never under-queries).
+
+## Open Questions
+
+- [non-blocking] Default of `MAVEN_MCP_PUBLIC_FALLBACK` when scope is declared: plan sets OFF (correctness-first); flip if real public-project usage regresses (covered by the no-regression test + L5).

--- a/docs/plans/maven-repo-resolution/progress.md
+++ b/docs/plans/maven-repo-resolution/progress.md
@@ -1,0 +1,17 @@
+# Progress: maven-mcp repository resolution layer (#310 + #311; core of #299)
+
+> Plan: ./plan.md · Tasks: ./tasks.md · Branch fix/maven-repo-resolution
+
+## Status
+- [ ] T-1 — brace-depth block scanner
+- [ ] T-2 — Gradle/Maven repository parsers
+- [ ] T-3 — scoped discovery orchestrator
+- [ ] T-4 — ResolutionContext + project-first `_repos_for` + fallback
+- [ ] T-5 — merge metadata, keep raise-contract (#311)
+- [ ] T-6 — thread ctx through all resolvers + tool schemas
+- [ ] T-7 — docs + coverage-map + L5 smoke
+- [ ] T-8 — open PR
+
+## Learnings
+<!-- one line per completed task -->
+- Cycle-1 review (build-engineer/architecture/pr-test-analyzer) → FAIL, ~25 findings. Revised: descoped #299 to core (deferred #317–#320), added hand-written brace scanner (regex can't balance), thread ctx through ALL resolvers (not just handlers), keep fetch_metadata raise-contract, Google-group heuristic in fallback, naive-union merge w/ stability-aware selection (dropped false "matches resolveAll"), buildscript→plugin scope, mavenLocal-only→fallback, per-invocation memoization, baseline 211.

--- a/docs/plans/maven-repo-resolution/tasks.md
+++ b/docs/plans/maven-repo-resolution/tasks.md
@@ -1,0 +1,51 @@
+# Tasks: maven-mcp repository resolution layer (#310 + #311; core of #299)
+
+> Plan: ./plan.md · One PR (branch `fix/maven-repo-resolution`). Closes #310, #311; partial #299 (defers #317–#320). Baseline = 211 existing tests.
+
+## T-1 — brace-depth block scanner (the risky core)
+- after: none
+- files: `plugins/maven-mcp/plugin/server/server.py`, `plugins/maven-mcp/tests/test_repo_discovery.py`
+- acceptance: THE SYSTEM SHALL add `_extract_block(content, header)` that locates a block header and returns the balanced `{…}` body via a `{`/`}` depth counter that ignores braces inside string literals (`"`/`'`) and line comments. Returns the body (or None/empty if absent).
+- check: tests — nested `pluginManagement { repositories { maven("X") } }`; sibling `pluginManagement{}` + `dependencyResolutionManagement{}` extracted independently (no over/under-capture); a `}` inside a quoted URL does not terminate the block; missing header → empty
+
+## T-2 — Gradle/Maven repository parsers
+- after: T-1
+- files: `plugins/maven-mcp/plugin/server/server.py`, `plugins/maven-mcp/tests/test_repo_discovery.py`
+- acceptance: THE SYSTEM SHALL add `_parse_gradle_repos(block)` (shorthands `mavenCentral/google/gradlePluginPortal/mavenLocal()`; explicit `maven("…")`/`maven(url=…)`) and for `maven { … }` BLOCKS use `_extract_block` to get each balanced maven body THEN regex `url`/`uri(...)` within it (NOT the brace-naive `maven\s*\{[^}]*url` — that skips `maven { credentials{…}; url=… }`). And `_parse_maven_repos(xml)` (`<repositories>` AND `<pluginRepositories>` → `<url>`s). Returns RepoEntry `{name,url,scope}`; dedup by URL.
+- check: tests per Gradle form + a `maven { credentials { username=… }; url = uri("X") }` block (url AFTER a nested credentials block) is discovered; each Maven container; dedup; `mavenLocal()` parsed with a `file://` marker
+
+## T-3 — scoped discovery orchestrator
+- after: T-2
+- files: `plugins/maven-mcp/plugin/server/server.py`, `plugins/maven-mcp/tests/test_repo_discovery.py`
+- acceptance: THE SYSTEM SHALL add `discover_repositories(project_root)` → `{"dependency":[RepoEntry],"plugin":[RepoEntry]}`: Gradle `pluginManagement`+`buildscript` repos → plugin; `dependencyResolutionManagement`+project (bare top-level) `repositories{}` → dependency; Maven `<repositories>`→dependency, `<pluginRepositories>`→plugin; shorthands→URLs; gradle-first/pom-exclusive. MUST EXCISE already-consumed container spans (pluginManagement/dependencyResolutionManagement/buildscript) from the content BEFORE searching for the bare top-level `repositories{}`, else the buildscript-nested `repositories` is mis-read as dependency scope. Result IS `ctx.scoped_repos` (computed once at ctx construction — no separate cache map).
+- check: tests — (1) the 2×2 NO-LEAK crux: ONE settings.gradle with `pluginManagement{repositories{maven("X")}}` AND `dependencyResolutionManagement{repositories{maven("Y")}}` → assert X∈plugin, X∉dependency, Y∈dependency, Y∉plugin; (2) build.gradle with `buildscript{repositories{maven("A")}}` + bare `repositories{maven("B")}}` → A∈plugin only, B∈dependency only; Maven dual-container separation; shorthand→URL; gradle-wins-over-pom; discover on an empty dir → both scopes empty
+
+## T-4 — ResolutionContext + project-first `_repos_for` + fallback policy
+- after: T-3
+- files: `plugins/maven-mcp/plugin/server/server.py`, `plugins/maven-mcp/tests/test_resolution.py`
+- acceptance: THE SYSTEM SHALL build a `ResolutionContext {project_path, scoped_repos, public_fallback}` once at the handler boundary (reading `MAVEN_MCP_PUBLIC_FALLBACK` there, not in leaves) and rework `_repos_for(group_id, artifact_id, ctx)` returning rich entries `{name,url,scope,is_public_fallback}`: coordinate kind by `.gradle.plugin` suffix; if relevant scope has ≥1 HTTP-queryable repo → exactly those (no public append); else → public fallback INCLUDING the Google-Maven group-prefix heuristic; `public_fallback=on` forces public append even when declared.
+- check: test_resolution.py — (a) #310: custom `maven{url}` queried AND Central URL NOT in urlopen calls; (b) NO-REGRESSION: project declaring `mavenCentral()` → Central queried, resolves normally; (c) no build file → public fallback; (d) Google-group coord with no declaration → Google Maven queried; (e) toggle on → public appended despite declaration; (f) plugin coord → plugin scope only; (g) library coord ignores pluginManagement-only repo → falls back; (h) build file present but scope empty → public fallback; (i) mavenLocal-only → public fallback
+
+## T-5 — merge metadata across repos, keep raise-contract (#311)
+- after: T-4
+- files: `plugins/maven-mcp/plugin/server/server.py`, `plugins/maven-mcp/tests/test_resolution.py`
+- acceptance: THE SYSTEM SHALL change `fetch_metadata(g, a, ctx)` (ctx REQUIRED) to query all `ctx` repos, MERGE versions (union+dedup+sort) from those returning 200, and carry `lastUpdated` = MAX (most recent) across answering repos into the merged dict (health reads it); if NO repo answers → `raise ValueError("Could not fetch metadata…")` (same message as today; preserves unwrapped callers). Post-merge latest/release via existing stability-aware `find_latest_version*`. Intentional divergence from TS `resolveAll`: no proxy-dedup (documented).
+- check: tests — A[1.0,2.0]+B[3.0]→merged latest 3.0 (#311); single-repo unchanged (versions AND lastUpdated identical); repo A 404 + repo B 200 → B's versions, no raise; overlapping version across repos → deduped; SNAPSHOT-repo + release-repo → `release` is the stable one; merged `lastUpdated` = most recent; all repos 404 → `get_latest_version` raises `ValueError("Could not fetch metadata…")` (assert the message, not NoneType — this is the all-404 path, distinct from #263 which is the all-200 no-newer-version guard)
+
+## T-6 — thread ctx through ALL resolvers + tool schemas
+- after: T-4
+- files: `plugins/maven-mcp/plugin/server/server.py`, `plugins/maven-mcp/tests/test_handlers.py`
+- acceptance: THE SYSTEM SHALL thread `ctx` as a REQUIRED arg into `check_version_in_repos`(:170), `fetch_pom`(:187), `discover_github_repo`(:563), `_get_dependency_changes_impl`(:591) and build `ctx` in the 7 resolution handlers (`project_path = args.get("projectPath") or os.getcwd()`); add optional `projectPath` to each tool's input schema. UPDATE the existing baseline tests for the contract change: `test_maven_search_osv.py` `TestReposFor` assertions → rich-dict shape, all old-arity `_repos_for/fetch_metadata/check_version_in_repos/fetch_pom` calls → pass a ctx, and **REWRITE `test_first_hit_not_resolveall_merge` to assert the cross-repo MERGE** (it encoded the now-fixed #311 bug); `test_github.py` `discover_github_repo`/`_get_dependency_changes_impl` calls → ctx arity. New resolution-handler tests pass an explicit repo-less tempdir.
+- check: handler test — `check_version_exists` against a custom-repo-only artifact (projectPath) routes to the declared repo, Central not queried; `get_dependency_health` single-repo → `lastPublishedToMaven` unchanged; whole suite green AFTER the intentional baseline edits; `discover_repositories` on a build-file-free dir returns empty scopes (proves existing no-projectPath handler tests stay hermetic)
+
+## T-7 — docs + coverage-map + L5 smoke
+- after: T-5, T-6
+- files: `plugins/maven-mcp/CLAUDE.md`, `docs/plans/maven-python-migration/coverage-map.md`
+- acceptance: THE SYSTEM SHALL document project-first resolution, scoping, `MAVEN_MCP_PUBLIC_FALLBACK`, and the documented limitations (#317–#320, #290, mavenLocal, variable URLs); update coverage-map (discovery/* + maven/resolver → ported); L5 stdio smoke: public `get_latest_version` works AND a tempfile project with a custom `maven{url}` repo → that URL queried, Central not.
+- check: `bash scripts/validate.sh` rc=0; full `python3 -m unittest discover` green (211 + new); L5 transcript in progress.md
+
+## T-8 — open PR
+- after: T-7
+- files: (PR)
+- acceptance: THE SYSTEM SHALL open a ready PR from `fix/maven-repo-resolution`, body: `Closes #310`, `Closes #311`, "partially addresses #299 (see #317–#320)", link the plan; python-tests(3.9/3.13)+validate-marketplace green.
+- check: PR open, required checks green

--- a/plugins/maven-mcp/CLAUDE.md
+++ b/plugins/maven-mcp/CLAUDE.md
@@ -36,7 +36,7 @@ python3 -m unittest discover -s plugins/maven-mcp/tests -p test_handlers.py
 
 `server.py` is one file organised into logical sections (no package tree):
 
-- **Constants & routing** — `MAVEN_CENTRAL_URL`, `GOOGLE_MAVEN_URL`, `GRADLE_PLUGIN_PORTAL_URL`, `GOOGLE_MAVEN_GROUPS`. `_repos_for(group_id, artifact_id)` returns the candidate repos for an artifact by **static group-prefix routing** (most-specific first): Gradle Plugin Portal for plugin markers, Google Maven for the AndroidX/Google group prefixes, Maven Central always as fallback.
+- **Constants & routing** — `MAVEN_CENTRAL_URL`, `GOOGLE_MAVEN_URL`, `GRADLE_PLUGIN_PORTAL_URL`, `GOOGLE_MAVEN_GROUPS`. `_public_repos(group_id, artifact_id)` is the **static well-known routing** (most-specific first): Gradle Plugin Portal for plugin markers, Google Maven for the AndroidX/Google group prefixes, Maven Central always last. This is only the **public fallback** — the live entry point is `_repos_for(group_id, artifact_id, ctx)`, which is project-first (see *Repository resolution* below).
 - **HTTP** — `http_get` / `http_post_json` over `urllib.request.urlopen`; both return `(status, bytes)` and map `urllib.error.HTTPError → (code, b"")`. Single attempt — no retry/backoff.
 - **Versioning** — `classify_version` (stability detection), `compare_versions`, `find_latest_version` / `find_latest_version_for_current` (selection), plus `_parse_segments` / `_extract_prerelease_numbers`.
 - **Metadata & POM** — `fetch_metadata`, `check_version_in_repos`, `fetch_pom`, `_parse_metadata_xml` (regex).
@@ -47,11 +47,35 @@ python3 -m unittest discover -s plugins/maven-mcp/tests -p test_handlers.py
 
 **Tools:** `get_latest_version`, `check_version_exists`, `check_multiple_dependencies`, `compare_dependency_versions`, `get_dependency_changes`, `scan_project_dependencies`, `get_dependency_vulnerabilities`, `get_dependency_health`, `search_artifacts`, `audit_project_dependencies`.
 
-**Repository resolution:** `fetch_metadata` returns the metadata of the **first** repo in `_repos_for` that responds successfully — first-hit, no cross-repo merge. Routing is static group-prefix only; the server does **not** parse build files for custom/private repositories (`maven { url = ... }`), so version answers for projects relying on custom repos can be incomplete.
+## Repository resolution
+
+Version answers resolve through the repositories the **project actually declares**, not a hardcoded public list — public well-known repos are only a fallback.
+
+**Project-first resolution.** `discover_repositories(project_root)` parses the project's build files for declared repositories and scopes them into `{"dependency": [...], "plugin": [...]}`:
+
+- **Gradle** (preferred when any Gradle build/settings file is present): `repositories {}` (dependency scope), `pluginManagement {}` and `buildscript {}` (plugin scope), `dependencyResolutionManagement {}` (dependency scope). Shorthands (`mavenCentral()`, `google()`, `gradlePluginPortal()`, `mavenLocal()`), `maven("url")` / `maven(url = "url")`, and `maven { url = ... }` blocks are all recognised. Block bodies are read with a hand-written brace-depth scanner (`_scan_balanced` / `_find_block`), not a brace-naive regex, so `maven { credentials {…}; url = uri("…") }` is parsed correctly.
+- **Maven** (read only when no Gradle file exists — gradle-first / pom-exclusive): `<repositories>` (dependency scope) and `<pluginRepositories>` (plugin scope).
+
+**Scoping by coordinate kind.** `_repos_for(group_id, artifact_id, ctx)` (the live entry point; `ctx` is REQUIRED — a public-only default would silently resurrect the bug) picks the scope from the coordinate: a `.gradle.plugin` marker artifact resolves in the **plugin** scope, everything else in the **dependency** scope. If that scope declares ≥1 HTTP-queryable repository, those declared repos are returned **exactly** — no implicit public append. Only when the scope declares none does the static public routing (`_public_repos`) act as the fallback.
+
+**Cross-repo merge.** `fetch_metadata(group_id, artifact_id, ctx)` queries **every** repo in the resolved set and **merges** the results from those answering HTTP 200: version sets are unioned, deduped, and sorted, so a private repo's extra versions are not lost to a first-hit short-circuit; `lastUpdated` carries the most-recent value across answering repos. If no repo answers, it raises `ValueError` with the legacy message so unwrapped callers keep working. A single-repo result is identical to the legacy path (union/sort of one set = itself). This intentionally diverges from the retired TS `resolveAll`: no proxy-target dedup.
+
+**`MAVEN_MCP_PUBLIC_FALLBACK`** (default OFF — see *Environment*): when ON, the public repos are appended even when the project declares its own repositories in that scope (escape hatch for implicit/inherited-repo builds), deduped by URL.
+
+**Optional `projectPath`.** Every resolution tool accepts an optional `projectPath` arg; it defaults to the current working directory. `build_resolution_context(args)` builds the `ResolutionContext` once at the handler boundary (project path + discovered repos + the toggle, read once) and threads it down to every leaf resolver.
+
+### Documented limitations
+
+- **Root-only discovery** — only the project-root build files are read; per-submodule `build.gradle*` / `pom.xml` repositories are not discovered.
+- **`mavenLocal()`** is recorded (as a `file://` marker) but never HTTP-queried, so it does not count as a queryable repo for fallback decisions.
+- **Variable-interpolated repo URLs are unsupported** — a `url = "…/${repoPath}"` is captured verbatim (the `${...}` is not expanded), so such a URL will not resolve.
+- **Resolved plugin impl-GAV scoping** — only the `.gradle.plugin` marker suffix classifies as plugin scope; a resolved plugin implementation GAV classifies as a library (deferred to #290; documented, not a defect).
+- **Deferred #299 pieces** (this layer addresses the core; the rest are follow-ups): provenance reporting (`resolvedFrom` / `viaPublicFallback`) — #317; `repositoriesMode` semantics — #318 (current behavior unions settings + project repos, so it **may over-report** when a build restricts project-level repos); parent-POM / Maven-profile inheritance — #319; content / group filtering — #320.
 
 ## Environment
 
 - `GITHUB_TOKEN` — optional, enables higher GitHub API rate limits (5000 req/h vs 60) for `get_dependency_changes` and `get_dependency_health` (the health tool also uses the rate-limited Search API for issue stats).
+- `MAVEN_MCP_PUBLIC_FALLBACK` — optional toggle (default OFF; accepts `1`/`true`/`on`/`yes`). When ON, public well-known repos are appended even for a scope that declares its own repositories. Read once at the handler boundary into the `ResolutionContext`, never sniffed in leaf resolvers. See *Repository resolution*.
 - No persistent cache. Memoization is in-memory per call only (e.g. the `metadata_cache` dict inside `audit_project_dependencies` dedupes lookups within a single audit run); nothing is written to disk.
 
 ## Conventions

--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -975,6 +975,269 @@ def _parse_maven_modules(content: str) -> List[str]:
     return modules
 
 
+# ---------------------------------------------------------------------------
+# Repository discovery (project-declared repos) — discovery layer only.
+# A hand-written brace scanner is required because regex cannot balance nested
+# `{ }` blocks; scoping correctness (plugin vs dependency repos) depends on it.
+# ---------------------------------------------------------------------------
+
+# Gradle shorthand repository accessors → (function name, friendly name, URL).
+_GRADLE_SHORTHANDS = (
+    ("mavenCentral", "Maven Central", MAVEN_CENTRAL_URL),
+    ("google", "Google Maven", GOOGLE_MAVEN_URL),
+    ("gradlePluginPortal", "Gradle Plugin Portal", GRADLE_PLUGIN_PORTAL_URL),
+)
+
+# Container blocks whose nested repositories belong to the PLUGIN scope.
+_GRADLE_PLUGIN_CONTAINERS = ("pluginManagement", "buildscript")
+# Container block whose nested repositories belong to the DEPENDENCY scope.
+_GRADLE_DEP_CONTAINER = "dependencyResolutionManagement"
+
+
+def _maven_local_url() -> str:
+    """file:// marker for mavenLocal(); never HTTP-queried, just recorded."""
+    return "file://" + os.path.expanduser(os.path.join("~", ".m2", "repository"))
+
+
+def _skip_string_literal(content: str, i: int) -> int:
+    """`content[i]` is an opening quote; return the index just past its match.
+    Handles backslash escapes; an unterminated string consumes to end."""
+    quote = content[i]
+    n = len(content)
+    i += 1
+    while i < n:
+        c = content[i]
+        if c == "\\":
+            i += 2
+            continue
+        if c == quote:
+            return i + 1
+        i += 1
+    return n
+
+
+def _scan_balanced(content: str, brace_idx: int) -> Tuple[str, int]:
+    """Given the index of an opening `{`, walk a brace-depth counter and return
+    (body_without_outer_braces, index_just_past_the_closing_brace). Braces inside
+    string literals (`"`/`'`) and `//` line comments are ignored. An unbalanced
+    block returns the remainder of the content."""
+    n = len(content)
+    body_start = brace_idx + 1
+    depth = 0
+    i = brace_idx
+    while i < n:
+        c = content[i]
+        if c == '"' or c == "'":
+            i = _skip_string_literal(content, i)
+            continue
+        if c == "/" and i + 1 < n and content[i + 1] == "/":
+            nl = content.find("\n", i)
+            i = n if nl == -1 else nl
+            continue
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return content[body_start:i], i + 1
+        i += 1
+    return content[body_start:], n
+
+
+def _find_block(content: str, header: str, start: int = 0) -> Optional[Tuple[str, int, int]]:
+    """Locate the first `header { ... }` block at/after `start`. Returns
+    (body, header_start_index, index_past_closing_brace) or None.
+
+    The header token is matched on word boundaries (so `maven` does not match
+    `mavenCentral`, and `maven(...)` calls are skipped — only `maven {` counts).
+    Limitation: the header search itself is NOT string/comment-aware (only the
+    body brace-scan is), so a commented-out `// pluginManagement {` header could
+    still be picked up; real builds rarely comment out container headers."""
+    pattern = re.compile(r"\b" + re.escape(header) + r"\b")
+    pos = start
+    n = len(content)
+    while True:
+        m = pattern.search(content, pos)
+        if not m:
+            return None
+        i = m.end()
+        while i < n and content[i] in " \t\r\n":
+            i += 1
+        if i < n and content[i] == "{":
+            body, after = _scan_balanced(content, i)
+            return body, m.start(), after
+        pos = m.end()
+
+
+def _extract_block(content: str, header: str) -> Optional[str]:
+    """Return the balanced `{ ... }` body of the first `header` block, or None
+    if no such block exists. String/comment-aware (see `_scan_balanced`)."""
+    found = _find_block(content, header)
+    return found[0] if found else None
+
+
+def _excise_spans(content: str, spans: List[Tuple[int, int]]) -> str:
+    """Return `content` with the given [start, end) ranges removed (merging
+    overlaps). Used to drop already-consumed container blocks before searching
+    for the bare top-level `repositories {}`."""
+    if not spans:
+        return content
+    out = []
+    last = 0
+    for s, e in sorted(spans):
+        if s < last:
+            last = max(last, e)
+            continue
+        out.append(content[last:s])
+        last = e
+    out.append(content[last:])
+    return "".join(out)
+
+
+def _dedup_repos(entries: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    """Dedup RepoEntry dicts by URL, preserving first-seen (declaration) order."""
+    seen = set()
+    out = []
+    for e in entries:
+        if e["url"] in seen:
+            continue
+        seen.add(e["url"])
+        out.append(e)
+    return out
+
+
+def _parse_gradle_repos(block_body: str) -> List[Dict[str, str]]:
+    """Parse a Gradle `repositories { ... }` body into RepoEntry dicts
+    ``{"name", "url"}`` (scope is filled in by the caller). Handles shorthand
+    accessors, explicit `maven("url")` / `maven(url = "url")` calls, and
+    `maven { ... }` blocks (whose URL is extracted from the balanced body via the
+    brace scanner — NOT a brace-naive regex, so `maven { credentials{…}; url=… }`
+    is handled). Deduped by URL, declaration order preserved."""
+    entries: List[Dict[str, str]] = []
+
+    for fn, name, url in _GRADLE_SHORTHANDS:
+        if re.search(r"\b" + fn + r"\s*\(\s*\)", block_body):
+            entries.append({"name": name, "url": url})
+    if re.search(r"\bmavenLocal\s*\(\s*\)", block_body):
+        entries.append({"name": "Maven Local", "url": _maven_local_url()})
+
+    # Explicit maven("url") and maven(url = "url") (optionally wrapped in uri()).
+    for m in re.finditer(
+        r"\bmaven\s*\(\s*(?:url\s*=\s*)?(?:uri\s*\(\s*)?[\"']([^\"']+)[\"']",
+        block_body,
+    ):
+        entries.append({"name": m.group(1), "url": m.group(1)})
+
+    # maven { ... } blocks — extract each balanced body, then find its URL.
+    pos = 0
+    while True:
+        found = _find_block(block_body, "maven", pos)
+        if not found:
+            break
+        body, _start, after = found
+        um = re.search(r"\burl\b\s*(?:=\s*)?(?:uri\s*\(\s*)?[\"']([^\"']+)[\"']", body)
+        if um:
+            entries.append({"name": um.group(1), "url": um.group(1)})
+        pos = after
+
+    return _dedup_repos(entries)
+
+
+def _parse_maven_repos(pom_xml: str) -> Tuple[List[Dict[str, str]], List[Dict[str, str]]]:
+    """Parse a Maven POM into (dependency repos, plugin repos). `<repositories>`
+    entries are dependency-scoped, `<pluginRepositories>` entries plugin-scoped.
+    Per repo: `<url>` is the URL, `<id>` the name (falling back to the URL)."""
+
+    def parse_container(container: str, entry: str) -> List[Dict[str, str]]:
+        out: List[Dict[str, str]] = []
+        cm = re.search(r"<" + container + r">([\s\S]*?)</" + container + r">", pom_xml)
+        if not cm:
+            return out
+        block = cm.group(1)
+        for em in re.finditer(r"<" + entry + r">([\s\S]*?)</" + entry + r">", block):
+            rb = em.group(1)
+            um = re.search(r"<url>([^<]+)</url>", rb)
+            if not um:
+                continue
+            url = um.group(1).strip()
+            idm = re.search(r"<id>([^<]+)</id>", rb)
+            name = idm.group(1).strip() if idm else url
+            out.append({"name": name, "url": url})
+        return out
+
+    deps = parse_container("repositories", "repository")
+    plugins = parse_container("pluginRepositories", "pluginRepository")
+    return deps, plugins
+
+
+def _read_build_file(path: str) -> str:
+    """Read a build file as UTF-8 text; returns "" if unreadable."""
+    try:
+        with open(path, "r", encoding="utf-8", errors="ignore") as fh:
+            return fh.read()
+    except OSError:
+        return ""
+
+
+def discover_repositories(project_root: str) -> Dict[str, List[Dict[str, str]]]:
+    """Discover project-declared repositories, scoped into plugin vs dependency.
+
+    Returns ``{"dependency": [RepoEntry], "plugin": [RepoEntry]}`` where each
+    RepoEntry tags itself with ``"scope"``. Gradle is preferred; the POM is read
+    only when NO Gradle build/settings file exists (gradle-first / pom-exclusive).
+    Only the project_root build files are read — submodules are out of scope."""
+    result: Dict[str, List[Dict[str, str]]] = {"dependency": [], "plugin": []}
+
+    gradle_files = GRADLE_BUILD_FILES + GRADLE_SETTINGS_FILES
+    gradle_present = any(
+        os.path.exists(os.path.join(project_root, f)) for f in gradle_files
+    )
+
+    if gradle_present:
+        plugin_entries: List[Dict[str, str]] = []
+        dep_entries: List[Dict[str, str]] = []
+        for fname in GRADLE_SETTINGS_FILES + GRADLE_BUILD_FILES:
+            path = os.path.join(project_root, fname)
+            if not os.path.exists(path):
+                continue
+            content = _read_build_file(path)
+            consumed: List[Tuple[int, int]] = []
+            for header in _GRADLE_PLUGIN_CONTAINERS + (_GRADLE_DEP_CONTAINER,):
+                found = _find_block(content, header)
+                if not found:
+                    continue
+                body, start, after = found
+                consumed.append((start, after))
+                repos_body = _extract_block(body, "repositories")
+                if repos_body is None:
+                    continue
+                parsed = _parse_gradle_repos(repos_body)
+                if header == _GRADLE_DEP_CONTAINER:
+                    dep_entries.extend(parsed)
+                else:
+                    plugin_entries.extend(parsed)
+            # Excise consumed container spans BEFORE the bare top-level
+            # repositories{} search, else a buildscript/pluginManagement-nested
+            # `repositories` would be mis-read as dependency scope.
+            stripped = _excise_spans(content, consumed)
+            bare = _extract_block(stripped, "repositories")
+            if bare is not None:
+                dep_entries.extend(_parse_gradle_repos(bare))
+        result["plugin"] = _dedup_repos(plugin_entries)
+        result["dependency"] = _dedup_repos(dep_entries)
+    else:
+        pom_path = os.path.join(project_root, "pom.xml")
+        if os.path.exists(pom_path):
+            deps, plugins = _parse_maven_repos(_read_build_file(pom_path))
+            result["dependency"] = _dedup_repos(deps)
+            result["plugin"] = _dedup_repos(plugins)
+
+    for scope, repos in result.items():
+        for entry in repos:
+            entry["scope"] = scope
+    return result
+
+
 def _detect_build_system(project_root: str) -> str:
     for f in GRADLE_BUILD_FILES + GRADLE_SETTINGS_FILES:
         if os.path.exists(os.path.join(project_root, f)):

--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -4,6 +4,7 @@ Maven MCP server — MCP stdio (JSON-RPC 2.0) over stdin/stdout.
 No external dependencies; Python 3.9+ standard library only.
 """
 
+import functools
 import json
 import os
 import re
@@ -125,15 +126,90 @@ def _pom_url(base: str, group_id: str, artifact_id: str, version: str) -> str:
     return f"{base.rstrip('/')}/{gp}/{artifact_id}/{version}/{artifact_id}-{version}.pom"
 
 
-def _repos_for(group_id: str, artifact_id: str) -> List[Tuple[str, str]]:
-    """Return (name, url) list to try for this artifact, most-specific first."""
-    repos = []
+class ResolutionContext:
+    """Repository-resolution context built ONCE at the handler boundary and
+    threaded down to every resolver. ``scoped_repos`` is the
+    ``discover_repositories`` result and doubles as the per-invocation memo (no
+    separate cache map); ``public_fallback`` is read from
+    MAVEN_MCP_PUBLIC_FALLBACK at construction, never sniffed in leaf functions."""
+
+    def __init__(
+        self,
+        project_path: str,
+        scoped_repos: Dict[str, List[Dict[str, str]]],
+        public_fallback: bool,
+    ) -> None:
+        self.project_path = project_path
+        self.scoped_repos = scoped_repos
+        self.public_fallback = public_fallback
+
+
+def _public_fallback_enabled() -> bool:
+    """MAVEN_MCP_PUBLIC_FALLBACK toggle. Default OFF (closed-mode #294 wants it
+    off); when ON, public repos are appended even for projects that declare
+    their own repositories (escape hatch for implicit/inherited-repo builds)."""
+    return os.environ.get("MAVEN_MCP_PUBLIC_FALLBACK", "").strip().lower() in (
+        "1", "true", "on", "yes",
+    )
+
+
+def build_resolution_context(args: Dict) -> "ResolutionContext":
+    """Build a ResolutionContext from a tool-call args dict at the handler
+    boundary. project_path defaults to the current working directory; the toggle
+    is read here once, not in the leaf resolvers."""
+    project_path = args.get("projectPath") or os.getcwd()
+    return ResolutionContext(
+        project_path, discover_repositories(project_path), _public_fallback_enabled()
+    )
+
+
+def _public_repos(group_id: str, artifact_id: str) -> List[Tuple[str, str]]:
+    """Static well-known routing (most-specific first): Gradle Plugin Portal for
+    plugin markers, Google Maven for the AndroidX/Google group prefixes, Maven
+    Central always last. Used as the public fallback when the project declares no
+    HTTP-queryable repository for the coordinate's scope."""
+    repos: List[Tuple[str, str]] = []
     if artifact_id.endswith(".gradle.plugin"):
         repos.append(("Gradle Plugin Portal", GRADLE_PLUGIN_PORTAL_URL))
     if any(group_id.startswith(p) for p in GOOGLE_MAVEN_GROUPS):
         repos.append(("Google Maven", GOOGLE_MAVEN_URL))
     repos.append(("Maven Central", MAVEN_CENTRAL_URL))
     return repos
+
+
+def _repos_for(
+    group_id: str, artifact_id: str, ctx: "ResolutionContext"
+) -> List[Dict[str, Any]]:
+    """Project-first repository resolution. ``ctx`` is REQUIRED — a public-only
+    default would silently resurrect #310. Returns rich entries
+    ``{name, url, scope, is_public_fallback}``, most-specific first.
+
+    Coordinate kind: a ``.gradle.plugin`` marker artifact resolves in the plugin
+    scope, everything else in the dependency scope. If that scope declares >=1
+    HTTP-queryable repository (mavenLocal's ``file://`` marker does NOT count) the
+    declared repos are returned EXACTLY, with no implicit public append — the
+    #299/#310 core. Otherwise the static public routing is the fallback. When
+    ``ctx.public_fallback`` is ON the public repos are appended even for a
+    declared scope (deduped by URL)."""
+    scope = "plugin" if artifact_id.endswith(".gradle.plugin") else "dependency"
+    declared = ctx.scoped_repos.get(scope, [])
+    queryable = [r for r in declared if not r["url"].startswith("file://")]
+
+    public_entries = [
+        {"name": name, "url": url, "scope": scope, "is_public_fallback": True}
+        for name, url in _public_repos(group_id, artifact_id)
+    ]
+
+    if queryable:
+        entries = [
+            {"name": r["name"], "url": r["url"], "scope": scope, "is_public_fallback": False}
+            for r in queryable
+        ]
+        if ctx.public_fallback:
+            entries.extend(public_entries)
+            return _dedup_repos(entries)
+        return entries
+    return public_entries
 
 
 def _parse_metadata_xml(xml: str, group_id: str, artifact_id: str) -> Dict[str, Any]:
@@ -151,43 +227,72 @@ def _parse_metadata_xml(xml: str, group_id: str, artifact_id: str) -> Dict[str, 
     }
 
 
-def fetch_metadata(group_id: str, artifact_id: str) -> Dict[str, Any]:
-    """Try repos in order and return first successful metadata parse."""
-    repos = _repos_for(group_id, artifact_id)
+def fetch_metadata(group_id: str, artifact_id: str, ctx: "ResolutionContext") -> Dict[str, Any]:
+    """Query every repo in ``ctx`` and MERGE results across those answering 200:
+    version sets are unioned, deduped and sorted ascending so a private repo's
+    extra versions are not lost to a first-hit short-circuit (#311); ``lastUpdated``
+    carries the most-recent value across answering repos. If NO repo answers (all
+    404/error) a ``ValueError`` is raised with the same message as the legacy
+    first-hit code, so unwrapped callers keep working. The single-repo result is
+    identical to the legacy path (union/sort of one ascending set = itself).
+    Intentionally diverges from the retired TS ``resolveAll``: no proxy-dedup."""
+    repos = _repos_for(group_id, artifact_id, ctx)
+    merged_versions: List[str] = []
+    last_updated: Optional[str] = None
+    answered = False
     last_err = None
-    for name, base in repos:
-        url = _metadata_url(base, group_id, artifact_id)
+    for entry in repos:
+        url = _metadata_url(entry["url"], group_id, artifact_id)
         try:
             status, body = http_get(url)
             if status == 200:
-                return _parse_metadata_xml(body.decode("utf-8", errors="replace"), group_id, artifact_id)
-            last_err = f"HTTP {status} from {name}"
+                # "answered" is gated on HTTP 200 itself, not on a non-empty
+                # version list — a 200 with empty <versions> still counts as a
+                # reachable repo, matching the legacy first-hit contract.
+                answered = True
+                parsed = _parse_metadata_xml(body.decode("utf-8", errors="replace"), group_id, artifact_id)
+                merged_versions.extend(parsed["versions"])
+                lu = parsed.get("lastUpdated")
+                if lu and (last_updated is None or lu > last_updated):
+                    last_updated = lu
+            else:
+                last_err = f"HTTP {status} from {entry['name']}"
         except Exception as e:
             last_err = str(e)
-    raise ValueError(f"Could not fetch metadata for {group_id}:{artifact_id}: {last_err}")
+    if not answered:
+        raise ValueError(f"Could not fetch metadata for {group_id}:{artifact_id}: {last_err}")
+    versions = sorted(set(merged_versions), key=functools.cmp_to_key(compare_versions))
+    return {
+        "groupId": group_id,
+        "artifactId": artifact_id,
+        "versions": versions,
+        "latest": find_latest_version(versions, "PREFER_STABLE"),
+        "release": find_latest_version(versions, "STABLE_ONLY"),
+        "lastUpdated": last_updated,
+    }
 
 
-def check_version_in_repos(group_id: str, artifact_id: str, version: str) -> Optional[str]:
+def check_version_in_repos(group_id: str, artifact_id: str, version: str, ctx: "ResolutionContext") -> Optional[str]:
     """Returns repo name if version exists, else None."""
-    repos = _repos_for(group_id, artifact_id)
-    for name, base in repos:
-        url = _metadata_url(base, group_id, artifact_id)
+    repos = _repos_for(group_id, artifact_id, ctx)
+    for entry in repos:
+        url = _metadata_url(entry["url"], group_id, artifact_id)
         try:
             status, body = http_get(url)
             if status == 200:
                 xml = body.decode("utf-8", errors="replace")
                 versions = re.findall(r"<version>([^<]+)</version>", xml)
                 if version in versions:
-                    return name
+                    return entry["name"]
         except Exception:
             continue
     return None
 
 
-def fetch_pom(group_id: str, artifact_id: str, version: str) -> Optional[str]:
-    repos = _repos_for(group_id, artifact_id)
-    for _name, base in repos:
-        url = _pom_url(base, group_id, artifact_id, version)
+def fetch_pom(group_id: str, artifact_id: str, version: str, ctx: "ResolutionContext") -> Optional[str]:
+    repos = _repos_for(group_id, artifact_id, ctx)
+    for entry in repos:
+        url = _pom_url(entry["url"], group_id, artifact_id, version)
         try:
             status, body = http_get(url)
             if status == 200:
@@ -560,9 +665,9 @@ def _summarize_releases(releases: List[Dict]) -> Dict:
     return {"last": last, "cadenceDays": round(median_sec / 86400), "count": count}
 
 
-def discover_github_repo(group_id: str, artifact_id: str, version: str) -> Optional[Dict[str, str]]:
+def discover_github_repo(group_id: str, artifact_id: str, version: str, ctx: "ResolutionContext") -> Optional[Dict[str, str]]:
     """Try POM SCM, then guess from groupId. Returns {owner, repo} or None."""
-    pom = fetch_pom(group_id, artifact_id, version)
+    pom = fetch_pom(group_id, artifact_id, version, ctx)
     if pom:
         r = extract_github_repo_from_pom(pom)
         if r:
@@ -588,7 +693,7 @@ def _filter_version_range(versions: List[str], from_v: str, to_v: str) -> List[s
     return result
 
 
-def _get_dependency_changes_impl(group_id: str, artifact_id: str, from_version: str, to_version: str) -> Dict:
+def _get_dependency_changes_impl(group_id: str, artifact_id: str, from_version: str, to_version: str, ctx: "ResolutionContext") -> Dict:
     base = {
         "groupId": group_id,
         "artifactId": artifact_id,
@@ -597,7 +702,7 @@ def _get_dependency_changes_impl(group_id: str, artifact_id: str, from_version: 
         "changes": [],
     }
     try:
-        metadata = fetch_metadata(group_id, artifact_id)
+        metadata = fetch_metadata(group_id, artifact_id, ctx)
     except Exception as e:
         return {**base, "error": str(e)}
 
@@ -605,7 +710,7 @@ def _get_dependency_changes_impl(group_id: str, artifact_id: str, from_version: 
     if not versions_in_range:
         return {**base, "error": f"No versions found between {from_version} and {to_version}"}
 
-    gh_repo = discover_github_repo(group_id, artifact_id, to_version)
+    gh_repo = discover_github_repo(group_id, artifact_id, to_version, ctx)
     if not gh_repo:
         return {**base, "repositoryNotFound": True}
 
@@ -1499,7 +1604,8 @@ def handle_get_latest_version(args: Dict) -> Any:
     group_id = args["groupId"]
     artifact_id = args["artifactId"]
     filter_mode = args.get("stabilityFilter", "PREFER_STABLE")
-    metadata = fetch_metadata(group_id, artifact_id)
+    ctx = build_resolution_context(args)
+    metadata = fetch_metadata(group_id, artifact_id, ctx)
     selected = find_latest_version(metadata["versions"], filter_mode)
     if not selected:
         raise ValueError(f"No stable version found for {group_id}:{artifact_id}")
@@ -1516,7 +1622,8 @@ def handle_check_version_exists(args: Dict) -> Any:
     group_id = args["groupId"]
     artifact_id = args["artifactId"]
     version = args["version"]
-    repo_name = check_version_in_repos(group_id, artifact_id, version)
+    ctx = build_resolution_context(args)
+    repo_name = check_version_in_repos(group_id, artifact_id, version, ctx)
     if repo_name:
         return {
             "groupId": group_id,
@@ -1535,10 +1642,11 @@ def handle_check_version_exists(args: Dict) -> Any:
 
 
 def handle_check_multiple_dependencies(args: Dict) -> Any:
+    ctx = build_resolution_context(args)
     results = []
     for dep in args["dependencies"]:
         try:
-            metadata = fetch_metadata(dep["groupId"], dep["artifactId"])
+            metadata = fetch_metadata(dep["groupId"], dep["artifactId"], ctx)
             latest = find_latest_version(metadata["versions"], "PREFER_STABLE")
             if not latest:
                 raise ValueError("No version found")
@@ -1560,10 +1668,11 @@ def handle_check_multiple_dependencies(args: Dict) -> Any:
 
 
 def handle_compare_dependency_versions(args: Dict) -> Any:
+    ctx = build_resolution_context(args)
     results = []
     for dep in args["dependencies"]:
         try:
-            metadata = fetch_metadata(dep["groupId"], dep["artifactId"])
+            metadata = fetch_metadata(dep["groupId"], dep["artifactId"], ctx)
             latest = find_latest_version_for_current(metadata["versions"], dep["currentVersion"])
             if not latest:
                 raise ValueError("No matching version found")
@@ -1599,11 +1708,13 @@ def handle_compare_dependency_versions(args: Dict) -> Any:
 
 
 def handle_get_dependency_changes(args: Dict) -> Any:
+    ctx = build_resolution_context(args)
     return _get_dependency_changes_impl(
         args["groupId"],
         args["artifactId"],
         args["fromVersion"],
         args["toVersion"],
+        ctx,
     )
 
 
@@ -1624,6 +1735,7 @@ def handle_get_dependency_vulnerabilities(args: Dict) -> Any:
 
 
 def handle_get_dependency_health(args: Dict) -> Any:
+    ctx = build_resolution_context(args)
     results = []
     for dep in args["dependencies"]:
         group_id = dep["groupId"]
@@ -1639,7 +1751,7 @@ def handle_get_dependency_health(args: Dict) -> Any:
             "signals": [],
         }
         try:
-            metadata = fetch_metadata(group_id, artifact_id)
+            metadata = fetch_metadata(group_id, artifact_id, ctx)
         except Exception as e:
             result["healthError"] = str(e)
             results.append(result)
@@ -1659,7 +1771,7 @@ def handle_get_dependency_health(args: Dict) -> Any:
         gh_repo = None
         pom_licenses: List[str] = []
         if target_version:
-            pom = fetch_pom(group_id, artifact_id, target_version)
+            pom = fetch_pom(group_id, artifact_id, target_version, ctx)
             if pom:
                 gh_repo = extract_github_repo_from_pom(pom)
                 pom_licenses = extract_licenses_from_pom(pom)
@@ -1768,6 +1880,7 @@ def handle_audit_project_dependencies(args: Dict) -> Any:
     if production_only is None:
         production_only = True
 
+    ctx = build_resolution_context(args)
     scan = scan_project(project_path)
 
     def is_included_in_production(dep: Dict) -> bool:
@@ -1798,7 +1911,7 @@ def handle_audit_project_dependencies(args: Dict) -> Any:
         ga_key = f"{dep['groupId']}:{dep['artifactId']}"
         try:
             if ga_key not in metadata_cache:
-                metadata_cache[ga_key] = fetch_metadata(dep["groupId"], dep["artifactId"])
+                metadata_cache[ga_key] = fetch_metadata(dep["groupId"], dep["artifactId"], ctx)
             metadata = metadata_cache[ga_key]
             latest = find_latest_version_for_current(metadata["versions"], dep["version"])
             upgrade_type = get_upgrade_type(dep["version"], latest) if latest else "none"
@@ -1894,6 +2007,7 @@ TOOLS = [
                     "enum": ["PREFER_STABLE", "STABLE_ONLY", "ALL"],
                     "description": "Version stability filter. Default: PREFER_STABLE",
                 },
+                "projectPath": {"type": "string", "description": "Project root used to resolve declared repositories. Defaults to the current working directory."},
             },
             "required": ["groupId", "artifactId"],
         },
@@ -1907,6 +2021,7 @@ TOOLS = [
                 "groupId": {"type": "string"},
                 "artifactId": {"type": "string"},
                 "version": {"type": "string"},
+                "projectPath": {"type": "string", "description": "Project root used to resolve declared repositories. Defaults to the current working directory."},
             },
             "required": ["groupId", "artifactId", "version"],
         },
@@ -1927,7 +2042,8 @@ TOOLS = [
                         },
                         "required": ["groupId", "artifactId"],
                     },
-                }
+                },
+                "projectPath": {"type": "string", "description": "Project root used to resolve declared repositories. Defaults to the current working directory."},
             },
             "required": ["dependencies"],
         },
@@ -1949,7 +2065,8 @@ TOOLS = [
                         },
                         "required": ["groupId", "artifactId", "currentVersion"],
                     },
-                }
+                },
+                "projectPath": {"type": "string", "description": "Project root used to resolve declared repositories. Defaults to the current working directory."},
             },
             "required": ["dependencies"],
         },
@@ -1964,6 +2081,7 @@ TOOLS = [
                 "artifactId": {"type": "string"},
                 "fromVersion": {"type": "string", "description": "Starting version (exclusive)"},
                 "toVersion": {"type": "string", "description": "Target version (inclusive)"},
+                "projectPath": {"type": "string", "description": "Project root used to resolve declared repositories. Defaults to the current working directory."},
             },
             "required": ["groupId", "artifactId", "fromVersion", "toVersion"],
         },
@@ -2017,7 +2135,8 @@ TOOLS = [
                         },
                         "required": ["groupId", "artifactId"],
                     },
-                }
+                },
+                "projectPath": {"type": "string", "description": "Project root used to resolve declared repositories. Defaults to the current working directory."},
             },
             "required": ["dependencies"],
         },

--- a/plugins/maven-mcp/tests/_helpers.py
+++ b/plugins/maven-mcp/tests/_helpers.py
@@ -31,7 +31,16 @@ import server  # noqa: E402  (must follow the sys.path shim above)
 # Public test API re-exported for ``from _helpers import ...``. Listing
 # ``server`` makes the shimmed import above an intentional re-export rather
 # than an unused import.
-__all__ = ["server", "mock_urlopen", "http_error", "temp_project"]
+__all__ = ["server", "mock_urlopen", "http_error", "temp_project", "empty_ctx"]
+
+
+def empty_ctx(public_fallback: bool = False) -> "server.ResolutionContext":
+    """A ResolutionContext with no project-declared repositories, so resolution
+    falls back to the static public routing — the legacy behavior the pre-#310
+    suite asserted. Hermetic (no filesystem read)."""
+    return server.ResolutionContext(
+        "/__no_project__", {"dependency": [], "plugin": []}, public_fallback
+    )
 
 # A single response spec: (status, body) tuple, or an Exception to raise.
 ResponseSpec = Union["_MockResponse", BaseException, Any]

--- a/plugins/maven-mcp/tests/test_github.py
+++ b/plugins/maven-mcp/tests/test_github.py
@@ -23,7 +23,7 @@ import re
 import unittest
 import unittest.mock
 
-from _helpers import server, mock_urlopen, http_error
+from _helpers import server, mock_urlopen, http_error, empty_ctx
 
 
 # POM fixtures mirror discover-repo.test.ts / github-provider.test.ts.
@@ -248,7 +248,7 @@ class DiscoverGithubRepoTest(unittest.TestCase):
             side_effect=mock_urlopen([(200, POM_WITH_SCM_OKHTTP.encode())]),
         ) as m:
             result = server.discover_github_repo(
-                "com.squareup.okhttp3", "okhttp", "4.12.0"
+                "com.squareup.okhttp3", "okhttp", "4.12.0", empty_ctx()
             )
         self.assertEqual(result, {"owner": "square", "repo": "okhttp"})
         self.assertEqual(len(m.call_args_list), 1)
@@ -263,7 +263,7 @@ class DiscoverGithubRepoTest(unittest.TestCase):
         with unittest.mock.patch(
             "urllib.request.urlopen", side_effect=mock_urlopen(responses)
         ) as m:
-            result = server.discover_github_repo("io.github.javalin", "javalin", "5.0.0")
+            result = server.discover_github_repo("io.github.javalin", "javalin", "5.0.0", empty_ctx())
         self.assertEqual(result, {"owner": "javalin", "repo": "javalin"})
         self.assertEqual(len(m.call_args_list), 2)
 
@@ -273,7 +273,7 @@ class DiscoverGithubRepoTest(unittest.TestCase):
         responses = [(200, POM_WITHOUT_SCM.encode()), err]
         with unittest.mock.patch("urllib.request.urlopen", side_effect=mock_urlopen(responses)):
             result = server.discover_github_repo(
-                "io.github.someuser", "nonexistent-lib", "1.0.0"
+                "io.github.someuser", "nonexistent-lib", "1.0.0", empty_ctx()
             )
         self.assertIsNone(result)
 
@@ -284,7 +284,7 @@ class DiscoverGithubRepoTest(unittest.TestCase):
             "urllib.request.urlopen", side_effect=mock_urlopen([err])
         ) as m:
             result = server.discover_github_repo(
-                "org.apache.commons", "commons-lang3", "3.14.0"
+                "org.apache.commons", "commons-lang3", "3.14.0", empty_ctx()
             )
         self.assertIsNone(result)
         # POM fetch only (1 call); no guess possible -> no gh_repo_exists call.
@@ -341,7 +341,7 @@ class DependencyChangesImplTest(unittest.TestCase):
         ]
         with unittest.mock.patch("urllib.request.urlopen", side_effect=mock_urlopen(responses)):
             result = server._get_dependency_changes_impl(
-                "io.ktor", "ktor-core", "1.0.0", "2.0.0"
+                "io.ktor", "ktor-core", "1.0.0", "2.0.0", empty_ctx()
             )
         self.assertNotIn("error", result)
         self.assertNotIn("repositoryNotFound", result)
@@ -366,7 +366,7 @@ class DependencyChangesImplTest(unittest.TestCase):
         ]
         with unittest.mock.patch("urllib.request.urlopen", side_effect=mock_urlopen(responses)):
             result = server._get_dependency_changes_impl(
-                "io.ktor", "ktor-core", "1.0.0", "1.5.0"
+                "io.ktor", "ktor-core", "1.0.0", "1.5.0", empty_ctx()
             )
         by_version = {c["version"]: c for c in result["changes"]}
         self.assertEqual(by_version["1.5.0"]["body"], "mid")
@@ -379,7 +379,7 @@ class DependencyChangesImplTest(unittest.TestCase):
         ]
         with unittest.mock.patch("urllib.request.urlopen", side_effect=mock_urlopen(responses)):
             result = server._get_dependency_changes_impl(
-                "com.example", "lib", "1.0.0", "2.0.0"
+                "com.example", "lib", "1.0.0", "2.0.0", empty_ctx()
             )
         self.assertTrue(result["repositoryNotFound"])
         self.assertNotIn("repositoryUrl", result)
@@ -395,7 +395,7 @@ class DependencyChangesImplTest(unittest.TestCase):
         ]
         with unittest.mock.patch("urllib.request.urlopen", side_effect=mock_urlopen(responses)):
             result = server._get_dependency_changes_impl(
-                "io.ktor", "ktor-core", "1.0.0", "2.0.0"
+                "io.ktor", "ktor-core", "1.0.0", "2.0.0", empty_ctx()
             )
         self.assertNotIn("error", result)
         self.assertEqual(result["repositoryUrl"], "https://github.com/ktorio/ktor")
@@ -408,7 +408,7 @@ class DependencyChangesImplTest(unittest.TestCase):
             "urllib.request.urlopen", side_effect=mock_urlopen(responses)
         ) as m:
             result = server._get_dependency_changes_impl(
-                "io.ktor", "ktor-core", "2.0.0", "3.0.0"
+                "io.ktor", "ktor-core", "2.0.0", "3.0.0", empty_ctx()
             )
         self.assertEqual(result["error"], "No versions found between 2.0.0 and 3.0.0")
         self.assertEqual(len(m.call_args_list), 1)  # only the metadata fetch
@@ -418,7 +418,7 @@ class DependencyChangesImplTest(unittest.TestCase):
         err = http_error("https://repo1.maven.org/maven2/x/maven-metadata.xml", 404)
         with unittest.mock.patch("urllib.request.urlopen", side_effect=mock_urlopen([err])):
             result = server._get_dependency_changes_impl(
-                "io.ktor", "ktor-core", "1.0.0", "2.0.0"
+                "io.ktor", "ktor-core", "1.0.0", "2.0.0", empty_ctx()
             )
         self.assertIn("error", result)
         self.assertEqual(result["changes"], [])

--- a/plugins/maven-mcp/tests/test_maven_search_osv.py
+++ b/plugins/maven-mcp/tests/test_maven_search_osv.py
@@ -3,13 +3,14 @@
 Mirrors the retired TypeScript suite:
   - src/maven/__tests__/repository.test.ts  -> TestReposFor / TestParseMetadataXml
   - src/maven/__tests__/resolver.test.ts    -> TestFetchMetadata
-        NOTE: Python semantics DIFFER from resolver.test.ts. The TS layer had two
-        strategies, `resolveFirst` (sequential, stop at first hit) and `resolveAll`
-        (parallel fetch + cross-repo version-set MERGE). server.py kept only the
-        first-hit behavior: `fetch_metadata` returns the FIRST successful repo's
-        metadata and never merges across repos. The resolver.test.ts merge cases
-        therefore have NO Python equivalent (divergence #6); only the first-hit
-        contract is portable and is asserted here.
+        Resolution is now project-first: `_repos_for(group, artifact, ctx)` returns
+        the project-declared repos for the coordinate's scope, or — when none are
+        declared (the empty_ctx() used here) — the static public routing. With no
+        declared repos these tests assert that public fallback. `fetch_metadata`
+        MERGES version sets across every answering repo (#311), so the resolveAll
+        cross-repo merge IS now the Python behavior (see
+        test_merges_versions_across_repos). It still diverges from TS resolveAll in
+        one way: no proxy-target dedup.
   - src/search/__tests__/maven-search.test.ts     -> TestSearchMavenCentral
   - src/vulnerabilities/__tests__/osv-client.test.ts -> TestQueryOsvBatch
 
@@ -24,7 +25,7 @@ import unittest
 import urllib.error
 import unittest.mock
 
-from _helpers import server, mock_urlopen, http_error
+from _helpers import server, mock_urlopen, http_error, empty_ctx
 
 
 def _metadata_xml(versions, latest=None, release=None, last_updated=None):
@@ -45,52 +46,65 @@ def _metadata_xml(versions, latest=None, release=None, last_updated=None):
 # ---------------------------------------------------------------------------
 # _repos_for routing + URL builders + XML parse
 # Mirrors src/maven/__tests__/repository.test.ts (URL construction, parse,
-# well-known repo constants). server.py's repo selection is the static
-# group-prefix router `_repos_for` (server.py:128), not a configurable repo
-# object; the AndroidX/Google prefix constant lives at server.py:29-32.
+# well-known repo constants). With an empty_ctx() (no project-declared repos)
+# `_repos_for(group, artifact, ctx)` returns the static public routing as rich
+# entries {name, url, scope, is_public_fallback}; the AndroidX/Google prefix
+# constant lives at server.py:29-32.
 # ---------------------------------------------------------------------------
 class TestReposFor(unittest.TestCase):
     def test_plain_artifact_uses_central_only(self):
         # A non-Google, non-plugin artifact resolves to Maven Central only.
-        repos = server._repos_for("io.ktor", "ktor-server-core")
-        self.assertEqual(repos, [("Maven Central", server.MAVEN_CENTRAL_URL)])
+        repos = server._repos_for("io.ktor", "ktor-server-core", empty_ctx())
+        self.assertEqual(
+            repos,
+            [{"name": "Maven Central", "url": server.MAVEN_CENTRAL_URL,
+              "scope": "dependency", "is_public_fallback": True}],
+        )
 
     def test_androidx_routes_google_first_then_central(self):
         # AndroidX prefix routing (server.py:30): Google Maven is tried first,
         # Maven Central second -> most-specific-first.
-        repos = server._repos_for("androidx.core", "core-ktx")
+        repos = server._repos_for("androidx.core", "core-ktx", empty_ctx())
         self.assertEqual(
-            repos,
+            [(r["name"], r["url"]) for r in repos],
             [
                 ("Google Maven", server.GOOGLE_MAVEN_URL),
                 ("Maven Central", server.MAVEN_CENTRAL_URL),
             ],
         )
+        self.assertTrue(all(r["is_public_fallback"] for r in repos))
+        self.assertTrue(all(r["scope"] == "dependency" for r in repos))
 
     def test_google_firebase_group_routes_to_google(self):
         # Another entry of the GOOGLE_MAVEN_GROUPS prefix constant (server.py:30);
         # the prefix carries a trailing dot, so the group must be a sub-group.
-        repos = server._repos_for("com.google.firebase.crashlytics", "firebase-crashlytics")
-        self.assertEqual(repos[0], ("Google Maven", server.GOOGLE_MAVEN_URL))
-        self.assertEqual(repos[-1], ("Maven Central", server.MAVEN_CENTRAL_URL))
+        repos = server._repos_for(
+            "com.google.firebase.crashlytics", "firebase-crashlytics", empty_ctx()
+        )
+        self.assertEqual(repos[0]["name"], "Google Maven")
+        self.assertEqual(repos[0]["url"], server.GOOGLE_MAVEN_URL)
+        self.assertEqual(repos[-1]["name"], "Maven Central")
 
     def test_gradle_plugin_marker_routes_to_plugin_portal_first(self):
         repos = server._repos_for(
-            "org.jetbrains.kotlin.jvm", "org.jetbrains.kotlin.jvm.gradle.plugin"
+            "org.jetbrains.kotlin.jvm", "org.jetbrains.kotlin.jvm.gradle.plugin",
+            empty_ctx(),
         )
         self.assertEqual(
-            repos,
+            [(r["name"], r["url"]) for r in repos],
             [
                 ("Gradle Plugin Portal", server.GRADLE_PLUGIN_PORTAL_URL),
                 ("Maven Central", server.MAVEN_CENTRAL_URL),
             ],
         )
+        # A .gradle.plugin marker resolves in the plugin scope.
+        self.assertTrue(all(r["scope"] == "plugin" for r in repos))
 
     def test_most_specific_first_ordering_plugin_then_google_then_central(self):
         # Plugin marker AND a Google group: portal, then Google, then Central.
-        repos = server._repos_for("androidx.tooling", "x.gradle.plugin")
+        repos = server._repos_for("androidx.tooling", "x.gradle.plugin", empty_ctx())
         self.assertEqual(
-            [name for name, _ in repos],
+            [r["name"] for r in repos],
             ["Gradle Plugin Portal", "Google Maven", "Maven Central"],
         )
 
@@ -150,44 +164,44 @@ class TestParseMetadataXml(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# fetch_metadata (server.py:154)
-# Mirrors src/maven/__tests__/resolver.test.ts, but only the first-hit contract
-# is portable. The resolveAll MERGE cases have NO Python equivalent -> see the
-# divergence #6 test below.
+# fetch_metadata (server.py)
+# fetch_metadata now MERGES version sets across every repo answering 200 (#311);
+# the single-repo path is unchanged. The empty_ctx() routes via the public
+# fallback, so io.ktor -> Maven Central only and androidx.* -> Google + Central.
 # ---------------------------------------------------------------------------
 class TestFetchMetadata(unittest.TestCase):
-    def test_returns_first_successful_repo_metadata(self):
-        # Mirrors resolver.test.ts "returns metadata from first repo that has it".
+    def test_returns_single_repo_metadata_unchanged(self):
+        # Single-repo result is identical to the legacy first-hit path: io.ktor
+        # routes to Maven Central only, so the merge of one set = that set.
         with unittest.mock.patch(
             "urllib.request.urlopen",
             side_effect=mock_urlopen([(200, _metadata_xml(["1.0.0", "2.0.0"]))]),
         ):
-            result = server.fetch_metadata("io.ktor", "ktor-core")
+            result = server.fetch_metadata("io.ktor", "ktor-core", empty_ctx())
         self.assertEqual(result["versions"], ["1.0.0", "2.0.0"])
 
-    def test_first_hit_not_resolveall_merge(self):
-        # DIVERGENCE #6: fetch_metadata returns the FIRST successful repo's set,
-        # it does NOT merge version sets across repos like the retired TS
-        # resolveAll. androidx.* routes Google Maven (#1) then Maven Central (#2).
-        # Google returns [1.0.0, 2.0.0]; Central would return [3.0.0]. First-hit
-        # means only Google's set is returned (no 3.0.0) AND Central is never
-        # queried -- urlopen is called exactly once.
+    def test_merges_versions_across_repos(self):
+        # #311 fix: fetch_metadata MERGES version sets across repos rather than
+        # stopping at the first hit. androidx.* routes Google Maven (#1) then
+        # Maven Central (#2). Google returns [1.0.0, 2.0.0]; Central returns
+        # [3.0.0]. Both are queried and the union (sorted) is returned.
         responses = [
             (200, _metadata_xml(["1.0.0", "2.0.0"])),  # Google Maven (#1)
-            (200, _metadata_xml(["3.0.0"])),           # Maven Central (#2) -- never reached
+            (200, _metadata_xml(["3.0.0"])),           # Maven Central (#2)
         ]
         with unittest.mock.patch(
             "urllib.request.urlopen", side_effect=mock_urlopen(responses)
         ) as m:
-            result = server.fetch_metadata("androidx.core", "core-ktx")
-        self.assertEqual(result["versions"], ["1.0.0", "2.0.0"])
-        self.assertNotIn("3.0.0", result["versions"])  # NOT merged with Central
-        self.assertEqual(m.call_count, 1)  # Central (#2) never queried
-        first_url = m.call_args_list[0].args[0].full_url
-        self.assertTrue(first_url.startswith(server.GOOGLE_MAVEN_URL))
+            result = server.fetch_metadata("androidx.core", "core-ktx", empty_ctx())
+        self.assertEqual(result["versions"], ["1.0.0", "2.0.0", "3.0.0"])  # merged
+        self.assertIn("3.0.0", result["versions"])  # Central's version IS merged
+        self.assertEqual(m.call_count, 2)  # both repos queried
+        queried = [c.args[0].full_url for c in m.call_args_list]
+        self.assertTrue(any(u.startswith(server.GOOGLE_MAVEN_URL) for u in queried))
+        self.assertTrue(any(u.startswith(server.MAVEN_CENTRAL_URL) for u in queried))
 
-    def test_skips_non_200_repo_and_continues_to_next(self):
-        # Google Maven 404 -> falls through to Maven Central, which returns 200.
+    def test_skips_non_200_repo_and_merges_the_rest(self):
+        # Google Maven 404 -> only Maven Central's 200 contributes to the merge.
         responses = [
             http_error(server.GOOGLE_MAVEN_URL, 404, "Not Found"),
             (200, _metadata_xml(["9.9.9"])),
@@ -195,11 +209,11 @@ class TestFetchMetadata(unittest.TestCase):
         with unittest.mock.patch(
             "urllib.request.urlopen", side_effect=mock_urlopen(responses)
         ) as m:
-            result = server.fetch_metadata("androidx.core", "core-ktx")
+            result = server.fetch_metadata("androidx.core", "core-ktx", empty_ctx())
         self.assertEqual(result["versions"], ["9.9.9"])
         self.assertEqual(m.call_count, 2)
 
-    def test_network_error_on_first_repo_is_caught_and_continues(self):
+    def test_network_error_on_one_repo_is_caught_and_others_merge(self):
         # http_get does NOT catch URLError (only HTTPError) -> it propagates and
         # fetch_metadata's broad `except Exception` swallows it, then continues.
         responses = [
@@ -209,7 +223,7 @@ class TestFetchMetadata(unittest.TestCase):
         with unittest.mock.patch(
             "urllib.request.urlopen", side_effect=mock_urlopen(responses)
         ):
-            result = server.fetch_metadata("androidx.core", "core-ktx")
+            result = server.fetch_metadata("androidx.core", "core-ktx", empty_ctx())
         self.assertEqual(result["versions"], ["4.5.6"])
 
     def test_raises_when_all_repos_fail(self):
@@ -219,7 +233,7 @@ class TestFetchMetadata(unittest.TestCase):
             side_effect=mock_urlopen([http_error("u", 500, "boom")]),
         ):
             with self.assertRaises(ValueError):
-                server.fetch_metadata("io.ktor", "ktor-core")
+                server.fetch_metadata("io.ktor", "ktor-core", empty_ctx())
 
 
 # ---------------------------------------------------------------------------
@@ -231,7 +245,7 @@ class TestCheckVersionInRepos(unittest.TestCase):
             "urllib.request.urlopen",
             side_effect=mock_urlopen([(200, _metadata_xml(["1.0.0", "2.0.0"]))]),
         ):
-            name = server.check_version_in_repos("io.ktor", "ktor-core", "2.0.0")
+            name = server.check_version_in_repos("io.ktor", "ktor-core", "2.0.0", empty_ctx())
         self.assertEqual(name, "Maven Central")
 
     def test_returns_none_when_version_absent(self):
@@ -239,7 +253,7 @@ class TestCheckVersionInRepos(unittest.TestCase):
             "urllib.request.urlopen",
             side_effect=mock_urlopen([(200, _metadata_xml(["1.0.0"]))]),
         ):
-            name = server.check_version_in_repos("io.ktor", "ktor-core", "9.9.9")
+            name = server.check_version_in_repos("io.ktor", "ktor-core", "9.9.9", empty_ctx())
         self.assertIsNone(name)
 
     def test_checks_google_then_central_when_only_central_has_version(self):
@@ -252,7 +266,7 @@ class TestCheckVersionInRepos(unittest.TestCase):
         with unittest.mock.patch(
             "urllib.request.urlopen", side_effect=mock_urlopen(responses)
         ) as m:
-            name = server.check_version_in_repos("androidx.core", "core-ktx", "2.0.0")
+            name = server.check_version_in_repos("androidx.core", "core-ktx", "2.0.0", empty_ctx())
         self.assertEqual(name, "Maven Central")
         self.assertEqual(m.call_count, 2)
 
@@ -266,7 +280,7 @@ class TestFetchPom(unittest.TestCase):
             "urllib.request.urlopen",
             side_effect=mock_urlopen([(200, b"<project><scm/></project>")]),
         ) as m:
-            pom = server.fetch_pom("io.ktor", "ktor-core", "3.1.1")
+            pom = server.fetch_pom("io.ktor", "ktor-core", "3.1.1", empty_ctx())
         self.assertEqual(pom, "<project><scm/></project>")
         # POM URL shape includes the version directory and the -version.pom file.
         self.assertTrue(m.call_args_list[0].args[0].full_url.endswith("ktor-core-3.1.1.pom"))
@@ -276,7 +290,7 @@ class TestFetchPom(unittest.TestCase):
             "urllib.request.urlopen",
             side_effect=mock_urlopen([http_error("u", 404, "Not Found")]),
         ):
-            self.assertIsNone(server.fetch_pom("io.ktor", "ktor-core", "3.1.1"))
+            self.assertIsNone(server.fetch_pom("io.ktor", "ktor-core", "3.1.1", empty_ctx()))
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/maven-mcp/tests/test_repo_discovery.py
+++ b/plugins/maven-mcp/tests/test_repo_discovery.py
@@ -1,0 +1,210 @@
+"""Tests for the project repository-discovery layer.
+
+Covers the brace-depth block scanner (`_extract_block` / `_find_block`), the
+Gradle/Maven repository parsers, and the scoped `discover_repositories`
+orchestrator. Stdlib only; build files are written into real temp directories.
+"""
+
+import os
+import tempfile
+import unittest
+
+from _helpers import server
+
+
+def _urls(entries):
+    return [e["url"] for e in entries]
+
+
+class TestExtractBlock(unittest.TestCase):
+    def test_nested_blocks(self):
+        content = 'pluginManagement { repositories { maven("X") } }'
+        body = server._extract_block(content, "pluginManagement")
+        self.assertIsNotNone(body)
+        self.assertIn("repositories", body)
+        repos = server._extract_block(body, "repositories")
+        self.assertIsNotNone(repos)
+        self.assertIn('maven("X")', repos)
+        self.assertNotIn("pluginManagement", repos)
+
+    def test_sibling_blocks_extracted_independently(self):
+        content = (
+            'pluginManagement { repositories { maven("PLUG") } }\n'
+            'dependencyResolutionManagement { repositories { maven("DEP") } }'
+        )
+        plug = server._extract_block(content, "pluginManagement")
+        dep = server._extract_block(content, "dependencyResolutionManagement")
+        # No over-capture: each body holds only its own marker.
+        self.assertIn("PLUG", plug)
+        self.assertNotIn("DEP", plug)
+        self.assertIn("DEP", dep)
+        self.assertNotIn("PLUG", dep)
+
+    def test_brace_inside_quoted_url_does_not_terminate(self):
+        content = 'repositories { maven("https://host/path}weird") }'
+        body = server._extract_block(content, "repositories")
+        self.assertIsNotNone(body)
+        # The full call survives; the `}` inside the string was not treated as
+        # the block terminator.
+        self.assertIn('maven("https://host/path}weird")', body)
+
+    def test_brace_inside_line_comment_ignored(self):
+        content = 'repositories { // closing here }\n maven("X") }'
+        body = server._extract_block(content, "repositories")
+        self.assertIsNotNone(body)
+        self.assertIn('maven("X")', body)
+
+    def test_missing_header_returns_falsy(self):
+        # Spec allows None or empty for absent header.
+        self.assertFalse(server._extract_block("nothing here {}", "buildscript"))
+
+    def test_maven_call_is_not_a_block(self):
+        # `maven("url")` is a call, not a `maven { }` block.
+        self.assertIsNone(server._find_block('maven("url")', "maven"))
+
+    def test_word_boundary_does_not_match_substring(self):
+        # `maven {` must not be found inside `mavenCentral { ... }`.
+        self.assertIsNone(server._find_block("mavenCentral { x }", "maven"))
+
+
+class TestParseGradleRepos(unittest.TestCase):
+    def test_shorthands(self):
+        body = " mavenCentral()\n google()\n gradlePluginPortal() "
+        urls = _urls(server._parse_gradle_repos(body))
+        self.assertIn(server.MAVEN_CENTRAL_URL, urls)
+        self.assertIn(server.GOOGLE_MAVEN_URL, urls)
+        self.assertIn(server.GRADLE_PLUGIN_PORTAL_URL, urls)
+
+    def test_maven_local_marker(self):
+        urls = _urls(server._parse_gradle_repos("mavenLocal()"))
+        self.assertEqual(len(urls), 1)
+        self.assertTrue(urls[0].startswith("file://"), urls[0])
+
+    def test_explicit_maven_call(self):
+        urls = _urls(server._parse_gradle_repos('maven("https://a/r")'))
+        self.assertEqual(urls, ["https://a/r"])
+
+    def test_explicit_maven_url_named_arg(self):
+        urls = _urls(server._parse_gradle_repos('maven(url = "https://b/r")'))
+        self.assertEqual(urls, ["https://b/r"])
+
+    def test_maven_block_kotlin_uri(self):
+        urls = _urls(server._parse_gradle_repos('maven { url = uri("https://c/r") }'))
+        self.assertEqual(urls, ["https://c/r"])
+
+    def test_maven_block_groovy_single_quote(self):
+        urls = _urls(server._parse_gradle_repos("maven { url 'https://d/r' }"))
+        self.assertEqual(urls, ["https://d/r"])
+
+    def test_maven_block_url_after_credentials(self):
+        # The crux: url AFTER a nested credentials{} block. A brace-naive
+        # `maven\s*\{[^}]*url` regex would stop at the first `}` and miss it.
+        body = 'maven { credentials { username = "u" }; url = uri("https://nexus/r") }'
+        urls = _urls(server._parse_gradle_repos(body))
+        self.assertEqual(urls, ["https://nexus/r"])
+
+    def test_dedup_by_url(self):
+        body = 'mavenCentral()\n maven("https://repo1.maven.org/maven2")'
+        urls = _urls(server._parse_gradle_repos(body))
+        self.assertEqual(urls.count(server.MAVEN_CENTRAL_URL), 1)
+
+    def test_multiple_maven_blocks(self):
+        body = 'maven { url = uri("https://a/r") }\n maven { url = uri("https://b/r") }'
+        urls = _urls(server._parse_gradle_repos(body))
+        self.assertEqual(urls, ["https://a/r", "https://b/r"])
+
+
+class TestParseMavenRepos(unittest.TestCase):
+    def test_dual_container_separation(self):
+        pom = """
+        <project>
+          <repositories>
+            <repository><id>central-mirror</id><url>https://dep/r</url></repository>
+          </repositories>
+          <pluginRepositories>
+            <pluginRepository><id>plug</id><url>https://plug/r</url></pluginRepository>
+          </pluginRepositories>
+        </project>
+        """
+        deps, plugins = server._parse_maven_repos(pom)
+        self.assertEqual(_urls(deps), ["https://dep/r"])
+        self.assertEqual(deps[0]["name"], "central-mirror")
+        self.assertEqual(_urls(plugins), ["https://plug/r"])
+
+    def test_url_name_fallback(self):
+        pom = "<repositories><repository><url>https://noid/r</url></repository></repositories>"
+        deps, _plugins = server._parse_maven_repos(pom)
+        self.assertEqual(deps[0]["name"], "https://noid/r")
+
+    def test_empty_pom(self):
+        deps, plugins = server._parse_maven_repos("<project></project>")
+        self.assertEqual(deps, [])
+        self.assertEqual(plugins, [])
+
+
+class TestDiscoverRepositories(unittest.TestCase):
+    def _discover(self, files):
+        with tempfile.TemporaryDirectory() as root:
+            for rel, content in files.items():
+                with open(os.path.join(root, rel), "w", encoding="utf-8") as fh:
+                    fh.write(content)
+            return server.discover_repositories(root)
+
+    def test_2x2_no_leak_settings(self):
+        settings = (
+            'pluginManagement { repositories { maven("https://X/r") } }\n'
+            'dependencyResolutionManagement { repositories { maven("https://Y/r") } }'
+        )
+        res = self._discover({"settings.gradle": settings})
+        plugin_urls = _urls(res["plugin"])
+        dep_urls = _urls(res["dependency"])
+        self.assertIn("https://X/r", plugin_urls)
+        self.assertNotIn("https://X/r", dep_urls)
+        self.assertIn("https://Y/r", dep_urls)
+        self.assertNotIn("https://Y/r", plugin_urls)
+
+    def test_buildscript_vs_bare_repositories(self):
+        build = (
+            'buildscript { repositories { maven("https://A/r") } }\n'
+            'repositories { maven("https://B/r") }'
+        )
+        res = self._discover({"build.gradle": build})
+        plugin_urls = _urls(res["plugin"])
+        dep_urls = _urls(res["dependency"])
+        self.assertEqual(plugin_urls, ["https://A/r"])
+        self.assertEqual(dep_urls, ["https://B/r"])
+
+    def test_scope_tag_present(self):
+        res = self._discover({"build.gradle": 'repositories { mavenCentral() }'})
+        self.assertEqual(res["dependency"][0]["scope"], "dependency")
+
+    def test_maven_dual_container(self):
+        pom = (
+            "<project>"
+            "<repositories><repository><url>https://dep/r</url></repository></repositories>"
+            "<pluginRepositories><pluginRepository><url>https://plug/r</url>"
+            "</pluginRepository></pluginRepositories>"
+            "</project>"
+        )
+        res = self._discover({"pom.xml": pom})
+        self.assertEqual(_urls(res["dependency"]), ["https://dep/r"])
+        self.assertEqual(_urls(res["plugin"]), ["https://plug/r"])
+
+    def test_empty_dir(self):
+        res = self._discover({})
+        self.assertEqual(res["dependency"], [])
+        self.assertEqual(res["plugin"], [])
+
+    def test_gradle_wins_over_pom(self):
+        files = {
+            "settings.gradle": 'dependencyResolutionManagement { repositories { maven("https://G/r") } }',
+            "pom.xml": "<repositories><repository><url>https://P/r</url></repository></repositories>",
+        }
+        res = self._discover(files)
+        dep_urls = _urls(res["dependency"])
+        self.assertIn("https://G/r", dep_urls)
+        self.assertNotIn("https://P/r", dep_urls)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/maven-mcp/tests/test_resolution.py
+++ b/plugins/maven-mcp/tests/test_resolution.py
@@ -1,0 +1,290 @@
+"""Project-first scoped resolution + cross-repo metadata merge (T-4 / T-5).
+
+These tests are NET-NEW (no retired TS counterpart): they exercise the
+project-aware resolution layer added for #310 (custom/private repos) and #311
+(cross-repo version merge).
+
+Network is mocked by patching ``urllib.request.urlopen``; build files are written
+into a real ``TemporaryDirectory`` (via ``temp_project``) and a
+``ResolutionContext`` is built from that path with ``build_resolution_context``,
+so the discovery + routing path is exercised end-to-end. Each test is
+falsifiable: it asserts which repo URLs reach urlopen (and, for #310, that Maven
+Central is ABSENT) or the exact merged version set / raised message.
+"""
+
+import os
+import unittest
+import unittest.mock
+
+from _helpers import server, mock_urlopen, http_error, temp_project
+
+
+CUSTOM_URL = "https://nexus.example.com/m2"
+REPO_A = "https://repo-a.example/m2"
+REPO_B = "https://repo-b.example/m2"
+PLUGIN_URL = "https://plugins.example.com/m2"
+
+
+def _meta(versions, last_updated=None):
+    """maven-metadata.xml bytes with the given version list (+ optional
+    lastUpdated). The parser only reads <version> / <lastUpdated>."""
+    vers = "".join(f"<version>{v}</version>" for v in versions)
+    lu = f"<lastUpdated>{last_updated}</lastUpdated>" if last_updated else ""
+    xml = f"<metadata><versioning>{lu}<versions>{vers}</versions></versioning></metadata>"
+    return xml.encode("utf-8")
+
+
+def _settings(repos_body, container="dependencyResolutionManagement"):
+    """A settings.gradle.kts whose <container> declares the given repositories."""
+    return "%s { repositories { %s } }" % (container, repos_body)
+
+
+def _urls(mock):
+    return [c.args[0].full_url for c in mock.call_args_list]
+
+
+# ---------------------------------------------------------------------------
+# T-4 — project-first routing & fallback policy
+# ---------------------------------------------------------------------------
+class TestProjectFirstRouting(unittest.TestCase):
+    def test_310_custom_repo_queried_and_central_absent(self):
+        # #310: a project declaring a custom maven{url} repo routes there and
+        # Maven Central is NEVER queried.
+        files = {"settings.gradle.kts": _settings('maven { url = uri("%s") }' % CUSTOM_URL)}
+        with temp_project(files) as root:
+            ctx = server.build_resolution_context({"projectPath": root})
+        with unittest.mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen([(200, _meta(["1.0.0"]))])
+        ) as m:
+            result = server.fetch_metadata("com.acme", "lib", ctx)
+        self.assertEqual(result["versions"], ["1.0.0"])
+        urls = _urls(m)
+        self.assertTrue(any(u.startswith(CUSTOM_URL) for u in urls))
+        self.assertFalse(any(u.startswith(server.MAVEN_CENTRAL_URL) for u in urls))
+
+    def test_no_regression_mavenCentral_declared_resolves(self):
+        # A project declaring mavenCentral() still resolves via Central.
+        files = {"settings.gradle.kts": _settings("mavenCentral()")}
+        with temp_project(files) as root:
+            ctx = server.build_resolution_context({"projectPath": root})
+        with unittest.mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, _meta(["1.0.0", "2.0.0"]))]),
+        ) as m:
+            result = server.fetch_metadata("com.acme", "lib", ctx)
+        self.assertEqual(result["versions"], ["1.0.0", "2.0.0"])
+        self.assertTrue(any(u.startswith(server.MAVEN_CENTRAL_URL) for u in _urls(m)))
+
+    def test_no_build_file_falls_back_to_public(self):
+        # No build file -> empty scopes -> public fallback (Maven Central).
+        with temp_project({"README.md": "no build files"}) as root:
+            ctx = server.build_resolution_context({"projectPath": root})
+        repos = server._repos_for("com.acme", "lib", ctx)
+        self.assertEqual([r["url"] for r in repos], [server.MAVEN_CENTRAL_URL])
+        self.assertTrue(all(r["is_public_fallback"] for r in repos))
+
+    def test_google_group_no_declaration_routes_to_google(self):
+        # No declaration + a Google-group coordinate -> the Google-Maven prefix
+        # heuristic is preserved in the public fallback.
+        with temp_project({"README.md": "x"}) as root:
+            ctx = server.build_resolution_context({"projectPath": root})
+        repos = server._repos_for("androidx.core", "core-ktx", ctx)
+        self.assertEqual(repos[0]["url"], server.GOOGLE_MAVEN_URL)
+        self.assertTrue(all(r["is_public_fallback"] for r in repos))
+
+    def test_toggle_on_appends_public_despite_declaration(self):
+        # MAVEN_MCP_PUBLIC_FALLBACK=on appends the public repos even when the
+        # project declares its own. A non-Central custom URL is used so the
+        # appended Central is a distinct entry (no dedup collapse).
+        files = {"settings.gradle.kts": _settings('maven { url = uri("%s") }' % CUSTOM_URL)}
+        with temp_project(files) as root:
+            with unittest.mock.patch.dict(
+                os.environ, {"MAVEN_MCP_PUBLIC_FALLBACK": "on"}
+            ):
+                ctx = server.build_resolution_context({"projectPath": root})
+        repos = server._repos_for("com.acme", "lib", ctx)
+        urls = [r["url"] for r in repos]
+        self.assertIn(CUSTOM_URL, urls)
+        self.assertIn(server.MAVEN_CENTRAL_URL, urls)
+        by_url = {r["url"]: r for r in repos}
+        self.assertFalse(by_url[CUSTOM_URL]["is_public_fallback"])
+        self.assertTrue(by_url[server.MAVEN_CENTRAL_URL]["is_public_fallback"])
+
+    def test_plugin_coord_routes_to_plugin_scope(self):
+        # A .gradle.plugin marker coord resolves against the pluginManagement repo.
+        files = {"settings.gradle.kts": _settings(
+            'maven { url = uri("%s") }' % PLUGIN_URL, container="pluginManagement"
+        )}
+        with temp_project(files) as root:
+            ctx = server.build_resolution_context({"projectPath": root})
+        repos = server._repos_for("com.acme", "com.acme.gradle.plugin", ctx)
+        self.assertEqual([r["url"] for r in repos], [PLUGIN_URL])
+        self.assertEqual(repos[0]["scope"], "plugin")
+        self.assertFalse(repos[0]["is_public_fallback"])
+
+    def test_library_coord_ignores_plugin_only_repo_and_falls_back(self):
+        # A pluginManagement-only project has an EMPTY dependency scope, so a
+        # library coord falls back to public rather than using the plugin repo.
+        files = {"settings.gradle.kts": _settings(
+            'maven { url = uri("%s") }' % PLUGIN_URL, container="pluginManagement"
+        )}
+        with temp_project(files) as root:
+            ctx = server.build_resolution_context({"projectPath": root})
+        repos = server._repos_for("com.acme", "lib", ctx)
+        self.assertEqual([r["url"] for r in repos], [server.MAVEN_CENTRAL_URL])
+        self.assertTrue(repos[0]["is_public_fallback"])
+
+    def test_build_file_present_but_scope_empty_falls_back(self):
+        # A build file with no repositories block -> empty scope -> public fallback.
+        with temp_project({"build.gradle.kts": 'plugins { id("x") }'}) as root:
+            ctx = server.build_resolution_context({"projectPath": root})
+        repos = server._repos_for("com.acme", "lib", ctx)
+        self.assertEqual([r["url"] for r in repos], [server.MAVEN_CENTRAL_URL])
+        self.assertTrue(repos[0]["is_public_fallback"])
+
+    def test_maven_local_only_does_not_count_and_falls_back(self):
+        # mavenLocal() is recorded with a file:// marker that is NOT HTTP-queryable,
+        # so a mavenLocal-only scope still falls back to public.
+        files = {"settings.gradle.kts": _settings("mavenLocal()")}
+        with temp_project(files) as root:
+            ctx = server.build_resolution_context({"projectPath": root})
+        repos = server._repos_for("com.acme", "lib", ctx)
+        self.assertEqual([r["url"] for r in repos], [server.MAVEN_CENTRAL_URL])
+        self.assertTrue(repos[0]["is_public_fallback"])
+
+
+# ---------------------------------------------------------------------------
+# T-5 — cross-repo metadata merge (#311), raise-contract preserved
+# ---------------------------------------------------------------------------
+class TestMetadataMerge(unittest.TestCase):
+    def _two_repo_ctx(self):
+        body = ('maven { url = uri("%s") }; maven { url = uri("%s") }' % (REPO_A, REPO_B))
+        with temp_project({"settings.gradle.kts": _settings(body)}) as root:
+            return server.build_resolution_context({"projectPath": root})
+
+    def test_merges_two_repos_latest_is_highest(self):
+        # A[1.0,2.0] + B[3.0] -> merged latest 3.0 (#311).
+        ctx = self._two_repo_ctx()
+        responses = [(200, _meta(["1.0.0", "2.0.0"])), (200, _meta(["3.0.0"]))]
+        with unittest.mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen(responses)
+        ) as m:
+            result = server.fetch_metadata("com.acme", "lib", ctx)
+        self.assertEqual(result["versions"], ["1.0.0", "2.0.0", "3.0.0"])
+        self.assertEqual(result["latest"], "3.0.0")
+        self.assertEqual(m.call_count, 2)
+
+    def test_single_repo_versions_and_lastupdated_unchanged(self):
+        files = {"settings.gradle.kts": _settings('maven { url = uri("%s") }' % CUSTOM_URL)}
+        with temp_project(files) as root:
+            ctx = server.build_resolution_context({"projectPath": root})
+        with unittest.mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, _meta(["1.0.0", "2.0.0"], "20240101000000"))]),
+        ):
+            result = server.fetch_metadata("com.acme", "lib", ctx)
+        self.assertEqual(result["versions"], ["1.0.0", "2.0.0"])
+        self.assertEqual(result["lastUpdated"], "20240101000000")
+
+    def test_one_repo_404_other_200_no_raise(self):
+        # A 404 + B 200 -> B's versions, no raise.
+        ctx = self._two_repo_ctx()
+        responses = [http_error(REPO_A, 404, "Not Found"), (200, _meta(["3.0.0"]))]
+        with unittest.mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen(responses)
+        ) as m:
+            result = server.fetch_metadata("com.acme", "lib", ctx)
+        self.assertEqual(result["versions"], ["3.0.0"])
+        self.assertEqual(m.call_count, 2)
+
+    def test_overlapping_versions_deduped(self):
+        ctx = self._two_repo_ctx()
+        responses = [(200, _meta(["1.0.0", "2.0.0"])), (200, _meta(["2.0.0", "3.0.0"]))]
+        with unittest.mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen(responses)
+        ):
+            result = server.fetch_metadata("com.acme", "lib", ctx)
+        self.assertEqual(result["versions"], ["1.0.0", "2.0.0", "3.0.0"])
+
+    def test_snapshot_repo_plus_release_repo_release_is_stable(self):
+        # A SNAPSHOT-only repo merged with a release repo: `release` is the stable
+        # one, never the -SNAPSHOT.
+        ctx = self._two_repo_ctx()
+        responses = [(200, _meta(["2.0.0-SNAPSHOT"])), (200, _meta(["1.5.0"]))]
+        with unittest.mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen(responses)
+        ):
+            result = server.fetch_metadata("com.acme", "lib", ctx)
+        self.assertEqual(result["release"], "1.5.0")
+        self.assertEqual(result["latest"], "1.5.0")
+
+    def test_merged_lastupdated_is_most_recent(self):
+        # Both timestamps use the full yyyyMMddHHmmss form so MAX is unambiguous.
+        ctx = self._two_repo_ctx()
+        responses = [
+            (200, _meta(["1.0.0"], "20240101000000")),
+            (200, _meta(["3.0.0"], "20250601000000")),
+        ]
+        with unittest.mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen(responses)
+        ):
+            result = server.fetch_metadata("com.acme", "lib", ctx)
+        self.assertEqual(result["lastUpdated"], "20250601000000")
+
+    def test_all_repos_404_raises_same_message(self):
+        # All-404 path -> ValueError with the same message string as legacy code
+        # (distinct from #263, which is the all-200-no-newer guard in the handler).
+        ctx = self._two_repo_ctx()
+        responses = [http_error(REPO_A, 404, "x"), http_error(REPO_B, 404, "x")]
+        with unittest.mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen(responses)
+        ):
+            with self.assertRaises(ValueError) as cm:
+                server.fetch_metadata("com.acme", "lib", ctx)
+        self.assertTrue(str(cm.exception).startswith("Could not fetch metadata for com.acme:lib"))
+
+
+# ---------------------------------------------------------------------------
+# T-6 — handlers build ctx from projectPath and thread it down
+# ---------------------------------------------------------------------------
+class TestHandlerThreading(unittest.TestCase):
+    def test_check_version_exists_routes_to_declared_repo_only(self):
+        # check_version_exists with a custom-repo-only project routes to the
+        # declared repo; Maven Central is not queried.
+        files = {"settings.gradle.kts": _settings('maven { url = uri("%s") }' % CUSTOM_URL)}
+        with temp_project(files) as root:
+            with unittest.mock.patch(
+                "urllib.request.urlopen",
+                side_effect=mock_urlopen([(200, _meta(["1.0.0", "2.0.0"]))]),
+            ) as m:
+                out = server.handle_check_version_exists({
+                    "groupId": "com.acme", "artifactId": "lib", "version": "2.0.0",
+                    "projectPath": root,
+                })
+        self.assertTrue(out["exists"])
+        self.assertEqual(out["repository"], CUSTOM_URL)
+        self.assertFalse(any(u.startswith(server.MAVEN_CENTRAL_URL) for u in _urls(m)))
+
+    def test_get_dependency_health_single_repo_preserves_last_published(self):
+        # get_dependency_health single-repo -> lastPublishedToMaven carries the
+        # merged metadata's lastUpdated. POM 404 (com.acme is not guessable), so
+        # the chain stops after metadata + pom with no further network.
+        files = {"settings.gradle.kts": _settings('maven { url = uri("%s") }' % CUSTOM_URL)}
+        responses = [
+            (200, _meta(["1.0.0"], "20240515000000")),
+            http_error(CUSTOM_URL, 404, "Not Found"),  # POM
+        ]
+        with temp_project(files) as root:
+            with unittest.mock.patch(
+                "urllib.request.urlopen", side_effect=mock_urlopen(responses)
+            ):
+                out = server.handle_get_dependency_health({
+                    "dependencies": [{"groupId": "com.acme", "artifactId": "lib"}],
+                    "projectPath": root,
+                })
+        result = out["results"][0]
+        self.assertEqual(result["lastPublishedToMaven"], "20240515000000")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

The repository-resolution layer for epic #293. Fixes two shipped correctness bugs and lays the project-first foundation the rest of #293 builds on.

Plan: `docs/plans/maven-repo-resolution/plan.md` (2-cycle multiexpert-review: build-engineer / architecture / pr-test-analyzer).

## Fixes (correctness)
- **#310** — the Python port had NO build-file repository discovery (`_repos_for` was static group-prefix routing); custom/private repos (`maven { url … }`, Maven `<repositories>`, Nexus/Artifactory/JitPack) were invisible → wrong answers. Now discovered and queried.
- **#311** — `fetch_metadata` returned the FIRST repo's metadata; now MERGES versions (union + dedup + sort) across all resolved repos → correct "latest" for multi-repo artifacts.

## Core of #299 (partial — see below)
- Project-first, coordinate-kind-scoped resolution: declared repos (Gradle `repositories{}`/`pluginManagement{}`/`buildscript{}`/`dependencyResolutionManagement{}`, Maven `<repositories>`/`<pluginRepositories>`) used first, scoped (plugin vs dependency); public well-known repos demoted to fallback (used only when the scope declares none, or `MAVEN_MCP_PUBLIC_FALLBACK=on`). Google-Maven group heuristic preserved in the fallback path.
- New `projectPath` optional arg on the resolution tools (defaults to cwd); `ResolutionContext` resolves policy + repos once at the handler boundary and threads it (required) through every resolver.

## Implementation notes
- Hand-written brace-depth scanner (`_extract_block`) for block/`maven{}` extraction (regex can't balance nested `{}`; handles `maven { credentials{} url … }`, the private-repo case). XML stays regex-based (no XML-parser dependency).
- `fetch_metadata` keeps its `raise`-on-no-match contract and carries merged `lastUpdated` (health reads it).

## Tests
254 green (was 211): +25 discovery (`test_repo_discovery.py`, incl. the 2×2 plugin/dependency no-leak crux + url-after-credentials), +18 resolution (`test_resolution.py`, incl. #310 Central-absent, no-regression for `mavenCentral()`, merge/partial-failure/dedup/SNAPSHOT-vs-release/lastUpdated). Baseline `TestReposFor` updated to the rich-entry shape; the old first-hit test rewritten to assert the merge. L5: public `get_latest_version` works; an explicit `maven{url}` declared repo resolves gson end-to-end.

## #299 is PARTIAL (not auto-closed)
This PR delivers discovery + project-first scoping + merge. Deferred to follow-ups: provenance reporting #317, Gradle `repositoriesMode` #318, Maven parent-POM/profile inheritance #319, content/group filtering #320. Documented limitations in plugin CLAUDE.md.

Closes #310
Closes #311