### PR TITLE
Close Gradle parser coverage gaps and fix datetime.utcnow()

### DIFF
--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -680,7 +680,12 @@ def _months_since(iso: Optional[str]) -> Optional[int]:
     try:
         import datetime
         dt = _parse_iso(iso)
-        now = datetime.datetime.utcnow()
+        # datetime.utcnow() is deprecated on Python 3.12+; now(timezone.utc) is the
+        # replacement. tzinfo is stripped so `now` stays offset-naive: `dt` is forced
+        # naive just below, and subtracting a naive from an aware datetime raises
+        # TypeError. The wall-clock UTC value is identical to the old utcnow(), so the
+        # months delta is unchanged.
+        now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         # Make both offset-naive for comparison
         if hasattr(dt, 'utcoffset') and dt.utcoffset() is not None:
             dt = dt.replace(tzinfo=None)
@@ -1058,6 +1063,21 @@ def _parse_gradle_deps(content: str, source_file: str) -> List[Dict]:
     return deps
 
 
+# Gradle `kotlin("X")` shorthand expands to the `org.jetbrains.kotlin.X` plugin
+# id. Well-known shorthands are mapped explicitly; any other arg falls back to
+# the generic `org.jetbrains.kotlin.<arg>` form.
+_KOTLIN_SHORTHAND_MAP = {
+    "jvm": "org.jetbrains.kotlin.jvm",
+    "android": "org.jetbrains.kotlin.android",
+    "kapt": "org.jetbrains.kotlin.kapt",
+    "plugin.serialization": "org.jetbrains.kotlin.plugin.serialization",
+    "multiplatform": "org.jetbrains.kotlin.multiplatform",
+    "plugin.compose": "org.jetbrains.kotlin.plugin.compose",
+    "native.cocoapods": "org.jetbrains.kotlin.native.cocoapods",
+    "plugin.parcelize": "org.jetbrains.kotlin.plugin.parcelize",
+}
+
+
 def _parse_gradle_plugins_block(content: str, is_settings: bool = False) -> List[Dict]:
     """Parse plugins {} DSL blocks. Returns list of {pluginId, version, catalogRef}."""
     results = []
@@ -1065,10 +1085,22 @@ def _parse_gradle_plugins_block(content: str, is_settings: bool = False) -> List
     plugins_re = re.compile(r'\bplugins\s*\{([^}]*)\}', re.DOTALL)
     for block_m in plugins_re.finditer(content):
         block = block_m.group(1)
-        # id("plugin.id") version "1.0"
+        # id("plugin.id") version "1.0" — Kotlin/Groovy DSL with parentheses.
         id_ver_re = re.compile(r'\bid\s*\(\s*["\']([^"\']+)["\']\s*\)(?:\s+version\s+["\']([^"\']+)["\'])?')
         for m in id_ver_re.finditer(block):
             results.append({"pluginId": m.group(1), "version": m.group(2), "catalogRef": None, "settingsBlock": is_settings})
+        # id 'plugin.id' version '1.0' — Groovy DSL without parentheses (space
+        # separator). `\s+` after `id` excludes the parenthesised form above, so
+        # no declaration is matched twice.
+        id_noparen_re = re.compile(r'\bid\s+["\']([^"\']+)["\'](?:\s+version\s+["\']([^"\']+)["\'])?')
+        for m in id_noparen_re.finditer(block):
+            results.append({"pluginId": m.group(1), "version": m.group(2), "catalogRef": None, "settingsBlock": is_settings})
+        # kotlin("jvm") version "1.9.0" — shorthand mapped to org.jetbrains.kotlin.<arg>.
+        kotlin_re = re.compile(r'\bkotlin\s*\(\s*["\']([^"\']+)["\']\s*\)(?:\s+version\s+["\']([^"\']+)["\'])?')
+        for m in kotlin_re.finditer(block):
+            arg = m.group(1)
+            plugin_id = _KOTLIN_SHORTHAND_MAP.get(arg, f"org.jetbrains.kotlin.{arg}")
+            results.append({"pluginId": plugin_id, "version": m.group(2), "catalogRef": None, "settingsBlock": is_settings})
         # alias(libs.plugins.foo)
         alias_re = re.compile(r'\balias\s*\(\s*([a-zA-Z_][a-zA-Z0-9_]*)\.plugins\.([a-zA-Z0-9.]+)\s*\)')
         for m in alias_re.finditer(block):
@@ -1104,9 +1136,19 @@ def _parse_settings_catalogs(content: str) -> List[Dict]:
     vc_re = re.compile(r'\bversionCatalogs\s*\{([\s\S]*?)\}(?=\s*\}|\s*$)', re.DOTALL)
     for vc_m in vc_re.finditer(content):
         block = vc_m.group(1)
-        # name { from(files("path")) }
+        # Groovy DSL: name { from(files("path")) }
         entry_re = re.compile(r'(\w+)\s*\{[^}]*from\s*\(\s*files?\s*\(\s*"([^"]+)"\s*\)', re.DOTALL)
         for m in entry_re.finditer(block):
+            results.append({"name": m.group(1), "tomlPath": m.group(2)})
+        # Kotlin DSL: create("name") { from(files("path")) }. The `create(` literal
+        # is not matched by the Groovy `\w+\s*\{` form above, so the two never
+        # double-count. A bodyless create("name") with no from(files(...)) yields
+        # no descriptor — scan_project() then supplies the default libs catalog.
+        create_re = re.compile(
+            r'create\s*\(\s*["\']([^"\']+)["\']\s*\)\s*\{[^}]*from\s*\(\s*files?\s*\(\s*["\']([^"\']+)["\']\s*\)',
+            re.DOTALL,
+        )
+        for m in create_re.finditer(block):
             results.append({"name": m.group(1), "tomlPath": m.group(2)})
     return results
 

--- a/plugins/maven-mcp/tests/test_parsers.py
+++ b/plugins/maven-mcp/tests/test_parsers.py
@@ -14,11 +14,12 @@ Python-vs-TS behavioral differences (documented inline and in test comments):
   1. _parse_settings_catalogs returns [] for absent/empty versionCatalogs block;
      the TS parseSettingsCatalogs returns a default libs descriptor. The fallback
      is handled in scan_project(), not in the parser function itself.
-  2. _parse_settings_catalogs uses old-style Groovy block syntax
-     `name { from(files("...")) }` and does NOT parse Kotlin DSL
-     `create("name") { from(files("...")) }`.
-  3. _parse_gradle_plugins_block has no kotlin("shorthand") support
-     (TS plugins-block-parser handles kotlin("jvm") etc.; Python does not).
+  2. _parse_settings_catalogs parses both old-style Groovy block syntax
+     `name { from(files("...")) }` and Kotlin DSL
+     `create("name") { from(files("...")) }` (gap closed in #313).
+  3. _parse_gradle_plugins_block supports the `kotlin("jvm")` shorthand (mapped to
+     org.jetbrains.kotlin.jvm) and the no-paren Groovy `id 'x'` form (gap closed
+     in #313).
   4. _parse_gradle_deps return dicts have no "source" key; the source is
      attached by scan_project(). TS parseGradleDependencies includes source
      directly.
@@ -27,7 +28,9 @@ Python-vs-TS behavioral differences (documented inline and in test comments):
      TS module are skipped (divergence guardrail #5).
 """
 
+import datetime
 import unittest
+import warnings
 
 from _helpers import server, temp_project
 
@@ -284,23 +287,50 @@ class TestParseGradlePluginsBlock(unittest.TestCase):
         self.assertEqual(result[0]["pluginId"], "com.example.plugin")
         self.assertEqual(result[0]["version"], "1.0")
 
-    # Python-specific: Groovy space-style `id 'plugin' version '1.0'` (no parens) is NOT parsed.
-    # TS plugins-block-parser handles both Groovy and Kotlin DSL id() forms.
-    def test_groovy_space_style_without_parens_not_parsed(self):
+    # Groovy space-style `id 'plugin' version '1.0'` (no parens) — gap closed in #313.
+    # Mirrors: plugins-block-parser.test.ts > Groovy DSL without parens.
+    def test_groovy_space_style_without_parens_with_version(self):
         content = "plugins {\n    id 'com.example.plugin' version '1.0'\n}"
         result = server._parse_gradle_plugins_block(content)
-        # Python does not parse id without parentheses — result is empty.
-        self.assertEqual(result, [])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["pluginId"], "com.example.plugin")
+        self.assertEqual(result[0]["version"], "1.0")
 
-    # NOTE: Python does NOT support kotlin("jvm") shorthand notation.
-    # TS plugins-block-parser handles kotlin("jvm") version "2.0.0"
-    # -> { pluginId: "org.jetbrains.kotlin.jvm", version: "2.0.0" }.
-    # Python returns no entry for kotlin("jvm") in the plugins block.
-    def test_kotlin_shorthand_not_supported_in_python(self):
+    # No-paren `id 'x'` (single quote) and `id "x"` (double quote) without version.
+    def test_groovy_space_style_without_parens_no_version(self):
+        single = server._parse_gradle_plugins_block("plugins {\n    id 'com.example.a'\n}")
+        self.assertEqual(len(single), 1)
+        self.assertEqual(single[0]["pluginId"], "com.example.a")
+        self.assertIsNone(single[0]["version"])
+        double = server._parse_gradle_plugins_block('plugins {\n    id "com.example.b"\n}')
+        self.assertEqual(len(double), 1)
+        self.assertEqual(double[0]["pluginId"], "com.example.b")
+        self.assertIsNone(double[0]["version"])
+
+    # kotlin("jvm") shorthand — gap closed in #313. Maps to org.jetbrains.kotlin.jvm.
+    # Mirrors: plugins-block-parser.test.ts > kotlin() shorthand.
+    def test_kotlin_shorthand_jvm(self):
         content = 'plugins {\n    kotlin("jvm") version "2.0.0"\n}'
         result = server._parse_gradle_plugins_block(content)
-        # Python does not parse kotlin() shorthand — result is empty.
-        self.assertEqual(result, [])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["pluginId"], "org.jetbrains.kotlin.jvm")
+        self.assertEqual(result[0]["version"], "2.0.0")
+
+    # kotlin("plugin.serialization") version "1.9.0" — dotted shorthand with version.
+    def test_kotlin_shorthand_plugin_serialization_with_version(self):
+        content = 'plugins {\n    kotlin("plugin.serialization") version "1.9.0"\n}'
+        result = server._parse_gradle_plugins_block(content)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["pluginId"], "org.jetbrains.kotlin.plugin.serialization")
+        self.assertEqual(result[0]["version"], "1.9.0")
+
+    # kotlin("X") with no version, and an unknown arg falling back to the generic form.
+    def test_kotlin_shorthand_no_version_and_generic_fallback(self):
+        content = 'plugins {\n    kotlin("android")\n    kotlin("foo.bar")\n}'
+        result = server._parse_gradle_plugins_block(content)
+        ids = {r["pluginId"]: r["version"] for r in result}
+        self.assertIsNone(ids["org.jetbrains.kotlin.android"])
+        self.assertIn("org.jetbrains.kotlin.foo.bar", ids)
 
 
 # ---------------------------------------------------------------------------
@@ -461,10 +491,9 @@ class TestParseSettingsCatalogs(unittest.TestCase):
         self.assertEqual(names["libs"], "gradle/libs.versions.toml")
         self.assertEqual(names["testLibs"], "gradle/test.versions.toml")
 
-    # NOTE: Python does NOT parse Kotlin DSL create("name") syntax.
-    # Mirrors: settings-catalogs-parser.test.ts > "parses Kotlin DSL versionCatalogs with create block"
-    # but asserts the ACTUAL Python behavior (empty), not TS behavior.
-    def test_kotlin_dsl_create_syntax_not_parsed_by_python(self):
+    # Kotlin DSL create("name") syntax — gap closed in #313.
+    # Mirrors: settings-catalogs-parser.test.ts > "parses Kotlin DSL versionCatalogs with create block".
+    def test_kotlin_dsl_create_syntax(self):
         content = (
             'dependencyResolutionManagement {\n'
             '  versionCatalogs {\n'
@@ -475,9 +504,52 @@ class TestParseSettingsCatalogs(unittest.TestCase):
             '}'
         )
         result = server._parse_settings_catalogs(content)
-        # Python does not parse create("name") DSL — returns [].
-        # TS would return [{name:"libs",...}, {name:"testLibs",...}].
+        self.assertEqual(result, [{"name": "testLibs", "tomlPath": "gradle/test.versions.toml"}])
+
+    # Kotlin DSL create("libs") { from(files(...)) } — explicit default-named catalog.
+    def test_kotlin_dsl_create_libs_with_body(self):
+        content = (
+            'dependencyResolutionManagement {\n'
+            '  versionCatalogs {\n'
+            '    create("libs") {\n'
+            '      from(files("gradle/libs.versions.toml"))\n'
+            '    }\n'
+            '  }\n'
+            '}'
+        )
+        result = server._parse_settings_catalogs(content)
+        self.assertEqual(result, [{"name": "libs", "tomlPath": "gradle/libs.versions.toml"}])
+
+    # create("libs") with no body / no from(files(...)) yields no descriptor — the
+    # parser only emits catalogs with a resolved tomlPath; scan_project() supplies
+    # the implicit default libs catalog (same convention as the empty-block case).
+    def test_kotlin_dsl_create_no_body_returns_empty(self):
+        content = (
+            'dependencyResolutionManagement {\n'
+            '  versionCatalogs {\n'
+            '    create("libs")\n'
+            '  }\n'
+            '}'
+        )
+        result = server._parse_settings_catalogs(content)
         self.assertEqual(result, [])
+
+    # Groovy `name { from(files(...)) }` still works alongside the new create() form.
+    def test_groovy_and_kotlin_dsl_mixed(self):
+        content = (
+            'versionCatalogs {\n'
+            '  libs {\n'
+            '    from(files("gradle/libs.versions.toml"))\n'
+            '  }\n'
+            '  create("testLibs") {\n'
+            '    from(files("gradle/test.versions.toml"))\n'
+            '  }\n'
+            '}'
+        )
+        result = server._parse_settings_catalogs(content)
+        names = {r["name"]: r["tomlPath"] for r in result}
+        self.assertEqual(names["libs"], "gradle/libs.versions.toml")
+        self.assertEqual(names["testLibs"], "gradle/test.versions.toml")
 
 
 # ---------------------------------------------------------------------------
@@ -1166,6 +1238,50 @@ class TestScanProjectMaven(unittest.TestCase):
             result = server.scan_project(root)
         self.assertEqual(result["buildSystem"], "unknown")
         self.assertEqual(result["dependencies"], [])
+
+
+# ---------------------------------------------------------------------------
+# _months_since — datetime.utcnow() deprecation (gap closed in #313)
+# ---------------------------------------------------------------------------
+
+class TestMonthsSince(unittest.TestCase):
+    """Tests for server._months_since after the utcnow() -> now(timezone.utc)
+    migration. The 3.13 CI leg promotes DeprecationWarning, so utcnow() must be
+    gone, and the naive-UTC arithmetic semantics must be preserved exactly."""
+
+    # The removed utcnow() emitted a DeprecationWarning on Python 3.12+; with the
+    # warning promoted to an error, any residual utcnow() call would raise here.
+    def test_no_deprecation_warning(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            iso = "2020-01-01T00:00:00Z"
+            result = server._months_since(iso)
+        self.assertIsInstance(result, int)
+        self.assertGreater(result, 0)
+
+    # Semantics unchanged: the result is the integer-month delta between the
+    # current naive-UTC clock and the parsed timestamp, identical to the old
+    # utcnow()-based computation. Cross-check against an independent naive-UTC
+    # reference using the same formula.
+    def test_output_matches_naive_utc_reference(self):
+        iso = "2021-06-15T12:00:00Z"
+        result = server._months_since(iso)
+        ref_now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        ref_dt = datetime.datetime(2021, 6, 15, 12, 0, 0)
+        expected = int((ref_now - ref_dt).days / 30)
+        # Allow a 1-month tolerance for clock advance between the two reads.
+        self.assertLessEqual(abs(result - expected), 1)
+
+    # A recent timestamp yields a 0-month delta (not negative, not a crash).
+    def test_recent_timestamp_returns_zero(self):
+        recent = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        iso = recent.strftime("%Y-%m-%dT%H:%M:%SZ")
+        self.assertEqual(server._months_since(iso), 0)
+
+    # None / unparseable input degrades to None (unchanged contract).
+    def test_none_and_invalid_input(self):
+        self.assertIsNone(server._months_since(None))
+        self.assertIsNone(server._months_since("not-a-date"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Restores Gradle parsing behaviors silently dropped in the #302 TS→Python port (surfaced while porting parser tests).

## Changes (`plugins/maven-mcp/plugin/server/server.py`)
- **`_parse_gradle_plugins_block`** — `kotlin("X")` shorthand now expands to `org.jetbrains.kotlin.X` (8 well-known shorthands mapped explicitly, generic fallback for the rest); the no-paren Groovy `id 'x' version '1.0'` form is now parsed. The `\bid\s+["']` regex excludes the parenthesised `id(...)` form, so no declaration is double-counted.
- **`_parse_settings_catalogs`** — Kotlin DSL `create("name") { from(files("...")) }` is now discovered alongside the existing Groovy `name { ... }` form.
- **`_months_since`** — deprecated `datetime.utcnow()` → `now(timezone.utc).replace(tzinfo=None)` (identical offset-naive UTC value; the result feeds arithmetic, not serialization, so output is unchanged). Clears the `DeprecationWarning` emitted under the 3.13 CI leg.

Regex patterns ported from the retired TS parsers (`plugins-block-parser.ts`, `settings-catalogs-parser.ts`), not reinvented.

## Tests
3 tests that asserted the old broken behavior flipped; new cases added for every syntax above plus a `DeprecationWarning`-as-error guard on `_months_since`. **292 tests, 0 failures, 0 DeprecationWarning** on Python 3.13/3.14; `validate.sh` rc=0.

## Out of scope (flagged for potential follow-up)
The retired TS catalog parser also handled the chained `create("name").from(files(...))` and Groovy no-paren `from files("...")` forms. The issue named only the block `create(...) { from(files(...)) }` form, so only that was ported.

Closes #313