### PR TITLE
Add PreToolUse write-time dependency guard hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,8 @@ jobs:
       # node build job provided).
       - if: steps.changes.outputs.maven_mcp == 'true'
         run: python -m compileall plugins/maven-mcp/plugin/server
+
+      # Shellcheck is preinstalled on ubuntu-latest.
+      - if: steps.changes.outputs.maven_mcp == 'true'
+        name: Shellcheck hooks
+        run: shellcheck plugins/maven-mcp/plugin/hooks/*.sh

--- a/docs/plans/maven-write-guard-hook/plan.md
+++ b/docs/plans/maven-write-guard-hook/plan.md
@@ -1,0 +1,247 @@
+---
+type: plan
+slug: maven-write-guard-hook
+date: 2026-06-30
+status: approved
+spec: none
+risk_areas:
+  - "hook hard-blocking edits on network/lookup failure (must fail-open)"
+  - "false-positive deny on a real coordinate (offline 'unknown' misread as absent)"
+  - "latency added to every build-file edit"
+  - "coordinate extraction misparsing build-file syntaxes"
+  - "shell→python invocation surface (quoting, untrusted file content)"
+review_verdict: PASS
+---
+
+# Plan: maven-mcp PreToolUse write-time guard hook (#283)
+
+## Context & Decision
+
+maven-mcp's only hook today is **PostToolUse** (`post-edit-deps.sh`): after a build file is edited it
+prints an advisory `{"systemMessage": "...run /check-deps"}`. Epic #281's thesis (Sonatype: *safety
+comes from real-time software intelligence, not a bigger model*) is that the valuable moment is
+**before** the coordinate lands. #283 adds a **PreToolUse** guard that intercepts `Edit|Write` on
+build files, verifies the coordinates being added, and — when one definitively does not exist or a
+pinned version carries a CRITICAL/HIGH CVE — returns a `deny` + reason so the agent self-corrects in
+the same turn. It must be **advisory and safe-by-default**: any uncertainty or failure (offline,
+rate-limited, parse miss, tool error) **fails open** (the edit proceeds).
+
+This consumes the already-shipped `verify_coordinates` (#282) and `get_dependency_vulnerabilities`
+tools; it adds **no new MCP tool**.
+
+## Technical Approach
+
+A new `command`-type PreToolUse hook script `pre-edit-deps.sh` (bash + jq, mirroring
+`post-edit-deps.sh`), registered in `hooks/hooks.json`. Flow:
+
+1. **Fast gate (no cost on unrelated edits).** Read stdin JSON once. If `tool_name` ∉
+   {`Edit`,`Write`,`MultiEdit`} → `exit 0`. `basename(tool_input.file_path)` must be in the
+   build-file allow-list (same as `post-edit-deps.sh`: `build.gradle[.kts]`, `settings.gradle[.kts]`,
+   `pom.xml`, `libs.versions.toml`) → else `exit 0`. If `jq` is absent → `exit 0` (no-op, like the
+   existing hook).
+2. **Extract candidate coordinates from the NEW content only** — `tool_input.new_string` (Edit),
+   `tool_input.content` (Write), or the concatenation of `tool_input.edits[].new_string`
+   (MultiEdit). This is a **recall-limited best-effort heuristic**, NOT a robust parser: a missed
+   coordinate just means the guard does not fire on it (fail-open, never a wrong block), so the bar
+   is "cheap superset filter feeding a fail-open verifier," not "match the server's Python parsers."
+   PreToolUse fires *before* the edit, so the script only sees the new *fragment* (which for an Edit
+   may be a partial block) — extraction therefore favors **fragment-safe single-token forms**:
+   - **Gradle** (`build.gradle[.kts]`): string-notation `"group:artifact:version"` /
+     `'group:artifact:version'` (self-contained token; fragment-safe).
+   - **TOML** (`libs.versions.toml`): `[libraries]` `module = "g:a"` (single line; fragment-safe).
+     `version.ref` and inline `version` are best-effort; a `version.ref` (or any non-literal version)
+     resolves to **GA-only** (no concrete version) rather than reaching for an associative-array
+     lookup (see bash-3.2 constraint below).
+   - **Maven** (`pom.xml`): a `<dependency>`/`<plugin>` block parsed only when the fragment/content
+     contains the full `<groupId>`+`<artifactId>` pair; a fragment changing only `<version>` yields
+     no GA → not extracted (acceptable: fail-open, the PostToolUse audit nudge still covers it).
+   - **Version sanitation:** if an extracted version contains `$` (Gradle `"g:a:$ver"` /
+     `"g:a:${libs.x}"`, Maven `${x}`) or is otherwise not a literal version token, **drop the
+     version → treat the coordinate as GA-only** (existence check, no CVE query). Enforce a coordinate
+     charset of `[A-Za-z0-9._-]` (defense-in-depth; reject anything else).
+   - De-duplicate; **cap at `MAX_COORDS = 8`** (interactive gate — keep the synchronous I/O small;
+     ARCH/devops perf concern). If zero coordinates parsed → `exit 0` (no python spawn).
+   - **bash-3.2 constraint** (macOS default `/bin/bash` is 3.2): NO `declare -A`, `${var,,}`,
+     `mapfile`/`readarray`; guard every array expansion as `"${arr[@]:-}"`. All constructs must run
+     on bash 3.2.
+3. **Verify (one bounded python invocation).** Build each JSON-RPC request with `jq -c -n --arg`
+   (NEVER string-interpolate file content); **omit** the `version` key for GA-only coords (do not
+   send `null`/`""`); pass `projectPath` only when stdin `.cwd` is non-empty. Send
+   `verify_coordinates` with `id:1` (all coords) and — **only when ≥1 versioned coord exists** —
+   `get_dependency_vulnerabilities` with `id:2` (`handle_get_dependency_vulnerabilities` does a hard
+   `args["dependencies"]`, so never send it an empty/absent list). Pipe the 1-or-2 request lines into
+   `<timeout-cmd> 8 python3 "${CLAUDE_PLUGIN_ROOT}/server/server.py"` (line-oriented stdio loop;
+   `tools/call` needs no `initialize`; reads to EOF). Resolve `<timeout-cmd>` as
+   `timeout` → `gtimeout` → none (darwin lacks `timeout`; without either, fail-open and skip rather
+   than risk a hung edit). **Scrub `GITHUB_TOKEN`** from the spawned env (neither tool uses it —
+   least privilege). Unwrap each response by **matching JSON-RPC `id`** (not line order) →
+   `.result.content[0].text | fromjson`; a response carrying `.error`, missing `.result`, or null
+   `.text` → treat as fail-open (that tool contributed nothing).
+4. **Decide** (assemble the decision in a variable; print once at the very end — see fail-open).
+   - **Actionable — existence:** `existenceStatus == "absent"` **AND** (`likelyHallucination == true`
+     OR non-empty `suggestions`). Never act on `exists` or `unknown`. **Bare `absent` (no
+     hallucination flag, no suggestion) must ALLOW** — a private/internal/androidx coordinate that
+     404s across all probed repos is `absent` without a Central suggestion; denying it would
+     false-block a legitimate private dependency. Consequence (documented limitation): the existence
+     guard is effectively **Maven-Central-scoped** — it does not catch a confidently-absent
+     non-Central coordinate. This is the *safe* direction (a miss is fail-open; denying on bare
+     `absent` would be a wrong block). An inline comment + CLAUDE.md must record this so a future
+     change does not "tighten" it.
+   - **Actionable — vulnerability:** a versioned coordinate with a `CRITICAL`/`HIGH` vulnerability.
+   - **Decision verbs differ by arm:** existence/hallucination → `permissionDecision: "deny"`
+     (a 404-everywhere coordinate would not resolve at build time anyway; near-perfect precision,
+     agent self-corrects from the reason). CVE → `permissionDecision: "ask"` (a real, resolvable,
+     possibly-deliberately-pinned version; a hard deny with no `fixedVersion` would dead-end the
+     user). Aggregate all findings into one decision (deny wins over ask if both present).
+   - **Reason JSON** built with `jq -n --arg` from KNOWN structured fields only — `groupId:artifactId
+     [:version]`, `severity`, `fixedVersion`, and for suggestions `groupId:artifactId` + `versionCount`
+     — **never** pass through arbitrary network-returned text. Phrase suggestions as **candidates to
+     verify, not an instruction to substitute** ("`g:a` not found in resolved repositories; if you
+     intended a real package, verify candidates before use: …") — `verify_coordinates` does not flag
+     typosquats-of-existing (#322), so an imperative "replace with X" could steer the agent to an
+     attacker-seeded near-name. The embedded **suggestion** coordinate (the one network-derived
+     string reaching the agent) is itself charset-filtered `[A-Za-z0-9._-]` and length-capped before
+     embedding (last sliver of untrusted-text-into-agent). For `Write` (whole-file content), the
+     reason **names the exact offending coordinate(s)** so the agent distinguishes a pre-existing bad
+     coord from the line it just edited.
+   - Otherwise → `exit 0` with **no stdout JSON** (normal permission flow = allow).
+5. **Fail-open is guaranteed structurally, not by `set -e`.** Only exit code **2** blocks a
+   PreToolUse tool call; `jq`/`grep` can exit 2 on usage/parse errors and `pipefail` propagates them,
+   so a stray failure under `set -euo pipefail` is a **fail-CLOSED** hazard (esp. the *envelope*
+   `jq` parsing stdin, and `jq` parsing empty/non-JSON python stdout). Therefore:
+   `trap 'exit 0' EXIT` immediately after `set -euo pipefail` (both allow and deny are exit-0, so the
+   trap is a clean fail-open net); wrap **every** external call so its failure routes to allow
+   (`out=$(… ) || out=""`, `coords=$(grep … || true)`); the script must be able to reach **only**
+   `exit 0` — never `exit 2`. Triggers that all map to allow: missing `jq`/`python3`/timeout-cmd;
+   non-zero/`timeout`(124) exit; **empty** stdout; **garbage** stdout; `.error`/missing-`.result`;
+   malformed/non-JSON **stdin**; any coordinate `existenceStatus == "unknown"` (degraded, *not*
+   clean — never gates, never swallowed-as-problem). The one stderr diagnostic line must never echo
+   env, the token, or raw file content (redaction rule).
+
+### Why a `command` hook (not `mcp_tool`)
+
+Claude Code also offers a `type: "mcp_tool"` hook that calls a connected server tool directly with
+`${tool_input.*}` placeholders. It does **not** fit here: `verify_coordinates` needs
+`{dependencies:[{groupId,artifactId,version}]}`, but `tool_input` carries raw file text
+(`new_string`/`content`). The coordinate **extraction/transformation** step has no home in an
+`mcp_tool` placeholder mapping, so a `command` hook that parses then calls the server is required.
+
+### Why the JSON-RPC pipe (not `python3 -c` direct import)
+
+Piping a `tools/call` line into `python3 server.py` reuses the **exact** interpreter+path the plugin
+already registers for the MCP server (`plugin.json` → `python3 ${CLAUDE_PLUGIN_ROOT}/server/server.py`)
+and depends only on the **public tool contract**, not internal handler names — robust to server
+refactors. Cost: output is double-encoded (`jq` twice). The `python3 -c "import server; ..."`
+alternative yields raw `{"results":...}` but couples the hook to internal function names and inline
+quoting; rejected for fragility.
+
+### Why parse coordinates in bash (not a server-side parse-from-text tool)
+
+The server already owns robust multi-syntax parsers (`_parse_gradle_deps`, `_parse_maven_deps`,
+`_parse_toml_catalog`). A clean alternative is a new server tool `extract_coordinates(fileType, text)`
+reusing them — but it is **rejected** for two reasons: (1) #283 explicitly scopes to "no new MCP
+tool"; (2) those parsers are **whole-file** parsers and PreToolUse only sees a *fragment*, so they
+would need fragment-tolerance work anyway. Because extraction is a recall-limited best-effort filter
+feeding a **fail-open** verifier (a miss = no guard, never a wrong block), a thin bash heuristic is an
+acceptable, deliberately-documented trade-off rather than a second robust parser. **Accepted
+limitation:** the bash heuristic and the Python parsers may diverge; the bash side only needs to be a
+superset *filter*, and its misses are safe.
+
+| Path | Change | Note |
+|---|---|---|
+| `plugins/maven-mcp/plugin/hooks/hooks.json` | modify | add a `PreToolUse` array (matcher `Edit|Write|MultiEdit`, `${CLAUDE_PLUGIN_ROOT}/hooks/pre-edit-deps.sh`, `timeout`) alongside the existing PostToolUse |
+| `plugins/maven-mcp/plugin/hooks/pre-edit-deps.sh` | add (git mode 100755) | the guard; bash-3.2-safe + jq; structurally fail-open; SHIPPED content → English |
+| `plugins/maven-mcp/tests/test_pre_edit_hook.py` | add | Python `unittest` running the hook as a subprocess against a **stub server** (no network); skips if `jq`/`timeout` absent |
+| `.github/workflows/ci.yml` | modify | add a `shellcheck plugins/maven-mcp/plugin/hooks/*.sh` step (shellcheck is preinstalled on `ubuntu-latest`) |
+| `plugins/maven-mcp/README.md` | modify | PreToolUse-guard subsection + GITHUB_TOKEN/offline/macOS-no-`timeout` degradation note (SHIPPED → English) |
+| `plugins/maven-mcp/CLAUDE.md` | modify | document the hook, the fail-open contract, and the Central-scope existence limitation (SHIPPED → English) |
+
+## Decisions Made
+
+1. **`command` hook + JSON-RPC pipe into `python3 server.py`** — robust, public-contract-only.
+   `mcp_tool`, `-c` import, and a server-side parse-from-text tool all rejected (see rationale above).
+2. **Fail-open is guaranteed structurally** — `trap 'exit 0' EXIT`, every external call wrapped to
+   route failure → allow, the script can only ever `exit 0` (never the block-triggering exit 2). Deny
+   only on a confident finding; every uncertainty/error/`unknown`/empty/garbage/malformed-stdin
+   allows. (SEC-1/DEVOPS-1/TEST-1 convergent critical.)
+3. **Decision verb by arm: `deny` for absent/hallucination, `ask` for CRITICAL/HIGH CVE.** Absent is
+   near-perfect precision (404-everywhere wouldn't build); CVE is a real, possibly-deliberate version
+   where a hard deny — especially with no `fixedVersion` — would dead-end the user. (SEC-4.)
+4. **Existence guard stays conservative: `absent AND (likelyHallucination OR suggestions)`.** Bare
+   `absent` ALLOWS (a private/internal/androidx coord 404s everywhere → `absent` with no Central
+   suggestion; denying it would false-block a real private dep). Documented consequence: the existence
+   guard is **Maven-Central-scoped**. This is the *safe direction* (a miss is fail-open; deny-on-bare-
+   absent is a wrong block). Inline comment + CLAUDE.md must forbid "tightening" it. (SEC-5 over ARCH-2.)
+5. **Only CRITICAL/HIGH CVEs gate** (→ `ask`); MEDIUM/LOW not surfaced. Full audit stays the
+   PostToolUse `/check-deps` nudge (kept — complementary, not folded).
+6. **Untrusted-content discipline:** both the inbound JSON-RPC request and the outbound
+   `permissionDecisionReason` are built with `jq -c -n --arg` from known structured fields only —
+   never string-interpolated, never passing arbitrary network text; coordinate charset
+   `[A-Za-z0-9._-]`. Suggestions are phrased as candidates-to-verify, not substitute-instructions
+   (anti-slopsquat, #322). `GITHUB_TOKEN` scrubbed from the spawned env. (SEC-2/SEC-3/SEC-7.)
+7. **bash-3.2-safe + bounded:** no bash-4 constructs (macOS default shell is 3.2); `MAX_COORDS = 8`;
+   inner `timeout 8` < `hooks.json` `"timeout": 12` so the script wins the race and fails open;
+   `timeout`→`gtimeout`→none fallback; `shellcheck` CI gate. (DEVOPS-2/3/4/5, ARCH-6.)
+8. **New content only**, recall-limited best-effort extraction. For `Write` (whole-file content) the
+   guard checks every coordinate present and the deny reason **names the exact offending one**; a
+   non-literal/`${…}` version is treated GA-only. (ARCH-1/ARCH-3/ARCH-4.)
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| **Accidental hard-block** (`set -e`/`pipefail` → exit 2; jq parse error on stdin or empty python stdout) | `trap 'exit 0' EXIT`; every external call wrapped `… || true`; script can only `exit 0`; tests for empty-stdout, garbage-stdout, malformed-stdin, JSON-RPC-error → all allow |
+| Hard-blocking edits when offline/rate-limited | fail-open on `unknown`/error/timeout(124)/missing-tool; deny only on confident finding |
+| False-positive deny on a real (esp. private/androidx) coordinate | never deny on `unknown`/`exists`/bare-`absent`; existence deny requires `likelyHallucination`/suggestion (Central-scoped, conservative) |
+| Latency on every build-file edit | fast gate exits before any python spawn; `MAX_COORDS=8`; inner `timeout 8`; no spawn when zero coords; single python invocation for both tools |
+| Misparsing / fragment / `${ver}` | best-effort heuristic, fail-open on miss; `${…}`/non-literal version → GA-only; charset-restricted |
+| Untrusted file content → shell/python/agent | requests AND reason built with `jq -n --arg` (never interpolated, never raw network text into the reason); coordinate charset `[A-Za-z0-9._-]`; `GITHUB_TOKEN` scrubbed from spawned env; stderr never echoes env/content/token |
+| Suggestion steers agent to attacker-seeded near-name (#322) | reason phrases suggestions as candidates-to-verify (non-imperative) + `versionCount`; never "replace with X" |
+| `timeout`/`gtimeout`/`python3`/`jq` absent (macOS) | detected → fail-open; guard silently no-ops (documented); `gtimeout` probed as fallback |
+| Guard silently never fires (wrong decision envelope) | tests assert full `hookSpecificOutput.hookEventName=="PreToolUse"` envelope, not just `permissionDecision` |
+
+## Verification & Sources
+
+- **Source of truth for "done":** this plan + issue #283's acceptance criteria (hallucinated coord →
+  surfaced, not silently allowed; known-CVE version → CVE+fix surfaced; network failure → fail-open;
+  only build files trigger). No separate spec. The CC PreToolUse contract
+  (`hookSpecificOutput.permissionDecision` `deny|allow|ask`, exit-0+JSON; exit-2+stderr alternative;
+  `tool_input` shapes for Edit/Write/MultiEdit) is the integration contract, verified against
+  code.claude.com/docs/en/hooks.md (2026-06-30).
+- **Testing strategy (pyramid):**
+  - **L0 Build:** `python3 -m compileall plugins/maven-mcp/plugin/server/server.py` (unchanged);
+    `bash -n pre-edit-deps.sh` syntax check; hook committed with git mode 100755 (validate.sh L6).
+  - **L1 Static:** `bash scripts/validate.sh` rc=0; CodeQL clean (tests: `import unittest.mock`+
+    qualified, no unused import, commented `except`); **`shellcheck` as a CI gate** on
+    `plugins/maven-mcp/plugin/hooks/*.sh` (preinstalled on ubuntu-latest; also lint `post-edit-deps.sh`).
+  - **L2 Unit/integration:** `test_pre_edit_hook.py` runs `pre-edit-deps.sh` as a subprocess with
+    crafted stdin and `CLAUDE_PLUGIN_ROOT` → a **fixture dir whose `server/server.py` is a stub** that
+    LOOPS over stdin to EOF (handles 1-or-2 requests), RECORDS the args it received (so extraction is
+    actually proven, not just the response consumed), and emits canned `id`-correlated JSON-RPC. Every
+    **allow**-case drops/asserts a "stub-invoked" marker (positive control vs vacuous pass), with stub
+    wiring byte-identical to a paired deny-case. Full case list in `tasks.md` — including the fail-open
+    paths (empty-stdout, garbage-stdout, malformed-stdin, JSON-RPC-error-envelope, python/jq/timeout
+    absent, `unknown`), the over-deny boundary (bare `absent`→allow), GA-only/`${ver}`→excluded-from-
+    vuln-args, full deny-envelope assertion, and a test that feeds the hook's **exact emitted JSON-RPC**
+    into the **real** `dispatch`/handlers (urlopen mocked) to catch hook↔server contract drift.
+  - **L5 manual smoke:** run the hook by hand with a hallucinated coord (`org.apache.commons:commons-lang:9.9.9`)
+    → `deny` JSON with a candidate suggestion; a real coord → allow; stub `unknown` → allow.
+- This is additive (a new hook); no before-state behavior to preserve. The new tests + the existing
+  334-test suite are the regression guard.
+
+## Out of Scope
+
+- New MCP tools or changes to `verify_coordinates`/`get_dependency_vulnerabilities` internals.
+- Compatibility-aware messages (H2 #285) — richer reasons later.
+- A true added-vs-removed coordinate diff (new-content scan is sufficient for hallucination/CVE).
+- Caching the guard's lookups across edits / a batch-level deadline (the #328 concern); the per-call
+  `timeout` + `MAX_COORDS` cap is the bound here.
+- Private-repo auth (H3 #290), plugin-marker→GAV (H3).
+
+## Open Questions
+
+_None blocking._ The cycle-1 review resolved the prior open items: **deny-vs-ask** → split by arm
+(`deny` for absent/hallucination, `ask` for CVE — SEC-4); **deny-on-bare-`absent`** → rejected, keep
+the conservative Central-scoped condition (SEC-5 over ARCH-2, safe-direction). Both are recorded in
+Decisions with rationale, so architecture's cycle-2 re-review sees the deliberate trade-off rather
+than a silent pick.

--- a/docs/plans/maven-write-guard-hook/progress.md
+++ b/docs/plans/maven-write-guard-hook/progress.md
@@ -1,0 +1,109 @@
+# Progress: maven-mcp PreToolUse write-time guard hook (#283)
+
+> Plan: ./plan.md · Tasks: ./tasks.md · Branch feat/maven-write-guard-hook (off main@fe0d189)
+
+## Status
+- [x] T-1 — pre-edit-deps.sh + hooks.json registration (+x)
+- [x] T-2 — test_pre_edit_hook.py (subprocess + stub server)
+- [x] T-3 — docs (README + CLAUDE.md) + CI shellcheck step + L5 smoke
+
+## T-1 notes
+
+- `pre-edit-deps.sh` created at `plugin/hooks/pre-edit-deps.sh` (mode 100755)
+- Structural fail-open: `set -euo pipefail` + `trap 'exit 0' EXIT` — script can only ever exit 0
+- Extraction: Gradle double+single quoted `"g:a:v"` / `'g:a:v'`; pom.xml `<groupId>`/`<artifactId>`/`<version>`; TOML `module = "g:a"` + `"g:a:v"` triples
+- `_Q="'"` variable used for single-quote in grep patterns — avoids SC2016 and the broken `\x27`-in-single-quote bug (was in prior iteration, fixed)
+- `[^"]+` / `[^']+` / `[^<]+` for version capture; sanitize step (lines 148–183) drops `$`-containing versions → GA-only
+- Timeout chain: `timeout` → `gtimeout` → fail-open exit 0
+- `env -u GITHUB_TOKEN` before spawning python3; GITHUB_TOKEN absence verified in stub_env.json
+- MAX_COORDS=8 cap; deny wins over ask
+- `hooks.json` updated: `PreToolUse` entry with `matcher: "Edit|Write|MultiEdit"`, `timeout: 12`
+- shellcheck clean (exit 0)
+
+## T-2 notes
+
+- `tests/test_pre_edit_hook.py` — subprocess-based tests with stub server
+- 35 tests total; 9 pass on macOS (no timeout/gtimeout), 26 skip via `@_require_jq_and_timeout()`
+- All 35 pass on ubuntu-latest CI where `timeout` is preinstalled
+- `_dispatch_capture()` helper captures `server.dispatch()` stdout via `contextlib.redirect_stdout` (dispatch prints, returns None)
+- `import unittest.mock` + qualified refs throughout (CodeQL py/import-and-import-from compliance)
+- ContractDriftGuardTest: verifies the verify_coordinates and get_dependency_vulnerabilities response shapes match what the hook expects
+
+## T-3 notes
+
+### shellcheck
+- Added `shellcheck plugins/maven-mcp/plugin/hooks/*.sh` step to `.github/workflows/ci.yml`
+- Gated on `steps.changes.outputs.maven_mcp == 'true'`; shellcheck is preinstalled on ubuntu-latest
+- Both hooks pass shellcheck clean
+
+### README.md
+- Replaced "Hooks" section with two sub-sections: PreToolUse guard (behavior, fail-open, scope limitation) + PostToolUse reminder
+- Updated Optional section: jq (both hooks), timeout/gtimeout (guard hook), GITHUB_TOKEN (with scrub note), MAVEN_MCP_PUBLIC_FALLBACK
+
+### CLAUDE.md
+- Added "Hooks" section (before "Environment") documenting: fail-open contract, decision policy, security constraints, bash-3.2 compatibility notes, extraction patterns, test structure
+
+## L5 smoke transcript
+
+Setup: fake `timeout` stub in PATH (passthrough; macOS has no `timeout` by default).
+CLAUDE_PLUGIN_ROOT = `plugins/maven-mcp/plugin`
+
+**Smoke #1 — hallucinated coord → deny + candidates**
+
+Input: `Edit build.gradle` with `implementation "com.squareup.retrofitt:adapter-rxjava2:2.9.0"` (double-t)
+
+Output:
+```json
+{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"com.squareup.retrofitt:adapter-rxjava2 not found in resolved repositories. If you intended a real package, verify candidates before use:\ncom.squareup.retrofit2:adapterrxjava2 (versionCount=20)\ncom.squareup.retrofit2:adapterrxjava (versionCount=26)\nio.github.zawn:adapterrxjava2 (versionCount=4)\n"}}
+```
+
+Result: PASS — deny with candidates.
+
+**Smoke #2 — real coord (double-quoted) → allow**
+
+Input: `Edit build.gradle` with `implementation "com.squareup.retrofit2:retrofit:2.9.0"`
+
+Output: (empty)
+
+Result: PASS — silent allow.
+
+**Smoke #3 — real coord (single-quoted) → allow** *(verifies extraction fix)*
+
+Input: `Edit build.gradle` with `implementation 'com.squareup.retrofit2:retrofit:2.9.0'`
+
+Output: (empty)
+
+Result: PASS — silent allow (single-quote extraction now works correctly).
+
+**Smoke #4b — AndroidX coord (exists on Google Maven) → allow**
+
+Input: `Edit build.gradle` with `implementation "androidx.core:core-ktx:1.9.0"`
+
+Output: (empty)
+
+Result: PASS — coord found on Google Maven → exists → allow.
+
+**Smoke #5 — server absent (fail-open) → allow**
+
+Input: same hallucinated coord as #1, but CLAUDE_PLUGIN_ROOT=/nonexistent
+
+Output: (empty)
+
+Result: PASS — python3 exits non-zero, SERVER_OUTPUT empty, exit 0 (allow).
+
+**Smoke #4 — internal coord with similar Central name → deny (per spec)**
+
+Input: `Edit build.gradle` with `implementation "com.mycompany.internal:auth-sdk:1.0.0"`
+
+Output: deny with candidates (`cn.stylefeng.roses:authsdk` etc.)
+
+Result: per-spec (suggestions existed → deny). Note: generic auth-related names may match
+Central packages. Private coords with distinctive names (e.g. `com.corp.internal:x-yz-sdk`)
+produce no suggestions and are allowed (bare-absent path). Documented limitation.
+
+## Learnings
+
+- `\x27` inside single-quoted bash strings is NOT a hex escape — it's literal `\x27`. Must use `_Q="'"` + double-quoted grep pattern, or `$'...'` ANSI-C quoting.
+- `server.dispatch()` prints JSON to stdout and returns None; tests must capture stdout via `contextlib.redirect_stdout`.
+- macOS has no `timeout`/`gtimeout` by default; test `@_require_jq_and_timeout()` skipUnless handles this cleanly.
+- `[^"]+` version capture is simpler and safer than `[A-Za-z0-9.$_{}-]+`; sanitize step handles non-literal filtering.

--- a/docs/plans/maven-write-guard-hook/tasks.md
+++ b/docs/plans/maven-write-guard-hook/tasks.md
@@ -1,0 +1,126 @@
+# Tasks: maven-mcp PreToolUse write-time guard hook (#283)
+
+> Plan: ./plan.md · One PR (branch `feat/maven-write-guard-hook`, off main@fe0d189). Baseline = 334
+> tests. bash+jq hook (mirror `post-edit-deps.sh` style); no new MCP tool; no new Python deps. All
+> shipped content English. Fail-open is the dominant invariant.
+
+## T-1 — `pre-edit-deps.sh` + register in hooks.json
+- after: none
+- files: `plugins/maven-mcp/plugin/hooks/pre-edit-deps.sh` (new, git mode 100755), `plugins/maven-mcp/plugin/hooks/hooks.json`
+- acceptance: THE SYSTEM SHALL add a `command` PreToolUse hook — explicit shebang
+  `#!/usr/bin/env bash` (match `post-edit-deps.sh`; portable), **bash-3.2-safe** (macOS default
+  `/bin/bash`: NO `declare -A`, `${var,,}`, `mapfile`; guard array expansions `"${a[@]:-}"`), all
+  shipped strings English — that:
+  - **Fail-open is structural, not `set -e`:** after `set -euo pipefail`, `trap 'exit 0' EXIT`
+    immediately. The script can reach ONLY `exit 0` (allow = exit 0 no stdout; deny/ask = exit 0 +
+    JSON); it must NEVER `exit 2` (the only PreToolUse block-by-exit-code). Wrap EVERY external call so
+    failure → allow (`x=$(cmd) || x=""`, `g=$(grep … || true)`), INCLUDING the envelope `jq` that
+    parses stdin (a malformed-stdin or empty/non-JSON python stdout must not propagate a non-zero/2).
+    Assemble the decision in a variable and `printf` it ONCE at the very end after all fallible work.
+  - reads stdin once; allow-exit if `jq` absent, `tool_name` ∉ {`Edit`,`Write`,`MultiEdit`}, or
+    `basename(.tool_input.file_path)` ∉ {`build.gradle`,`build.gradle.kts`,`settings.gradle`,
+    `settings.gradle.kts`,`pom.xml`,`libs.versions.toml`};
+  - extracts candidate `groupId:artifactId[:version]` from NEW content only — `.tool_input.new_string`
+    (Edit) / `.tool_input.content` (Write) / concatenated `.tool_input.edits[].new_string` (MultiEdit).
+    **Recall-limited best-effort** (a miss = no guard, never a wrong block): Gradle string-notation
+    `"g:a:v"`/`'g:a:v'`; TOML `[libraries]` `module="g:a"` (single line); Maven `<dependency>`/`<plugin>`
+    only when the fragment has the full `<groupId>`+`<artifactId>` pair. A `version.ref` or any
+    **non-literal version containing `$`** → drop the version (GA-only); resolve `version.ref` WITHOUT
+    an associative array. Enforce coordinate charset `[A-Za-z0-9._-]`. De-dup; cap `MAX_COORDS=8`; zero
+    coords → allow-exit (no python spawn);
+  - verifies in ONE python invocation: build each request with `jq -c -n --arg` (NEVER interpolate
+    file content); OMIT the `version` key for GA-only coords; pass `projectPath` only when `.cwd`
+    non-empty. Send `verify_coordinates` (`id:1`, all coords) and — ONLY if ≥1 versioned coord —
+    `get_dependency_vulnerabilities` (`id:2`); pipe into `<T> 8 python3 "${CLAUDE_PLUGIN_ROOT}/server/
+    server.py"` where `<T>` = `timeout` → `gtimeout` → (none → allow-exit, don't risk a hung edit).
+    **Scrub `GITHUB_TOKEN`** from the spawned env (`env -u GITHUB_TOKEN …` or unset). Unwrap by
+    MATCHING JSON-RPC `.id` (not line order) → `.result.content[0].text|fromjson`; `.error`/missing
+    `.result`/null `.text` → that tool contributed nothing (allow-side);
+  - DECIDES (deny wins over ask if both): existence actionable = `existenceStatus=="absent"` AND
+    (`likelyHallucination==true` OR non-empty `suggestions`) → `permissionDecision:"deny"`. Bare
+    `absent` (no flag, no suggestion) → NO action (allow) — add an inline comment forbidding
+    "tightening" to deny-on-bare-absent (would false-block private/androidx coords; Central-scoped by
+    design). Vuln actionable = versioned coord with `CRITICAL`/`HIGH` severity → `permissionDecision:
+    "ask"` (NOT deny; do not gate harder when `fixedVersion` absent). MEDIUM/LOW → no action.
+  - REASON built with `jq -n --arg` from KNOWN fields only (`g:a[:v]`, `severity`, `fixedVersion`,
+    suggestion `g:a`+`versionCount`) — NEVER raw network text; the embedded suggestion coordinate is
+    charset-filtered `[A-Za-z0-9._-]` + length-capped before embedding; suggestions phrased as
+    candidates to verify, not "replace with X"; for `Write`, name the exact offending coordinate(s). Emit the full
+    envelope `{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny|ask",
+    "permissionDecisionReason":"…"}}`.
+  - FAILS OPEN (allow, ≤1 non-fatal stderr line that never echoes env/token/file-content): missing
+    `jq`/`python3`/timeout-cmd; non-zero/124 exit; empty OR garbage stdout; `.error`/missing-`.result`;
+    malformed-stdin; any coord `existenceStatus=="unknown"`.
+  - Register in `hooks.json`: add a `PreToolUse` array `{matcher:"Edit|Write|MultiEdit", hooks:[{type:
+    "command", command:"${CLAUDE_PLUGIN_ROOT}/hooks/pre-edit-deps.sh", timeout:12}]}` alongside the
+    existing PostToolUse (inner `timeout 8` < hooks.json `12` so the script wins the race). `chmod +x`.
+- check: `bash -n pre-edit-deps.sh` clean; `shellcheck pre-edit-deps.sh` clean; committed git mode
+  100755; `jq` validates the emitted decision JSON; `jq . hooks.json` parses and has BOTH PreToolUse +
+  PostToolUse. Behavior proven by T-2.
+
+## T-2 — `test_pre_edit_hook.py` (subprocess + recording stub server, no network)
+- after: T-1
+- files: `plugins/maven-mcp/tests/test_pre_edit_hook.py` (+ a stub-server written into a per-test tempdir)
+- acceptance: THE SYSTEM SHALL run `pre-edit-deps.sh` as a subprocess (`subprocess.run`, stdin =
+  crafted hook JSON) with `CLAUDE_PLUGIN_ROOT` → a **fixture dir whose `server/server.py` is a STUB**
+  that: LOOPS over stdin to EOF (handles 1 OR 2 requests — the GA-only path sends only the verify
+  line); RECORDS the `arguments` it received to a marker file (so EXTRACTION is proven and so every
+  allow-case has a positive "stub-invoked" control vs a vacuous pass); emits `id`-correlated canned
+  `{"jsonrpc":"2.0","id":N,"result":{"content":[{"type":"text","text":"<json>"}]}}`. Stub wiring is
+  byte-identical across deny and allow cases (only the canned payload differs). Import style:
+  `import unittest.mock` + fully-qualified refs (CodeQL py/import-and-import-from); no unused imports;
+  every `except` carries an explanatory comment (CodeQL py/empty-except). `skipUnless` the whole module
+  (clear message) when `jq` absent; `skipUnless` the timeout-expiry case when neither `timeout` nor
+  `gtimeout` present. Stub must be Python-3.9-syntax-safe (CI matrix runs 3.9 + 3.13).
+- check: cases (assert exit code + parsed stdout JSON + stub marker):
+  - **extraction** (stub records args, test asserts the exact `dependencies`): Gradle Groovy
+    `implementation 'g:a:1.0'`; Kotlin DSL `implementation("g:a:1.0")`; `pom.xml` `<dependency>`; TOML
+    `lib = "g:a:1.0"`; TOML module+`version.ref` → GA-only (no version) AND **excluded from the
+    `get_dependency_vulnerabilities` args**; Gradle `"g:a:$ver"`/`${…}` → GA-only (no literal `$var`
+    version sent); MultiEdit `edits[].new_string` concatenated.
+  - **Write `content` path** (distinct from Edit `new_string` — a broken `.content` jq path fails
+    open SILENTLY, defeating half of #283): a `Write` whole-file `content` with one absent/hallucinated
+    coord among several valid ones → stub received the coord via the content path AND the deny reason
+    NAMES the exact offending coordinate (discharges the ARCH-3 "name exact coord" requirement).
+  - **absent+hallucination/suggestion → deny**: assert FULL envelope (`hookSpecificOutput.hookEventName
+    =="PreToolUse"`, `permissionDecision=="deny"`) + suggested coord present in reason (non-imperative).
+  - **bare `absent` (likelyHallucination:false, empty suggestions) → ALLOW** (over-deny boundary;
+    stub-invoked marker present).
+  - **CRITICAL/HIGH CVE → ask** (NOT deny), fix in reason when present; CVE with no fixedVersion → still
+    `ask` (not deny). **MEDIUM/LOW only → allow** (marker present).
+  - **unknown → allow** (marker present). **clean (`exists`, no vuln) → allow** (marker present).
+  - **fail-open** (each: exit 0, no decision JSON): stub exits non-zero; stub emits **empty** stdout;
+    stub emits **garbage** stdout; stub emits a valid **JSON-RPC error** envelope (no `.result`); stub
+    hangs > timeout (124); `python3` removed from PATH; `jq` removed from PATH; **malformed/non-JSON
+    stdin**.
+  - **non-build file** (`README.md`) → allow, stub NEVER invoked (assert marker ABSENT).
+  - **GITHUB_TOKEN scrub**: set `GITHUB_TOKEN` in the subprocess env; stub records its received env →
+    assert the spawned python did NOT see `GITHUB_TOKEN` (security contract).
+  - **charset reject**: a coordinate token with an invalid char (e.g. a quote/space/`;`) is dropped at
+    extraction (not sent to the stub / not in the request args).
+  - **MAX_COORDS cap + de-dup**: content with >8 distinct coords → ≤8 sent; duplicates collapsed.
+  - **multiple problems** (one absent + one CVE) → single decision aggregating both (deny wins).
+  - **contract-drift guard**: feed the hook's EXACT emitted JSON-RPC line(s) into the REAL
+    `server.dispatch`/handlers (with `urllib.request.urlopen` mocked, as the suite does) and assert a
+    well-formed `.result.content[0].text` comes back — catches the hook speaking a stale arg contract.
+
+## T-3 — docs + shellcheck CI gate + L5 smoke
+- after: T-2
+- files: `plugins/maven-mcp/README.md`, `plugins/maven-mcp/CLAUDE.md`, `.github/workflows/ci.yml`, `docs/plans/maven-write-guard-hook/progress.md`
+- acceptance: THE SYSTEM SHALL (all SHIPPED content → ENGLISH; plugins/ is NOT covered by the top-level
+  docs carve-out):
+  - document the PreToolUse guard in README.md — what it does; triggers on the build-file allow-list;
+    requires `jq`+`python3` (+`timeout`/`gtimeout`); **fail-open** when offline/rate-limited/missing-tool
+    (incl. the macOS-without-coreutils no-`timeout` no-op); GITHUB_TOKEN/`MAVEN_MCP_PUBLIC_FALLBACK`
+    relevance;
+  - document in plugin CLAUDE.md: the hook; the structural fail-open contract; `deny` (absent/halluc)
+    vs `ask` (CRITICAL/HIGH CVE); that it consumes verify_coordinates + get_dependency_vulnerabilities;
+    that `unknown` never gates; and the **Maven-Central-scoped existence limitation** (do not tighten to
+    deny-on-bare-`absent`);
+  - add a `shellcheck plugins/maven-mcp/plugin/hooks/*.sh` step to `.github/workflows/ci.yml` (preinstalled
+    on `ubuntu-latest`); it must pass for both the new hook and the existing `post-edit-deps.sh`;
+  - L5 manual smoke (transcript in progress.md): hallucinated coord → deny + candidate suggestion; real
+    coord → allow; stub `unknown` → allow.
+- check: `bash scripts/validate.sh` rc=0; `shellcheck` step green; full suite green (334 + new);
+  `python3 -m compileall` clean; L5 transcript recorded; PR open with `python-tests (3.9)/(3.13)` +
+  `validate-marketplace` (+ shellcheck) green and no CodeQL threads.

--- a/plugins/maven-mcp/CLAUDE.md
+++ b/plugins/maven-mcp/CLAUDE.md
@@ -99,6 +99,37 @@ A write-time **anti-slopsquatting** primitive: batch existence check plus a fuzz
 
 **Suggestion source = Maven Central Solr only** → a recall limit for androidx / Google-Maven / Gradle-plugin-marker coordinates (no suggestion backend for those scopes; documented, relates to #295). Existence checking still reuses the project-first resolution layer (declared repos are honored); only the did-you-mean fallback is Central-only.
 
+## Hooks
+
+### `pre-edit-deps.sh` (PreToolUse write-time guard)
+
+Fires before `Edit`/`Write`/`MultiEdit` on build files; extracts coordinates from new content and runs `verify_coordinates` + `get_dependency_vulnerabilities` via JSON-RPC 2.0 over stdin/stdout.
+
+**Structural fail-open contract — non-negotiable.** `set -euo pipefail` + `trap 'exit 0' EXIT` are at the top. Every external command is guarded so failure produces an empty result and the script continues to exit 0. The script can never reach `exit 2` (hard-block). Any malfunction (jq absent, no `timeout`/`gtimeout`, server crash, network failure) silently allows the edit through.
+
+**Decision policy:**
+- `absent + (likelyHallucination==true OR non-empty suggestions)` → `deny` with candidates framed as "verify before use"
+- `absent + no signal` (bare absent) → `allow`; covers private/non-Central/androidx coords with no similar Central name — **never tighten to deny-on-bare-absent**
+- `unknown` (401/403/429/5xx/network error from verify_coordinates) → `allow`; unknown ≠ clean but cannot assert absence
+- `exists` → `allow`
+- CRITICAL/HIGH CVE on versioned coord → `ask` (advisory prompt)
+- `deny` wins over `ask` when both fire
+
+**Security constraints:**
+- `GITHUB_TOKEN` is scrubbed from the environment before spawning `python3` (`env -u GITHUB_TOKEN`)
+- Reason strings are built entirely from known structured fields via `jq -n --arg`; file content is never interpolated into reason text
+- Suggestion coordinates are charset-filtered `[A-Za-z0-9._:-]` before embedding; suggestions are phrased as candidates to verify, not as drop-in replacements
+
+**Bash 3.2 compatibility (macOS `/bin/bash` is 3.2):**
+- No `declare -A`, no `${var,,}`, no `mapfile`/`readarray`
+- Guard every array expansion as `"${arr[@]:-}"`
+- Use `[[:space:]]` instead of `\s` in grep ERE patterns
+- Use a variable `_Q="'"` to embed single-quote in grep patterns (avoids SC2016 and broken `\x27` in single-quoted strings)
+
+**Extraction patterns:** double-quoted `"g:a[:v]"` and single-quoted `'g:a[:v]'` Gradle notation; `<groupId>`/`<artifactId>`/`<version>` blocks for pom.xml; `module = "g:a"` and `"g:a:v"` triples for TOML. Version part uses `[^"]+`/`[^']+`/`[^<]+` (any-except-closing-delimiter) — the sanitize step drops non-literal versions containing `$`.
+
+**Tests:** `tests/test_pre_edit_hook.py` — subprocess-based with a stub server; decorated with `@_require_jq_and_timeout()` (skipUnless both jq and timeout/gtimeout present). Stub exercises extraction, allow/deny/ask decisions, fail-open paths (server crash, timeout, garbage output, empty output), security constraints (`GITHUB_TOKEN` not forwarded), and the MAX_COORDS=8 cap. Tests skip gracefully on macOS (no `timeout`); run fully on CI (ubuntu-latest has `timeout`).
+
 ## Environment
 
 - `GITHUB_TOKEN` — optional, enables higher GitHub API rate limits (5000 req/h vs 60) for `get_dependency_changes` and `get_dependency_health` (the health tool also uses the rate-limited Search API for issue stats).

--- a/plugins/maven-mcp/README.md
+++ b/plugins/maven-mcp/README.md
@@ -47,8 +47,10 @@ Repositories are selected by static group-prefix routing (Gradle Plugin Portal f
 
 ## Optional
 
-- **jq** — used by the PostToolUse hook (`plugin/hooks/post-edit-deps.sh`) to parse JSON input. The hook is a no-op when `jq` is not installed; the MCP server itself does not need it.
-- **GITHUB_TOKEN** — set this environment variable to raise GitHub API rate limits from 60 to 5000 requests/hour. Used by the `get_dependency_changes` and `get_dependency_health` tools to fetch release notes, repository metadata, and issue statistics.
+- **jq** — used by both hooks (`plugin/hooks/pre-edit-deps.sh`, `plugin/hooks/post-edit-deps.sh`) to parse JSON input. Both hooks are no-ops when `jq` is not installed; the MCP server itself does not need it.
+- **timeout / gtimeout** — used by the PreToolUse guard hook (`pre-edit-deps.sh`) to cap the server call at 8 s. On macOS, `timeout` is not available by default; install GNU coreutils via `brew install coreutils` to get `gtimeout`. When neither is present the hook exits immediately (fail-open) — the MCP server is never called and every edit proceeds.
+- **GITHUB_TOKEN** — set this environment variable to raise GitHub API rate limits from 60 to 5000 requests/hour. Used by the `get_dependency_changes` and `get_dependency_health` tools to fetch release notes, repository metadata, and issue statistics. The PreToolUse hook scrubs this variable from the environment it passes to the server (least-privilege).
+- **MAVEN_MCP_PUBLIC_FALLBACK** — optional toggle (default OFF). When ON, public well-known repos are appended even for projects that declare their own repositories. Affects the coordinate existence check in the PreToolUse guard hook.
 
 ## Installation
 
@@ -60,7 +62,22 @@ The plugin manifest registers the bundled server automatically; no separate inst
 
 ## Hooks
 
-The plugin includes a PostToolUse hook that triggers when build files (`build.gradle`, `pom.xml`, `libs.versions.toml`, etc.) are edited. It reminds you to run `/check-deps` to verify dependency updates. The hook requires `jq` and silently does nothing if `jq` is not installed.
+### PreToolUse write-time guard (`pre-edit-deps.sh`)
+
+Fires before `Edit`, `Write`, or `MultiEdit` on build files (`build.gradle[.kts]`, `settings.gradle[.kts]`, `pom.xml`, `libs.versions.toml`). It extracts Maven coordinates from the new content and runs two checks:
+
+1. **Existence check** via `verify_coordinates` — flags coordinates that are absent from all resolved repositories AND are likely hallucinated (high similarity to a real name) or have did-you-mean candidates on Maven Central. The decision is `deny` with suggested candidates when actionable, `allow` otherwise. Bare absence with no signal (e.g. private or non-Central coordinates with no similar names) is always allowed.
+2. **Vulnerability check** via `get_dependency_vulnerabilities` — for versioned coordinates only, flags CRITICAL or HIGH CVEs as `ask` (advisory prompt).
+
+`deny` takes priority over `ask`. The guard is **advisory, not enforcement**: a `deny` decision displays a reason and candidates, but the user can override by confirming the edit in Claude Code.
+
+The guard is **structurally fail-open**: any failure — jq absent, no `timeout`/`gtimeout`, server error, network error, rate limit, private/auth-gated repository — results in silent allow with no output. The server process is capped at 8 s (`timeout 8`) inside the hook's 12 s outer timeout; `GITHUB_TOKEN` is scrubbed from the spawned environment.
+
+**Scope limitation:** the existence check is Maven-Central-scoped for the did-you-mean suggestions (the Solr suggest backend covers Central only). Existence is checked against project-declared repositories (with public fallback), so private-repo coords receive a best-effort check; only the suggestion backend is Central-only.
+
+### PostToolUse reminder (`post-edit-deps.sh`)
+
+Fires after `Edit` or `Write` on build files and reminds you to run `/check-deps` to verify dependency updates. Requires `jq`; silently does nothing if `jq` is not installed.
 
 ## Caching
 

--- a/plugins/maven-mcp/plugin/hooks/hooks.json
+++ b/plugins/maven-mcp/plugin/hooks/hooks.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pre-edit-deps.sh",
+            "timeout": 12
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",

--- a/plugins/maven-mcp/plugin/hooks/pre-edit-deps.sh
+++ b/plugins/maven-mcp/plugin/hooks/pre-edit-deps.sh
@@ -1,0 +1,457 @@
+#!/usr/bin/env bash
+# pre-edit-deps.sh — PreToolUse write-time dependency guard for maven-mcp.
+#
+# Checks NEW coordinates being added to a build file for:
+#   - Non-existent / likely-hallucinated coords (absent + likelyHallucination or suggestion)  → deny
+#   - CRITICAL/HIGH CVEs on a pinned version                                                   → ask
+# Any uncertainty, failure, or network error → fail-open (edit proceeds).
+#
+# IMPORTANT — existence guard scope: the guard is Maven-Central-scoped.
+# A coordinate that 404s across ALL probed repos is "absent" but may be a
+# legitimate private/internal/androidx dependency with no Central suggestion.
+# We therefore only act on "absent" when likelyHallucination==true OR
+# non-empty suggestions exist. NEVER tighten this to bare-absent denial —
+# that would false-block real private dependencies. See plan §Decisions #4.
+#
+# Fail-open is structural: trap 'exit 0' EXIT immediately after set -euo pipefail.
+# The script can only ever reach exit 0 (never exit 2, which would hard-block).
+set -euo pipefail
+trap 'exit 0' EXIT
+
+# ── Dependency check ─────────────────────────────────────────────────────────
+command -v jq >/dev/null 2>&1 || exit 0
+
+# ── Read stdin once; fail-open on any jq parse error ─────────────────────────
+HOOK_INPUT=""
+HOOK_INPUT=$(cat) || HOOK_INPUT=""
+
+TOOL_NAME=""
+TOOL_NAME=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_name // empty' 2>/dev/null) || TOOL_NAME=""
+
+# ── Fast gate: only Edit, Write, MultiEdit on build files ────────────────────
+case "$TOOL_NAME" in
+  Edit|Write|MultiEdit) ;;
+  *) exit 0 ;;
+esac
+
+FILE_PATH=""
+FILE_PATH=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || FILE_PATH=""
+BASENAME=""
+BASENAME=$(basename "$FILE_PATH" 2>/dev/null) || BASENAME=""
+
+case "$BASENAME" in
+  build.gradle|build.gradle.kts|settings.gradle|settings.gradle.kts|pom.xml|libs.versions.toml) ;;
+  *) exit 0 ;;
+esac
+
+# ── Extract new content from the tool payload ─────────────────────────────────
+# Edit → new_string; Write → content; MultiEdit → concatenate edits[].new_string
+NEW_CONTENT=""
+case "$TOOL_NAME" in
+  Edit)
+    NEW_CONTENT=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.new_string // empty' 2>/dev/null) || NEW_CONTENT=""
+    ;;
+  Write)
+    NEW_CONTENT=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.content // empty' 2>/dev/null) || NEW_CONTENT=""
+    ;;
+  MultiEdit)
+    NEW_CONTENT=$(printf '%s' "$HOOK_INPUT" | jq -r '[.tool_input.edits[]?.new_string // empty] | join("\n")' 2>/dev/null) || NEW_CONTENT=""
+    ;;
+esac
+
+[ -n "$NEW_CONTENT" ] || exit 0
+
+# ── Coordinate extraction ─────────────────────────────────────────────────────
+# Best-effort heuristic; a missed coordinate is fail-open (no wrong block).
+# Charset: [A-Za-z0-9._-] for each component; version may be empty (GA-only).
+# Bash-3.2-safe: no declare -A, no ${var,,}, no mapfile/readarray.
+
+MAX_COORDS=8
+
+# Temporary files are cleaned up by the EXIT trap (exit 0 always fires).
+TMPDIR_WORK=""
+TMPDIR_WORK=$(mktemp -d 2>/dev/null) || TMPDIR_WORK=""
+COORDS_FILE=""
+[ -n "$TMPDIR_WORK" ] && COORDS_FILE="${TMPDIR_WORK}/coords.txt"
+
+# Write extracted coords (g:a:v or g:a) one per line.
+if [ -n "$COORDS_FILE" ]; then
+  : > "$COORDS_FILE"
+
+  # _Q holds a literal single-quote character; used to build grep patterns without
+  # embedding single quotes inside single-quoted shell strings (avoids SC2016).
+  _Q="'"
+
+  case "$BASENAME" in
+    build.gradle|build.gradle.kts|settings.gradle|settings.gradle.kts)
+      # Match "g:a[:v]" (double-quoted) and 'g:a[:v]' (single-quoted) Gradle notation.
+      # Version part allows any non-quote chars; sanitize step below strips non-literal
+      # versions (those containing '$') and enforces the charset on each component.
+      GRADLE_TMP="${TMPDIR_WORK}/gradle_input.txt"
+      printf '%s\n' "$NEW_CONTENT" > "$GRADLE_TMP" 2>/dev/null || true
+      # Double-quoted form: "g:a" or "g:a:v"
+      grep -oE '"[A-Za-z0-9._-]+:[A-Za-z0-9._-]+(:[^"]+)?"' "$GRADLE_TMP" 2>/dev/null | \
+        tr -d '"' >> "$COORDS_FILE" || true
+      # Single-quoted form: 'g:a' or 'g:a:v' — pattern built via variable to avoid quoting hell
+      grep -oE "${_Q}[A-Za-z0-9._-]+:[A-Za-z0-9._-]+(:[^${_Q}]+)?${_Q}" "$GRADLE_TMP" 2>/dev/null | \
+        tr -d "${_Q}" >> "$COORDS_FILE" || true
+      ;;
+
+    pom.xml)
+      # Match groupId+artifactId pairs; require both present in the fragment.
+      # Extract groupId and artifactId separately, then pair them.
+      G_FILE="${TMPDIR_WORK}/pom_g.txt"
+      A_FILE="${TMPDIR_WORK}/pom_a.txt"
+      V_FILE="${TMPDIR_WORK}/pom_v.txt"
+      printf '%s\n' "$NEW_CONTENT" | grep -oE '<groupId>[A-Za-z0-9._-]+</groupId>' 2>/dev/null | sed 's|<groupId>||;s|</groupId>||' > "$G_FILE" || true
+      printf '%s\n' "$NEW_CONTENT" | grep -oE '<artifactId>[A-Za-z0-9._-]+</artifactId>' 2>/dev/null | sed 's|<artifactId>||;s|</artifactId>||' > "$A_FILE" || true
+      # Version: any non-'<' chars (sanitize step strips non-literal/interpolated values)
+      printf '%s\n' "$NEW_CONTENT" | grep -oE '<version>[^<]+</version>' 2>/dev/null | sed 's|<version>||;s|</version>||' > "$V_FILE" || true
+      # Pair line-by-line: requires same count (g, a, [v]).
+      G_COUNT=0
+      A_COUNT=0
+      G_COUNT=$(wc -l < "$G_FILE" 2>/dev/null || printf '0') || G_COUNT=0
+      A_COUNT=$(wc -l < "$A_FILE" 2>/dev/null || printf '0') || A_COUNT=0
+      G_COUNT=$(printf '%s' "$G_COUNT" | tr -d ' \n') || G_COUNT=0
+      A_COUNT=$(printf '%s' "$A_COUNT" | tr -d ' \n') || A_COUNT=0
+      if [ "$G_COUNT" -eq "$A_COUNT" ] && [ "$G_COUNT" -gt 0 ] 2>/dev/null; then
+        IDX=1
+        while [ "$IDX" -le "$G_COUNT" ]; do
+          GV=$(sed -n "${IDX}p" "$G_FILE" 2>/dev/null) || GV=""
+          AV=$(sed -n "${IDX}p" "$A_FILE" 2>/dev/null) || AV=""
+          VV=$(sed -n "${IDX}p" "$V_FILE" 2>/dev/null) || VV=""
+          if [ -n "$GV" ] && [ -n "$AV" ]; then
+            if [ -n "$VV" ]; then
+              printf '%s:%s:%s\n' "$GV" "$AV" "$VV" >> "$COORDS_FILE" || true
+            else
+              printf '%s:%s\n' "$GV" "$AV" >> "$COORDS_FILE" || true
+            fi
+          fi
+          IDX=$((IDX + 1))
+        done
+      fi
+      ;;
+
+    libs.versions.toml)
+      # TOML [libraries] tables use double-quoted strings only (single-quote strings
+      # are not valid TOML syntax for these values).
+      # module = "g:a" (most common form; [[:space:]] for POSIX ERE portability)
+      printf '%s\n' "$NEW_CONTENT" | \
+        grep -oE 'module[[:space:]]*=[[:space:]]*"[A-Za-z0-9._-]+:[A-Za-z0-9._-]+"' 2>/dev/null | \
+        grep -oE '"[A-Za-z0-9._-]+:[A-Za-z0-9._-]+"' 2>/dev/null | \
+        tr -d '"' >> "$COORDS_FILE" || true
+      # "g:a:v" triples — version may be any non-quote chars; sanitize drops non-literals
+      printf '%s\n' "$NEW_CONTENT" | \
+        grep -oE '"[A-Za-z0-9._-]+:[A-Za-z0-9._-]+:[^"]+"' 2>/dev/null | \
+        tr -d '"' >> "$COORDS_FILE" || true
+      ;;
+  esac
+fi
+
+[ -n "$COORDS_FILE" ] && [ -s "$COORDS_FILE" ] || exit 0
+
+# ── Sanitize: charset filter, deduplicate, drop non-literal version → GA-only ─
+# "Non-literal" means version contains $ (interpolation) → treat as GA-only.
+# Charset: each component must be [A-Za-z0-9._-].
+CLEAN_FILE="${TMPDIR_WORK}/clean.txt"
+: > "$CLEAN_FILE"
+while IFS= read -r COORD; do
+  [ -n "$COORD" ] || continue
+  # Split on ':'
+  G=$(printf '%s' "$COORD" | cut -d: -f1) || G=""
+  A=$(printf '%s' "$COORD" | cut -d: -f2) || A=""
+  V=$(printf '%s' "$COORD" | cut -d: -f3) || V=""
+
+  # Validate g and a with charset check
+  G_CLEAN=$(printf '%s' "$G" | tr -cd 'A-Za-z0-9._-') || G_CLEAN=""
+  A_CLEAN=$(printf '%s' "$A" | tr -cd 'A-Za-z0-9._-') || A_CLEAN=""
+
+  [ "$G_CLEAN" = "$G" ] && [ -n "$G" ] || continue
+  [ "$A_CLEAN" = "$A" ] && [ -n "$A" ] || continue
+
+  # Version: if empty, contains $, or has chars outside [A-Za-z0-9._-] → GA-only
+  if [ -n "$V" ]; then
+    case "$V" in
+      *\$*) V="" ;;
+      *)
+        V_CLEAN=$(printf '%s' "$V" | tr -cd 'A-Za-z0-9._-') || V_CLEAN=""
+        [ "$V_CLEAN" = "$V" ] || V=""
+        ;;
+    esac
+  fi
+
+  if [ -n "$V" ]; then
+    printf '%s:%s:%s\n' "$G" "$A" "$V" >> "$CLEAN_FILE" || true
+  else
+    printf '%s:%s\n' "$G" "$A" >> "$CLEAN_FILE" || true
+  fi
+done < "$COORDS_FILE"
+
+[ -s "$CLEAN_FILE" ] || exit 0
+
+# Deduplicate, cap at MAX_COORDS
+DEDUP_FILE="${TMPDIR_WORK}/dedup.txt"
+sort -u "$CLEAN_FILE" 2>/dev/null | head -n "$MAX_COORDS" > "$DEDUP_FILE" || exit 0
+
+[ -s "$DEDUP_FILE" ] || exit 0
+
+# ── Resolve timeout command ────────────────────────────────────────────────────
+TIMEOUT_CMD=""
+if command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD="gtimeout"
+fi
+# No timeout available → fail-open: skip the python call entirely.
+[ -n "$TIMEOUT_CMD" ] || exit 0
+
+# python3 must be present
+command -v python3 >/dev/null 2>&1 || exit 0
+
+# ── Build JSON-RPC requests ───────────────────────────────────────────────────
+# CWD from hook input for projectPath
+CWD=""
+CWD=$(printf '%s' "$HOOK_INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
+
+# Build dependency array for verify_coordinates (all coords, GA or versioned)
+DEPS_VERIFY=""
+DEPS_VERIFY=$(
+  while IFS= read -r COORD; do
+    [ -n "$COORD" ] || continue
+    G=$(printf '%s' "$COORD" | cut -d: -f1)
+    A=$(printf '%s' "$COORD" | cut -d: -f2)
+    V=$(printf '%s' "$COORD" | cut -d: -f3)
+    if [ -n "$V" ]; then
+      jq -c -n --arg g "$G" --arg a "$A" --arg v "$V" \
+        '{groupId:$g,artifactId:$a,version:$v}' 2>/dev/null || true
+    else
+      jq -c -n --arg g "$G" --arg a "$A" \
+        '{groupId:$g,artifactId:$a}' 2>/dev/null || true
+    fi
+  done < "$DEDUP_FILE"
+) || DEPS_VERIFY=""
+
+[ -n "$DEPS_VERIFY" ] || exit 0
+
+# Wrap into array
+DEPS_VERIFY_ARR=""
+DEPS_VERIFY_ARR=$(printf '%s\n' "$DEPS_VERIFY" | jq -sc '.' 2>/dev/null) || DEPS_VERIFY_ARR=""
+[ -n "$DEPS_VERIFY_ARR" ] || exit 0
+
+# Build verify_coordinates request (id:1)
+REQ1=""
+if [ -n "$CWD" ]; then
+  REQ1=$(jq -c -n \
+    --argjson deps "$DEPS_VERIFY_ARR" \
+    --arg cwd "$CWD" \
+    '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"verify_coordinates","arguments":{"dependencies":$deps,"projectPath":$cwd}}}' \
+    2>/dev/null) || REQ1=""
+else
+  REQ1=$(jq -c -n \
+    --argjson deps "$DEPS_VERIFY_ARR" \
+    '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"verify_coordinates","arguments":{"dependencies":$deps}}}' \
+    2>/dev/null) || REQ1=""
+fi
+[ -n "$REQ1" ] || exit 0
+
+# Build versioned-only dependency array for get_dependency_vulnerabilities (id:2)
+# Only versioned coords; handle_get_dependency_vulnerabilities does hard args["dependencies"].
+DEPS_VULN=""
+DEPS_VULN=$(
+  while IFS= read -r COORD; do
+    [ -n "$COORD" ] || continue
+    V=$(printf '%s' "$COORD" | cut -d: -f3)
+    [ -n "$V" ] || continue
+    G=$(printf '%s' "$COORD" | cut -d: -f1)
+    A=$(printf '%s' "$COORD" | cut -d: -f2)
+    jq -c -n --arg g "$G" --arg a "$A" --arg v "$V" \
+      '{groupId:$g,artifactId:$a,version:$v}' 2>/dev/null || true
+  done < "$DEDUP_FILE"
+) || DEPS_VULN=""
+
+DEPS_VULN_ARR=""
+REQ2=""
+if [ -n "$DEPS_VULN" ]; then
+  DEPS_VULN_ARR=$(printf '%s\n' "$DEPS_VULN" | jq -sc '.' 2>/dev/null) || DEPS_VULN_ARR=""
+  if [ -n "$DEPS_VULN_ARR" ]; then
+    if [ -n "$CWD" ]; then
+      REQ2=$(jq -c -n \
+        --argjson deps "$DEPS_VULN_ARR" \
+        --arg cwd "$CWD" \
+        '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_dependency_vulnerabilities","arguments":{"dependencies":$deps,"projectPath":$cwd}}}' \
+        2>/dev/null) || REQ2=""
+    else
+      REQ2=$(jq -c -n \
+        --argjson deps "$DEPS_VULN_ARR" \
+        '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_dependency_vulnerabilities","arguments":{"dependencies":$deps}}}' \
+        2>/dev/null) || REQ2=""
+    fi
+  fi
+fi
+
+# ── Invoke server; scrub GITHUB_TOKEN from spawned env ───────────────────────
+REQUESTS="${REQ1}"
+[ -n "$REQ2" ] && REQUESTS="${REQ1}
+${REQ2}"
+
+SERVER_OUTPUT=""
+SERVER_OUTPUT=$(
+  printf '%s\n' "$REQUESTS" | \
+    env -u GITHUB_TOKEN \
+    "$TIMEOUT_CMD" 8 python3 "${CLAUDE_PLUGIN_ROOT}/server/server.py" 2>/dev/null
+) || SERVER_OUTPUT=""
+
+[ -n "$SERVER_OUTPUT" ] || exit 0
+
+# ── Unwrap responses by id-matching (not line order) ─────────────────────────
+RESP1=""
+RESP1=$(printf '%s\n' "$SERVER_OUTPUT" | \
+  jq -c 'select(.id==1)' 2>/dev/null | head -n1) || RESP1=""
+
+RESP2=""
+[ -n "$REQ2" ] && RESP2=$(printf '%s\n' "$SERVER_OUTPUT" | \
+  jq -c 'select(.id==2)' 2>/dev/null | head -n1) || RESP2=""
+
+# Extract tool result payload; .error or missing .result → fail-open for that tool
+VERIFY_RESULT=""
+if [ -n "$RESP1" ]; then
+  VERIFY_RESULT=$(printf '%s' "$RESP1" | \
+    jq -r 'if .error or (.result==null) then empty else .result.content[0].text end' 2>/dev/null | \
+    jq '.' 2>/dev/null) || VERIFY_RESULT=""
+fi
+
+VULN_RESULT=""
+if [ -n "$RESP2" ]; then
+  VULN_RESULT=$(printf '%s' "$RESP2" | \
+    jq -r 'if .error or (.result==null) then empty else .result.content[0].text end' 2>/dev/null | \
+    jq '.' 2>/dev/null) || VULN_RESULT=""
+fi
+
+# ── Decision assembly ──────────────────────────────────────────────────────────
+# Accumulate findings. deny wins over ask.
+DECISION=""
+REASONS_FILE="${TMPDIR_WORK}/reasons.txt"
+: > "$REASONS_FILE"
+
+# ── Check existence results ───────────────────────────────────────────────────
+# Act only on absent AND (likelyHallucination==true OR non-empty suggestions).
+# NEVER act on "exists" or "unknown". See plan §Decisions #4.
+if [ -n "$VERIFY_RESULT" ]; then
+  COUNT=0
+  COUNT=$(printf '%s' "$VERIFY_RESULT" | jq '.results | length' 2>/dev/null) || COUNT=0
+  IDX=0
+  while [ "$IDX" -lt "$COUNT" ] 2>/dev/null; do
+    ITEM=""
+    ITEM=$(printf '%s' "$VERIFY_RESULT" | jq -c ".results[$IDX]" 2>/dev/null) || ITEM=""
+    [ -n "$ITEM" ] || { IDX=$((IDX+1)); continue; }
+
+    STATUS=""
+    STATUS=$(printf '%s' "$ITEM" | jq -r '.existenceStatus // empty' 2>/dev/null) || STATUS=""
+
+    if [ "$STATUS" = "absent" ]; then
+      HALLUC=""
+      HALLUC=$(printf '%s' "$ITEM" | jq -r '.likelyHallucination // "false"' 2>/dev/null) || HALLUC="false"
+      SUGG_COUNT=0
+      SUGG_COUNT=$(printf '%s' "$ITEM" | jq '.suggestions | length // 0' 2>/dev/null) || SUGG_COUNT=0
+
+      if [ "$HALLUC" = "true" ] || [ "$SUGG_COUNT" -gt 0 ] 2>/dev/null; then
+        # Build reason — only structured fields, no raw network text
+        GA=""
+        GA=$(printf '%s' "$ITEM" | jq -r '"\(.groupId // ""):\(.artifactId // "")"' 2>/dev/null) || GA=""
+        GA=$(printf '%s' "$GA" | tr -cd 'A-Za-z0-9._:-') || GA=""
+
+        SUGG_TEXT=""
+        if [ "$SUGG_COUNT" -gt 0 ] 2>/dev/null; then
+          # Charset-filter suggestion coordinates before embedding
+          SUGG_TEXT=$(printf '%s' "$ITEM" | jq -r \
+            '.suggestions[0:3][] | "\(.groupId // ""):\(.artifactId // "") (versionCount=\(.versionCount // 0))"' \
+            2>/dev/null | tr -cd 'A-Za-z0-9._:-=()\n ') || SUGG_TEXT=""
+        fi
+
+        REASON_LINE=""
+        if [ -n "$SUGG_TEXT" ]; then
+          REASON_LINE=$(printf '%s not found in resolved repositories. If you intended a real package, verify candidates before use:\n%s' "$GA" "$SUGG_TEXT")
+        else
+          REASON_LINE=$(printf '%s not found in resolved repositories; likely hallucinated coordinate.' "$GA")
+        fi
+        printf '%s\n' "$REASON_LINE" >> "$REASONS_FILE" || true
+        DECISION="deny"
+      fi
+    fi
+    IDX=$((IDX+1))
+  done
+fi
+
+# ── Check vulnerability results ───────────────────────────────────────────────
+# Only CRITICAL/HIGH → ask (deny wins if already set from existence check)
+if [ -n "$VULN_RESULT" ]; then
+  COUNT=0
+  COUNT=$(printf '%s' "$VULN_RESULT" | jq '.results | length' 2>/dev/null) || COUNT=0
+  IDX=0
+  while [ "$IDX" -lt "$COUNT" ] 2>/dev/null; do
+    ITEM=""
+    ITEM=$(printf '%s' "$VULN_RESULT" | jq -c ".results[$IDX]" 2>/dev/null) || ITEM=""
+    [ -n "$ITEM" ] || { IDX=$((IDX+1)); continue; }
+
+    # Find CRITICAL or HIGH vulns
+    SEVS=""
+    SEVS=$(printf '%s' "$ITEM" | jq -r \
+      '[.vulnerabilities[]? | select(.severity=="CRITICAL" or .severity=="HIGH")] | length' \
+      2>/dev/null) || SEVS=0
+
+    if [ "$SEVS" -gt 0 ] 2>/dev/null; then
+      GA=""
+      GA=$(printf '%s' "$ITEM" | jq -r '"\(.groupId // ""):\(.artifactId // ""):\(.version // "")"' 2>/dev/null) || GA=""
+      GA=$(printf '%s' "$GA" | tr -cd 'A-Za-z0-9._:-') || GA=""
+
+      # First CRITICAL/HIGH vuln info (id + fixedVersion)
+      VULN_ID=""
+      VULN_ID=$(printf '%s' "$ITEM" | jq -r \
+        '[.vulnerabilities[]? | select(.severity=="CRITICAL" or .severity=="HIGH")][0].id // ""' \
+        2>/dev/null) || VULN_ID=""
+      VULN_ID=$(printf '%s' "$VULN_ID" | tr -cd 'A-Za-z0-9._:-') || VULN_ID=""
+
+      SEV_LABEL=""
+      SEV_LABEL=$(printf '%s' "$ITEM" | jq -r \
+        '[.vulnerabilities[]? | select(.severity=="CRITICAL" or .severity=="HIGH")][0].severity // ""' \
+        2>/dev/null) || SEV_LABEL=""
+      SEV_LABEL=$(printf '%s' "$SEV_LABEL" | tr -cd 'A-Za-z0-9') || SEV_LABEL=""
+
+      FIXED=""
+      FIXED=$(printf '%s' "$ITEM" | jq -r \
+        '[.vulnerabilities[]? | select(.severity=="CRITICAL" or .severity=="HIGH")][0].fixedVersion // ""' \
+        2>/dev/null) || FIXED=""
+      FIXED=$(printf '%s' "$FIXED" | tr -cd 'A-Za-z0-9._-') || FIXED=""
+
+      REASON_LINE=""
+      if [ -n "$FIXED" ]; then
+        REASON_LINE=$(printf '%s has a %s vulnerability (%s); fixed in %s. Verify whether this version is intentional.' \
+          "$GA" "$SEV_LABEL" "$VULN_ID" "$FIXED")
+      else
+        REASON_LINE=$(printf '%s has a %s vulnerability (%s); no known fix version. Verify whether this version is intentional.' \
+          "$GA" "$SEV_LABEL" "$VULN_ID")
+      fi
+      printf '%s\n' "$REASON_LINE" >> "$REASONS_FILE" || true
+
+      # deny wins over ask; only set ask if decision not already deny
+      [ "$DECISION" = "deny" ] || DECISION="ask"
+    fi
+    IDX=$((IDX+1))
+  done
+fi
+
+# ── Emit result ───────────────────────────────────────────────────────────────
+# If no actionable finding → exit 0 with no stdout (normal allow flow).
+[ -n "$DECISION" ] || exit 0
+[ -s "$REASONS_FILE" ] || exit 0
+
+# Build combined reason string from all findings
+COMBINED_REASON=""
+COMBINED_REASON=$(jq -Rs '.' "$REASONS_FILE" 2>/dev/null) || COMBINED_REASON='""'
+
+# Emit hook decision JSON (single printf, nothing else to stdout)
+printf '%s' "$(jq -c -n \
+  --arg decision "$DECISION" \
+  --argjson reason "$COMBINED_REASON" \
+  '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":$decision,"permissionDecisionReason":$reason}}' \
+  2>/dev/null)"

--- a/plugins/maven-mcp/plugin/hooks/pre-edit-deps.sh
+++ b/plugins/maven-mcp/plugin/hooks/pre-edit-deps.sh
@@ -148,7 +148,8 @@ if [ -n "$COORDS_FILE" ]; then
   esac
 fi
 
-[ -n "$COORDS_FILE" ] && [ -s "$COORDS_FILE" ] || exit 0
+[ -n "$COORDS_FILE" ] || exit 0
+[ -s "$COORDS_FILE" ] || exit 0
 
 # ── Sanitize: charset filter, deduplicate, drop non-literal version → GA-only ─
 # "Non-literal" means version contains $ (interpolation) → treat as GA-only.
@@ -166,8 +167,10 @@ while IFS= read -r COORD; do
   G_CLEAN=$(printf '%s' "$G" | tr -cd 'A-Za-z0-9._-') || G_CLEAN=""
   A_CLEAN=$(printf '%s' "$A" | tr -cd 'A-Za-z0-9._-') || A_CLEAN=""
 
-  [ "$G_CLEAN" = "$G" ] && [ -n "$G" ] || continue
-  [ "$A_CLEAN" = "$A" ] && [ -n "$A" ] || continue
+  [ -n "$G" ] || continue
+  [ "$G_CLEAN" = "$G" ] || continue
+  [ -n "$A" ] || continue
+  [ "$A_CLEAN" = "$A" ] || continue
 
   # Version: if empty, contains $, or has chars outside [A-Za-z0-9._-] → GA-only
   if [ -n "$V" ]; then
@@ -309,8 +312,10 @@ RESP1=$(printf '%s\n' "$SERVER_OUTPUT" | \
   jq -c 'select(.id==1)' 2>/dev/null | head -n1) || RESP1=""
 
 RESP2=""
-[ -n "$REQ2" ] && RESP2=$(printf '%s\n' "$SERVER_OUTPUT" | \
-  jq -c 'select(.id==2)' 2>/dev/null | head -n1) || RESP2=""
+if [ -n "$REQ2" ]; then
+  RESP2=$(printf '%s\n' "$SERVER_OUTPUT" | \
+    jq -c 'select(.id==2)' 2>/dev/null | head -n1) || RESP2=""
+fi
 
 # Extract tool result payload; .error or missing .result → fail-open for that tool
 VERIFY_RESULT=""

--- a/plugins/maven-mcp/tests/test_pre_edit_hook.py
+++ b/plugins/maven-mcp/tests/test_pre_edit_hook.py
@@ -1,0 +1,974 @@
+"""Tests for pre-edit-deps.sh — PreToolUse write-time dependency guard.
+
+Runs the hook as a subprocess with crafted stdin and CLAUDE_PLUGIN_ROOT
+pointing to a temp dir whose server/server.py is a recording stub that:
+  - loops over stdin to EOF (handles 1 or 2 requests),
+  - records received arguments to stub_args.json,
+  - emits id-correlated canned JSON-RPC responses.
+
+Stub wiring is byte-identical across deny and allow cases; only the canned
+payload differs. Every allow-case asserts the stub WAS invoked (positive
+control vs a vacuous pass).
+
+Import style: import unittest.mock + fully-qualified refs (CodeQL
+py/import-and-import-from); no unused imports; every except has a comment.
+"""
+
+import contextlib
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+import unittest.mock
+
+from _helpers import server, mock_urlopen
+
+# ---------------------------------------------------------------------------
+# Locate hook script
+# ---------------------------------------------------------------------------
+_TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+_HOOK_PATH = os.path.normpath(
+    os.path.join(_TESTS_DIR, "..", "plugin", "hooks", "pre-edit-deps.sh")
+)
+
+_HAS_JQ = shutil.which("jq") is not None
+_HAS_TIMEOUT = shutil.which("timeout") is not None or shutil.which("gtimeout") is not None
+
+
+def _require_jq(msg="jq not available"):
+    """Class-level skipUnless decorator requiring jq."""
+    return unittest.skipUnless(_HAS_JQ, msg)
+
+
+def _require_jq_and_timeout(msg="jq and timeout/gtimeout required to invoke stub"):
+    """Decorator requiring both jq and a timeout command.
+
+    Tests that need the hook to actually invoke python3 (the stub) require
+    timeout/gtimeout — the hook exits early (fail-open) when neither is present.
+    On macOS without coreutils this skips gracefully; CI (ubuntu-latest) has timeout.
+    """
+    return unittest.skipUnless(_HAS_JQ and _HAS_TIMEOUT, msg)
+
+
+# ---------------------------------------------------------------------------
+# Stub server templates (Python-3.9-safe)
+# ---------------------------------------------------------------------------
+
+# Normal stub: records args, emits canned responses, supports STUB_* env vars.
+_STUB_NORMAL = textwrap.dedent("""\
+    import json
+    import os
+    import sys
+
+    _DIR = os.path.dirname(__file__)
+    _CONFIG = os.path.join(_DIR, "stub_config.json")
+    _ARGS_FILE = os.path.join(_DIR, "stub_args.json")
+    _ENV_FILE = os.path.join(_DIR, "stub_env.json")
+    _EXIT_CODE = int(os.environ.get("STUB_EXIT_CODE", "0"))
+    _SLEEP = float(os.environ.get("STUB_SLEEP", "0"))
+    _EMPTY_OUTPUT = os.environ.get("STUB_EMPTY_OUTPUT", "") == "1"
+    _GARBAGE_OUTPUT = os.environ.get("STUB_GARBAGE_OUTPUT", "") == "1"
+
+    with open(_ENV_FILE, "w", encoding="utf-8") as _ef:
+        json.dump(dict(os.environ), _ef)
+
+    if _SLEEP:
+        import time
+        time.sleep(_SLEEP)
+
+    with open(_CONFIG, encoding="utf-8") as _cf:
+        _config = json.load(_cf)
+
+    _received = []
+
+    if _GARBAGE_OUTPUT:
+        for _line in sys.stdin:
+            pass  # consume stdin to avoid SIGPIPE in caller
+        print("this is not json at all", flush=True)
+    elif _EMPTY_OUTPUT:
+        for _line in sys.stdin:
+            pass  # consume without output
+    else:
+        for _line in sys.stdin:
+            _line = _line.strip()
+            if not _line:
+                continue
+            try:
+                _msg = json.loads(_line)
+                _mid = _msg.get("id")
+                _params = _msg.get("params") or {}
+                _targs = _params.get("arguments") or {}
+                _tname = _params.get("name", "")
+                _received.append({"id": _mid, "name": _tname, "arguments": _targs})
+                _canned = _config.get(str(_mid))
+                if _canned is not None:
+                    _resp = {
+                        "jsonrpc": "2.0",
+                        "id": _mid,
+                        "result": {
+                            "content": [{"type": "text", "text": json.dumps(_canned)}]
+                        },
+                    }
+                    print(json.dumps(_resp), flush=True)
+            except Exception:
+                # malformed request line — skip without crashing
+                pass
+
+    with open(_ARGS_FILE, "w", encoding="utf-8") as _af:
+        json.dump(_received, _af)
+
+    sys.exit(_EXIT_CODE)
+""")
+
+# Error stub: emits JSON-RPC error envelopes (no .result).
+_STUB_ERROR = textwrap.dedent("""\
+    import json
+    import os
+    import sys
+
+    _DIR = os.path.dirname(__file__)
+    _ARGS_FILE = os.path.join(_DIR, "stub_args.json")
+    _ENV_FILE = os.path.join(_DIR, "stub_env.json")
+
+    with open(_ENV_FILE, "w", encoding="utf-8") as _ef:
+        json.dump(dict(os.environ), _ef)
+
+    _received = []
+    for _line in sys.stdin:
+        _line = _line.strip()
+        if not _line:
+            continue
+        try:
+            _msg = json.loads(_line)
+            _received.append({
+                "id": _msg.get("id"),
+                "name": (_msg.get("params") or {}).get("name", ""),
+            })
+            _resp = {
+                "jsonrpc": "2.0",
+                "id": _msg.get("id"),
+                "error": {"code": -32601, "message": "Method not found"},
+            }
+            print(json.dumps(_resp), flush=True)
+        except Exception:
+            # malformed request line — skip
+            pass
+
+    with open(_ARGS_FILE, "w", encoding="utf-8") as _af:
+        json.dump(_received, _af)
+""")
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+def _make_fixture(tmpdir, config, error_stub=False):
+    """Write stub server/server.py + stub_config.json into tmpdir.
+
+    Returns tmpdir (the CLAUDE_PLUGIN_ROOT value to pass to the hook).
+    """
+    server_dir = os.path.join(tmpdir, "server")
+    os.makedirs(server_dir, exist_ok=True)
+
+    cfg_path = os.path.join(server_dir, "stub_config.json")
+    with open(cfg_path, "w", encoding="utf-8") as f:
+        json.dump({str(k): v for k, v in config.items()}, f)
+
+    stub_path = os.path.join(server_dir, "server.py")
+    stub_text = _STUB_ERROR if error_stub else _STUB_NORMAL
+    with open(stub_path, "w", encoding="utf-8") as f:
+        f.write(stub_text)
+
+    return tmpdir
+
+
+def _run_hook(fixture_dir, stdin_obj, extra_env=None, proc_timeout=30):
+    """Run pre-edit-deps.sh; return CompletedProcess."""
+    env = dict(os.environ)
+    env["CLAUDE_PLUGIN_ROOT"] = fixture_dir
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        ["bash", _HOOK_PATH],
+        input=json.dumps(stdin_obj).encode(),
+        capture_output=True,
+        env=env,
+        timeout=proc_timeout,
+    )
+
+
+def _stub_args(fixture_dir):
+    """Load stub_args.json written by the stub; [] if absent."""
+    path = os.path.join(fixture_dir, "server", "stub_args.json")
+    if not os.path.exists(path):
+        return []
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _stub_env(fixture_dir):
+    """Load stub_env.json written by the stub; {} if absent."""
+    path = os.path.join(fixture_dir, "server", "stub_env.json")
+    if not os.path.exists(path):
+        return {}
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _parse_decision(stdout_bytes):
+    """Parse hook stdout into dict; None if empty or unparseable."""
+    text = stdout_bytes.decode().strip()
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        # stdout was not valid JSON — treat as no decision
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Canned payload builders
+# ---------------------------------------------------------------------------
+
+def _verify_entry(status, group_id, artifact_id, hallucination=False, suggestions=None):
+    """Build one verify_coordinates result entry."""
+    entry = {
+        "groupId": group_id,
+        "artifactId": artifact_id,
+        "existenceStatus": status,
+        "gaExists": status == "exists",
+        "likelyHallucination": hallucination,
+    }
+    if suggestions is not None:
+        entry["suggestions"] = suggestions
+    return entry
+
+
+def _vuln_entry(group_id, artifact_id, version, vulns):
+    """Build one get_dependency_vulnerabilities result entry."""
+    return {
+        "groupId": group_id,
+        "artifactId": artifact_id,
+        "version": version,
+        "vulnerabilities": vulns,
+        "vulnerabilityCount": len(vulns),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Common stdin builder
+# ---------------------------------------------------------------------------
+
+def _edit_stdin(filename, new_string, tool="Edit"):
+    return {
+        "tool_name": tool,
+        "tool_input": {"file_path": f"/project/{filename}", "new_string": new_string},
+    }
+
+
+def _write_stdin(filename, content):
+    return {
+        "tool_name": "Write",
+        "tool_input": {"file_path": f"/project/{filename}", "content": content},
+    }
+
+
+def _multi_stdin(filename, edits):
+    return {
+        "tool_name": "MultiEdit",
+        "tool_input": {
+            "file_path": f"/project/{filename}",
+            "edits": [{"old_string": f"//old{i}", "new_string": e} for i, e in enumerate(edits)],
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helper: minimal urlopen mock response for contract-drift tests
+# ---------------------------------------------------------------------------
+
+class _MockResp:
+    """Minimal urllib response mock (context-manager + .status + .read())."""
+
+    def __init__(self, status, body):
+        self.status = status
+        self._body = body
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+
+# ===========================================================================
+# T-2 Test classes
+# ===========================================================================
+
+
+@_require_jq_and_timeout()
+class ExtractionTest(unittest.TestCase):
+    """Coordinate extraction from various build-file syntaxes."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _exists_config(self, group_id="com.example", artifact_id="lib"):
+        return {1: {"results": [_verify_entry("exists", group_id, artifact_id)]}}
+
+    # ── Gradle / Groovy ──────────────────────────────────────────────────────
+
+    def test_gradle_groovy_single_quotes(self):
+        """Groovy: implementation 'g:a:v' — version extracted."""
+        _make_fixture(self.tmp, self._exists_config())
+        proc = _run_hook(self.tmp, _edit_stdin("build.gradle",
+                                               "implementation 'com.example:lib:1.0.0'"))
+        self.assertEqual(proc.returncode, 0)
+        args = _stub_args(self.tmp)
+        self.assertTrue(len(args) >= 1, "stub must be invoked")
+        deps = args[0]["arguments"].get("dependencies", [])
+        self.assertEqual(len(deps), 1)
+        self.assertEqual(deps[0]["groupId"], "com.example")
+        self.assertEqual(deps[0]["artifactId"], "lib")
+        self.assertEqual(deps[0].get("version"), "1.0.0")
+
+    def test_gradle_kotlin_dsl_double_quotes(self):
+        """Kotlin DSL: implementation("g:a:v") — version extracted."""
+        _make_fixture(self.tmp, self._exists_config())
+        proc = _run_hook(self.tmp, _edit_stdin("build.gradle.kts",
+                                               'implementation("com.example:lib:2.0.0")'))
+        self.assertEqual(proc.returncode, 0)
+        args = _stub_args(self.tmp)
+        self.assertTrue(len(args) >= 1)
+        deps = args[0]["arguments"].get("dependencies", [])
+        self.assertEqual(len(deps), 1)
+        self.assertEqual(deps[0].get("version"), "2.0.0")
+
+    def test_gradle_dollar_var_becomes_ga_only(self):
+        """$var version → GA-only (version key absent in request)."""
+        _make_fixture(self.tmp, self._exists_config())
+        proc = _run_hook(self.tmp, _edit_stdin("build.gradle",
+                                               'implementation "com.example:lib:$someVar"'))
+        self.assertEqual(proc.returncode, 0)
+        args = _stub_args(self.tmp)
+        self.assertTrue(len(args) >= 1)
+        deps = args[0]["arguments"].get("dependencies", [])
+        found = [d for d in deps if d.get("groupId") == "com.example"]
+        self.assertTrue(len(found) >= 1, "coord should be extracted as GA-only")
+        self.assertNotIn("version", found[0], "version must be absent for $var interpolation")
+
+    def test_gradle_dollar_var_excluded_from_vuln_check(self):
+        """GA-only coord (dropped $var version) NOT sent to get_dependency_vulnerabilities."""
+        _make_fixture(self.tmp, self._exists_config())
+        proc = _run_hook(self.tmp, _edit_stdin("build.gradle",
+                                               'implementation "com.example:lib:${libs.versions.x}"'))
+        self.assertEqual(proc.returncode, 0)
+        args = _stub_args(self.tmp)
+        ids = [a["id"] for a in args]
+        self.assertIn(1, ids, "verify_coordinates (id:1) should be called")
+        self.assertNotIn(2, ids, "get_dependency_vulnerabilities (id:2) must NOT be called for GA-only")
+
+    # ── pom.xml ──────────────────────────────────────────────────────────────
+
+    def test_pom_xml_dependency(self):
+        """pom.xml <dependency> with groupId+artifactId+version extracted."""
+        _make_fixture(self.tmp,
+                      {1: {"results": [_verify_entry("exists", "org.apache.commons", "commons-lang3")]}})
+        content = (
+            "<dependency>"
+            "<groupId>org.apache.commons</groupId>"
+            "<artifactId>commons-lang3</artifactId>"
+            "<version>3.12.0</version>"
+            "</dependency>"
+        )
+        proc = _run_hook(self.tmp, _edit_stdin("pom.xml", content))
+        self.assertEqual(proc.returncode, 0)
+        args = _stub_args(self.tmp)
+        self.assertTrue(len(args) >= 1)
+        deps = args[0]["arguments"].get("dependencies", [])
+        self.assertTrue(len(deps) >= 1)
+        self.assertEqual(deps[0]["groupId"], "org.apache.commons")
+        self.assertEqual(deps[0]["artifactId"], "commons-lang3")
+
+    # ── libs.versions.toml ───────────────────────────────────────────────────
+
+    def test_toml_module_line(self):
+        """TOML module = "g:a" extracted."""
+        _make_fixture(self.tmp,
+                      {1: {"results": [_verify_entry("exists", "com.example", "toml-lib")]}})
+        proc = _run_hook(self.tmp, _edit_stdin(
+            "libs.versions.toml",
+            'toml-lib = { module = "com.example:toml-lib", version = "1.0" }',
+        ))
+        self.assertEqual(proc.returncode, 0)
+        args = _stub_args(self.tmp)
+        self.assertTrue(len(args) >= 1)
+        deps = args[0]["arguments"].get("dependencies", [])
+        found = [d for d in deps
+                 if d.get("groupId") == "com.example" and d.get("artifactId") == "toml-lib"]
+        self.assertTrue(len(found) >= 1, "toml module coord should be extracted")
+
+    def test_toml_version_ref_becomes_ga_only_no_vuln_call(self):
+        """TOML module-only (no inline version) → GA-only; vuln call absent."""
+        _make_fixture(self.tmp,
+                      {1: {"results": [_verify_entry("exists", "com.example", "mylib")]}})
+        proc = _run_hook(self.tmp, _edit_stdin(
+            "libs.versions.toml",
+            'mylib = { module = "com.example:mylib", version.ref = "mylib" }',
+        ))
+        self.assertEqual(proc.returncode, 0)
+        args = _stub_args(self.tmp)
+        # GA-only → no vuln request
+        ids = [a["id"] for a in args]
+        self.assertNotIn(2, ids, "vuln check must not fire for GA-only coord")
+
+    # ── MultiEdit ────────────────────────────────────────────────────────────
+
+    def test_multiedit_edits_concatenated(self):
+        """MultiEdit: coords from all edits[].new_string combined."""
+        _make_fixture(self.tmp,
+                      {1: {"results": [_verify_entry("exists", "com.foo", "bar")]}})
+        stdin = _multi_stdin("build.gradle", [
+            'implementation "com.foo:bar:1.0"',
+            "// no coord here",
+        ])
+        proc = _run_hook(self.tmp, stdin)
+        self.assertEqual(proc.returncode, 0)
+        args = _stub_args(self.tmp)
+        self.assertTrue(len(args) >= 1)
+        deps = args[0]["arguments"].get("dependencies", [])
+        found = [d for d in deps if d.get("groupId") == "com.foo"]
+        self.assertTrue(len(found) >= 1)
+
+
+@_require_jq_and_timeout()
+class WriteContentPathTest(unittest.TestCase):
+    """Write tool uses .content (not .new_string) — critical distinct code path."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_write_content_absent_hallucinated_denies_with_coord_in_reason(self):
+        """Write .content path: absent+hallucination → deny naming the exact coord."""
+        absent = _verify_entry(
+            "absent", "com.fake", "nonexistent",
+            hallucination=True,
+            suggestions=[{"groupId": "com.real", "artifactId": "real-lib",
+                          "score": 0.92, "versionCount": 100}],
+        )
+        exists = _verify_entry("exists", "org.real", "somelib")
+        _make_fixture(self.tmp, {1: {"results": [absent, exists]}})
+        stdin = _write_stdin(
+            "build.gradle",
+            'implementation "org.real:somelib:1.0"\nimplementation "com.fake:nonexistent:9.9"\n',
+        )
+        proc = _run_hook(self.tmp, stdin)
+        args = _stub_args(self.tmp)
+        self.assertTrue(len(args) >= 1, "stub invoked via Write .content path (positive control)")
+        decision = _parse_decision(proc.stdout)
+        self.assertIsNotNone(decision, "should produce a deny decision")
+        hook_out = decision["hookSpecificOutput"]
+        self.assertEqual(hook_out["hookEventName"], "PreToolUse")
+        self.assertEqual(hook_out["permissionDecision"], "deny")
+        # Reason must name the offending coord so the agent distinguishes new vs pre-existing
+        self.assertIn("com.fake", hook_out["permissionDecisionReason"])
+
+
+@_require_jq_and_timeout()
+class AllowCasesTest(unittest.TestCase):
+    """Cases where the hook should allow (exit 0, no stdout decision JSON)."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_non_build_file_stub_never_invoked(self):
+        """README.md → fast-gate exit; stub must NOT be invoked."""
+        _make_fixture(self.tmp, {1: {"results": []}})
+        stdin = {
+            "tool_name": "Edit",
+            "tool_input": {
+                "file_path": "/project/README.md",
+                "new_string": 'implementation "com.example:lib:1.0"',
+            },
+        }
+        proc = _run_hook(self.tmp, stdin)
+        self.assertEqual(proc.returncode, 0)
+        self.assertEqual(proc.stdout, b"")
+        self.assertEqual(_stub_args(self.tmp), [], "stub must NOT be invoked for non-build files")
+
+    def test_bare_absent_no_hallucination_no_suggestions_allows(self):
+        """absent + likelyHallucination:false + empty suggestions → ALLOW."""
+        entry = _verify_entry("absent", "com.internal", "private-dep",
+                              hallucination=False, suggestions=[])
+        _make_fixture(self.tmp, {1: {"results": [entry]}})
+        proc = _run_hook(self.tmp, _edit_stdin("build.gradle",
+                                               'implementation "com.internal:private-dep:1.0"'))
+        self.assertEqual(proc.returncode, 0)
+        self.assertIsNone(_parse_decision(proc.stdout), "bare absent must ALLOW")
+        # Positive control: stub invoked (not a vacuous pass)
+        self.assertTrue(len(_stub_args(self.tmp)) >= 1, "stub must be invoked (positive control)")
+
+    def test_exists_clean_no_vuln_allows(self):
+        """exists + no CVE → allow."""
+        _make_fixture(self.tmp, {
+            1: {"results": [_verify_entry("exists", "com.example", "lib")]},
+            2: {"results": [_vuln_entry("com.example", "lib", "1.0", [])]},
+        })
+        proc = _run_hook(self.tmp, _edit_stdin("build.gradle",
+                                               'implementation "com.example:lib:1.0"'))
+        self.assertEqual(proc.returncode, 0)
+        self.assertIsNone(_parse_decision(proc.stdout))
+        self.assertTrue(len(_stub_args(self.tmp)) >= 1)
+
+    def test_medium_low_cve_allows(self):
+        """MEDIUM/LOW CVEs → allow (not surfaced by the hook)."""
+        _make_fixture(self.tmp, {
+            1: {"results": [_verify_entry("exists", "org.vuln", "lib")]},
+            2: {"results": [_vuln_entry("org.vuln", "lib", "1.0", [
+                {"id": "CVE-2024-111", "severity": "MEDIUM"},
+                {"id": "CVE-2024-222", "severity": "LOW"},
+            ])]},
+        })
+        proc = _run_hook(self.tmp, _edit_stdin("build.gradle",
+                                               'implementation "org.vuln:lib:1.0"'))
+        self.assertEqual(proc.returncode, 0)
+        self.assertIsNone(_parse_decision(proc.stdout))
+        self.assertTrue(len(_stub_args(self.tmp)) >= 1)
+
+    def test_unknown_status_allows(self):
+        """existenceStatus==unknown (degraded) → ALLOW; must not gate."""
+        entry = _verify_entry("unknown", "com.unknown", "thing")
+        _make_fixture(self.tmp, {1: {"results": [entry]}})
+        proc = _run_hook(self.tmp, _edit_stdin("build.gradle",
+                                               'implementation "com.unknown:thing:1.0"'))
+        self.assertEqual(proc.returncode, 0)
+        self.assertIsNone(_parse_decision(proc.stdout))
+        self.assertTrue(len(_stub_args(self.tmp)) >= 1)
+
+
+@_require_jq_and_timeout()
+class DenyCasesTest(unittest.TestCase):
+    """Cases that should produce permissionDecision:'deny'."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_absent_with_hallucination_denies(self):
+        """absent + likelyHallucination:true → deny with full envelope."""
+        entry = _verify_entry("absent", "com.fake", "nonexistent",
+                              hallucination=True, suggestions=[])
+        _make_fixture(self.tmp, {1: {"results": [entry]}})
+        proc = _run_hook(self.tmp, _edit_stdin("build.gradle",
+                                               'implementation "com.fake:nonexistent:1.0"'))
+        self.assertEqual(proc.returncode, 0)
+        decision = _parse_decision(proc.stdout)
+        self.assertIsNotNone(decision)
+        hook_out = decision["hookSpecificOutput"]
+        self.assertEqual(hook_out["hookEventName"], "PreToolUse")
+        self.assertEqual(hook_out["permissionDecision"], "deny")
+        self.assertIn("com.fake", hook_out["permissionDecisionReason"])
+        self.assertTrue(len(_stub_args(self.tmp)) >= 1)
+
+    def test_absent_with_suggestion_denies_non_imperative(self):
+        """absent + non-empty suggestions → deny; reason phrases as candidates-to-verify."""
+        entry = _verify_entry(
+            "absent", "com.fake", "fake-lib",
+            hallucination=False,
+            suggestions=[{"groupId": "com.real", "artifactId": "real-lib",
+                          "score": 0.9, "versionCount": 50}],
+        )
+        _make_fixture(self.tmp, {1: {"results": [entry]}})
+        proc = _run_hook(self.tmp, _edit_stdin("build.gradle",
+                                               'implementation "com.fake:fake-lib:1.0"'))
+        self.assertEqual(proc.returncode, 0)
+        decision = _parse_decision(proc.stdout)
+        self.assertIsNotNone(decision)
+        hook_out = decision["hookSpecificOutput"]
+        self.assertEqual(hook_out["permissionDecision"], "deny")
+        reason = hook_out["permissionDecisionReason"]
+        # Suggestion coord appears in reason as candidates-to-verify, not as a replacement directive
+        self.assertIn("com.real", reason)
+        self.assertNotIn("Replace", reason)
+        self.assertNotIn("replace with", reason.lower())
+
+    def test_deny_full_envelope_structure(self):
+        """Full hookSpecificOutput envelope matches the PreToolUse contract exactly."""
+        entry = _verify_entry("absent", "com.bad", "hallu",
+                              hallucination=True, suggestions=[])
+        _make_fixture(self.tmp, {1: {"results": [entry]}})
+        proc = _run_hook(self.tmp, _edit_stdin("build.gradle",
+                                               'implementation "com.bad:hallu:1.0"'))
+        decision = _parse_decision(proc.stdout)
+        self.assertIsNotNone(decision)
+        self.assertIn("hookSpecificOutput", decision)
+        ho = decision["hookSpecificOutput"]
+        self.assertIn("hookEventName", ho)
+        self.assertIn("permissionDecision", ho)
+        self.assertIn("permissionDecisionReason", ho)
+        self.assertEqual(ho["hookEventName"], "PreToolUse")
+        self.assertIsInstance(ho["permissionDecisionReason"], str)
+
+
+@_require_jq_and_timeout()
+class AskCasesTest(unittest.TestCase):
+    """Cases that should produce permissionDecision:'ask' (CRITICAL/HIGH CVE)."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _run_vuln_case(self, vulns):
+        """Run hook with given vuln list; return (proc, decision, args)."""
+        _make_fixture(self.tmp, {
+            1: {"results": [_verify_entry("exists", "org.vuln", "lib")]},
+            2: {"results": [_vuln_entry("org.vuln", "lib", "1.0", vulns)]},
+        })
+        proc = _run_hook(self.tmp, _edit_stdin("build.gradle",
+                                               'implementation "org.vuln:lib:1.0"'))
+        return proc, _parse_decision(proc.stdout), _stub_args(self.tmp)
+
+    def test_critical_cve_with_fix_asks(self):
+        """CRITICAL CVE with fixedVersion → ask; fix version present in reason."""
+        proc, decision, args = self._run_vuln_case([
+            {"id": "CVE-2024-1234", "severity": "CRITICAL", "fixedVersion": "2.0.0"},
+        ])
+        self.assertEqual(proc.returncode, 0)
+        self.assertIsNotNone(decision)
+        ho = decision["hookSpecificOutput"]
+        self.assertEqual(ho["hookEventName"], "PreToolUse")
+        self.assertEqual(ho["permissionDecision"], "ask")
+        self.assertIn("CVE-2024-1234", ho["permissionDecisionReason"])
+        self.assertIn("2.0.0", ho["permissionDecisionReason"])
+        self.assertTrue(len(args) >= 1)
+
+    def test_high_cve_no_fix_still_asks(self):
+        """HIGH CVE without fixedVersion → ask (no dead-end deny)."""
+        proc, decision, _ = self._run_vuln_case([
+            {"id": "CVE-2024-5678", "severity": "HIGH"},
+        ])
+        self.assertEqual(proc.returncode, 0)
+        self.assertIsNotNone(decision)
+        self.assertEqual(decision["hookSpecificOutput"]["permissionDecision"], "ask")
+
+    def test_critical_cve_uses_ask_not_deny(self):
+        """CVE arm must use 'ask', never 'deny'."""
+        proc, decision, _ = self._run_vuln_case([
+            {"id": "CVE-2024-9999", "severity": "CRITICAL", "fixedVersion": "3.0"},
+        ])
+        self.assertIsNotNone(decision)
+        self.assertNotEqual(decision["hookSpecificOutput"]["permissionDecision"], "deny")
+
+
+@_require_jq()
+class FailOpenCasesTest(unittest.TestCase):
+    """Every error condition must produce exit 0 with no decision JSON."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _gradle_stdin(self):
+        return _edit_stdin("build.gradle", 'implementation "com.example:lib:1.0"')
+
+    def _assert_fail_open(self, proc):
+        self.assertEqual(proc.returncode, 0, "hook must exit 0 (fail-open)")
+        self.assertIsNone(_parse_decision(proc.stdout), "no decision JSON on fail-open")
+
+    def test_stub_exits_nonzero(self):
+        """python3 exits non-zero → fail-open."""
+        _make_fixture(self.tmp, {1: {"results": []}})
+        proc = _run_hook(self.tmp, self._gradle_stdin(), extra_env={"STUB_EXIT_CODE": "1"})
+        self._assert_fail_open(proc)
+
+    def test_stub_empty_stdout(self):
+        """python3 emits empty stdout → fail-open."""
+        _make_fixture(self.tmp, {1: {"results": []}})
+        proc = _run_hook(self.tmp, self._gradle_stdin(), extra_env={"STUB_EMPTY_OUTPUT": "1"})
+        self._assert_fail_open(proc)
+
+    def test_stub_garbage_stdout(self):
+        """python3 emits non-JSON stdout → fail-open."""
+        _make_fixture(self.tmp, {1: {"results": []}})
+        proc = _run_hook(self.tmp, self._gradle_stdin(), extra_env={"STUB_GARBAGE_OUTPUT": "1"})
+        self._assert_fail_open(proc)
+
+    def test_stub_jsonrpc_error_envelope(self):
+        """JSON-RPC error response (no .result) → fail-open."""
+        _make_fixture(self.tmp, {1: {"results": []}}, error_stub=True)
+        proc = _run_hook(self.tmp, self._gradle_stdin())
+        self._assert_fail_open(proc)
+
+    def test_malformed_stdin(self):
+        """Non-JSON stdin → fail-open (hook can't parse tool_name)."""
+        _make_fixture(self.tmp, {1: {"results": []}})
+        proc = subprocess.run(
+            ["bash", _HOOK_PATH],
+            input=b"this is not json !!! {broken",
+            capture_output=True,
+            env={**os.environ, "CLAUDE_PLUGIN_ROOT": self.tmp},
+            timeout=30,
+        )
+        self._assert_fail_open(proc)
+
+    @unittest.skipUnless(_HAS_TIMEOUT, "timeout/gtimeout not available")
+    def test_stub_hangs_beyond_timeout(self):
+        """Stub sleeping past timeout (exit 124) → fail-open; ~8s wait expected."""
+        _make_fixture(self.tmp, {1: {"results": []}})
+        proc = _run_hook(
+            self.tmp,
+            self._gradle_stdin(),
+            extra_env={"STUB_SLEEP": "30"},
+            proc_timeout=15,  # outer: longer than inner 8s hook timeout
+        )
+        self._assert_fail_open(proc)
+
+    def test_python3_not_in_path(self):
+        """python3 absent from PATH → fail-open at command-v check."""
+        _make_fixture(self.tmp, {1: {"results": []}})
+        # Remove PATH entries that contain python3 while preserving other utilities.
+        # On most systems python3 is in one directory; other shell utils live elsewhere.
+        filtered = [
+            p for p in os.environ.get("PATH", "").split(os.pathsep)
+            if not os.path.isfile(os.path.join(p, "python3"))
+        ]
+        proc = _run_hook(
+            self.tmp,
+            self._gradle_stdin(),
+            extra_env={"PATH": os.pathsep.join(filtered)},
+        )
+        self._assert_fail_open(proc)
+
+    def test_jq_not_in_path(self):
+        """jq absent from PATH → fail-open at very first fast-gate check."""
+        _make_fixture(self.tmp, {1: {"results": []}})
+        filtered = [
+            p for p in os.environ.get("PATH", "").split(os.pathsep)
+            if not os.path.isfile(os.path.join(p, "jq"))
+        ]
+        proc = _run_hook(
+            self.tmp,
+            self._gradle_stdin(),
+            extra_env={"PATH": os.pathsep.join(filtered)},
+        )
+        self._assert_fail_open(proc)
+
+
+@_require_jq_and_timeout()
+class SecurityTest(unittest.TestCase):
+    """Security contracts: GITHUB_TOKEN scrub + charset filtering."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_github_token_scrubbed_from_spawned_env(self):
+        """GITHUB_TOKEN must NOT be present in the environment the stub sees."""
+        _make_fixture(self.tmp, {
+            1: {"results": [_verify_entry("exists", "com.example", "lib")]},
+        })
+        proc = _run_hook(
+            self.tmp,
+            _edit_stdin("build.gradle", 'implementation "com.example:lib:1.0"'),
+            extra_env={"GITHUB_TOKEN": "super-secret-token-xyz"},
+        )
+        self.assertEqual(proc.returncode, 0)
+        env = _stub_env(self.tmp)
+        self.assertNotIn(
+            "GITHUB_TOKEN", env,
+            "GITHUB_TOKEN must be scrubbed from the spawned python env (env -u GITHUB_TOKEN)",
+        )
+
+    def test_charset_invalid_coord_dropped(self):
+        """Coord token with invalid chars (semicolon) dropped at extraction."""
+        _make_fixture(self.tmp, {
+            1: {"results": [_verify_entry("exists", "com.example", "lib")]},
+        })
+        proc = _run_hook(
+            self.tmp,
+            _edit_stdin(
+                "build.gradle",
+                # Valid coord followed by an invalid-charset pseudo-coord
+                'implementation "com.example:lib:1.0"\n'
+                '// implementation "bad;grp:artifact:1.0"\n',
+            ),
+        )
+        self.assertEqual(proc.returncode, 0)
+        args = _stub_args(self.tmp)
+        if args:
+            deps = args[0]["arguments"].get("dependencies", [])
+            for dep in deps:
+                self.assertFalse(
+                    ";" in dep.get("groupId", "") or ";" in dep.get("artifactId", ""),
+                    "coord with ; must not reach the stub",
+                )
+
+
+@_require_jq_and_timeout()
+class BoundaryTest(unittest.TestCase):
+    """MAX_COORDS cap, deduplication, multi-finding aggregation."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_max_coords_capped_at_eight(self):
+        """Content with >8 distinct coords → at most 8 sent."""
+        lines = [f'implementation "com.lib{i}:art{i}:1.{i}"' for i in range(12)]
+        results = [_verify_entry("exists", f"com.lib{i}", f"art{i}") for i in range(8)]
+        _make_fixture(self.tmp, {1: {"results": results}})
+        proc = _run_hook(self.tmp, _edit_stdin("build.gradle", "\n".join(lines)))
+        self.assertEqual(proc.returncode, 0)
+        args = _stub_args(self.tmp)
+        self.assertTrue(len(args) >= 1)
+        deps = args[0]["arguments"].get("dependencies", [])
+        self.assertLessEqual(len(deps), 8, "at most MAX_COORDS=8 deps sent")
+
+    def test_duplicates_collapsed(self):
+        """Same coord repeated 3× → sent exactly once."""
+        entry = _verify_entry("exists", "com.example", "lib")
+        _make_fixture(self.tmp, {1: {"results": [entry]}})
+        content = "\n".join(['implementation "com.example:lib:1.0"'] * 3)
+        proc = _run_hook(self.tmp, _edit_stdin("build.gradle", content))
+        self.assertEqual(proc.returncode, 0)
+        args = _stub_args(self.tmp)
+        self.assertTrue(len(args) >= 1)
+        deps = args[0]["arguments"].get("dependencies", [])
+        matching = [d for d in deps
+                    if d.get("groupId") == "com.example" and d.get("artifactId") == "lib"]
+        self.assertEqual(len(matching), 1, "duplicate must be collapsed to one entry")
+
+    def test_deny_wins_over_ask_on_multiple_problems(self):
+        """One absent+hallucinated coord + one CRITICAL CVE → deny (deny > ask)."""
+        absent = _verify_entry("absent", "com.bad", "hallu",
+                               hallucination=True, suggestions=[])
+        exists = _verify_entry("exists", "org.vuln", "lib")
+        _make_fixture(self.tmp, {
+            1: {"results": [absent, exists]},
+            2: {"results": [_vuln_entry("org.vuln", "lib", "2.0", [
+                {"id": "CVE-2024-0001", "severity": "CRITICAL", "fixedVersion": "3.0"},
+            ])]},
+        })
+        proc = _run_hook(
+            self.tmp,
+            _edit_stdin("build.gradle",
+                        'implementation "com.bad:hallu:1.0"\n'
+                        'implementation "org.vuln:lib:2.0"\n'),
+        )
+        self.assertEqual(proc.returncode, 0)
+        decision = _parse_decision(proc.stdout)
+        self.assertIsNotNone(decision)
+        self.assertEqual(
+            decision["hookSpecificOutput"]["permissionDecision"],
+            "deny",
+            "deny must win over ask when both findings are present",
+        )
+
+
+@_require_jq()
+class ContractDriftGuardTest(unittest.TestCase):
+    """Feed the hook's JSON-RPC contract into the REAL dispatch to detect drift."""
+
+    # Minimal metadata XML for exists-response mocks
+    _META_XML = (
+        b"<metadata>"
+        b"<versioning><versions><version>1.0</version></versions></versioning>"
+        b"</metadata>"
+    )
+    _OSV_EMPTY = json.dumps({"results": [{"vulns": []}]}).encode()
+
+    def _urlopen_always(self, body, status=200):
+        """Return a side_effect that always yields (status, body)."""
+        def _effect(*_args, **_kwargs):
+            return _MockResp(status, body)
+        return _effect
+
+    def _dispatch_capture(self, request, urlopen_body):
+        """Call server.dispatch and capture the JSON-RPC response written to stdout."""
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            with unittest.mock.patch(
+                "urllib.request.urlopen",
+                side_effect=self._urlopen_always(urlopen_body),
+            ):
+                server.dispatch(request)
+        output = buf.getvalue().strip()
+        # dispatch prints JSON to stdout; parse it
+        return json.loads(output)
+
+    def test_verify_coordinates_request_accepted_by_real_dispatch(self):
+        """verify_coordinates JSON-RPC as emitted by the hook → accepted by real server."""
+        request = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {
+                "name": "verify_coordinates",
+                "arguments": {
+                    "dependencies": [
+                        {"groupId": "com.example", "artifactId": "lib", "version": "1.0"}
+                    ]
+                },
+            },
+        }
+        result = self._dispatch_capture(request, self._META_XML)
+        self.assertIn("result", result, "real dispatch must produce a result")
+        text = result["result"]["content"][0]["text"]
+        parsed = json.loads(text)
+        self.assertIn("results", parsed)
+        self.assertTrue(len(parsed["results"]) >= 1)
+        self.assertIn("existenceStatus", parsed["results"][0])
+
+    def test_get_dependency_vulnerabilities_request_accepted_by_real_dispatch(self):
+        """get_dependency_vulnerabilities JSON-RPC as emitted by hook → accepted."""
+        request = {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "get_dependency_vulnerabilities",
+                "arguments": {
+                    "dependencies": [
+                        {"groupId": "com.example", "artifactId": "lib", "version": "1.0"}
+                    ]
+                },
+            },
+        }
+        result = self._dispatch_capture(request, self._OSV_EMPTY)
+        self.assertIn("result", result)
+        text = result["result"]["content"][0]["text"]
+        parsed = json.loads(text)
+        self.assertIn("results", parsed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/maven-mcp/tests/test_pre_edit_hook.py
+++ b/plugins/maven-mcp/tests/test_pre_edit_hook.py
@@ -20,13 +20,12 @@ import json
 import os
 import shutil
 import subprocess
-import sys
 import tempfile
 import textwrap
 import unittest
 import unittest.mock
 
-from _helpers import server, mock_urlopen
+from _helpers import server
 
 # ---------------------------------------------------------------------------
 # Locate hook script
@@ -53,6 +52,60 @@ def _require_jq_and_timeout(msg="jq and timeout/gtimeout required to invoke stub
     On macOS without coreutils this skips gracefully; CI (ubuntu-latest) has timeout.
     """
     return unittest.skipUnless(_HAS_JQ and _HAS_TIMEOUT, msg)
+
+
+# ---------------------------------------------------------------------------
+# Shadow-bin helper for fail-open PATH tests
+# ---------------------------------------------------------------------------
+
+# All tools the hook invokes via PATH (bash builtins like printf/command excluded).
+# Used to build a minimal shadow PATH that is missing exactly one tool, so the
+# excluded tool is the only thing absent — all others remain reachable.
+_HOOK_SHELL_TOOLS = (
+    "bash", "cat", "basename", "mktemp", "grep", "sed",
+    "tr", "sort", "head", "wc", "env", "cut", "jq", "python3",
+)
+
+
+def _shadow_bin_without(excluded_tool, tmpdir_root):
+    """Build a shadow bin dir under tmpdir_root with symlinks for all _HOOK_SHELL_TOOLS
+    except excluded_tool, plus the system timeout command (timeout/gtimeout) if available.
+
+    Returns (shadow_dir, bash_abs_path) on success; (None, None) if any required
+    tool (other than excluded_tool) cannot be located on this runner — caller
+    should call skipTest() in that case.
+    """
+    bash_abs = shutil.which("bash")
+    if bash_abs is None:
+        return None, None
+
+    shadow = os.path.join(tmpdir_root, "shadow_bin")
+    os.makedirs(shadow, exist_ok=True)
+
+    for tool in _HOOK_SHELL_TOOLS:
+        if tool == excluded_tool:
+            continue  # intentionally absent in this shadow env
+        real = shutil.which(tool)
+        if real is None:
+            return None, None  # required tool missing on this runner
+        link = os.path.join(shadow, tool)
+        if not os.path.exists(link):
+            os.symlink(real, link)
+
+    # Also symlink the timeout command (timeout or gtimeout) if available.
+    # Required so the python3-absent test reaches the python3 check rather
+    # than exiting at the timeout check.
+    for tcmd in ("timeout", "gtimeout"):
+        if tcmd == excluded_tool:
+            continue
+        real = shutil.which(tcmd)
+        if real is not None:
+            link = os.path.join(shadow, tcmd)
+            if not os.path.exists(link):
+                os.symlink(real, link)
+            break  # only one timeout variant needed
+
+    return shadow, bash_abs
 
 
 # ---------------------------------------------------------------------------
@@ -338,7 +391,7 @@ class ExtractionTest(unittest.TestCase):
                                                "implementation 'com.example:lib:1.0.0'"))
         self.assertEqual(proc.returncode, 0)
         args = _stub_args(self.tmp)
-        self.assertTrue(len(args) >= 1, "stub must be invoked")
+        self.assertGreaterEqual(len(args), 1, "stub must be invoked")
         deps = args[0]["arguments"].get("dependencies", [])
         self.assertEqual(len(deps), 1)
         self.assertEqual(deps[0]["groupId"], "com.example")
@@ -352,7 +405,7 @@ class ExtractionTest(unittest.TestCase):
                                                'implementation("com.example:lib:2.0.0")'))
         self.assertEqual(proc.returncode, 0)
         args = _stub_args(self.tmp)
-        self.assertTrue(len(args) >= 1)
+        self.assertGreaterEqual(len(args), 1)
         deps = args[0]["arguments"].get("dependencies", [])
         self.assertEqual(len(deps), 1)
         self.assertEqual(deps[0].get("version"), "2.0.0")
@@ -364,10 +417,10 @@ class ExtractionTest(unittest.TestCase):
                                                'implementation "com.example:lib:$someVar"'))
         self.assertEqual(proc.returncode, 0)
         args = _stub_args(self.tmp)
-        self.assertTrue(len(args) >= 1)
+        self.assertGreaterEqual(len(args), 1)
         deps = args[0]["arguments"].get("dependencies", [])
         found = [d for d in deps if d.get("groupId") == "com.example"]
-        self.assertTrue(len(found) >= 1, "coord should be extracted as GA-only")
+        self.assertGreaterEqual(len(found), 1, "coord should be extracted as GA-only")
         self.assertNotIn("version", found[0], "version must be absent for $var interpolation")
 
     def test_gradle_dollar_var_excluded_from_vuln_check(self):
@@ -397,9 +450,9 @@ class ExtractionTest(unittest.TestCase):
         proc = _run_hook(self.tmp, _edit_stdin("pom.xml", content))
         self.assertEqual(proc.returncode, 0)
         args = _stub_args(self.tmp)
-        self.assertTrue(len(args) >= 1)
+        self.assertGreaterEqual(len(args), 1)
         deps = args[0]["arguments"].get("dependencies", [])
-        self.assertTrue(len(deps) >= 1)
+        self.assertGreaterEqual(len(deps), 1)
         self.assertEqual(deps[0]["groupId"], "org.apache.commons")
         self.assertEqual(deps[0]["artifactId"], "commons-lang3")
 
@@ -415,11 +468,11 @@ class ExtractionTest(unittest.TestCase):
         ))
         self.assertEqual(proc.returncode, 0)
         args = _stub_args(self.tmp)
-        self.assertTrue(len(args) >= 1)
+        self.assertGreaterEqual(len(args), 1)
         deps = args[0]["arguments"].get("dependencies", [])
         found = [d for d in deps
                  if d.get("groupId") == "com.example" and d.get("artifactId") == "toml-lib"]
-        self.assertTrue(len(found) >= 1, "toml module coord should be extracted")
+        self.assertGreaterEqual(len(found), 1, "toml module coord should be extracted")
 
     def test_toml_version_ref_becomes_ga_only_no_vuln_call(self):
         """TOML module-only (no inline version) → GA-only; vuln call absent."""
@@ -448,10 +501,10 @@ class ExtractionTest(unittest.TestCase):
         proc = _run_hook(self.tmp, stdin)
         self.assertEqual(proc.returncode, 0)
         args = _stub_args(self.tmp)
-        self.assertTrue(len(args) >= 1)
+        self.assertGreaterEqual(len(args), 1)
         deps = args[0]["arguments"].get("dependencies", [])
         found = [d for d in deps if d.get("groupId") == "com.foo"]
-        self.assertTrue(len(found) >= 1)
+        self.assertGreaterEqual(len(found), 1)
 
 
 @_require_jq_and_timeout()
@@ -480,7 +533,7 @@ class WriteContentPathTest(unittest.TestCase):
         )
         proc = _run_hook(self.tmp, stdin)
         args = _stub_args(self.tmp)
-        self.assertTrue(len(args) >= 1, "stub invoked via Write .content path (positive control)")
+        self.assertGreaterEqual(len(args), 1, "stub invoked via Write .content path (positive control)")
         decision = _parse_decision(proc.stdout)
         self.assertIsNotNone(decision, "should produce a deny decision")
         hook_out = decision["hookSpecificOutput"]
@@ -525,7 +578,7 @@ class AllowCasesTest(unittest.TestCase):
         self.assertEqual(proc.returncode, 0)
         self.assertIsNone(_parse_decision(proc.stdout), "bare absent must ALLOW")
         # Positive control: stub invoked (not a vacuous pass)
-        self.assertTrue(len(_stub_args(self.tmp)) >= 1, "stub must be invoked (positive control)")
+        self.assertGreaterEqual(len(_stub_args(self.tmp)), 1, "stub must be invoked (positive control)")
 
     def test_exists_clean_no_vuln_allows(self):
         """exists + no CVE → allow."""
@@ -537,7 +590,7 @@ class AllowCasesTest(unittest.TestCase):
                                                'implementation "com.example:lib:1.0"'))
         self.assertEqual(proc.returncode, 0)
         self.assertIsNone(_parse_decision(proc.stdout))
-        self.assertTrue(len(_stub_args(self.tmp)) >= 1)
+        self.assertGreaterEqual(len(_stub_args(self.tmp)), 1)
 
     def test_medium_low_cve_allows(self):
         """MEDIUM/LOW CVEs → allow (not surfaced by the hook)."""
@@ -552,7 +605,7 @@ class AllowCasesTest(unittest.TestCase):
                                                'implementation "org.vuln:lib:1.0"'))
         self.assertEqual(proc.returncode, 0)
         self.assertIsNone(_parse_decision(proc.stdout))
-        self.assertTrue(len(_stub_args(self.tmp)) >= 1)
+        self.assertGreaterEqual(len(_stub_args(self.tmp)), 1)
 
     def test_unknown_status_allows(self):
         """existenceStatus==unknown (degraded) → ALLOW; must not gate."""
@@ -562,7 +615,7 @@ class AllowCasesTest(unittest.TestCase):
                                                'implementation "com.unknown:thing:1.0"'))
         self.assertEqual(proc.returncode, 0)
         self.assertIsNone(_parse_decision(proc.stdout))
-        self.assertTrue(len(_stub_args(self.tmp)) >= 1)
+        self.assertGreaterEqual(len(_stub_args(self.tmp)), 1)
 
 
 @_require_jq_and_timeout()
@@ -589,7 +642,7 @@ class DenyCasesTest(unittest.TestCase):
         self.assertEqual(hook_out["hookEventName"], "PreToolUse")
         self.assertEqual(hook_out["permissionDecision"], "deny")
         self.assertIn("com.fake", hook_out["permissionDecisionReason"])
-        self.assertTrue(len(_stub_args(self.tmp)) >= 1)
+        self.assertGreaterEqual(len(_stub_args(self.tmp)), 1)
 
     def test_absent_with_suggestion_denies_non_imperative(self):
         """absent + non-empty suggestions → deny; reason phrases as candidates-to-verify."""
@@ -663,7 +716,7 @@ class AskCasesTest(unittest.TestCase):
         self.assertEqual(ho["permissionDecision"], "ask")
         self.assertIn("CVE-2024-1234", ho["permissionDecisionReason"])
         self.assertIn("2.0.0", ho["permissionDecisionReason"])
-        self.assertTrue(len(args) >= 1)
+        self.assertGreaterEqual(len(args), 1)
 
     def test_high_cve_no_fix_still_asks(self):
         """HIGH CVE without fixedVersion → ask (no dead-end deny)."""
@@ -749,32 +802,40 @@ class FailOpenCasesTest(unittest.TestCase):
         self._assert_fail_open(proc)
 
     def test_python3_not_in_path(self):
-        """python3 absent from PATH → fail-open at command-v check."""
+        """python3 absent from PATH → fail-open at command -v check."""
         _make_fixture(self.tmp, {1: {"results": []}})
-        # Remove PATH entries that contain python3 while preserving other utilities.
-        # On most systems python3 is in one directory; other shell utils live elsewhere.
-        filtered = [
-            p for p in os.environ.get("PATH", "").split(os.pathsep)
-            if not os.path.isfile(os.path.join(p, "python3"))
-        ]
-        proc = _run_hook(
-            self.tmp,
-            self._gradle_stdin(),
-            extra_env={"PATH": os.pathsep.join(filtered)},
+        # Build a shadow bin with every hook tool symlinked except python3.
+        # Invoke bash by its absolute path so subprocess.run does not depend
+        # on PATH to find bash itself (on Linux all tools share /usr/bin,
+        # so filtering by directory would also remove bash and cause an error).
+        shadow_dir, bash_abs = _shadow_bin_without("python3", self.tmp)
+        if shadow_dir is None:
+            self.skipTest("could not build shadow bin (required tool missing on this runner)")
+        proc = subprocess.run(
+            [bash_abs, _HOOK_PATH],
+            input=json.dumps(self._gradle_stdin()).encode(),
+            capture_output=True,
+            env={**os.environ, "CLAUDE_PLUGIN_ROOT": self.tmp, "PATH": shadow_dir},
+            timeout=30,
         )
         self._assert_fail_open(proc)
 
     def test_jq_not_in_path(self):
         """jq absent from PATH → fail-open at very first fast-gate check."""
         _make_fixture(self.tmp, {1: {"results": []}})
-        filtered = [
-            p for p in os.environ.get("PATH", "").split(os.pathsep)
-            if not os.path.isfile(os.path.join(p, "jq"))
-        ]
-        proc = _run_hook(
-            self.tmp,
-            self._gradle_stdin(),
-            extra_env={"PATH": os.pathsep.join(filtered)},
+        # Build a shadow bin with every hook tool symlinked except jq.
+        # Invoke bash by its absolute path so subprocess.run does not depend
+        # on PATH to find bash itself (on Linux all tools share /usr/bin,
+        # so filtering by directory would also remove bash and cause an error).
+        shadow_dir, bash_abs = _shadow_bin_without("jq", self.tmp)
+        if shadow_dir is None:
+            self.skipTest("could not build shadow bin (required tool missing on this runner)")
+        proc = subprocess.run(
+            [bash_abs, _HOOK_PATH],
+            input=json.dumps(self._gradle_stdin()).encode(),
+            capture_output=True,
+            env={**os.environ, "CLAUDE_PLUGIN_ROOT": self.tmp, "PATH": shadow_dir},
+            timeout=30,
         )
         self._assert_fail_open(proc)
 
@@ -849,7 +910,7 @@ class BoundaryTest(unittest.TestCase):
         proc = _run_hook(self.tmp, _edit_stdin("build.gradle", "\n".join(lines)))
         self.assertEqual(proc.returncode, 0)
         args = _stub_args(self.tmp)
-        self.assertTrue(len(args) >= 1)
+        self.assertGreaterEqual(len(args), 1)
         deps = args[0]["arguments"].get("dependencies", [])
         self.assertLessEqual(len(deps), 8, "at most MAX_COORDS=8 deps sent")
 
@@ -861,7 +922,7 @@ class BoundaryTest(unittest.TestCase):
         proc = _run_hook(self.tmp, _edit_stdin("build.gradle", content))
         self.assertEqual(proc.returncode, 0)
         args = _stub_args(self.tmp)
-        self.assertTrue(len(args) >= 1)
+        self.assertGreaterEqual(len(args), 1)
         deps = args[0]["arguments"].get("dependencies", [])
         matching = [d for d in deps
                     if d.get("groupId") == "com.example" and d.get("artifactId") == "lib"]
@@ -945,7 +1006,7 @@ class ContractDriftGuardTest(unittest.TestCase):
         text = result["result"]["content"][0]["text"]
         parsed = json.loads(text)
         self.assertIn("results", parsed)
-        self.assertTrue(len(parsed["results"]) >= 1)
+        self.assertGreaterEqual(len(parsed["results"]), 1)
         self.assertIn("existenceStatus", parsed["results"][0])
 
     def test_get_dependency_vulnerabilities_request_accepted_by_real_dispatch(self):


### PR DESCRIPTION
Flagship of epic #281 Horizon 1: shift maven-mcp from a post-hoc auditor to a **write-time guard**. A new PreToolUse hook verifies the coordinates an agent is adding to a build file *before* the edit lands, so the agent self-corrects in the same turn.

## What it does (`plugin/hooks/pre-edit-deps.sh`)
Fires on `Edit|Write|MultiEdit` of `build.gradle[.kts]` / `settings.gradle[.kts]` / `pom.xml` / `libs.versions.toml`. Extracts new `g:a[:v]` from the tool payload (Gradle string-notation, pom.xml blocks, TOML), then calls `verify_coordinates` + `get_dependency_vulnerabilities` via one JSON-RPC pipe into the bundled server:
- **`absent` + (`likelyHallucination` OR did-you-mean suggestions)** → `deny`, candidates framed as "verify before use" (non-imperative — anti-slopsquat, #322).
- **CRITICAL/HIGH CVE on a pinned version** → `ask` (a real, possibly-deliberate version; a hard deny with no fix would dead-end the user).
- **bare `absent` / `unknown` / `exists` / any failure** → `allow`.

## Safety (the dominant invariant: fail-open)
- **Structural fail-open**: `set -euo pipefail` + `trap 'exit 0' EXIT`; every external call guarded; the script can only ever `exit 0` — never the block-triggering `exit 2`. jq/`timeout`/python/server/network failure all silently allow the edit.
- **bash-3.2-safe** (macOS default `/bin/bash`): no `declare -A`/`${var,,}`/`mapfile`; `timeout`→`gtimeout`→fail-open.
- **Security**: `GITHUB_TOKEN` scrubbed from the spawned env; requests AND the deny/ask reason built with `jq --arg` from structured fields only (no interpolation of file or network text); suggestion coords charset-filtered.
- **Existence guard is Maven-Central-scoped by design** — bare `absent` never denies, so a legitimate private/internal/androidx coordinate is never false-blocked. Documented; "do not tighten".

## Review & tests
Plan + **2-cycle multiexpert review** (security / architecture / devops / test-coverage; the one cross-reviewer contradiction — deny-on-bare-`absent` — resolved by consensus toward the safe direction) under `docs/plans/maven-write-guard-hook/`. Adds `tests/test_pre_edit_hook.py` (subprocess + recording stub server, no network; 35 cases incl. every fail-open path, positive controls on allow-cases, a hook↔real-server contract-drift test) and a `shellcheck` CI gate. **369 tests, 0 failures**; `validate.sh` + `shellcheck` green. Keeps the existing PostToolUse `/check-deps` reminder (complementary).

Closes #283