### PR TITLE
maven-mcp: fix get_latest_version ranking bare release below suffixed build

### DIFF
--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -650,11 +650,8 @@ def compare_versions(a: str, b: str) -> int:
     has_suffix_a = "-" in a or "+" in a
     has_suffix_b = "-" in b or "+" in b
     if has_suffix_a != has_suffix_b:
-        # Same core, same stability class, but only one side carries a
-        # qualifier suffix at all (e.g. "0.8.0" vs "0.8.0-0.6.x-compat" or
-        # "0.8.0-compat", #325): the bare version ranks higher, never the one
-        # with an extra qualifier — regardless of whether that suffix
-        # contains digits.
+        # #325: same core, same stability class, but only one side carries a
+        # qualifier suffix at all — the bare version always ranks higher.
         return 1 if not has_suffix_a else -1
     tail_diff = _compare_int_lists(_extract_prerelease_numbers(a), _extract_prerelease_numbers(b))
     if tail_diff != 0:

--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -647,6 +647,15 @@ def compare_versions(a: str, b: str) -> int:
     weight_diff = PRERELEASE_WEIGHT.get(classify_version(a), 5) - PRERELEASE_WEIGHT.get(classify_version(b), 5)
     if weight_diff != 0:
         return weight_diff
+    has_suffix_a = "-" in a or "+" in a
+    has_suffix_b = "-" in b or "+" in b
+    if has_suffix_a != has_suffix_b:
+        # Same core, same stability class, but only one side carries a
+        # qualifier suffix at all (e.g. "0.8.0" vs "0.8.0-0.6.x-compat" or
+        # "0.8.0-compat", #325): the bare version ranks higher, never the one
+        # with an extra qualifier — regardless of whether that suffix
+        # contains digits.
+        return 1 if not has_suffix_a else -1
     tail_diff = _compare_int_lists(_extract_prerelease_numbers(a), _extract_prerelease_numbers(b))
     if tail_diff != 0:
         return tail_diff

--- a/plugins/maven-mcp/tests/test_handlers.py
+++ b/plugins/maven-mcp/tests/test_handlers.py
@@ -58,6 +58,16 @@ class TestGetLatestVersion(unittest.TestCase):
         self.assertEqual(out["stability"], "stable")
         self.assertEqual(out["allVersionsCount"], 2)
 
+    def test_prefers_bare_release_over_compat_suffix_build(self):
+        # #325 end-to-end repro: handle_get_latest_version must pick "0.8.0",
+        # not the same-core "0.8.0-0.6.x-compat" qualifier build.
+        with _patch_urlopen([(200, _meta(["0.6.0", "0.7.0", "0.7.1", "0.8.0-0.6.x-compat", "0.8.0"]))]):
+            out = server.handle_get_latest_version(
+                {"groupId": "org.jetbrains.kotlinx", "artifactId": "kotlinx-datetime"}
+            )
+        self.assertEqual(out["latestVersion"], "0.8.0")
+        self.assertEqual(out["stability"], "stable")
+
     def test_no_stable_version_raises(self):
         # STABLE_ONLY over a prerelease-only metadata -> find_latest_version None
         # -> handler raises ValueError (server.py :1235-:1236).

--- a/plugins/maven-mcp/tests/test_version.py
+++ b/plugins/maven-mcp/tests/test_version.py
@@ -8,6 +8,7 @@ Mirrors assertions from:
 All test methods call pure functions only — no network, no mocking required.
 """
 
+import functools
 import unittest
 
 from _helpers import server
@@ -120,6 +121,19 @@ class FindLatestVersionForCurrentTest(unittest.TestCase):
             "2.0.0",
         )
 
+    def test_bare_release_preferred_over_compat_suffix_build(self):
+        # #325: get_latest_version picked "0.8.0-0.6.x-compat" over "0.8.0".
+        # The candidate list mirrors how the server actually feeds this
+        # function — sorted ascending via compare_versions (server.py:557)
+        # before selection — so this exercises the real selection pipeline,
+        # not just the comparator in isolation.
+        raw = ["0.7.0", "0.8.0-0.6.x-compat", "0.8.0"]
+        versions = sorted(set(raw), key=functools.cmp_to_key(server.compare_versions))
+        self.assertEqual(
+            server.find_latest_version_for_current(versions, "0.7.0"),
+            "0.8.0",
+        )
+
 
 # ---------------------------------------------------------------------------
 # compare_versions
@@ -141,6 +155,39 @@ class CompareVersionsTest(unittest.TestCase):
         # mirrors compare.test.ts: "orders pre-releases relative to each other"
         self.assertGreater(server.compare_versions("2.0.0-RC1", "2.0.0-beta1"), 0)
         self.assertLess(server.compare_versions("2.0.0-alpha1", "2.0.0-beta1"), 0)
+
+    def test_bare_release_outranks_same_core_qualifier_suffix(self):
+        # #325: "0.8.0" and "0.8.0-0.6.x-compat" share the same numeric core
+        # and both classify as "stable" (no alpha/beta/rc/milestone/snapshot
+        # match in "-compat"), so the only signal left is the prerelease-number
+        # tail. A bare release (no suffix at all) must rank above a same-core
+        # release carrying a numeric qualifier suffix, not below it.
+        self.assertGreater(server.compare_versions("0.8.0", "0.8.0-0.6.x-compat"), 0)
+        self.assertLess(server.compare_versions("0.8.0-0.6.x-compat", "0.8.0"), 0)
+
+    def test_bare_release_outranks_digitless_qualifier_suffix(self):
+        # #325: a suffix with no digits at all (e.g. "-compat", "-jre") must
+        # not slip past the fix — _extract_prerelease_numbers returns [] for
+        # both a truly bare version AND a digitless suffix, so the fix must
+        # key on suffix presence, not on prerelease-number-list emptiness.
+        self.assertGreater(server.compare_versions("0.8.0", "0.8.0-compat"), 0)
+        self.assertLess(server.compare_versions("0.8.0-compat", "0.8.0"), 0)
+
+    def test_both_prerelease_number_tails_still_compare_correctly(self):
+        # #325 regression guard: the fix must not break ordering when BOTH
+        # sides carry a numeric suffix — rc.2 still ranks above rc.1.
+        self.assertGreater(server.compare_versions("1.0.0-rc.2", "1.0.0-rc.1"), 0)
+        self.assertLess(server.compare_versions("1.0.0-rc.1", "1.0.0-rc.2"), 0)
+
+    def test_both_suffixed_same_class_falls_back_to_prerelease_tail(self):
+        # #325 regression guard: when BOTH sides carry a suffix, the new
+        # suffix-presence branch must not fire (true == true), so ordering
+        # still falls through to the existing prerelease-number tail compare
+        # unaffected — "beta" (no digits) ranks below "beta2" exactly as
+        # before this fix, both within the same classify_version() class.
+        self.assertEqual(server.classify_version("1.0.0-beta"), server.classify_version("1.0.0-beta2"))
+        self.assertLess(server.compare_versions("1.0.0-beta", "1.0.0-beta2"), 0)
+        self.assertGreater(server.compare_versions("1.0.0-beta2", "1.0.0-beta"), 0)
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/maven-mcp/tests/test_version.py
+++ b/plugins/maven-mcp/tests/test_version.py
@@ -75,6 +75,21 @@ class ClassifyVersionTest(unittest.TestCase):
 _MIXED_VERSIONS = ["1.0.0", "2.0.0-alpha1", "2.0.0-beta1", "2.0.0-RC1", "2.0.0"]
 
 
+class FindLatestVersionTest(unittest.TestCase):
+    """find_latest_version is what handle_get_latest_version actually calls
+    (server.py ~:2008) — #325 was reported against that tool specifically,
+    so the regression must be pinned here, not only on the sibling
+    find_latest_version_for_current used by compare/audit tools."""
+
+    def test_bare_release_preferred_over_compat_suffix_build(self):
+        # #325: get_latest_version picked "0.8.0-0.6.x-compat" over "0.8.0".
+        # Mirrors how fetch_metadata builds the sorted versions list fed to
+        # find_latest_version (server.py:557).
+        raw = ["0.7.0", "0.8.0-0.6.x-compat", "0.8.0"]
+        versions = sorted(set(raw), key=functools.cmp_to_key(server.compare_versions))
+        self.assertEqual(server.find_latest_version(versions, "PREFER_STABLE"), "0.8.0")
+
+
 class FindLatestVersionForCurrentTest(unittest.TestCase):
 
     def test_returns_stable_when_current_is_stable(self):


### PR DESCRIPTION
## Root cause

`compare_versions` (`plugins/maven-mcp/plugin/server/server.py`) ranked a bare release
(e.g. `0.8.0`) **below** a same-core, same-stability-class release carrying a `-`/`+`
qualifier suffix (e.g. `0.8.0-0.6.x-compat`):

- `_parse_segments` gives both versions the same numeric core (`[0, 8, 0]`).
- `classify_version` classifies both as `"stable"` (`-compat` matches no
  alpha/beta/rc/milestone/snapshot pattern), so the stability-weight check is a tie.
- `_extract_prerelease_numbers("0.8.0")` → `[]`; `_extract_prerelease_numbers("0.8.0-0.6.x-compat")`
  → `[0, 6]` (digits pulled out of the free-text suffix).
- `_compare_int_lists([], [0, 6])` treats the missing list as all-zeros at every
  position → `0 < 6` at index 1 → returns `-1`, ranking the bare release *below* the
  suffixed one.

This flowed through `sorted(..., key=functools.cmp_to_key(compare_versions))`
(server.py:557) into `find_latest_version`/`find_latest_version_for_current`, so
`get_latest_version` (and `audit_project_dependencies`/`compare_dependency_versions`)
picked the qualifier build over the actual release.

## Fix

Added an early-return branch in `compare_versions`, between the existing
stability-weight check and the existing prerelease-number-tail check: when exactly one
of the two versions carries any `-`/`+` character at all, the bare (no-suffix) version
unconditionally ranks higher — regardless of whether the suffix contains digits.
`_compare_int_lists`, `_parse_segments`, and `_extract_prerelease_numbers` are untouched;
ordering between two genuinely-suffixed versions (e.g. `1.0.0-rc.1` vs `1.0.0-rc.2`) is
unaffected.

## Scope boundary (explicit, not silently dropped)

This fix covers the asymmetric case (exactly one side has a `-`/`+` suffix), which is
what #325 reports. Confirmed via before/after comparison against pre-fix `server.py`
that these related cases are **pre-existing** and unaffected by this diff — not fixed
here, filed as a follow-up:

- Dot-delimited qualifiers (`.RELEASE`/`.Final` — common Spring/Hibernate convention)
  are invisible to the suffix/core split.
- No-separator qualifiers (`1.0.0legacy`) are likewise invisible.
- Symmetric free-text suffixes (both sides have a suffix but neither is a true ordinal
  prerelease number, e.g. `0.8.0-compat` vs `0.8.0-0.6.x-compat`) still misorder.

Follow-up: #331

One accepted, intentional behavior change: `compare_versions("1.0.0", "1.0.0+build5")`
now ranks the bare version higher (previously the reverse, via the same buggy
mechanism above). This is a strict improvement — bare no longer loses to a
build-tagged variant — and `+` is effectively unused in real Maven coordinates.

## Tests

Red→green regression coverage at every level the bug manifests:
- `compare_versions` (exact #325 repro, digitless-suffix variant, both-suffixed
  non-regression guards for `rc.1`/`rc.2` and `beta`/`beta2`)
- `find_latest_version` and `find_latest_version_for_current` (pipeline-level:
  sort → select, mirroring how `server.py:557` actually feeds these functions)
- `handle_get_latest_version` handler test mirroring the issue's exact kotlinx-datetime
  example end-to-end (mocked HTTP metadata)

`python3 -m unittest discover -s plugins/maven-mcp/tests` — 376 tests, OK.
`python3 -m compileall plugins/maven-mcp/plugin/server` — clean.

## Verification

- `/finalize`: PASS after 1 round (8-angle deep scan, `code-reviewer` PASS 0 findings,
  `/simplify` comment cleanup, `pr-review-toolkit` quartet — `pr-test-analyzer` caught
  and fixed a real test-coverage gap, see `swarm-report/version-compat-suffix-ranking-finalize.md`).
- `/acceptance`: VERIFIED — issue's exact repro confirmed fixed end-to-end, see
  `swarm-report/version-compat-suffix-ranking-acceptance.md`.

Closes #325