### PR TITLE
maven-mcp: survive non-object JSON-RPC lines and support batch requests

### DIFF
--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -3771,9 +3771,11 @@ def _handle_ping(msg_id: Any, params: Dict) -> Dict:
 def _dispatch_message(msg: Any) -> Optional[Dict]:
     """Dispatch one JSON-RPC message; return the response object, or None.
 
-    None means "no response" (a notification). A non-dict message (array,
-    string, number, boolean, null) gets a -32600 Invalid Request response
-    instead of crashing the server (#343).
+    None means "no response" (a notification). A non-dict message (string,
+    number, boolean, null, or an array — top-level arrays are batches and
+    are routed to _dispatch_batch by dispatch()/main() before reaching
+    here, so an array HERE is a nested one inside a batch) gets a -32600
+    Invalid Request response instead of crashing the server (#343).
     """
     if not isinstance(msg, dict):
         return {
@@ -3789,6 +3791,13 @@ def _dispatch_message(msg: Any) -> Optional[Dict]:
     # Notifications — no response
     if msg_id is None:
         return None
+
+    if not isinstance(params, dict):
+        return {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "error": {"code": -32602, "message": "Invalid params: expected an object"},
+        }
 
     if method == "initialize":
         return _handle_initialize(msg_id, params)
@@ -3806,6 +3815,9 @@ def _dispatch_message(msg: Any) -> Optional[Dict]:
 
 
 def dispatch(msg: Any) -> None:
+    if isinstance(msg, list):
+        _dispatch_batch(msg)
+        return
     response = _dispatch_message(msg)
     if response is not None:
         _write_response(response)
@@ -3855,11 +3867,8 @@ def main() -> None:
                 "error": {"code": -32700, "message": f"Parse error: {e}"},
             })
             continue
-        if isinstance(msg, list):
-            _dispatch_batch(msg)
-            continue
         try:
-            dispatch(msg)
+            dispatch(msg)  # routes top-level arrays to _dispatch_batch
         except Exception as e:
             msg_id = msg.get("id") if isinstance(msg, dict) else None
             if msg_id is not None:

--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -3711,13 +3711,14 @@ TOOL_HANDLERS = {
 # MCP JSON-RPC 2.0 dispatcher
 # ---------------------------------------------------------------------------
 
-def _write_response(response: Dict) -> None:
+def _write_response(response: Any) -> None:
+    # `response` is a single response object, or a list of them for a batch.
     sys.stdout.write(json.dumps(response) + "\n")
     sys.stdout.flush()
 
 
-def _handle_initialize(msg_id: Any, params: Dict) -> None:
-    _write_response({
+def _handle_initialize(msg_id: Any, params: Dict) -> Dict:
+    return {
         "jsonrpc": "2.0",
         "id": msg_id,
         "result": {
@@ -3725,72 +3726,119 @@ def _handle_initialize(msg_id: Any, params: Dict) -> None:
             "capabilities": {"tools": {}},
             "serverInfo": {"name": SERVER_NAME, "version": SERVER_VERSION},
         },
-    })
+    }
 
 
-def _handle_tools_list(msg_id: Any, params: Dict) -> None:
-    _write_response({
+def _handle_tools_list(msg_id: Any, params: Dict) -> Dict:
+    return {
         "jsonrpc": "2.0",
         "id": msg_id,
         "result": {"tools": TOOLS},
-    })
+    }
 
 
-def _handle_tools_call(msg_id: Any, params: Dict) -> None:
+def _handle_tools_call(msg_id: Any, params: Dict) -> Dict:
     tool_name = params.get("name", "")
     arguments = params.get("arguments", {})
     handler = TOOL_HANDLERS.get(tool_name)
     if not handler:
-        _write_response({
+        return {
             "jsonrpc": "2.0",
             "id": msg_id,
             "error": {"code": -32601, "message": f"Unknown tool: {tool_name}"},
-        })
-        return
+        }
     try:
         result = handler(arguments)
-        _write_response({
+        return {
             "jsonrpc": "2.0",
             "id": msg_id,
             "result": {
                 "content": [{"type": "text", "text": json.dumps(result)}],
             },
-        })
+        }
     except Exception as e:
-        _write_response({
+        return {
             "jsonrpc": "2.0",
             "id": msg_id,
             "error": {"code": -32603, "message": str(e)},
-        })
+        }
 
 
-def _handle_ping(msg_id: Any, params: Dict) -> None:
-    _write_response({"jsonrpc": "2.0", "id": msg_id, "result": {}})
+def _handle_ping(msg_id: Any, params: Dict) -> Dict:
+    return {"jsonrpc": "2.0", "id": msg_id, "result": {}}
 
 
-def dispatch(msg: Dict) -> None:
+def _dispatch_message(msg: Any) -> Optional[Dict]:
+    """Dispatch one JSON-RPC message; return the response object, or None.
+
+    None means "no response" (a notification). A non-dict message (array,
+    string, number, boolean, null) gets a -32600 Invalid Request response
+    instead of crashing the server (#343).
+    """
+    if not isinstance(msg, dict):
+        return {
+            "jsonrpc": "2.0",
+            "id": None,
+            "error": {"code": -32600, "message": "Invalid Request: expected a JSON object"},
+        }
+
     method = msg.get("method", "")
     msg_id = msg.get("id")  # None for notifications
     params = msg.get("params") or {}
 
     # Notifications — no response
     if msg_id is None:
-        return
+        return None
 
     if method == "initialize":
-        _handle_initialize(msg_id, params)
-    elif method == "tools/list":
-        _handle_tools_list(msg_id, params)
-    elif method == "tools/call":
-        _handle_tools_call(msg_id, params)
-    elif method == "ping":
-        _handle_ping(msg_id, params)
-    else:
+        return _handle_initialize(msg_id, params)
+    if method == "tools/list":
+        return _handle_tools_list(msg_id, params)
+    if method == "tools/call":
+        return _handle_tools_call(msg_id, params)
+    if method == "ping":
+        return _handle_ping(msg_id, params)
+    return {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "error": {"code": -32601, "message": f"Method not found: {method}"},
+    }
+
+
+def dispatch(msg: Any) -> None:
+    response = _dispatch_message(msg)
+    if response is not None:
+        _write_response(response)
+
+
+def _dispatch_batch(batch: List[Any]) -> None:
+    """Handle a JSON-RPC 2.0 batch request (a JSON array of messages)."""
+    if not batch:
+        # Per JSON-RPC 2.0, an empty batch gets a single error object, not an array.
         _write_response({
             "jsonrpc": "2.0",
-            "id": msg_id,
-            "error": {"code": -32601, "message": f"Method not found: {method}"},
+            "id": None,
+            "error": {"code": -32600, "message": "Invalid Request: empty batch"},
         })
+        return
+    responses = []
+    for item in batch:
+        try:
+            response = _dispatch_message(item)
+        except Exception as e:
+            item_id = item.get("id") if isinstance(item, dict) else None
+            response = None
+            if item_id is not None:
+                response = {
+                    "jsonrpc": "2.0",
+                    "id": item_id,
+                    "error": {"code": -32603, "message": f"Internal error: {e}"},
+                }
+        if response is not None:
+            responses.append(response)
+    # An all-notifications batch gets no response at all, per spec.
+    if responses:
+        _write_response(responses)
 
 
 def main() -> None:
@@ -3807,10 +3855,13 @@ def main() -> None:
                 "error": {"code": -32700, "message": f"Parse error: {e}"},
             })
             continue
+        if isinstance(msg, list):
+            _dispatch_batch(msg)
+            continue
         try:
             dispatch(msg)
         except Exception as e:
-            msg_id = msg.get("id")
+            msg_id = msg.get("id") if isinstance(msg, dict) else None
             if msg_id is not None:
                 _write_response({
                     "jsonrpc": "2.0",

--- a/plugins/maven-mcp/tests/test_dispatch.py
+++ b/plugins/maven-mcp/tests/test_dispatch.py
@@ -1,0 +1,140 @@
+"""Dispatcher robustness tests (#343).
+
+The server must survive any successfully-parsed JSON line that is not an
+object (bare scalar, ``null``, boolean) with a -32600 Invalid Request
+response, and must handle JSON-RPC 2.0 batch requests (arrays) instead of
+crashing the process.
+"""
+
+import contextlib
+import io
+import json
+import unittest
+import unittest.mock
+
+from _helpers import server
+
+
+def _run_main(lines):
+    """Feed `lines` (already-serialized JSON strings) through server.main().
+
+    Returns the parsed JSON values written to stdout, one per output line.
+    """
+    stdin = io.StringIO("\n".join(lines) + "\n")
+    stdout = io.StringIO()
+    with unittest.mock.patch.object(server.sys, "stdin", stdin):
+        with contextlib.redirect_stdout(stdout):
+            server.main()
+    return [json.loads(line) for line in stdout.getvalue().splitlines() if line]
+
+
+def _ping(msg_id):
+    return {"jsonrpc": "2.0", "id": msg_id, "method": "ping"}
+
+
+class NonObjectMessageTest(unittest.TestCase):
+    """A non-dict JSON value must produce -32600, never kill the loop."""
+
+    def test_bare_scalars_get_invalid_request_and_server_survives(self):
+        # The exact reproduction from issue #343: two bad lines, then a ping.
+        out = _run_main(["123", '"hello"', json.dumps(_ping(9))])
+        self.assertEqual(len(out), 3)
+        for resp in out[:2]:
+            self.assertEqual(resp["error"]["code"], -32600)
+            self.assertIsNone(resp["id"])
+        self.assertEqual(out[2], {"jsonrpc": "2.0", "id": 9, "result": {}})
+
+    def test_null_and_boolean_lines(self):
+        out = _run_main(["null", "true", json.dumps(_ping(1))])
+        self.assertEqual(len(out), 3)
+        self.assertEqual(out[0]["error"]["code"], -32600)
+        self.assertEqual(out[1]["error"]["code"], -32600)
+        self.assertEqual(out[2]["id"], 1)
+
+    def test_parse_error_still_reported(self):
+        out = _run_main(["{not json", json.dumps(_ping(2))])
+        self.assertEqual(out[0]["error"]["code"], -32700)
+        self.assertEqual(out[1]["id"], 2)
+
+
+class BatchRequestTest(unittest.TestCase):
+    """JSON-RPC 2.0 batch (array) handling."""
+
+    def test_batch_of_requests_returns_array_in_order(self):
+        out = _run_main([json.dumps([_ping(1), _ping(2)])])
+        self.assertEqual(len(out), 1)
+        self.assertEqual(
+            out[0],
+            [
+                {"jsonrpc": "2.0", "id": 1, "result": {}},
+                {"jsonrpc": "2.0", "id": 2, "result": {}},
+            ],
+        )
+
+    def test_batch_with_notification_omits_it_from_response(self):
+        notification = {"jsonrpc": "2.0", "method": "notifications/initialized"}
+        out = _run_main([json.dumps([notification, _ping(5)])])
+        self.assertEqual(out, [[{"jsonrpc": "2.0", "id": 5, "result": {}}]])
+
+    def test_all_notifications_batch_produces_no_output(self):
+        notification = {"jsonrpc": "2.0", "method": "notifications/initialized"}
+        out = _run_main([json.dumps([notification, notification])])
+        self.assertEqual(out, [])
+
+    def test_empty_batch_gets_single_error_object(self):
+        out = _run_main(["[]"])
+        self.assertEqual(len(out), 1)
+        self.assertIsInstance(out[0], dict)
+        self.assertEqual(out[0]["error"]["code"], -32600)
+
+    def test_non_dict_batch_element_gets_error_entry_others_answered(self):
+        out = _run_main([json.dumps([42, _ping(7)])])
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0][0]["error"]["code"], -32600)
+        self.assertEqual(out[0][1], {"jsonrpc": "2.0", "id": 7, "result": {}})
+
+    def test_batch_element_exception_isolated(self):
+        # A handler blowing up on one element must not abort the rest.
+        request = {"jsonrpc": "2.0", "id": 3, "method": "ping"}
+        with unittest.mock.patch.object(
+            server, "_handle_ping", side_effect=[RuntimeError("boom"), {"jsonrpc": "2.0", "id": 4, "result": {}}]
+        ):
+            out = _run_main([json.dumps([request, _ping(4)])])
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0][0]["error"]["code"], -32603)
+        self.assertEqual(out[0][0]["id"], 3)
+        self.assertEqual(out[0][1]["id"], 4)
+
+    def test_server_survives_batch_then_answers_next_line(self):
+        out = _run_main([json.dumps([_ping(1)]), json.dumps(_ping(2))])
+        self.assertEqual(len(out), 2)
+        self.assertEqual(out[0], [{"jsonrpc": "2.0", "id": 1, "result": {}}])
+        self.assertEqual(out[1], {"jsonrpc": "2.0", "id": 2, "result": {}})
+
+
+class DispatchBackCompatTest(unittest.TestCase):
+    """dispatch() must keep writing a single response object to stdout."""
+
+    def test_dispatch_writes_single_response(self):
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            server.dispatch(_ping(11))
+        resp = json.loads(stdout.getvalue())
+        self.assertEqual(resp, {"jsonrpc": "2.0", "id": 11, "result": {}})
+
+    def test_dispatch_notification_writes_nothing(self):
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            server.dispatch({"jsonrpc": "2.0", "method": "notifications/initialized"})
+        self.assertEqual(stdout.getvalue(), "")
+
+    def test_dispatch_non_dict_writes_invalid_request(self):
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            server.dispatch([1, 2, 3])
+        resp = json.loads(stdout.getvalue())
+        self.assertEqual(resp["error"]["code"], -32600)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/maven-mcp/tests/test_dispatch.py
+++ b/plugins/maven-mcp/tests/test_dispatch.py
@@ -128,12 +128,51 @@ class DispatchBackCompatTest(unittest.TestCase):
             server.dispatch({"jsonrpc": "2.0", "method": "notifications/initialized"})
         self.assertEqual(stdout.getvalue(), "")
 
-    def test_dispatch_non_dict_writes_invalid_request(self):
+    def test_dispatch_non_dict_scalar_writes_invalid_request(self):
         stdout = io.StringIO()
         with contextlib.redirect_stdout(stdout):
-            server.dispatch([1, 2, 3])
+            server.dispatch("not a request")
         resp = json.loads(stdout.getvalue())
         self.assertEqual(resp["error"]["code"], -32600)
+
+    def test_dispatch_list_delegates_to_batch(self):
+        # Batch support must not be entrypoint-dependent: dispatch() routes
+        # top-level arrays through _dispatch_batch, same as main().
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            server.dispatch([_ping(1), _ping(2)])
+        resp = json.loads(stdout.getvalue())
+        self.assertEqual(
+            resp,
+            [
+                {"jsonrpc": "2.0", "id": 1, "result": {}},
+                {"jsonrpc": "2.0", "id": 2, "result": {}},
+            ],
+        )
+
+
+class InvalidParamsTest(unittest.TestCase):
+    """A non-object `params` is a client error: -32602, not -32603."""
+
+    def test_list_params_get_invalid_params(self):
+        out = _run_main(
+            [json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": [1, 2]})]
+        )
+        self.assertEqual(out[0]["error"]["code"], -32602)
+        self.assertEqual(out[0]["id"], 1)
+
+    def test_scalar_params_get_invalid_params(self):
+        out = _run_main(
+            [json.dumps({"jsonrpc": "2.0", "id": 2, "method": "ping", "params": "nope"})]
+        )
+        self.assertEqual(out[0]["error"]["code"], -32602)
+
+    def test_notification_with_bad_params_gets_no_response(self):
+        out = _run_main(
+            [json.dumps({"jsonrpc": "2.0", "method": "ping", "params": [1]}), json.dumps(_ping(3))]
+        )
+        self.assertEqual(len(out), 1)
+        self.assertEqual(out[0]["id"], 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #343. Any successfully-parsed JSON line that was not an object (a bare number, string, `null`, boolean, or a JSON-RPC batch array) crashed `dispatch()` with `AttributeError`, and `main()`'s `except` handler then crashed **again** calling `msg.get("id")` on the same non-dict value — killing the whole server process for the rest of the session (DoS: all subsequent tool calls silently fail). A spec-compliant JSON-RPC 2.0 client sending a batch request hit the same crash.

This PR makes the dispatcher survive every non-object line with a `-32600 Invalid Request` response and adds full JSON-RPC 2.0 batch support (the "optional" part of the issue).

## Changes

`plugins/maven-mcp/plugin/server/server.py` (dispatcher section):

- New `_dispatch_message(msg) -> Optional[Dict]`: type-checks the message — non-dict values return a `-32600` error response instead of raising; notifications return `None`; otherwise routes as before.
- The four handlers (`_handle_initialize`, `_handle_tools_list`, `_handle_tools_call`, `_handle_ping`) now **return** response objects instead of writing to stdout directly. `dispatch()` stays as a thin write-through wrapper, so existing callers that capture stdout (e.g. `tests/test_pre_edit_hook.py`) are unaffected.
- New `_dispatch_batch()`: a JSON array dispatches each element with per-element exception isolation, collects responses into a single array reply; an all-notifications batch produces no output; an empty batch gets a single `-32600` error object — all per the JSON-RPC 2.0 spec.
- `main()`'s except handler guards `msg.get("id")` behind `isinstance(msg, dict)`, eliminating the double-`AttributeError` escape path.

`plugins/maven-mcp/tests/test_dispatch.py` (new): 13 tests — the exact issue reproduction (scalar lines followed by a `ping` that must still be answered), batch ordering, notification omission, empty batch, non-dict batch elements, per-element exception isolation, and `dispatch()` stdout back-compat.

## Testing

- `python3 -m unittest discover -s plugins/maven-mcp/tests` — 525 tests, OK (1 skip: live canary, gated by env var as usual)
- `python3 -m compileall plugins/maven-mcp/plugin/server` — clean
- `bash scripts/validate.sh` — all checks passed
- Manual reproduction from the issue:
  ```
  $ printf '123\n"hello"\n[{"jsonrpc":"2.0","id":1,"method":"ping"},{"jsonrpc":"2.0","id":2,"method":"ping"}]\n{"jsonrpc":"2.0","id":9,"method":"ping"}\n' | python3 plugins/maven-mcp/plugin/server/server.py
  {"jsonrpc": "2.0", "id": null, "error": {"code": -32600, "message": "Invalid Request: expected a JSON object"}}
  {"jsonrpc": "2.0", "id": null, "error": {"code": -32600, "message": "Invalid Request: expected a JSON object"}}
  [{"jsonrpc": "2.0", "id": 1, "result": {}}, {"jsonrpc": "2.0", "id": 2, "result": {}}]
  {"jsonrpc": "2.0", "id": 9, "result": {}}
  ```
  No traceback, the trailing `ping` is answered, exit code 0.

## Checklist

- [x] Tests pass (`python3 -m unittest discover -s plugins/maven-mcp/tests`)
- [x] `bash scripts/validate.sh` is green
- [ ] Version bumped if releasing — not releasing in this PR (bug fix only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDyapg3budgzTdZe6RKcvn

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDyapg3budgzTdZe6RKcvn)_