### PR TITLE
maven-mcp: reject non-http(s) URL schemes in fetches (#348)

### DIFF
--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -173,6 +173,38 @@ def _parse_retry_after(headers: Any) -> Optional[float]:
     return min(secs, HTTP_RETRY_AFTER_MAX)
 
 
+# urllib's default opener registers handlers for file:// and ftp://. Repo URLs
+# are captured verbatim from build files, so a declared ``file:///...`` (or
+# uppercase ``FILE://``) must never reach urlopen. Only http/https are allowed.
+_ALLOWED_URL_SCHEMES = frozenset({"http", "https"})
+
+
+def _url_scheme(url: str) -> str:
+    """Return the URL scheme lowercased, or ``""`` if missing/unparseable."""
+    try:
+        return urllib.parse.urlsplit(url).scheme.lower()
+    except ValueError:
+        return ""
+
+
+def _assert_http_url(url: str) -> None:
+    """Raise ``URLError`` unless ``url`` uses an allowed http(s) scheme.
+
+    Checked before Request construction so the default opener never honors
+    ``file://`` / ``ftp://`` / other non-HTTP schemes (#348).
+    """
+    scheme = _url_scheme(url)
+    if scheme not in _ALLOWED_URL_SCHEMES:
+        raise urllib.error.URLError(
+            f"URL scheme not allowed: {scheme or '(none)'} (only http/https)"
+        )
+
+
+def _is_file_url(url: str) -> bool:
+    """True when ``url`` is a ``file:`` URL (scheme compared case-insensitively)."""
+    return _url_scheme(url) == "file"
+
+
 def _request_with_retry(req: urllib.request.Request) -> Tuple[int, bytes]:
     """Issue ``req`` with bounded retry/backoff on transient failures.
 
@@ -232,12 +264,15 @@ def _request_with_retry(req: urllib.request.Request) -> Tuple[int, bytes]:
 def http_get(url: str, headers: Optional[Dict[str, str]] = None) -> Tuple[int, bytes]:
     """Returns (status_code, body_bytes). Retries transient failures internally
     (see _request_with_retry); raises urllib.error.URLError / socket.timeout only
-    when every attempt hit a transport error."""
+    when every attempt hit a transport error. Non-http(s) schemes are rejected
+    before any network/filesystem open (#348)."""
+    _assert_http_url(url)
     req = urllib.request.Request(url, headers=headers or _make_headers())
     return _request_with_retry(req)
 
 
 def http_post_json(url: str, payload: Any, headers: Optional[Dict[str, str]] = None) -> Tuple[int, bytes]:
+    _assert_http_url(url)
     data = json.dumps(payload).encode()
     h = _make_headers({"Content-Type": "application/json"})
     if headers:
@@ -492,7 +527,9 @@ def _repos_for(
     declared scope (deduped by URL)."""
     scope = "plugin" if artifact_id.endswith(".gradle.plugin") else "dependency"
     declared = ctx.scoped_repos.get(scope, [])
-    queryable = [r for r in declared if not r["url"].startswith("file://")]
+    # mavenLocal / file:// markers are non-queryable; scheme check is
+    # case-insensitive so ``FILE://`` cannot bypass the guard (#348).
+    queryable = [r for r in declared if not _is_file_url(r["url"])]
 
     public_entries = [
         {"name": name, "url": url, "scope": scope, "is_public_fallback": True}

--- a/plugins/maven-mcp/tests/test_http.py
+++ b/plugins/maven-mcp/tests/test_http.py
@@ -109,6 +109,45 @@ class HttpGetTest(unittest.TestCase):
         self.assertEqual(headers["accept"], "application/json")
         self.assertEqual(headers["user-agent"], server.USER_AGENT)
 
+    def test_rejects_file_scheme_without_urlopen(self):
+        # #348: default urllib opener honors file:// — must never reach urlopen.
+        with unittest.mock.patch("urllib.request.urlopen") as urlopen:
+            with self.assertRaises(urllib.error.URLError) as cm:
+                server.http_get("file:///etc/hostname")
+        urlopen.assert_not_called()
+        self.assertIn("file", str(cm.exception.reason).lower())
+
+    def test_rejects_uppercase_file_scheme_without_urlopen(self):
+        with unittest.mock.patch("urllib.request.urlopen") as urlopen:
+            with self.assertRaises(urllib.error.URLError) as cm:
+                server.http_get("FILE:///etc/hostname")
+        urlopen.assert_not_called()
+        self.assertIn("file", str(cm.exception.reason).lower())
+
+    def test_rejects_ftp_and_other_non_http_schemes(self):
+        with unittest.mock.patch("urllib.request.urlopen") as urlopen:
+            for url in (
+                "ftp://example.test/pub/maven-metadata.xml",
+                "data:text/plain,hi",
+                "javascript:alert(1)",
+                "/relative/path",
+                "example.test/no-scheme",
+            ):
+                with self.subTest(url=url):
+                    with self.assertRaises(urllib.error.URLError):
+                        server.http_get(url)
+        urlopen.assert_not_called()
+
+    def test_allows_http_scheme(self):
+        with unittest.mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, b"ok")]),
+        ) as urlopen:
+            status, body = server.http_get("http://example.test/x")
+        self.assertEqual(status, 200)
+        self.assertEqual(body, b"ok")
+        self.assertEqual(urlopen.call_count, 1)
+
 
 class HttpPostJsonTest(unittest.TestCase):
     def test_encodes_json_body_and_sets_content_type(self):
@@ -133,6 +172,12 @@ class HttpPostJsonTest(unittest.TestCase):
             status, body = server.http_post_json("https://example.test/osv", {})
         self.assertEqual(status, 200)
         self.assertEqual(body, b'{"ok":true}')
+
+    def test_rejects_file_scheme_without_urlopen(self):
+        with unittest.mock.patch("urllib.request.urlopen") as urlopen:
+            with self.assertRaises(urllib.error.URLError):
+                server.http_post_json("file:///tmp/x", {})
+        urlopen.assert_not_called()
 
     def test_persistent_5xx_returns_code_and_empty_bytes_after_cap(self):
         url = "https://example.test/osv"

--- a/plugins/maven-mcp/tests/test_resolution.py
+++ b/plugins/maven-mcp/tests/test_resolution.py
@@ -154,6 +154,47 @@ class TestProjectFirstRouting(unittest.TestCase):
         self.assertEqual([r["url"] for r in repos], [server.MAVEN_CENTRAL_URL])
         self.assertTrue(repos[0]["is_public_fallback"])
 
+    def test_uppercase_file_scheme_is_non_queryable(self):
+        # #348: startswith("file://") was case-sensitive; FILE:// must still
+        # be treated as non-queryable so it falls back to public rather than
+        # being passed to http_get (which would open a local path).
+        ctx = server.ResolutionContext(
+            "/tmp",
+            {
+                "dependency": [
+                    {
+                        "name": "x",
+                        "url": "FILE:///etc",
+                        "scope": "dependency",
+                    }
+                ],
+                "plugin": [],
+            },
+            False,
+        )
+        repos = server._repos_for("com.example", "artifact", ctx)
+        self.assertEqual([r["url"] for r in repos], [server.MAVEN_CENTRAL_URL])
+        self.assertTrue(repos[0]["is_public_fallback"])
+
+    def test_mixed_case_file_scheme_is_non_queryable(self):
+        ctx = server.ResolutionContext(
+            "/tmp",
+            {
+                "dependency": [
+                    {
+                        "name": "x",
+                        "url": "File:///var/maven",
+                        "scope": "dependency",
+                    }
+                ],
+                "plugin": [],
+            },
+            False,
+        )
+        repos = server._repos_for("com.example", "artifact", ctx)
+        self.assertEqual([r["url"] for r in repos], [server.MAVEN_CENTRAL_URL])
+        self.assertTrue(repos[0]["is_public_fallback"])
+
 
 # ---------------------------------------------------------------------------
 # #320 — repository content / group filtering


### PR DESCRIPTION
## Summary
- Enforce an http/https allow-list in `http_get` / `http_post_json` so `file://`, `FILE://`, `ftp://`, and other non-HTTP schemes never reach urllib's default opener.
- Make `_repos_for`'s mavenLocal / `file://` non-queryable filter case-insensitive via `urlsplit(...).scheme.lower()`.
- Add unit coverage for scheme rejection and uppercase/`File://` mavenLocal bypass.

Fixes #348

## Test plan
- [x] `python3 -m compileall plugins/maven-mcp/plugin/server`
- [x] `python3 -m unittest discover -s plugins/maven-mcp/tests -p test_http.py -v`
- [x] `python3 -m unittest discover -s plugins/maven-mcp/tests -p test_resolution.py -v`
- [x] Full suite: `python3 -m unittest discover -s plugins/maven-mcp/tests` — 536 tests, OK (1 skipped)


Made with [Cursor](https://cursor.com)