### PR TITLE
Cap HTTP response body size in maven-mcp (#350)

### DIFF
--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -42,6 +42,12 @@ HTTP_BACKOFF_JITTER = 0.3      # seconds; uniform [0, jitter) added per attempt
 HTTP_RETRY_AFTER_MAX = 30.0    # cap an upstream Retry-After so a hostile header can't stall us
 HTTP_TOTAL_RETRY_BUDGET = 60.0  # wall-clock cap across all attempts + sleeps
 
+# Cap on a single HTTP response body. Maven metadata/POMs are KB-scale;
+# OSV/GitHub/Solr JSON is typically well under a few MB. A hostile or
+# misconfigured endpoint returning multi-GB bodies must not OOM the
+# long-lived stdio server (#350). HTTP_TIMEOUT only bounds time, not size.
+HTTP_MAX_RESPONSE_BYTES = 10 * 1024 * 1024  # 10 MiB
+
 MAVEN_CENTRAL_URL = "https://repo1.maven.org/maven2"
 GOOGLE_MAVEN_URL = "https://dl.google.com/dl/android/maven2"
 GRADLE_PLUGIN_PORTAL_URL = "https://plugins.gradle.org/m2"
@@ -205,6 +211,44 @@ def _is_file_url(url: str) -> bool:
     return _url_scheme(url) == "file"
 
 
+class ResponseTooLargeError(urllib.error.URLError):
+    """Raised when an HTTP response body exceeds ``HTTP_MAX_RESPONSE_BYTES``.
+
+    Not retried: re-fetching an oversized body cannot help and would only
+    amplify memory pressure (#350).
+    """
+
+
+def _read_response_body(resp: Any) -> bytes:
+    """Read ``resp`` body with an explicit size cap (#350).
+
+    Short-circuits on an oversized ``Content-Length`` before allocating, then
+    reads at most ``HTTP_MAX_RESPONSE_BYTES + 1`` bytes and raises
+    ``ResponseTooLargeError`` if the body exceeds the cap. Chunked / missing
+    Content-Length still cannot grow without bound because of the read cap.
+    """
+    headers = getattr(resp, "headers", None)
+    if headers is not None:
+        get = getattr(headers, "get", None)
+        raw_cl = get("Content-Length") if callable(get) else None
+        if raw_cl is not None and str(raw_cl).strip():
+            try:
+                content_length = int(str(raw_cl).strip())
+            except (TypeError, ValueError):
+                content_length = -1
+            if content_length > HTTP_MAX_RESPONSE_BYTES:
+                raise ResponseTooLargeError(
+                    f"HTTP response too large: Content-Length {content_length} "
+                    f"exceeds {HTTP_MAX_RESPONSE_BYTES} bytes"
+                )
+    body = resp.read(HTTP_MAX_RESPONSE_BYTES + 1)
+    if len(body) > HTTP_MAX_RESPONSE_BYTES:
+        raise ResponseTooLargeError(
+            f"HTTP response too large: body exceeds {HTTP_MAX_RESPONSE_BYTES} bytes"
+        )
+    return body
+
+
 def _request_with_retry(req: urllib.request.Request) -> Tuple[int, bytes]:
     """Issue ``req`` with bounded retry/backoff on transient failures.
 
@@ -214,6 +258,7 @@ def _request_with_retry(req: urllib.request.Request) -> Tuple[int, bytes]:
     error (URLError / socket.timeout) when EVERY attempt failed at the transport
     level without ever obtaining an HTTP response. A 4xx (incl. 404) is never
     turned into a raise. Retry is fully internal and transparent to callers.
+    Oversized bodies raise ``ResponseTooLargeError`` immediately (not retried).
     """
     deadline = time.monotonic() + HTTP_TOTAL_RETRY_BUDGET
     last_result: Optional[Tuple[int, bytes]] = None
@@ -222,13 +267,16 @@ def _request_with_retry(req: urllib.request.Request) -> Tuple[int, bytes]:
         retry_after: Optional[float] = None
         try:
             with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as resp:
-                status, body = resp.status, resp.read()
+                status, body = resp.status, _read_response_body(resp)
                 if not _is_retryable_status(status):
                     return status, body
                 # A retryable status surfaced as a success object (rare — urllib
                 # normally raises HTTPError for 4xx/5xx); remember it and retry.
                 last_result = (status, body)
                 retry_after = _parse_retry_after(getattr(resp, "headers", None))
+        except ResponseTooLargeError:
+            # Oversized body is definitive — do not retry (#350).
+            raise
         except urllib.error.HTTPError as e:
             # HTTPError IS-A URLError but represents a real HTTP response, not a
             # transport failure — must be caught first. Body stays b"" (the

--- a/plugins/maven-mcp/tests/_helpers.py
+++ b/plugins/maven-mcp/tests/_helpers.py
@@ -15,7 +15,7 @@ import sys
 import tempfile
 import unittest.mock
 import urllib.error
-from typing import Any, Callable, Dict, List, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 # --- sys.path shim ----------------------------------------------------------
 # Resolve plugin/server/ relative to THIS file, never the process cwd, so the
@@ -52,20 +52,45 @@ def empty_ctx(public_fallback: bool = False) -> "server.ResolutionContext":
 ResponseSpec = Union["_MockResponse", BaseException, Any]
 
 
+class _MockHeaders(dict):
+    """Minimal headers mapping with case-insensitive ``.get`` for Content-Length."""
+
+    def get(self, key: str, default: Any = None) -> Any:  # type: ignore[override]
+        key_l = key.lower()
+        for k, v in self.items():
+            if str(k).lower() == key_l:
+                return v
+        return default
+
+
 class _MockResponse:
     """Stand-in for the object returned by urllib.request.urlopen.
 
     server.py uses it as ``with urllib.request.urlopen(...) as resp:`` and reads
-    ``resp.status`` / ``resp.read()`` — so this is both a context manager and
-    exposes those two members.
+    ``resp.status`` / ``resp.read(n)`` / ``resp.headers`` — so this is both a
+    context manager and exposes those members. ``read(n)`` honors a size cap
+    like a real file-like body (#350).
     """
 
-    def __init__(self, status: int, body: bytes) -> None:
+    def __init__(
+        self,
+        status: int,
+        body: bytes,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> None:
         self.status = status
         self._body = body
+        self._pos = 0
+        self.headers = _MockHeaders(headers or {})
 
-    def read(self) -> bytes:
-        return self._body
+    def read(self, n: int = -1) -> bytes:
+        if n is None or n < 0:
+            chunk = self._body[self._pos :]
+            self._pos = len(self._body)
+            return chunk
+        chunk = self._body[self._pos : self._pos + n]
+        self._pos += len(chunk)
+        return chunk
 
     def __enter__(self) -> "_MockResponse":
         return self
@@ -81,6 +106,8 @@ def mock_urlopen(responses: Union[ResponseSpec, List[ResponseSpec]]) -> Callable
     across consecutive urlopen calls. Each item is one of:
       - ``(status: int, body: bytes)`` -> returned as a context manager exposing
         ``.status`` and ``.read()``
+      - ``(status: int, body: bytes, headers: dict)`` -> same, with headers
+        (e.g. ``Content-Length`` for #350 size-cap tests)
       - an ``Exception`` instance (e.g. ``http_error(...)``) -> raised
       - a ``_MockResponse`` -> returned as-is
 
@@ -105,6 +132,9 @@ def mock_urlopen(responses: Union[ResponseSpec, List[ResponseSpec]]) -> Callable
             raise spec
         if isinstance(spec, _MockResponse):
             return spec
+        if len(spec) == 3:
+            status, body, headers = spec
+            return _MockResponse(status, body, headers)
         status, body = spec
         return _MockResponse(status, body)
 

--- a/plugins/maven-mcp/tests/test_http.py
+++ b/plugins/maven-mcp/tests/test_http.py
@@ -338,5 +338,83 @@ class HttpRetryTest(unittest.TestCase):
                 sleep.assert_not_called()
 
 
+class HttpResponseSizeCapTest(unittest.TestCase):
+    """#350: HTTP bodies must not be read unbounded into memory."""
+
+    URL = "https://example.test/x"
+    # Tiny cap so tests never allocate multi-MiB buffers.
+    CAP = 64
+
+    def setUp(self):
+        self._cap_patch = unittest.mock.patch.object(
+            server, "HTTP_MAX_RESPONSE_BYTES", self.CAP
+        )
+        self._cap_patch.start()
+
+    def tearDown(self):
+        self._cap_patch.stop()
+
+    def test_body_at_cap_accepted(self):
+        body = b"x" * self.CAP
+        with unittest.mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, body)]),
+        ):
+            status, got = server.http_get(self.URL)
+        self.assertEqual(status, 200)
+        self.assertEqual(got, body)
+
+    def test_body_over_cap_raises_without_retry(self):
+        body = b"x" * (self.CAP + 1)
+        with unittest.mock.patch.object(server, "_sleep") as sleep, \
+                unittest.mock.patch(
+                    "urllib.request.urlopen",
+                    side_effect=mock_urlopen([(200, body)]),
+                ) as urlopen:
+            with self.assertRaises(server.ResponseTooLargeError) as cm:
+                server.http_get(self.URL)
+        self.assertIn("too large", str(cm.exception.reason).lower())
+        self.assertEqual(urlopen.call_count, 1)
+        sleep.assert_not_called()
+
+    def test_content_length_over_cap_raises_before_full_read(self):
+        # Declared Content-Length alone is enough to reject — body may be empty
+        # in the mock because we never allocate the claimed size.
+        oversized_cl = str(self.CAP + 1)
+        with unittest.mock.patch.object(server, "_sleep") as sleep, \
+                unittest.mock.patch(
+                    "urllib.request.urlopen",
+                    side_effect=mock_urlopen([
+                        (200, b"", {"Content-Length": oversized_cl}),
+                    ]),
+                ) as urlopen:
+            with self.assertRaises(server.ResponseTooLargeError) as cm:
+                server.http_get(self.URL)
+        self.assertIn("content-length", str(cm.exception.reason).lower())
+        self.assertEqual(urlopen.call_count, 1)
+        sleep.assert_not_called()
+
+    def test_post_json_body_over_cap_raises(self):
+        body = b"y" * (self.CAP + 1)
+        with unittest.mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, body)]),
+        ):
+            with self.assertRaises(server.ResponseTooLargeError):
+                server.http_post_json(self.URL, {})
+
+    def test_content_length_at_cap_with_matching_body_ok(self):
+        body = b"z" * self.CAP
+        with unittest.mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([
+                (200, body, {"Content-Length": str(len(body))}),
+            ]),
+        ):
+            status, got = server.http_get(self.URL)
+        self.assertEqual(status, 200)
+        self.assertEqual(got, body)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Cap all HTTP response body reads in `_request_with_retry` at `HTTP_MAX_RESPONSE_BYTES` (10 MiB), with an early reject on oversized `Content-Length`.
- Oversized bodies raise `ResponseTooLargeError` immediately (not retried), covering both `http_get` and `http_post_json`.
- Add unit tests for at-cap / over-cap / Content-Length short-circuit paths.

Fixes #350

## Test plan
- [x] `python3 -m unittest discover -s plugins/maven-mcp/tests -p test_http.py -v`
- [x] `python3 -m unittest discover -s plugins/maven-mcp/tests` (541 OK, 1 skipped)
- [x] `python3 -m compileall plugins/maven-mcp/plugin/server`


Made with [Cursor](https://cursor.com)