### PR TITLE
Cap vuln fan-out, chunk OSV batches, clamp search limit

### DIFF
--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -69,7 +69,17 @@ PRERELEASE_WEIGHT = {"snapshot": 0, "alpha": 1, "beta": 2, "milestone": 3, "rc":
 
 GITHUB_API = "https://api.github.com"
 OSV_API = "https://api.osv.dev/v1/querybatch"
+# OSV.dev documents a maximum of 1000 queries per /v1/querybatch request.
+# query_osv_batch chunks above this so a large monorepo audit cannot fail as a unit.
+OSV_QUERYBATCH_MAX = 1000
 SEARCH_API = "https://search.maven.org/solrsearch/select"
+# search_artifacts limit: coerced to int and clamped in the handler before the
+# Solr URL is built (MCP schema bounds are advisory client metadata only).
+SEARCH_LIMIT_DEFAULT = 10
+SEARCH_LIMIT_MAX = 100
+# get_dependency_vulnerabilities dependency-list cap — same bound and rationale
+# as verify_coordinates (enforced in-handler before any network I/O).
+MAX_VULN_DEPENDENCIES = 100
 
 # Persistent file cache TTLs and capacity (see FileCache below).
 TTL_POM = 7 * 86400     # 7 days — release POMs are immutable once published
@@ -1462,9 +1472,22 @@ def _is_malicious_id(vuln_id: str) -> bool:
 
 
 def query_osv_batch(deps: List[Dict]) -> List[Dict]:
-    """deps: list of {groupId, artifactId, version}. Returns list of {groupId, artifactId, version, vulnerabilities}."""
+    """deps: list of {groupId, artifactId, version}. Returns list of {groupId, artifactId, version, vulnerabilities}.
+
+    Chunks into ≤OSV_QUERYBATCH_MAX queries per POST (OSV.dev documented limit)
+    and concatenates per-chunk results in input order. A failed chunk degrades
+    only that slice to empty vulnerabilities — siblings still resolve.
+    """
     if not deps:
         return []
+    out: List[Dict] = []
+    for start in range(0, len(deps), OSV_QUERYBATCH_MAX):
+        out.extend(_query_osv_batch_chunk(deps[start:start + OSV_QUERYBATCH_MAX]))
+    return out
+
+
+def _query_osv_batch_chunk(deps: List[Dict]) -> List[Dict]:
+    """POST one ≤OSV_QUERYBATCH_MAX querybatch; empty vulns on non-200 / error."""
     queries = [
         {"package": {"name": f"{d['groupId']}:{d['artifactId']}", "ecosystem": "Maven"}, "version": d["version"]}
         for d in deps
@@ -2897,6 +2920,13 @@ def handle_scan_project_dependencies(args: Dict) -> Any:
 
 def handle_get_dependency_vulnerabilities(args: Dict) -> Any:
     original_deps = args["dependencies"]
+    # Caps are ENFORCED here, before any network I/O — an MCP inputSchema's
+    # maxItems is advisory client metadata the server never validates, so the
+    # bound on outbound fan-out (each dep -> OSV query, plus optional marker
+    # POM fetch) lives in code. Truncate an over-long batch (same pattern as
+    # verify_coordinates).
+    if len(original_deps) > MAX_VULN_DEPENDENCIES:
+        original_deps = original_deps[:MAX_VULN_DEPENDENCIES]
     # Only build a ResolutionContext (filesystem read of the project's build
     # files, see discover_repositories) when at least one requested dependency
     # is actually a plugin-marker shape — preserves the original zero-FS-I/O,
@@ -3077,7 +3107,13 @@ def handle_get_dependency_health(args: Dict) -> Any:
 
 def handle_search_artifacts(args: Dict) -> Any:
     query = args["query"]
-    limit = args.get("limit", 10)
+    # Coerce + clamp before the Solr URL is built — schema bounds are advisory
+    # only (same reasoning as verify_coordinates' suggestLimit clamp).
+    try:
+        limit = int(args.get("limit", SEARCH_LIMIT_DEFAULT))
+    except (TypeError, ValueError):
+        limit = SEARCH_LIMIT_DEFAULT
+    limit = max(1, min(limit, SEARCH_LIMIT_MAX))
     results = search_maven_central(query, limit)
     return {"results": results}
 
@@ -3688,6 +3724,7 @@ TOOLS = [
             "properties": {
                 "dependencies": {
                     "type": "array",
+                    "maxItems": 100,
                     "items": {
                         "type": "object",
                         "properties": {
@@ -3733,7 +3770,7 @@ TOOLS = [
             "type": "object",
             "properties": {
                 "query": {"type": "string", "description": "Search query"},
-                "limit": {"type": "integer", "description": "Maximum number of results (default 10)"},
+                "limit": {"type": "integer", "default": 10, "minimum": 1, "maximum": 100, "description": "Maximum number of results. Default 10, clamped to [1, 100]."},
             },
             "required": ["query"],
         },

--- a/plugins/maven-mcp/tests/test_handlers.py
+++ b/plugins/maven-mcp/tests/test_handlers.py
@@ -417,6 +417,22 @@ class TestGetDependencyVulnerabilities(unittest.TestCase):
         self.assertEqual(m.call_count, 1)  # only the OSV POST, no POM fetch attempted
         self.assertEqual(result["vulnerabilityCount"], 0)
 
+    def test_caps_truncate_dependencies_over_100(self):
+        # 101 deps -> the HANDLER truncates to 100 before any I/O (same pattern
+        # as verify_coordinates). Mock query_osv_batch to assert it only sees 100.
+        deps = [
+            {"groupId": "com.x", "artifactId": f"a{i}", "version": "1.0.0"}
+            for i in range(101)
+        ]
+        with unittest.mock.patch.object(
+            server, "query_osv_batch",
+            side_effect=lambda ds: [{**d, "vulnerabilities": []} for d in ds],
+        ) as m:
+            out = server.handle_get_dependency_vulnerabilities({"dependencies": deps})
+        self.assertEqual(len(out["results"]), 100)
+        m.assert_called_once()
+        self.assertEqual(len(m.call_args.args[0]), 100)
+
 
 # --- handle_get_dependency_health -------------------------------------------
 
@@ -493,6 +509,28 @@ class TestSearchArtifacts(unittest.TestCase):
         with _patch_urlopen([(503, b"")]):
             out = server.handle_search_artifacts({"query": "lib"})
         self.assertEqual(out["results"], [])
+
+    def test_clamps_limit_over_max(self):
+        # limit=500 -> handler clamps to SEARCH_LIMIT_MAX before the Solr URL.
+        body = {"response": {"docs": []}}
+        with _patch_urlopen([(200, _json(body))]) as m:
+            server.handle_search_artifacts({"query": "lib", "limit": 500})
+        url = m.call_args_list[0].args[0].full_url
+        self.assertIn(f"rows={server.SEARCH_LIMIT_MAX}", url)
+
+    def test_clamps_limit_below_one_and_rejects_non_int(self):
+        # 0 / negative -> 1; non-int -> SEARCH_LIMIT_DEFAULT.
+        body = {"response": {"docs": []}}
+        with _patch_urlopen([(200, _json(body))]) as m:
+            server.handle_search_artifacts({"query": "lib", "limit": 0})
+            server.handle_search_artifacts({"query": "lib", "limit": -5})
+            server.handle_search_artifacts({"query": "lib", "limit": "nope"})
+        self.assertIn("rows=1", m.call_args_list[0].args[0].full_url)
+        self.assertIn("rows=1", m.call_args_list[1].args[0].full_url)
+        self.assertIn(
+            f"rows={server.SEARCH_LIMIT_DEFAULT}",
+            m.call_args_list[2].args[0].full_url,
+        )
 
 
 # --- handle_audit_project_dependencies --------------------------------------

--- a/plugins/maven-mcp/tests/test_maven_search_osv.py
+++ b/plugins/maven-mcp/tests/test_maven_search_osv.py
@@ -653,6 +653,43 @@ class TestQueryOsvBatch(unittest.TestCase):
             "https://osv.dev/vulnerability/OSV-NO-ADVISORY",
         )
 
+    def test_chunks_over_osv_querybatch_max(self):
+        # >OSV_QUERYBATCH_MAX deps -> multiple POSTs, each ≤ the documented
+        # 1000-query limit; results concatenated in input order. Temporarily
+        # lower the constant so the test stays small.
+        n = 5
+        chunk = 2
+        deps = [
+            {"groupId": "com.x", "artifactId": f"a{i}", "version": "1.0.0"}
+            for i in range(n)
+        ]
+        # Three chunks: [0,1], [2,3], [4] — each response tags vulns by index.
+        responses = []
+        for start in range(0, n, chunk):
+            size = min(chunk, n - start)
+            responses.append((200, json.dumps({
+                "results": [
+                    {"vulns": [{"id": f"GHSA-chunk-{start + i}", "summary": "",
+                                "affected": [], "references": []}]}
+                    for i in range(size)
+                ],
+            }).encode()))
+        with unittest.mock.patch.object(server, "OSV_QUERYBATCH_MAX", chunk), \
+                unittest.mock.patch(
+                    "urllib.request.urlopen",
+                    side_effect=mock_urlopen(responses),
+                ) as m:
+            results = server.query_osv_batch(deps)
+        self.assertEqual(m.call_count, 3)
+        for call in m.call_args_list:
+            payload = json.loads(call.args[0].data)
+            self.assertLessEqual(len(payload["queries"]), chunk)
+        self.assertEqual(len(results), n)
+        self.assertEqual(
+            [r["vulnerabilities"][0]["id"] for r in results],
+            [f"GHSA-chunk-{i}" for i in range(n)],
+        )
+
 
 # ---------------------------------------------------------------------------
 # _is_malicious_id / `malicious` flag (#322 Layer 1 — OSSF malicious-package


### PR DESCRIPTION
## Summary
- Cap `get_dependency_vulnerabilities` dependency lists at 100 (same in-handler pattern as `verify_coordinates`).
- Chunk `query_osv_batch` into ≤1000-query POSTs and merge results so large audits do not fail as a unit.
- Coerce and clamp `search_artifacts` `limit` to `[1, 100]` before building the Solr URL.

Fixes #349

## Test plan
- [x] `python3 -m compileall plugins/maven-mcp/plugin/server`
- [x] `python3 -m unittest discover -s plugins/maven-mcp/tests -p test_handlers.py`
- [x] `python3 -m unittest discover -s plugins/maven-mcp/tests -p test_maven_search_osv.py`
- [x] Full suite: `python3 -m unittest discover -s plugins/maven-mcp/tests` (542 OK, 1 skipped)


Made with [Cursor](https://cursor.com)