### PR TITLE
Fix maven-mcp skill docs (#356, #357)

### DIFF
--- a/plugins/maven-mcp/plugin/skills/check-deps-vulnerabilities/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/check-deps-vulnerabilities/SKILL.md
@@ -106,7 +106,13 @@ which file each dependency came from for the report.
 
 ## Step 4 — Query OSV.dev for vulnerabilities
 
-Send a batch request to OSV.dev for all unique `groupId:artifactId:version` combinations.
+**Preferred:** call the `get_dependency_vulnerabilities` MCP tool with the collected
+coordinates. The server POSTs `/v1/querybatch`, then hydrates each unique id via
+`GET /v1/vulns/{id}` (deduped, capped), and returns `id` / `summary` / `severity` /
+`fixedVersion` / `malicious` ready for the report. Do not re-derive those fields from
+a raw querybatch response.
+
+**Fallback** (MCP tool unavailable): send a batch request yourself, then hydrate.
 
 **Request:**
 ```
@@ -130,11 +136,12 @@ Content-Type: application/json
 OSV.dev accepts up to 1000 entries per batch. If there are more, split into multiple
 requests and merge results.
 
-**Important:** `/v1/querybatch` returns only `{id, modified}` per vulnerability.
-The MCP server hydrates each unique id via `GET https://api.osv.dev/v1/vulns/{id}`
-before extracting severity/summary/fixedVersion. Prefer the
-`get_dependency_vulnerabilities` tool (which already hydrates) over calling
-querybatch yourself.
+**Required — bare querybatch is not enough.** `/v1/querybatch` returns only
+`{id, modified}` per vulnerability — never `summary`, `severity`, `references`, or
+`affected`. Before any severity/summary/fixed-in reporting, hydrate each unique id
+with `GET https://api.osv.dev/v1/vulns/{id}` (one extra call per unique id; dedupe
+across the batch). Skipping hydration leaves every finding as unknown severity with
+an empty summary.
 
 **Bare querybatch response shape (before hydration):**
 ```json

--- a/plugins/maven-mcp/plugin/skills/check-deps/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/check-deps/SKILL.md
@@ -166,7 +166,9 @@ overwhelming the network.
 
 ## Step 5 — Check vulnerabilities (optional, enabled by default)
 
-Send the collected dependencies to OSV.dev:
+**Preferred:** call `get_dependency_vulnerabilities` (hydrated severity/summary/fixedVersion).
+
+**Fallback:** POST to OSV.dev, then hydrate — never report severity from querybatch alone:
 
 ```
 POST https://api.osv.dev/v1/querybatch
@@ -182,18 +184,26 @@ Content-Type: application/json
 }
 ```
 
-`/v1/querybatch` returns only `{id, modified}` — hydrate via `GET /v1/vulns/{id}`
-(or use `get_dependency_vulnerabilities`, which already does) before deriving
-severity/fixed version as described in `/check-deps-vulnerabilities`.
+`/v1/querybatch` returns only `{id, modified}`. Hydrate each unique id via
+`GET /v1/vulns/{id}` (N extra calls; dedupe) before deriving severity/fixed version
+as described in `/check-deps-vulnerabilities`.
 
 ## Step 6 — Build the report
 
-Only include entries where `latestVersion !== currentVersion` OR `vulnerabilities` is
-non-empty. If nothing to show in a group, omit that section. If all sections are empty:
+Only include entries where `latestVersion !== currentVersion`. If nothing to show in a
+group, omit that section.
+
+**Terminal branch — nothing outdated and no vulnerabilities:**
 
 > All dependencies up to date.
 
-Then skip to the Vulnerabilities section.
+Stop here — do not continue to Steps 7–10.
+
+**Vulnerabilities only (no outdated deps):** skip the upgrade tables below and go to
+Step 7.
+
+**Outdated deps present:** render the matching sections below, then continue to Step 7
+(even if the vulnerabilities list is empty — Step 7 omits itself when empty).
 
 ---
 

--- a/plugins/maven-mcp/plugin/skills/dependency-changes/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/dependency-changes/SKILL.md
@@ -6,7 +6,18 @@ description: Show what changed between two versions of a Maven/Gradle dependency
 # Dependency Changes
 
 Show what changed between two versions of a Maven artifact by fetching release notes and
-changelog data from GitHub via HTTP.
+changelog data.
+
+**Preferred:** call the `get_dependency_changes` MCP tool with
+`groupId`, `artifactId`, `fromVersion`, and `toVersion`. The server discovers the
+GitHub repo and fetches releases using `GITHUB_TOKEN` server-side when present —
+never pass the token in headers yourself.
+
+**Fallback** (MCP tool unavailable): follow the HTTP steps below. Do **not** add an
+`Authorization` header or put `GITHUB_TOKEN` on a command line — WebFetch cannot set
+auth headers, and shelling out with the token leaks it into transcripts/process args.
+Unauthenticated GitHub calls are fine (lower rate limit); if rate-limited, say so
+and stop.
 
 ## Input formats
 
@@ -71,9 +82,8 @@ If a GitHub repo was found:
 https://api.github.com/repos/{owner}/{repo}/releases?per_page=100
 ```
 
-If `GITHUB_TOKEN` is configured in the environment, add header `Authorization: Bearer {token}`
-to raise rate limits. Without a token, GitHub allows 60 unauthenticated requests/hour — this
-call counts as one.
+Do not attach `Authorization` / `GITHUB_TOKEN` here (see Preferred path above).
+Unauthenticated GitHub allows 60 requests/hour — this call counts as one.
 
 Match each version in the range to GitHub release tags. Common tag patterns:
 `v{version}`, `{version}`, `{artifactId}-{version}`, `release-{version}`.
@@ -124,7 +134,8 @@ Maven: https://search.maven.org/artifact/{groupId}/{artifactId}
   artifact, and provide the Maven Central artifact URL as a starting point:
   `https://search.maven.org/artifact/{groupId}/{artifactId}`
 - **GitHub API rate limited (HTTP 403/429)** — note that the limit is reached and suggest
-  setting `GITHUB_TOKEN` in the environment.
+  retrying via `get_dependency_changes` (uses server-side `GITHUB_TOKEN` when configured)
+  rather than attaching the token to a client request.
 - **fromVersion equals toVersion** — tell the user the versions are the same, nothing to show.
 - **Artifact not found in Maven Central** — suggest checking spelling.
 

--- a/plugins/maven-mcp/plugin/skills/dependency-health/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/dependency-health/SKILL.md
@@ -4,17 +4,26 @@ description: >-
   Use when evaluating whether to adopt a Maven dependency: "is X maintained",
   "health of dependency", "check library health", "is this library active",
   "dependency activity", "GitHub stars", "is this abandoned", "release cadence",
-  "dependency maintenance", "license of library", or when the dependency-evaluator
-  agent needs raw maintenance signals for a library. Fetches latest version,
+  "dependency maintenance", or "license of library". Fetches latest version,
   stability, GitHub activity, issue dynamics, license, and archived status.
-  Do NOT use for: an adopt/avoid recommendation or new-dependency vetting (use
-  evaluate-dependency, which calls this skill for signals).
+  Do NOT use for an adopt/avoid recommendation — present raw signals only; the
+  caller (or user) weighs them.
 ---
 
 # Dependency Health
 
-Assess the maintenance health of one or more Maven dependencies by querying Maven Central
-and GitHub directly via HTTP.
+Assess the maintenance health of one or more Maven dependencies.
+
+**Preferred:** call the `get_dependency_health` MCP tool for each coordinate. The
+server resolves Maven metadata, discovers the GitHub repo, and fetches GitHub
+signals using `GITHUB_TOKEN` server-side when present — never pass the token in
+headers yourself.
+
+**Fallback** (MCP tool unavailable): query Maven Central and GitHub via HTTP as
+below. Do **not** add an `Authorization` header or put `GITHUB_TOKEN` on a
+command line — WebFetch cannot set auth headers, and shelling out with the token
+leaks it into transcripts/process args. Unauthenticated GitHub calls are fine
+(lower rate limit); if rate-limited, say so and stop.
 
 ## Arguments
 
@@ -72,7 +81,7 @@ If a GitHub repo was identified:
 GET https://api.github.com/repos/{owner}/{repo}
 ```
 
-If `GITHUB_TOKEN` is set in the environment, add header `Authorization: Bearer {token}`.
+Do not attach `Authorization` / `GITHUB_TOKEN` here (see Preferred path above).
 
 Extract: `stargazers_count`, `forks_count`, `archived`, `pushed_at` (last commit date),
 `license.name` (use this if POM license was missing), `open_issues_count`.
@@ -144,8 +153,8 @@ Open issues: {N} | Closed: {M} | Close ratio: {X}%
 ## Important constraints
 
 - Do NOT issue an adopt/reject verdict — present raw signals only.
-- If the user wants a recommendation, suggest they weigh the signals themselves or use an
-  agent with evaluation criteria.
+- If the user wants a recommendation, suggest they weigh the signals themselves.
 - Degrade gracefully: if GitHub is unavailable or rate-limited, present Maven-only data
   and note what is missing.
-- `GITHUB_TOKEN` in the environment raises the rate limit from 60 to 5000 req/h.
+- Prefer `get_dependency_health` so any configured `GITHUB_TOKEN` stays server-side
+  (5000 req/h vs 60 unauthenticated). Never hand-roll `Authorization: Bearer` headers.


### PR DESCRIPTION
## Summary
- **#356:** Document that OSV `/v1/querybatch` returns only `{id, modified}`; require `GET /v1/vulns/{id}` hydration (or `get_dependency_vulnerabilities`) before severity/summary/fixed-in reporting.
- **#357:** Remove phantom `dependency-evaluator` / `evaluate-dependency` refs; stop instructing hand-rolled `Authorization: Bearer` for GitHub (prefer MCP tools); reword contradictory check-deps Step 6 terminal branch.

## Test plan
- [x] `bash scripts/validate.sh` (skill frontmatter L7 green)
- [x] Grep: no `evaluate-dependency` / `dependency-evaluator` / `skip to the Vulnerabilities` / instructing Bearer auth
- [ ] Spot-check skill markdown reads coherently end-to-end

Fixes #356
Fixes #357


Made with [Cursor](https://cursor.com)