### PR TITLE
Route maven-mcp skills through plugin MCP tools

### DIFF
--- a/plugins/maven-mcp/plugin/skills/check-deps-vulnerabilities/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/check-deps-vulnerabilities/SKILL.md
@@ -14,179 +14,42 @@ description: >-
 Scan the current Maven/Gradle project for known CVE/GHSA advisories on declared
 dependencies and offer remediation through targeted version updates.
 
-## Step 1 — Discover build files
+## Step 1 — Collect coordinates via MCP (preferred)
 
-Use Glob to find all build files in the project:
+**Option A (full audit):** call `audit_project_dependencies` with
+`includeVulnerabilities: true` and `productionOnly: true` (unless the user asks to include
+test scopes). Use the per-dependency `vulnerabilities` from the result.
 
-```
-**/libs.versions.toml
-**/build.gradle.kts
-**/build.gradle
-**/pom.xml
-```
+**Option B (vulns only):**
 
-Exclude files under `.gradle/`, `build/`, `.idea/`, `node_modules/`, and any path
-containing `/build/`.
+1. Call `scan_project_dependencies` with `projectPath` (default cwd).
+2. Keep production-scoped, versioned coordinates (exclude test configurations unless asked).
+3. Call **`get_dependency_vulnerabilities`** with those `{groupId, artifactId, version}`
+   entries (and `projectPath` so Gradle plugin markers resolve to implementation GAVs).
 
-Read each found file with the Read tool.
+Use the tool output fields as-is: `id`, `summary`, `severity`, `fixedVersion`, `malicious`,
+and `resolvedImplementation` when present. Do **not** re-derive severity/summary from a raw
+OSV querybatch response while the MCP tool works.
 
-## Step 2 — Extract declared dependencies
+## Step 2 — Build the report
 
-Parse each file to collect `groupId`, `artifactId`, and `version` for every production
-dependency. Default: exclude test-scoped entries (see Scopes section). If the user passes
-`productionOnly: false`, include them.
-
-### Version catalogs (`libs.versions.toml`)
-
-In the `[versions]` section, collect `key = "value"` pairs as a version map.
-
-In the `[libraries]` section, each entry has one of these forms:
-```toml
-alias = "group:artifact:version"
-alias = { group = "...", name = "...", version = "..." }
-alias = { group = "...", name = "...", version.ref = "key" }
-```
-Resolve `version.ref` entries using the version map.
-
-In the `[plugins]` section:
-```toml
-alias = { id = "...", version = "..." }
-alias = { id = "...", version.ref = "key" }
-```
-Convert plugin ID to Maven coordinates: `groupId = id`, `artifactId = "{id}.gradle.plugin"`.
-
-### Gradle build files (`build.gradle.kts` / `build.gradle`)
-
-Match patterns like:
-```
-implementation("group:artifact:version")
-api("group:artifact:version")
-compileOnly("group:artifact:version")
-runtimeOnly("group:artifact:version")
-```
-Also the Kotlin DSL map form:
-```
-implementation(group = "...", name = "...", version = "...")
-```
-
-Skip entries that reference version catalog variables (e.g. `libs.ktor.client.core`) —
-those versions are already captured from the catalog.
-
-**Production scopes** (include): `implementation`, `api`, `compileOnly`, `runtimeOnly`,
-`compile`, `runtime`, `provided`, `releaseImplementation`, `debugImplementation`.
-
-**Test scopes** (exclude by default): `testImplementation`, `testApi`,
-`androidTestImplementation`, `kaptTest`, `kaptAndroidTest`, `testCompileOnly`,
-`testRuntimeOnly`.
-
-### Maven POM files (`pom.xml`)
-
-Match entries inside `<dependencies>`:
-```xml
-<dependency>
-  <groupId>...</groupId>
-  <artifactId>...</artifactId>
-  <version>...</version>
-  <scope>...</scope>
-</dependency>
-```
-
-**Production scopes** (include): `compile` (default), `runtime`, `provided`.
-**Exclude**: `test`, `system`.
-
-### Plugins blocks
-
-Match `plugins { id("...") version "..." }` and `id("...") version "..."` lines.
-Convert the plugin ID to Maven coordinates as above.
-
-## Step 3 — Deduplicate
-
-After parsing all files, deduplicate by `groupId:artifactId:version`. Keep track of
-which file each dependency came from for the report.
-
-## Step 4 — Query OSV.dev for vulnerabilities
-
-**Preferred:** call the `get_dependency_vulnerabilities` MCP tool with the collected
-coordinates. The server POSTs `/v1/querybatch`, then hydrates each unique id via
-`GET /v1/vulns/{id}` (deduped, capped), and returns `id` / `summary` / `severity` /
-`fixedVersion` / `malicious` ready for the report. Do not re-derive those fields from
-a raw querybatch response.
-
-**Fallback** (MCP tool unavailable): send a batch request yourself, then hydrate.
-
-**Request:**
-```
-POST https://api.osv.dev/v1/querybatch
-Content-Type: application/json
-
-{
-  "queries": [
-    {
-      "package": {
-        "name": "{groupId}:{artifactId}",
-        "ecosystem": "Maven"
-      },
-      "version": "{version}"
-    },
-    ...
-  ]
-}
-```
-
-OSV.dev accepts up to 1000 entries per batch. If there are more, split into multiple
-requests and merge results.
-
-**Required — bare querybatch is not enough.** `/v1/querybatch` returns only
-`{id, modified}` per vulnerability — never `summary`, `severity`, `references`, or
-`affected`. Before any severity/summary/fixed-in reporting, hydrate each unique id
-with `GET https://api.osv.dev/v1/vulns/{id}` (one extra call per unique id; dedupe
-across the batch). Skipping hydration leaves every finding as unknown severity with
-an empty summary.
-
-**Bare querybatch response shape (before hydration):**
-```json
-{
-  "results": [
-    {
-      "vulns": [
-        {"id": "GHSA-xxxx-xxxx-xxxx", "modified": "2024-01-01T00:00:00Z"}
-      ]
-    }
-  ]
-}
-```
-
-**Hydrated record** (`GET /v1/vulns/{id}`) carries `summary`, `severity`,
-`database_specific`, `affected`, and `references`. The `results` array from
-querybatch corresponds 1:1 to the `queries` array. For each result:
-- If `vulns` is empty or missing, the dependency has no known advisories.
-- For each vuln (after hydration), extract:
-  - `id` — advisory identifier (GHSA-... or CVE-...)
-  - `summary` — short description
-  - `severity` — derive from CVSS score: ≥9.0 CRITICAL, ≥7.0 HIGH, ≥4.0 MEDIUM,
-    <4.0 LOW; if no CVSS score is present use the `database_specific.severity` field
-    if available, otherwise "unknown"
-  - `fixedVersion` — the `fixed` event value from the first matching ECOSYSTEM range;
-    if absent, leave empty
-
-## Step 5 — Build the report
-
-Filter to dependencies where `vulns` is non-empty.
+Filter to dependencies with non-empty vulnerabilities.
 
 Sort: CRITICAL → HIGH → MEDIUM → LOW → unknown, then lexicographic by
 `groupId:artifactId`.
 
-Render as a markdown table. One row per `(dependency, finding)`:
+Render a markdown table (one row per dependency × finding):
 
 | Source file | Artifact | Current | Severity | CVE/GHSA | Summary | Fixed in |
 |-------------|----------|---------|----------|----------|---------|----------|
-| `gradle/libs.versions.toml` | `org.apache.logging.log4j:log4j-core` | 2.14.1 | CRITICAL | [GHSA-jfh8-c2jp-5v3q](https://osv.dev/vulnerability/GHSA-jfh8-c2jp-5v3q) | Remote code execution in Log4Shell | 2.17.1 |
 
-**Summary line after the table:**
+Link advisories as `https://osv.dev/vulnerability/{id}`.
+
+**Summary line:**
 `Total: N findings across M packages (X critical, Y high, Z medium, W low).`
 `Scanned: K dependencies total. Test configurations excluded.`
 
-**If no vulnerabilities found:**
+**If none:**
 > No known vulnerabilities found in production dependencies. (Scanned K dependencies. Test configurations were excluded.)
 
 Then stop — no remediation prompt.
@@ -195,58 +58,47 @@ Then stop — no remediation prompt.
 > Note: OSV does not cover shaded/uber JARs. Dependencies bundled inside a fat JAR may
 > carry CVEs that this scan will not surface.
 
-## Step 6 — Remediation
+## Step 3 — Remediation
 
-When at least one finding exists, ask the user with `AskUserQuestion` — one question,
-exactly four options:
+When at least one finding exists, ask the user — one question, four options:
 
 1. **Update all** — upgrade every vulnerable package to its recommended fixed version.
 2. **Update CRITICAL + HIGH only** — leave MEDIUM/LOW for later.
-3. **Show details for a specific CVE/GHSA** — ask which one, then fetch:
-   `https://api.osv.dev/v1/vulns/{id}` and present the full advisory text.
+3. **Show details for a specific CVE/GHSA** — ask which one; prefer the hydrated fields
+   already returned, or fetch `https://api.osv.dev/v1/vulns/{id}` only if more detail is needed.
 4. **Report only** — make no changes.
 
-**Recommended fixed version per package:** `max(fixedVersion)` across all findings for
-that `groupId:artifactId`. If a finding has no `fixedVersion`, exclude it from the max;
-if every finding lacks one, list under "Manual upgrade required".
+**Recommended fixed version per package:** `max(fixedVersion)` across findings for that GA.
+If every finding lacks `fixedVersion`, list under "Manual upgrade required".
 
-## Step 7 — Apply updates
+## Step 4 — Apply updates
 
 When the user picks option 1 or 2:
 
-1. Edit the appropriate file:
-   - **Version catalog** (`libs.versions.toml`): update the `[versions]` entry or inline
-     version in `[libraries]`/`[plugins]`. Touch only the version value.
-   - **Gradle build file**: update the inline version string in the dependency declaration.
-   - **pom.xml**: update `<version>` inside the `<dependency>` block.
-
-2. **MANDATORY: Run the project build to verify compatibility.** Do NOT skip this step.
-   - Gradle: `./gradlew build` (or `./gradlew assembleDebug` for Android)
-   - Maven: `mvn compile`
-
-3. If the build succeeds, report which dependencies were updated and which CVEs each
-   upgrade closes.
-
-4. If the build fails, identify the incompatibility, attempt to fix it (API changes, import
-   updates). If non-trivial, revert that entry and mark it "manual upgrade required".
-   Re-run the build to confirm it passes. Report what was updated and what was reverted.
+1. Edit only the version value in the catalog / build file / pom.xml.
+2. **MANDATORY:** run the project build (`./gradlew build` or `mvn compile`).
+3. On success, report what was updated and which advisories each upgrade closes.
+4. On failure, attempt a trivial fix or revert that entry; re-run the build.
 
 **Never report "vulnerabilities patched" without a passing build.**
 
 ## Known limitations
 
-State these at the top of the report when relevant:
+State when relevant:
 
-- Test, build, and annotation-processor configurations are excluded by default.
-- Version catalog entries referenced via `version.ref` are resolved; complex expressions
-  (e.g. multi-catalog from() form) may not be detected.
-- Transitive dependencies are not scanned — only direct declarations in build files.
-- Variant-specific configurations (`releaseImplementation`, `debugImplementation`, etc.)
-  are included in production scope but flavor-prefixed ones
-  (`<flavor>ReleaseImplementation`) may be missed.
-- OSV coverage for Gradle plugin marker artifacts is limited — plugin CVEs may not appear.
-- `buildSrc/` and `build-logic/` convention-plugin dependency declarations are scanned;
-  composite builds added via `includeBuild` are not.
+- Test / build / annotation-processor configurations excluded by default.
+- Transitive dependencies are not scanned — only scanner-declared coordinates.
+- OSV coverage for unresolved Gradle plugin markers is limited; the MCP tool resolves
+  markers to implementation GAVs when possible.
+- Composite builds via `includeBuild` may be incomplete.
+
+## Fallback (MCP unavailable only)
+
+Glob/Read build files, extract production GAVs, POST
+`https://api.osv.dev/v1/querybatch`, then **hydrate** each unique id with
+`GET https://api.osv.dev/v1/vulns/{id}` before reporting severity/summary/fixedVersion.
+Bare querybatch `{id, modified}` is not enough. Note that plugin-marker resolution and
+project-repo awareness are skipped on this path.
 
 ## Language
 

--- a/plugins/maven-mcp/plugin/skills/check-deps/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/check-deps/SKILL.md
@@ -9,323 +9,89 @@ description: >-
 
 # Check Dependencies
 
-Scan the current project — version catalogs, all submodules, plugin DSL blocks, and
-buildscript classpath — and report which dependencies have newer versions available, then
-apply the updates the user confirms.
+Scan the current project and report which dependencies have newer versions available, then
+apply the updates the user confirms. Prefer the plugin MCP tools — they use project-declared
+repositories, version classification, and OSV hydration already implemented in the server.
 
-## Step 1 — Discover build files
+## Step 1 — Audit via MCP (preferred)
 
-Use Glob to find all build files:
+Call **`audit_project_dependencies`** with:
 
-```
-**/libs.versions.toml
-**/build.gradle.kts
-**/build.gradle
-**/pom.xml
-**/settings.gradle.kts
-**/settings.gradle
-```
+- `projectPath` — project root (default: cwd)
+- `includeVulnerabilities` — `true` by default; set `false` if the user only wants updates
+- `productionOnly` — `true` by default; set `false` to include test-scoped deps
 
-Exclude files under `.gradle/`, `build/`, `.idea/`, `node_modules/`, and any path
-containing `/build/`.
+This single call scans build files (catalogs, modules, plugin DSL, buildscript, Maven POMs,
+`buildSrc` / `build-logic`), resolves latest versions against project repos, and optionally
+queries OSV.
 
-Read each found file with the Read tool.
+Alternatively, when you only need the declared list first:
 
-## Step 2 — Extract declared dependencies
+1. `scan_project_dependencies` → extract coordinates
+2. `compare_dependency_versions` with `{groupId, artifactId, currentVersion}` per entry
+3. `get_dependency_vulnerabilities` for versioned coordinates (optional)
 
-Parse each file to collect a list of dependency records. Each record has:
-- `groupId`, `artifactId`, `version` (resolved, not a variable reference)
-- `source.kind` — one of: `catalog-library`, `catalog-plugin`, `module-direct`,
-  `plugins-dsl`, `buildscript-classpath`
-- `source.file` — path to the file containing the declaration
-- `source.tomlPath` — for catalog entries, path to the .toml file
-- `source.alias` — for catalog entries, the alias key
-- `source.settingsBlock` — `true` for `pluginManagement { plugins {} }` entries
-- `usages` — list of `{ module, configuration }` for where the dependency is used
+Do **not** hand-parse `maven-metadata.xml` or POST to OSV yourself while MCP tools work.
 
-### Version catalogs (`libs.versions.toml`) — `catalog-library` and `catalog-plugin`
+## Step 2 — Build the report
 
-In the `[versions]` section, collect `key = "value"` pairs as a version map.
+From the audit / compare results, only include entries where an upgrade is available
+(`upgradeType` ≠ `none`, or `latestVersion` ≠ `currentVersion`). Group by `source.kind`:
 
-In the `[libraries]` section:
-```toml
-alias = "group:artifact:version"
-alias = { group = "...", name = "...", version = "..." }
-alias = { group = "...", name = "...", version.ref = "key" }
-```
-Resolve `version.ref` using the version map.
-
-In the `[plugins]` section:
-```toml
-alias = { id = "...", version = "..." }
-alias = { id = "...", version.ref = "key" }
-```
-Convert plugin ID to Maven coordinates: `groupId = id`, `artifactId = "{id}.gradle.plugin"`.
-Set `source.kind = "catalog-plugin"`.
-
-To find which Gradle modules use a catalog alias, scan `build.gradle[.kts]` files for
-`libs.{alias-with-dots}` references. Record the module name (derived from the file path
-relative to the project root).
-
-### Gradle build files — `module-direct`
-
-Match dependency declarations with inline string versions:
-```
-implementation("group:artifact:version")
-api("group:artifact:version")
-implementation(group = "...", name = "...", version = "...")
-```
-
-**Include** (production scopes): `implementation`, `api`, `compileOnly`, `runtimeOnly`,
-`compile`, `runtime`, `provided`, `releaseImplementation`, `debugImplementation`,
-`ksp`, `kapt`, `annotationProcessor`.
-
-**Exclude** (test scopes): `testImplementation`, `testApi`, `androidTestImplementation`,
-`kaptTest`, `kaptAndroidTest`, `testCompileOnly`, `testRuntimeOnly`.
-
-Skip entries that reference catalog variables (no inline version string).
-
-Set `source.kind = "module-direct"`.
-
-### Plugin DSL blocks — `plugins-dsl`
-
-Match `plugins { }` blocks:
-```
-id("plugin.id") version "1.0.0"
-kotlin("jvm") version "2.0.0"
-```
-
-Also match `pluginManagement { plugins { } }` in `settings.gradle[.kts]` — set
-`source.settingsBlock = true`.
-
-Set `source.kind = "plugins-dsl"`.
-Convert plugin ID to Maven coordinates as described above.
-
-### Buildscript classpath — `buildscript-classpath`
-
-Match inside `buildscript { dependencies { ... } }` blocks:
-```
-classpath("group:artifact:version")
-classpath("group:artifact:version") { ... }
-```
-
-Set `source.kind = "buildscript-classpath"`.
-
-### Maven POM files — `module-direct`
-
-Match `<dependency>` blocks with `<version>` present and scope `compile` (default),
-`runtime`, or `provided`. Exclude `test` and `system` scope.
-
-## Step 3 — Deduplicate
-
-If the same `groupId:artifactId` appears both as a `catalog-library` entry and as a
-`module-direct` entry (same or different version), flag it as a drift case. Keep both
-records.
-
-## Step 4 — Check latest versions from Maven Central
-
-For each unique `groupId:artifactId`, fetch the Maven metadata. Build the group path by
-replacing `.` with `/` in the groupId.
-
-**Maven Central:**
-```
-https://repo1.maven.org/maven2/{group_path}/{artifactId}/maven-metadata.xml
-```
-
-**Google Maven** (for `androidx.*`, `com.google.android.*`, `com.android.*`,
-`com.google.firebase.*`, `com.google.gms.*`, `com.google.mlkit.*`):
-```
-https://dl.google.com/dl/android/maven2/{group_path}/{artifactId}/maven-metadata.xml
-```
-
-**Gradle Plugin Portal** (for plugin marker artifacts — `artifactId` ends in
-`.gradle.plugin`):
-```
-https://plugins.gradle.org/m2/{group_path}/{artifactId}/maven-metadata.xml
-```
-
-Extract all `<version>` entries from the XML.
-
-**Version classification** (same rules as `/latest-version` skill):
-- STABLE: no pre-release suffix
-- RC: contains `-rc`, `-RC`
-- BETA: contains `-beta`, `-b`
-- ALPHA: contains `-alpha`, `-dev`, `-SNAPSHOT`, `-milestone`, `-M`, `-preview`, `-eap`
-
-**Latest stable:** highest version classified as STABLE.
-If no stable version, use the highest RC, then BETA, then ALPHA.
-
-**Upgrade type** (comparing `currentVersion` to `latestVersion`):
-Split both versions into `[major, minor, patch]`. First differing segment:
-- Different `major` → `MAJOR`
-- Different `minor` → `MINOR`
-- Different `patch` or rest → `PATCH`
-
-Batch fetches: run up to 10 fetches in parallel. Process in batches of 10 to avoid
-overwhelming the network.
-
-## Step 5 — Check vulnerabilities (optional, enabled by default)
-
-**Preferred:** call `get_dependency_vulnerabilities` (hydrated severity/summary/fixedVersion).
-
-**Fallback:** POST to OSV.dev, then hydrate — never report severity from querybatch alone:
-
-```
-POST https://api.osv.dev/v1/querybatch
-Content-Type: application/json
-
-{
-  "queries": [
-    {
-      "package": {"name": "{groupId}:{artifactId}", "ecosystem": "Maven"},
-      "version": "{currentVersion}"
-    }
-  ]
-}
-```
-
-`/v1/querybatch` returns only `{id, modified}`. Hydrate each unique id via
-`GET /v1/vulns/{id}` (N extra calls; dedupe) before deriving severity/fixed version
-as described in `/check-deps-vulnerabilities`.
-
-## Step 6 — Build the report
-
-Only include entries where `latestVersion !== currentVersion`. If nothing to show in a
-group, omit that section.
+- **catalog-library** / **catalog-plugin** — alias, current → latest, upgrade type, catalog file, usages
+- **module-direct** — module, file, artifact, current → latest, configuration; flag catalog drift
+- **plugins-dsl** — split settings `pluginManagement` vs root/module `plugins {}`
+- **buildscript-classpath** — artifact, current → latest, file; note legacy style
 
 **Terminal branch — nothing outdated and no vulnerabilities:**
 
 > All dependencies up to date.
 
-Stop here — do not continue to Steps 7–10.
+Stop — do not continue to edit steps.
 
-**Vulnerabilities only (no outdated deps):** skip the upgrade tables below and go to
-Step 7.
+**Vulnerabilities:** after upgrade tables, add a **Vulnerabilities** section for every entry
+with non-empty `vulnerabilities`. Use server fields (`id`, `severity`, `summary`,
+`fixedVersion`, `malicious`) — do not re-derive severity from a raw querybatch response.
+Sort CRITICAL → HIGH → MEDIUM → LOW → unknown. Omit the section when empty.
 
-**Outdated deps present:** render the matching sections below, then continue to Step 7
-(even if the vulnerabilities list is empty — Step 7 omits itself when empty).
+Surface `resolvedFrom.viaPublicFallback` when true (coordinate missing from declared repos).
+Surface `deadRepositoryHints` from the scan/audit when present (e.g. `jcenter()`).
 
----
-
-### Catalog libraries (`source.kind === "catalog-library"`)
-
-Columns: alias | current → latest | upgrade type | catalog file | used by
-
-- `alias` — catalog alias key
-- `current → latest` — e.g., `2.3.12 → 3.1.3`
-- `upgrade type` — MAJOR / MINOR / PATCH
-- `catalog file` — source.tomlPath
-- `used by` — count of usages (e.g. `4 modules`) or `unused`
-
-When there are multiple catalogs, prefix alias with catalog name: `libs.alias`.
-
-Example:
-```
-| ktor-client-core | 2.3.12 → 3.1.3 | MAJOR | gradle/libs.versions.toml | 4 modules |
-```
-
----
-
-### Catalog plugins (`source.kind === "catalog-plugin"`)
-
-Columns: alias | plugin ID | current → latest | upgrade type | catalog file | used by
-
----
-
-### Module direct (`source.kind === "module-direct"`)
-
-Columns: module | file | artifact | current → latest | configuration
-
-- `module` — relative path of the module (or `(root)`)
-- `file` — source file path
-- `artifact` — `groupId:artifactId`
-- `configuration` — e.g. `implementation`
-
-Drift flag: if the same artifact is also a catalog entry, append:
-> ⚠ drift — same artifact declared in catalog and hardcoded here
-
----
-
-### Plugin DSL (`source.kind === "plugins-dsl"`)
-
-Split by `source.settingsBlock`:
-
-**Root / module `plugins {}` block** (`settingsBlock` is false/undefined):
-Columns: plugin ID | current → latest | upgrade type | file
-
-**Settings `pluginManagement { plugins {} }` block** (`settingsBlock === true`):
-Same columns.
-
----
-
-### Buildscript classpath (`source.kind === "buildscript-classpath"`)
-
-Columns: artifact | current → latest | file
-
-> *Note: `buildscript { dependencies { classpath … } }` is the pre-Plugin-DSL style.
-> Consider migrating to `plugins {}` blocks.*
-
----
-
-## Step 7 — Vulnerabilities section
-
-After all upgrade tables, add a **Vulnerabilities** section for every entry where
-vulnerabilities are non-empty (regardless of whether an upgrade is available).
-
-Columns: artifact | version | severity | advisory | fixed in | source | where to fix
-
-Sort: CRITICAL → HIGH → MEDIUM → LOW → unknown, then lexicographic by artifact.
-
-If no vulnerabilities: omit this section entirely.
-
-## Step 8 — Confirmation step
+## Step 3 — Confirmation
 
 Present the full report and **ask before making any edits**. Default proposal: update
-catalog entries first (single source of truth, safest edit).
+catalog entries first. Ask separately for non-catalog groups. Flag every MAJOR upgrade
+explicitly.
 
-Ask separately for each non-catalog group (Module direct, Plugin DSL, Buildscript
-classpath) — they require targeted edits in different files.
+## Step 4 — Edit pass
 
-Flag every MAJOR upgrade explicitly — major version bumps may contain breaking changes and
-warrant individual confirmation.
+Apply only the groups the user confirms. Touch only version values:
 
-## Step 9 — Edit pass
+- Catalog — `[versions]` or inline version in `[libraries]` / `[plugins]`
+- Module direct / Plugin DSL / Buildscript — inline version string in the build file
+- pom.xml — `<version>` inside the matching `<dependency>`
 
-Apply only the groups the user confirms.
-
-**Catalog libraries / plugins** — Edit the `.toml` file. Update `[versions]` value or the
-inline version in `[libraries]`/`[plugins]`. If the entry uses `version.ref`, update the
-referenced `[versions]` key. Touch only the version value.
-
-**Module direct** — Edit the build file. Update only the inline version string.
-
-**Plugin DSL root / module** — Edit the build file, update version in `plugins {}` block.
-
-**Plugin DSL settings** — Edit `settings.gradle[.kts]`, update version in
-`pluginManagement { plugins {} }` block.
-
-**Buildscript classpath** — Edit the root build file, update version in
-`buildscript { dependencies { classpath … } }` block.
-
-## Step 10 — Build verification
+## Step 5 — Build verification
 
 After every edit pass:
 
-- **Gradle:** `./gradlew build` — or `./gradlew :module:dependencies` for a fast
-  dependency-resolve check when a full build is slow.
-- **Maven:** `mvn dependency:tree`.
+- **Gradle:** `./gradlew build` (or a faster resolve check when a full build is slow)
+- **Maven:** `mvn dependency:tree`
 
-Surface any build failure immediately. Identify which updated dependency caused it.
-Attempt to fix incompatibilities. If non-trivial, revert that entry and note it as
-"manual upgrade required". Re-run the build to confirm it passes.
-
-**Never report "versions updated" without a passing build.**
+Surface failures immediately. Attempt trivial fixes; otherwise revert that entry and note
+"manual upgrade required". **Never report "versions updated" without a passing build.**
 
 ## Constraints and non-goals
 
-- **Major version bumps** require explicit per-entry confirmation.
-- **Multi-catalog `from("g:a:v")` form** is not supported.
-- **Transitive dependencies** are not enumerated — only direct declarations.
-- This skill does not auto-select unstable/pre-release versions.
-- **Vulnerabilities for plugin entries** may not be detected (OSV coverage gap for
-  `.gradle.plugin` marker artifacts).
+- Major version bumps require explicit per-entry confirmation.
+- Transitive dependencies are not enumerated — only what the scanner returns.
+- This skill does not auto-select unstable/pre-release versions (server uses prefer-stable).
+- Multi-catalog `from("g:a:v")` form may be incomplete in the scanner.
+
+## Fallback (MCP unavailable only)
+
+If MCP tools cannot be called: Glob/Read build files, extract GAVs, fetch public
+`maven-metadata.xml` (Central / Google / Plugin Portal), classify versions, and optionally
+POST OSV `/v1/querybatch` then hydrate via `GET /v1/vulns/{id}`. State clearly that
+project-private repos, plugin-marker→implementation resolution, and server-side cache are
+skipped.

--- a/plugins/maven-mcp/plugin/skills/dependency-changes/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/dependency-changes/SKILL.md
@@ -8,139 +8,40 @@ description: Show what changed between two versions of a Maven/Gradle dependency
 Show what changed between two versions of a Maven artifact by fetching release notes and
 changelog data.
 
-**Preferred:** call the `get_dependency_changes` MCP tool with
-`groupId`, `artifactId`, `fromVersion`, and `toVersion`. The server discovers the
-GitHub repo and fetches releases using `GITHUB_TOKEN` server-side when present —
-never pass the token in headers yourself.
+## Preferred — MCP
 
-**Fallback** (MCP tool unavailable): follow the HTTP steps below. Do **not** add an
-`Authorization` header or put `GITHUB_TOKEN` on a command line — WebFetch cannot set
-auth headers, and shelling out with the token leaks it into transcripts/process args.
-Unauthenticated GitHub calls are fine (lower rate limit); if rate-limited, say so
-and stop.
+1. Parse `groupId`, `artifactId`, `fromVersion`, `toVersion` from the user or conversation
+   (e.g. a prior check-deps table). If `fromVersion` is missing, ask or use the current
+   version from context. If `fromVersion` equals `toVersion`, say there is nothing to show.
 
-## Input formats
+2. Call **`get_dependency_changes`** with:
+   - `groupId`, `artifactId`
+   - `fromVersion` (exclusive)
+   - `toVersion` (inclusive)
+   - optional `projectPath`
 
-The user can provide versions in several ways:
+   The server discovers the GitHub repo and fetches releases using `GITHUB_TOKEN`
+   server-side when present — never pass the token in headers yourself.
 
-- **Explicit range:** "what changed in io.ktor:ktor-client-core from 2.3.0 to 3.1.3"
-- **After check-deps:** "show me the changelog for the ktor upgrade" — infer from the
-  update table in the conversation.
-- **Single artifact, one version:** "what's new in compose-bom 2025.01.00" — ask for the
-  from-version, or assume the user's current version if visible in context.
-
-## Steps
-
-### 1. Parse input
-
-Extract `groupId`, `artifactId`, `fromVersion`, `toVersion` from the user's input or
-conversation context.
-
-If `fromVersion` is missing and the current version is visible in context (e.g., from a
-check-deps table), use it. Otherwise ask.
-
-### 2. Discover GitHub repository
-
-Find the GitHub owner/repo for this artifact using one of these strategies in order:
-
-**a. Fetch the POM file** to extract the SCM URL:
-```
-https://repo1.maven.org/maven2/{group_path}/{artifactId}/{toVersion}/{artifactId}-{toVersion}.pom
-```
-(Convert groupId dots to slashes for `group_path`.)
-
-Look for `<scm><url>` or `<scm><connection>` in the POM XML. Extract the GitHub owner/repo
-from URLs like `https://github.com/owner/repo` or `scm:git:github.com/owner/repo.git`.
-
-**b. Guess from groupId** if POM has no SCM info:
-- `io.github.{owner}.*` → `{owner}/{artifactId}`
-- `com.github.{owner}.*` → `{owner}/{artifactId}`
-- `org.{word}.*` → try `{word}/{artifactId}`
-
-**c. Use Maven Central search** as fallback:
-```
-https://search.maven.org/solrsearch/select?q=g:{groupId}+AND+a:{artifactId}&rows=1&wt=json
-```
-The `response.docs[0]` may include a project URL field.
-
-### 3. Determine versions in range
-
-Fetch `maven-metadata.xml` from Maven Central:
-```
-https://repo1.maven.org/maven2/{group_path}/{artifactId}/maven-metadata.xml
-```
-
-Extract all `<version>` entries between `fromVersion` (exclusive) and `toVersion`
-(inclusive), sorted newest-first. If there are more than 20 versions in the range, note
-the count and show only the first and last 5.
-
-### 4. Fetch GitHub release notes
-
-If a GitHub repo was found:
-
-```
-https://api.github.com/repos/{owner}/{repo}/releases?per_page=100
-```
-
-Do not attach `Authorization` / `GITHUB_TOKEN` here (see Preferred path above).
-Unauthenticated GitHub allows 60 requests/hour — this call counts as one.
-
-Match each version in the range to GitHub release tags. Common tag patterns:
-`v{version}`, `{version}`, `{artifactId}-{version}`, `release-{version}`.
-
-Collect matching releases and their `body` fields.
-
-### 5. Check for CHANGELOG.md
-
-If the GitHub repo is known, fetch the raw changelog file:
-```
-https://raw.githubusercontent.com/{owner}/{repo}/HEAD/CHANGELOG.md
-```
-(Also try `CHANGELOG.md`, `CHANGES.md`, `HISTORY.md`.)
-
-If found, extract sections for versions in the range. A section header typically looks like
-`## [3.1.3]`, `## 3.1.3`, or `### Version 3.1.3`.
-
-### 6. Present results
-
-**If release notes exist** — render each version as a section:
-```
-## io.ktor:ktor-client-core — 2.3.0 → 3.1.3
-
-### 3.1.3
-<release notes body>
-[Release](https://github.com/...)
-
-### 3.1.2
-<release notes body>
-```
-
-**If no release notes / CHANGELOG found** — show a version list and the project URL:
-```
-## io.ktor:ktor-client-core — 2.3.0 → 3.1.3
-
-Versions in range: 3.1.3, 3.1.2, 3.1.1, 3.1.0 (4 versions)
-No release notes found.
-GitHub: https://github.com/{owner}/{repo}/releases
-Maven: https://search.maven.org/artifact/{groupId}/{artifactId}
-```
-
-**If many versions in range (>6)** — collapse the middle:
-> Showing notes for 3.1.3, 3.1.2, 3.1.1 ... (8 more) ... 3.0.0
-
-## Error handling
-
-- **No GitHub repo found** — tell the user a GitHub repo could not be determined for the
-  artifact, and provide the Maven Central artifact URL as a starting point:
-  `https://search.maven.org/artifact/{groupId}/{artifactId}`
-- **GitHub API rate limited (HTTP 403/429)** — note that the limit is reached and suggest
-  retrying via `get_dependency_changes` (uses server-side `GITHUB_TOKEN` when configured)
-  rather than attaching the token to a client request.
-- **fromVersion equals toVersion** — tell the user the versions are the same, nothing to show.
-- **Artifact not found in Maven Central** — suggest checking spelling.
+3. Present the tool result: versions in range, release notes / bodies, links. If notes are
+   sparse, still show the version list plus GitHub releases / Maven Central URLs from the
+   response. Collapse the middle when many versions are returned.
 
 ## Context: used after check-deps
 
-When the user runs `check-deps` and sees an update table, they may ask "show me what changed
-for X" without re-typing coordinates. Pull `groupId`, `artifactId`, current version
-(→ fromVersion), and latest version (→ toVersion) from the table in context.
+When the user asks "show me what changed for X" after an update table, pull coordinates and
+current → latest versions from that table without re-asking.
+
+## Error handling
+
+- **No GitHub repo / no notes** — say so and provide the Maven Central artifact URL.
+- **Rate limited** — note the limit; retry via `get_dependency_changes` (server-side token)
+  rather than attaching a token to a client request.
+- **Artifact not found** — suggest checking spelling; do not invent changelog text.
+
+## Fallback (MCP unavailable only)
+
+If the tool cannot be called: fetch the POM for SCM, public `maven-metadata.xml` for the
+version list, then unauthenticated GitHub `/releases` (and optionally raw CHANGELOG.md).
+Do **not** add `Authorization` / `GITHUB_TOKEN` on the client. State that project-private
+repos are skipped. If rate-limited, say so and stop.

--- a/plugins/maven-mcp/plugin/skills/dependency-health/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/dependency-health/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   "health of dependency", "check library health", "is this library active",
   "dependency activity", "GitHub stars", "is this abandoned", "release cadence",
   "dependency maintenance", or "license of library". Fetches latest version,
-  stability, GitHub activity, issue dynamics, license, and archived status.
+  stability, GitHub activity, issue stats, license, and archived status.
   Do NOT use for an adopt/avoid recommendation — present raw signals only; the
   caller (or user) weighs them.
 ---
@@ -14,147 +14,44 @@ description: >-
 
 Assess the maintenance health of one or more Maven dependencies.
 
-**Preferred:** call the `get_dependency_health` MCP tool for each coordinate. The
-server resolves Maven metadata, discovers the GitHub repo, and fetches GitHub
-signals using `GITHUB_TOKEN` server-side when present — never pass the token in
-headers yourself.
+## Preferred — MCP
 
-**Fallback** (MCP tool unavailable): query Maven Central and GitHub via HTTP as
-below. Do **not** add an `Authorization` header or put `GITHUB_TOKEN` on a
-command line — WebFetch cannot set auth headers, and shelling out with the token
-leaks it into transcripts/process args. Unauthenticated GitHub calls are fine
-(lower rate limit); if rate-limited, say so and stop.
+Call **`get_dependency_health`** with:
 
-## Arguments
-
-The user provides one or more `groupId:artifactId` coordinates, optionally with a specific version:
-- `io.ktor:ktor-server-core`
-- `com.squareup.okhttp3:okhttp:4.12.0`
-
-## Steps
-
-For each dependency, execute steps 1–5 in parallel where possible.
-
-### 1. Fetch Maven metadata
-
-Build the group path: replace `.` with `/` in the groupId.
-
-Fetch from Maven Central:
-```
-https://repo1.maven.org/maven2/{group_path}/{artifactId}/maven-metadata.xml
+```json
+{
+  "dependencies": [
+    {"groupId": "io.ktor", "artifactId": "ktor-server-core"},
+    {"groupId": "com.squareup.okhttp3", "artifactId": "okhttp", "version": "4.12.0"}
+  ],
+  "projectPath": "<optional project root>"
+}
 ```
 
-For Android/Google artifacts (`androidx.*`, `com.google.android.*`, `com.android.*`,
-`com.google.firebase.*`), also try:
-```
-https://dl.google.com/dl/android/maven2/{group_path}/{artifactId}/maven-metadata.xml
-```
+The server resolves Maven metadata (project-aware repos), discovers the GitHub repo from
+POM SCM / groupId heuristics, and fetches GitHub signals using `GITHUB_TOKEN` server-side
+when present — never pass the token in headers yourself.
 
-Extract:
-- All `<version>` entries → total version count
-- `<latest>` and `<release>` tags → determine current stable and latest versions
-- `<lastUpdated>` → last publish date (format: `YYYYMMDDHHMMSS`)
+Present the tool fields as raw signals (do not invent an adopt/reject verdict):
 
-Classify the latest version for stability (STABLE / RC / BETA / ALPHA) using the same
-rules as the `/latest-version` skill.
+- Version: latest / stability / version count / last Maven publish / `resolvedFrom`
+- Repository: GitHub URL, license, stars, forks, archived, last commit / release, cadence
+- Issues: open / closed / close ratio when present
+- `signals` — list red flags from the tool as bullet points
 
-### 2. Fetch POM to find GitHub repo and license
-
-Fetch the POM for the latest version:
-```
-https://repo1.maven.org/maven2/{group_path}/{artifactId}/{version}/{artifactId}-{version}.pom
-```
-
-Extract:
-- `<scm><url>` or `<scm><connection>` → GitHub owner/repo
-- `<licenses><license><name>` → license name
-
-If no SCM URL in POM, guess from groupId:
-- `io.github.{owner}.*` → `github.com/{owner}/{artifactId}`
-- `com.github.{owner}.*` → `github.com/{owner}/{artifactId}`
-
-### 3. Fetch GitHub repository info
-
-If a GitHub repo was identified:
-
-```
-GET https://api.github.com/repos/{owner}/{repo}
-```
-
-Do not attach `Authorization` / `GITHUB_TOKEN` here (see Preferred path above).
-
-Extract: `stargazers_count`, `forks_count`, `archived`, `pushed_at` (last commit date),
-`license.name` (use this if POM license was missing), `open_issues_count`.
-
-### 4. Fetch recent releases
-
-```
-GET https://api.github.com/repos/{owner}/{repo}/releases?per_page=20
-```
-
-From the releases list:
-- `published_at` of the most recent release → last release date
-- Compute release cadence: median days between the last 5 releases
-
-### 5. Assess issue health (optional — skip if rate-limited)
-
-GitHub's REST API does not expose closed issue counts directly. Use the Search API:
-
-```
-GET https://api.github.com/search/issues?q=repo:{owner}/{repo}+type:issue+state:closed&per_page=1
-```
-
-This returns `total_count` for closed issues. Combine with `open_issues_count` from step 3
-to compute a close ratio. **Note:** This endpoint is heavily rate-limited (30 req/min with
-token, 10 without). If it returns 403/429, skip this step and note issue stats as unavailable.
-
-### 6. Present results
-
-For each dependency, show signals in this order:
-
-**Identity & version**
-```
-## groupId:artifactId
-
-Latest stable: {version} ({stability})
-Versions published: {count}
-Last Maven publish: {date}
-```
-
-**Repository** (if found)
-```
-GitHub: https://github.com/{owner}/{repo}
-License: {license}
-Stars: {stars} | Forks: {forks} | Archived: yes/no
-Last commit: {date} ({N months ago})
-Last release: {date}
-Release cadence: ~{N} days between releases
-```
-
-**Issues** (if available)
-```
-Open issues: {N} | Closed: {M} | Close ratio: {X}%
-```
-
-**Signals** — list any red flags as bullet points:
-- Archived repository — no further development
-- No stable release available
-- Last commit more than 12 months ago
-- Last release more than 18 months ago
-- Release cadence slower than 365 days
-- Close ratio below 50% (more issues open than ever closed)
-- Only 1 version published (may indicate abandoned project)
-
-**No GitHub repo found:**
-- State what Maven data was retrieved
-- Note that GitHub signals are unavailable
-- Provide Maven Central URL: `https://search.maven.org/artifact/{groupId}/{artifactId}`
+**No GitHub data:** state what Maven data was returned and link
+`https://search.maven.org/artifact/{groupId}/{artifactId}`.
 
 ## Important constraints
 
 - Do NOT issue an adopt/reject verdict — present raw signals only.
-- If the user wants a recommendation, suggest they weigh the signals themselves.
-- Degrade gracefully: if GitHub is unavailable or rate-limited, present Maven-only data
-  and note what is missing.
+- Degrade gracefully when GitHub is rate-limited or missing.
 - Prefer `get_dependency_health` so any configured `GITHUB_TOKEN` stays server-side
   (5000 req/h vs 60 unauthenticated). Never hand-roll `Authorization: Bearer` headers.
+
+## Fallback (MCP unavailable only)
+
+If the tool cannot be called: fetch public `maven-metadata.xml` + POM, then unauthenticated
+GitHub REST (`/repos`, `/releases`, search issues). Do **not** put `GITHUB_TOKEN` on a
+command line or in WebFetch headers. Note that project-private repos are skipped.
+Unauthenticated GitHub is fine (lower rate limit); if rate-limited, say so and stop.

--- a/plugins/maven-mcp/plugin/skills/latest-version/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/latest-version/SKILL.md
@@ -8,7 +8,8 @@ description: >-
 
 # Latest Version
 
-Find the latest version of a specific Maven artifact by querying Maven Central directly.
+Find the latest version of a Maven artifact via the plugin MCP server (project-aware
+repository resolution, cache, relocation detection).
 
 ## Arguments
 
@@ -22,65 +23,36 @@ The user provides `groupId:artifactId`, for example:
 1. Parse the user's input to extract `groupId` and `artifactId` (split by `:`).
    If the input has no `:`, ask the user to provide it in `groupId:artifactId` form.
 
-2. Convert `groupId` to a URL path by replacing every `.` with `/`.
-   Example: `io.ktor` → `io/ktor`.
+2. **Call `get_latest_version`** with:
+   - `groupId`, `artifactId`
+   - optional `stabilityFilter`: `PREFER_STABLE` (default), `STABLE_ONLY`, or `ALL`
+   - optional `projectPath` when the user is inside a project (uses declared repos)
 
-3. Fetch metadata from Maven repositories. Use WebFetch in order:
+3. Present the tool result:
+   - `latestVersion` and `stability`
+   - `allVersionsCount` when useful
+   - `resolvedFrom` (which repo answered; note `viaPublicFallback` if true)
+   - `relocatedTo` when present — surface the new coordinates clearly
 
-   **a. Maven Central** (always try first):
-   ```
-   https://repo1.maven.org/maven2/{group_path}/{artifactId}/maven-metadata.xml
-   ```
-
-   **b. Google Maven** (try if the artifact looks Android-related — `groupId` starts with
-   `androidx.`, `com.google.android.`, `com.android.`, `com.google.firebase.`,
-   `com.google.gms.`, `com.google.mlkit.`):
-   ```
-   https://dl.google.com/dl/android/maven2/{group_path}/{artifactId}/maven-metadata.xml
-   ```
-
-   **c. Gradle Plugin Portal** (try if `artifactId` ends with `.gradle.plugin` or the
-   groupId matches known Gradle plugin patterns):
-   ```
-   https://plugins.gradle.org/m2/{group_path}/{artifactId}/maven-metadata.xml
-   ```
-
-4. From the XML response, extract all `<version>` entries inside `<versions>`.
-   Also note `<latest>` and `<release>` tags if present.
-
-5. Classify each version for stability:
-   - **STABLE** — no pre-release suffix (no alpha/beta/rc/dev/snapshot/milestone/preview,
-     case-insensitive)
-   - **RC** — contains `-rc`, `-RC`, `-RC.`, `-rc.`
-   - **BETA** — contains `-beta`, `-Beta`, `-b`
-   - **ALPHA** — contains `-alpha`, `-Alpha`, `-dev`, `-Dev`, `-SNAPSHOT`, `-snapshot`,
-     `-milestone`, `-M`, `-preview`, `-Preview`, `-eap`, `-EAP`
-
-6. Determine the latest versions to display:
-   - **Latest stable** — highest stable version (by semantic version ordering).
-     If no stable versions exist, note that.
-   - **Latest overall** — highest version across all stability levels (if different from
-     stable, show it too).
-
-7. Display the result:
+   Example:
 
    ```
    ## io.ktor:ktor-client-core
 
-   Latest stable:  3.1.3
-   Latest overall: 3.1.3
-
-   Recent versions: 3.1.3, 3.1.2, 3.1.1, 3.1.0, 3.0.3 ... (N total)
+   Latest: 3.1.3 (STABLE)
+   Resolved from: https://repo1.maven.org/maven2 (dependency)
    ```
 
-   If stable and overall are the same, show only "Latest: X".
-   If there are more than 10 versions total, show the 5 most recent and note "(N total)".
+## Error handling
 
-## Error Handling
+- If the tool reports not found / error, tell the user and suggest checking spelling.
+  Do **not** invent a version from memory.
+- Optional: `verify_coordinates` with the same GA if the user may have hallucinated the name.
 
-- If all repository fetches return 404 or fail, tell the user the artifact was not found
-  and suggest checking the `groupId` and `artifactId` spelling.
-- If only Google Maven succeeds (404 on Maven Central), present that result and note the
-  source.
-- If the XML response is empty or malformed, note the parse failure and surface the raw URL
-  so the user can check manually.
+## Fallback (MCP unavailable only)
+
+If `get_latest_version` cannot be called, fetch `maven-metadata.xml` from public repos
+(Maven Central → Google Maven for Android/Google groups → Gradle Plugin Portal for
+`.gradle.plugin` markers), parse `<version>` / `<latest>` / `<release>`, and pick the
+highest stable version. Note that this path **skips project-declared private repos** and
+relocation detection — say so when reporting.


### PR DESCRIPTION
## Summary
- Rewrite all five maven-mcp skills to call the plugin MCP tools first (`get_latest_version`, `audit_project_dependencies` / `scan_project_dependencies` + `compare_dependency_versions`, `get_dependency_vulnerabilities`, `get_dependency_health`, `get_dependency_changes`) instead of hand-rolled HTTP/metadata/OSV flows.
- Keep manual WebFetch/HTTP paths only as documented fallbacks when MCP is unavailable, with explicit caveats (no project-private repos, no server-side token/cache).
- Completes the migration started by #356/#357 skill-doc nudges.

Fixes #355

## Test plan
- [x] `bash scripts/validate.sh` (skill frontmatter + marketplace)
- [ ] Spot-check each skill mentions the matching MCP tool name before any fallback
- [ ] Confirm no skill instructs primary-path hand parsing of `maven-metadata.xml` / OSV querybatch


Made with [Cursor](https://cursor.com)