### PR TITLE
Harden post-edit-deps for MultiEdit and fail-open

### DIFF
--- a/plugins/maven-mcp/README.md
+++ b/plugins/maven-mcp/README.md
@@ -77,7 +77,7 @@ The guard is **structurally fail-open**: any failure — jq absent, no `timeout`
 
 ### PostToolUse reminder (`post-edit-deps.sh`)
 
-Fires after `Edit` or `Write` on build files and reminds you to run `/check-deps` to verify dependency updates. Requires `jq`; silently does nothing if `jq` is not installed.
+Fires after `Edit`, `Write`, or `MultiEdit` on build files when the changed content contains dependency-coordinate shapes, and reminds you to run `/check-deps` to verify dependency updates. Structurally fail-open (same convention as the PreToolUse guard): malformed input or a `jq` failure exits silently with no reminder. Requires `jq`; silently does nothing if `jq` is not installed.
 
 ## Caching
 

--- a/plugins/maven-mcp/plugin/hooks/hooks.json
+++ b/plugins/maven-mcp/plugin/hooks/hooks.json
@@ -14,7 +14,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|Write|MultiEdit",
         "hooks": [
           {
             "type": "command",

--- a/plugins/maven-mcp/plugin/hooks/post-edit-deps.sh
+++ b/plugins/maven-mcp/plugin/hooks/post-edit-deps.sh
@@ -1,32 +1,89 @@
-#!/bin/bash
+#!/usr/bin/env bash
+# post-edit-deps.sh — PostToolUse /check-deps reminder for maven-mcp.
+#
+# After Edit/Write/MultiEdit on a build file, emit a systemMessage nudge to run
+# /check-deps — but only when the changed content looks coordinate-shaped
+# (avoids nagging on comment/formatting-only edits).
+#
+# Fail-open is structural: trap 'exit 0' EXIT immediately after set -euo
+# pipefail. Malformed stdin, jq failure, or any other error exits 0 with no
+# reminder (never surfaces a hook error for a best-effort nudge).
 set -euo pipefail
+trap 'exit 0' EXIT
 
-# Dependencies
+# ── Dependency check ─────────────────────────────────────────────────────────
 command -v jq >/dev/null 2>&1 || exit 0
 
-# Read hook input from stdin
-HOOK_INPUT=$(cat)
+# ── Read stdin once; fail-open on any jq parse error ─────────────────────────
+HOOK_INPUT=""
+HOOK_INPUT=$(cat) || HOOK_INPUT=""
 
-# Extract tool name and file path
-TOOL_NAME=$(echo "$HOOK_INPUT" | jq -r '.tool_name // empty')
-FILE_PATH=$(echo "$HOOK_INPUT" | jq -r '.tool_input.file_path // empty')
+TOOL_NAME=""
+TOOL_NAME=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_name // empty' 2>/dev/null) || TOOL_NAME=""
 
-# Only care about Edit and Write tools
-if [[ "$TOOL_NAME" != "Edit" && "$TOOL_NAME" != "Write" ]]; then
-  exit 0
-fi
+# ── Fast gate: only Edit, Write, MultiEdit on build files ────────────────────
+case "$TOOL_NAME" in
+  Edit|Write|MultiEdit) ;;
+  *) exit 0 ;;
+esac
 
-# Check if the file is a build dependency file
-BASENAME=$(basename "$FILE_PATH")
+FILE_PATH=""
+FILE_PATH=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || FILE_PATH=""
+BASENAME=""
+BASENAME=$(basename "$FILE_PATH" 2>/dev/null) || BASENAME=""
+
 case "$BASENAME" in
-  build.gradle|build.gradle.kts|settings.gradle|settings.gradle.kts|pom.xml|libs.versions.toml)
+  build.gradle|build.gradle.kts|settings.gradle|settings.gradle.kts|pom.xml|libs.versions.toml) ;;
+  *) exit 0 ;;
+esac
+
+# ── Extract new content from the tool payload ─────────────────────────────────
+# Edit → new_string; Write → content; MultiEdit → concatenate edits[].new_string
+NEW_CONTENT=""
+case "$TOOL_NAME" in
+  Edit)
+    NEW_CONTENT=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.new_string // empty' 2>/dev/null) || NEW_CONTENT=""
     ;;
-  *)
-    exit 0
+  Write)
+    NEW_CONTENT=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.content // empty' 2>/dev/null) || NEW_CONTENT=""
+    ;;
+  MultiEdit)
+    NEW_CONTENT=$(printf '%s' "$HOOK_INPUT" | jq -r '[.tool_input.edits[]?.new_string // empty] | join("\n")' 2>/dev/null) || NEW_CONTENT=""
     ;;
 esac
 
-# Output reminder as JSON systemMessage
-cat <<'EOF'
-{"systemMessage":"Build dependency file was modified. Consider running /check-deps to verify dependency versions are up to date."}
-EOF
+[ -n "$NEW_CONTENT" ] || exit 0
+
+# ── Coordinate-shaped gate (noise reduction) ──────────────────────────────────
+# Emit only when the changed content contains dependency-coordinate shapes.
+# Missed coordinates → no reminder (fail-open for a nudge is correct).
+_Q="'"
+HAS_COORDS=0
+case "$BASENAME" in
+  build.gradle|build.gradle.kts|settings.gradle|settings.gradle.kts)
+    # Quoted Gradle notation: "g:a" / "g:a:v" or 'g:a' / 'g:a:v'
+    if printf '%s\n' "$NEW_CONTENT" | grep -qE '"[A-Za-z0-9._-]+:[A-Za-z0-9._-]+(:[^"]+)?"' 2>/dev/null; then
+      HAS_COORDS=1
+    elif printf '%s\n' "$NEW_CONTENT" | grep -qE "${_Q}[A-Za-z0-9._-]+:[A-Za-z0-9._-]+(:[^${_Q}]+)?${_Q}" 2>/dev/null; then
+      HAS_COORDS=1
+    fi
+    ;;
+  pom.xml)
+    # Any dependency GAV tag in the changed span
+    if printf '%s\n' "$NEW_CONTENT" | grep -qE '<(groupId|artifactId|dependency)>' 2>/dev/null; then
+      HAS_COORDS=1
+    fi
+    ;;
+  libs.versions.toml)
+    if printf '%s\n' "$NEW_CONTENT" | grep -qE 'module[[:space:]]*=[[:space:]]*"[A-Za-z0-9._-]+:[A-Za-z0-9._-]+"' 2>/dev/null; then
+      HAS_COORDS=1
+    elif printf '%s\n' "$NEW_CONTENT" | grep -qE '"[A-Za-z0-9._-]+:[A-Za-z0-9._-]+:[^"]+"' 2>/dev/null; then
+      HAS_COORDS=1
+    fi
+    ;;
+esac
+
+[ "$HAS_COORDS" -eq 1 ] || exit 0
+
+# ── Emit reminder ─────────────────────────────────────────────────────────────
+printf '%s\n' '{"systemMessage":"Build dependency file was modified. Consider running /check-deps to verify dependency versions are up to date."}'

--- a/plugins/maven-mcp/tests/test_post_edit_hook.py
+++ b/plugins/maven-mcp/tests/test_post_edit_hook.py
@@ -1,0 +1,245 @@
+"""Tests for post-edit-deps.sh — PostToolUse /check-deps reminder.
+
+Runs the hook as a subprocess with crafted stdin. No MCP server stub is
+needed: the reminder is pure local heuristics (tool gate + basename +
+coordinate-shaped content).
+
+Import style: import unittest.mock + fully-qualified refs (CodeQL
+py/import-and-import-from); no unused imports; every except has a comment.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import unittest
+
+_TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+_HOOK_PATH = os.path.normpath(
+    os.path.join(_TESTS_DIR, "..", "plugin", "hooks", "post-edit-deps.sh")
+)
+_HOOKS_JSON = os.path.normpath(
+    os.path.join(_TESTS_DIR, "..", "plugin", "hooks", "hooks.json")
+)
+
+_HAS_JQ = shutil.which("jq") is not None
+
+_REMINDER_MSG = (
+    "Build dependency file was modified. Consider running /check-deps "
+    "to verify dependency versions are up to date."
+)
+
+
+def _require_jq(msg="jq not available"):
+    """Class-level skipUnless decorator requiring jq."""
+    return unittest.skipUnless(_HAS_JQ, msg)
+
+
+def _run_hook(stdin_obj=None, stdin_raw=None, extra_env=None, proc_timeout=10):
+    """Run post-edit-deps.sh; return CompletedProcess.
+
+    Pass either stdin_obj (JSON-serialized) or stdin_raw (bytes/str as-is).
+    """
+    env = dict(os.environ)
+    if extra_env:
+        env.update(extra_env)
+    if stdin_raw is not None:
+        if isinstance(stdin_raw, str):
+            payload = stdin_raw.encode()
+        else:
+            payload = stdin_raw
+    else:
+        payload = json.dumps(stdin_obj if stdin_obj is not None else {}).encode()
+    return subprocess.run(
+        ["bash", _HOOK_PATH],
+        input=payload,
+        capture_output=True,
+        env=env,
+        timeout=proc_timeout,
+    )
+
+
+def _parse_stdout(stdout_bytes):
+    """Parse hook stdout into dict; None if empty or unparseable."""
+    text = stdout_bytes.decode().strip()
+    if not text:
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        # stdout was not valid JSON — treat as no reminder
+        return None
+
+
+def _edit_payload(file_path, new_string, tool_name="Edit"):
+    """Build a minimal Edit/Write-shaped PostToolUse payload."""
+    if tool_name == "Write":
+        return {
+            "tool_name": "Write",
+            "tool_input": {"file_path": file_path, "content": new_string},
+        }
+    return {
+        "tool_name": tool_name,
+        "tool_input": {"file_path": file_path, "new_string": new_string},
+    }
+
+
+def _multiedit_payload(file_path, new_strings):
+    """Build a MultiEdit-shaped PostToolUse payload."""
+    return {
+        "tool_name": "MultiEdit",
+        "tool_input": {
+            "file_path": file_path,
+            "edits": [{"old_string": "x", "new_string": s} for s in new_strings],
+        },
+    }
+
+
+@_require_jq()
+class TestPostEditReminderEmits(unittest.TestCase):
+    """Reminder fires when coordinate-shaped content is present."""
+
+    def test_edit_gradle_kts_with_coordinate(self):
+        result = _run_hook(
+            _edit_payload(
+                "/proj/build.gradle.kts",
+                'implementation("com.example:lib:1.2.3")',
+            )
+        )
+        self.assertEqual(result.returncode, 0)
+        out = _parse_stdout(result.stdout)
+        self.assertIsNotNone(out)
+        self.assertEqual(out.get("systemMessage"), _REMINDER_MSG)
+
+    def test_write_pom_with_dependency_tags(self):
+        result = _run_hook(
+            _edit_payload(
+                "/proj/pom.xml",
+                "<dependency><groupId>com.example</groupId>"
+                "<artifactId>lib</artifactId></dependency>",
+                tool_name="Write",
+            )
+        )
+        self.assertEqual(result.returncode, 0)
+        out = _parse_stdout(result.stdout)
+        self.assertIsNotNone(out)
+        self.assertEqual(out.get("systemMessage"), _REMINDER_MSG)
+
+    def test_multiedit_gradle_with_coordinate(self):
+        result = _run_hook(
+            _multiedit_payload(
+                "/proj/app/build.gradle",
+                [
+                    "// formatting only",
+                    "implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.9.0'",
+                ],
+            )
+        )
+        self.assertEqual(result.returncode, 0)
+        out = _parse_stdout(result.stdout)
+        self.assertIsNotNone(out)
+        self.assertEqual(out.get("systemMessage"), _REMINDER_MSG)
+
+    def test_libs_versions_toml_module(self):
+        result = _run_hook(
+            _edit_payload(
+                "/proj/gradle/libs.versions.toml",
+                'okhttp = { module = "com.squareup.okhttp3:okhttp", version = "4.12.0" }',
+            )
+        )
+        self.assertEqual(result.returncode, 0)
+        out = _parse_stdout(result.stdout)
+        self.assertIsNotNone(out)
+        self.assertEqual(out.get("systemMessage"), _REMINDER_MSG)
+
+
+@_require_jq()
+class TestPostEditReminderSkips(unittest.TestCase):
+    """No reminder for non-build files, wrong tools, or non-coordinate edits."""
+
+    def test_comment_only_edit_no_reminder(self):
+        result = _run_hook(
+            _edit_payload(
+                "/proj/build.gradle.kts",
+                "// just a formatting comment\n",
+            )
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIsNone(_parse_stdout(result.stdout))
+
+    def test_non_build_file_no_reminder(self):
+        result = _run_hook(
+            _edit_payload(
+                "/proj/src/Main.kt",
+                'implementation("com.example:lib:1.0.0")',
+            )
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIsNone(_parse_stdout(result.stdout))
+
+    def test_wrong_tool_no_reminder(self):
+        result = _run_hook(
+            {
+                "tool_name": "Bash",
+                "tool_input": {
+                    "file_path": "/proj/build.gradle.kts",
+                    "new_string": 'implementation("com.example:lib:1.0.0")',
+                },
+            }
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIsNone(_parse_stdout(result.stdout))
+
+    def test_multiedit_comment_only_no_reminder(self):
+        result = _run_hook(
+            _multiedit_payload(
+                "/proj/build.gradle.kts",
+                ["// tidy", "/* still no coords */"],
+            )
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIsNone(_parse_stdout(result.stdout))
+
+
+@_require_jq()
+class TestPostEditFailOpen(unittest.TestCase):
+    """Malformed input / jq failure must exit 0 with empty stdout."""
+
+    def test_malformed_json_exits_zero(self):
+        result = _run_hook(stdin_raw=b"not-json{{{")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.decode().strip(), "")
+
+    def test_empty_stdin_exits_zero(self):
+        result = _run_hook(stdin_raw=b"")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.decode().strip(), "")
+
+    def test_missing_tool_input_exits_zero(self):
+        result = _run_hook({"tool_name": "Edit"})
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.decode().strip(), "")
+
+
+class TestPostEditHooksJson(unittest.TestCase):
+    """hooks.json PostToolUse matcher includes MultiEdit."""
+
+    def test_post_tool_use_matcher_includes_multiedit(self):
+        with open(_HOOKS_JSON, encoding="utf-8") as f:
+            data = json.load(f)
+        matchers = [
+            entry.get("matcher", "")
+            for entry in data.get("hooks", {}).get("PostToolUse", [])
+        ]
+        self.assertTrue(
+            any("MultiEdit" in m for m in matchers),
+            f"PostToolUse matchers missing MultiEdit: {matchers!r}",
+        )
+        self.assertTrue(
+            any("Edit" in m and "Write" in m for m in matchers),
+            f"PostToolUse matchers missing Edit|Write: {matchers!r}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Cover `MultiEdit` in PostToolUse matcher and `post-edit-deps.sh` tool gate (parity with PreToolUse).
- Adopt structural fail-open (`trap 'exit 0' EXIT`, guarded `jq`/`printf`) matching `pre-edit-deps.sh`.
- Emit `/check-deps` reminder only when changed content looks coordinate-shaped (cuts comment/formatting noise).
- Add `test_post_edit_hook.py` coverage for emit/skip/fail-open and hooks.json matcher.

Fixes #354

## Test plan
- [x] `python3 -m unittest tests.test_post_edit_hook -v`
- [x] `bash scripts/validate.sh`
- [ ] CI green on draft PR


Made with [Cursor](https://cursor.com)