### PR TITLE
Parse Groovy and multi-arg settings include()

### DIFF
--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -1860,10 +1860,27 @@ def _parse_buildscript_classpath(content: str) -> List[Dict]:
 
 
 def _parse_settings_modules(content: str) -> List[str]:
-    """Extract include(":module") declarations from settings.gradle[.kts]."""
+    """Extract include(":module") / include ':module' declarations from settings.gradle[.kts].
+
+    Accepts parenthesised and Groovy space-form calls, and every quoted argument in a
+    multi-module statement (`include(":app", ":core")` / `include ':app', ':core'`).
+    `includeBuild` is not matched (`\\binclude\\b` requires a word boundary after
+    `include`).
+    """
     results = []
-    for m in re.finditer(r'\binclude\s*\(\s*["\']([^"\']+)["\']\s*\)', content):
-        results.append(m.group(1))
+    for m in re.finditer(r"\binclude\b\s*", content):
+        rest = content[m.end() :]
+        if rest.startswith("("):
+            end = rest.find(")")
+            args = rest[1:] if end == -1 else rest[1:end]
+        else:
+            nl = rest.find("\n")
+            args = rest if nl == -1 else rest[:nl]
+            comment = args.find("//")
+            if comment != -1:
+                args = args[:comment]
+        for q in re.finditer(r"""["']([^"']+)["']""", args):
+            results.append(q.group(1))
     return results
 
 

--- a/plugins/maven-mcp/tests/test_parsers.py
+++ b/plugins/maven-mcp/tests/test_parsers.py
@@ -487,6 +487,27 @@ class TestParseSettingsModules(unittest.TestCase):
         result = server._parse_settings_modules("include(':feature')")
         self.assertEqual(result, [":feature"])
 
+    # #345: Groovy space-form (no parentheses)
+    def test_groovy_space_form(self):
+        content = "include ':app'\ninclude ':core'"
+        result = server._parse_settings_modules(content)
+        self.assertEqual(result, [":app", ":core"])
+
+    # #345: multi-module parenthesised statement
+    def test_multi_module_parenthesised(self):
+        result = server._parse_settings_modules('include(":app", ":core", ":data")')
+        self.assertEqual(result, [":app", ":core", ":data"])
+
+    # #345: multi-module Groovy space-form
+    def test_multi_module_groovy_space_form(self):
+        result = server._parse_settings_modules("include ':app', ':core'")
+        self.assertEqual(result, [":app", ":core"])
+
+    # #345: includeBuild must not be treated as include
+    def test_include_build_not_matched(self):
+        result = server._parse_settings_modules('includeBuild("composite")\ninclude(":app")')
+        self.assertEqual(result, [":app"])
+
 
 # ---------------------------------------------------------------------------
 # _parse_settings_catalogs


### PR DESCRIPTION
## Summary
- Broaden `_parse_settings_modules` to accept Groovy space-form `include ':app'` and multi-module statements (`include(":app", ":core")` / `include ':app', ':core'`).
- Add regression tests for space-form, multi-arg, and `includeBuild` non-match.

Fixes #345

## Test plan
- [x] `python3 -m unittest discover -s plugins/maven-mcp/tests -p test_parsers.py`
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)