### PR TITLE
Parse buildscript classpath with balanced braces

### DIFF
--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -1848,14 +1848,28 @@ def _parse_gradle_plugins_block(content: str, is_settings: bool = False) -> List
 
 
 def _parse_buildscript_classpath(content: str) -> List[Dict]:
-    """Parse buildscript { dependencies { classpath(...) } }"""
+    """Parse buildscript { dependencies { classpath(...) } } using brace-balanced blocks.
+
+    Uses `_find_block` so nested `repositories { }` / `dependencies { }` do not truncate
+    the buildscript body at the first `}` (brace-naive non-greedy regex did).
+    """
     results = []
-    bs_re = re.compile(r'\bbuildscript\s*\{([\s\S]*?)\}', re.DOTALL)
-    for bs_m in bs_re.finditer(content):
-        block = bs_m.group(1)
-        cp_re = re.compile(r'\bclasspath\s*\(["\']([^"\':\s]+):([^"\':\s]+)(?::([^"\']+))?["\']')
-        for m in cp_re.finditer(block):
-            results.append({"groupId": m.group(1), "artifactId": m.group(2), "version": m.group(3)})
+    cp_re = re.compile(
+        r'\bclasspath\s*\(["\']([^"\':\s]+):([^"\':\s]+)(?::([^"\']+))?["\']'
+    )
+    pos = 0
+    while True:
+        found = _find_block(content, "buildscript", pos)
+        if not found:
+            break
+        bs_body, _start, end = found
+        deps = _find_block(bs_body, "dependencies")
+        scan = deps[0] if deps else bs_body
+        for m in cp_re.finditer(scan):
+            results.append(
+                {"groupId": m.group(1), "artifactId": m.group(2), "version": m.group(3)}
+            )
+        pos = end
     return results
 
 

--- a/plugins/maven-mcp/tests/test_parsers.py
+++ b/plugins/maven-mcp/tests/test_parsers.py
@@ -457,6 +457,42 @@ class TestParseBuildscriptClasspath(unittest.TestCase):
         self.assertIn("gradle", artifacts)
         self.assertIn("kotlin-gradle-plugin", artifacts)
 
+    # #344: nested repositories {} must not truncate before classpath
+    def test_nested_repositories_before_classpath(self):
+        content = (
+            'buildscript {\n'
+            '    repositories { google() }\n'
+            '    dependencies {\n'
+            '        classpath("com.android.tools.build:gradle:8.5.0")\n'
+            '    }\n'
+            '}'
+        )
+        result = server._parse_buildscript_classpath(content)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["groupId"], "com.android.tools.build")
+        self.assertEqual(result[0]["artifactId"], "gradle")
+        self.assertEqual(result[0]["version"], "8.5.0")
+
+    # #344: nested credentials {} inside repositories still reaches classpath
+    def test_deeply_nested_braces_before_classpath(self):
+        content = (
+            'buildscript {\n'
+            '    repositories {\n'
+            '        maven {\n'
+            '            url = uri("https://example.com")\n'
+            '            credentials { username = "u"; password = "p" }\n'
+            '        }\n'
+            '    }\n'
+            '    dependencies {\n'
+            '        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.1.0")\n'
+            '    }\n'
+            '}'
+        )
+        result = server._parse_buildscript_classpath(content)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["artifactId"], "kotlin-gradle-plugin")
+        self.assertEqual(result[0]["version"], "2.1.0")
+
 
 # ---------------------------------------------------------------------------
 # _parse_settings_modules


### PR DESCRIPTION
## Summary
- Replace brace-naive `buildscript { … }` regex in `_parse_buildscript_classpath` with `_find_block` so nested `repositories { }` no longer truncates before `classpath(...)`.
- Prefer scanning the inner `dependencies { }` block when present; add regression tests for nested repos and deep braces.

Fixes #344

## Test plan
- [x] `python3 -m unittest discover -s plugins/maven-mcp/tests -p test_parsers.py`
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)