### PR TITLE
Recognize dot and free-text version qualifiers

### DIFF
--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -812,10 +812,47 @@ def classify_version(version: str) -> str:
     return "stable"
 
 
+# Digits attached to known prerelease tokens only — free-text qualifier digits
+# (e.g. "0.6.x-compat") must not be treated as ordinal prerelease numbers (#331).
+_PRERELEASE_ORDINAL_RE = re.compile(
+    r"(?:alpha|a(?=\d)|beta|b(?=\d)|milestone|m(?=\d)|rc|cr|snapshot)[-.]?(\d+)",
+    re.IGNORECASE,
+)
+
+
+def _split_core_and_qualifier(version: str) -> Tuple[str, str]:
+    """Split a version into numeric core and qualifier suffix.
+
+    Qualifier begins at the earliest of: ``-`` / ``+``, a ``.`` whose next
+    segment is non-numeric (``.Final`` / ``.RELEASE``), or a non-digit glued
+    onto the core (``1.0.0legacy`` / ``1.0.0_legacy``). Pure numeric dotted
+    tails (``1.0.0.1``) stay in the core.
+    """
+    if not version:
+        return "", ""
+    i = 0
+    n = len(version)
+    while i < n and version[i].isdigit():
+        i += 1
+    while i < n and version[i] == ".":
+        j = i + 1
+        while j < n and version[j].isdigit():
+            j += 1
+        if j == i + 1:
+            # Non-numeric segment after '.' — qualifier boundary (#331).
+            return version[:i], version[i:]
+        i = j
+    if i < n:
+        return version[:i], version[i:]
+    return version, ""
+
+
 def _parse_segments(version: str) -> List[int]:
-    core = re.split(r"[-+]", version, maxsplit=1)[0]
+    core, _qual = _split_core_and_qualifier(version)
     parts = []
     for p in core.split("."):
+        if not p:
+            continue
         try:
             parts.append(int(p))
         except ValueError:
@@ -824,15 +861,10 @@ def _parse_segments(version: str) -> List[int]:
 
 
 def _extract_prerelease_numbers(version: str) -> List[int]:
-    cut = -1
-    for ch in ("-", "+"):
-        idx = version.find(ch)
-        if idx != -1 and (cut == -1 or idx < cut):
-            cut = idx
-    if cut == -1:
+    _core, qual = _split_core_and_qualifier(version)
+    if not qual:
         return []
-    suffix = version[cut + 1:]
-    return [int(m) for m in re.findall(r"\d+", suffix)]
+    return [int(m.group(1)) for m in _PRERELEASE_ORDINAL_RE.finditer(qual)]
 
 
 def _compare_int_lists(a: List[int], b: List[int]) -> int:
@@ -853,11 +885,11 @@ def compare_versions(a: str, b: str) -> int:
     weight_diff = PRERELEASE_WEIGHT.get(classify_version(a), 5) - PRERELEASE_WEIGHT.get(classify_version(b), 5)
     if weight_diff != 0:
         return weight_diff
-    has_suffix_a = "-" in a or "+" in a
-    has_suffix_b = "-" in b or "+" in b
+    has_suffix_a = bool(_split_core_and_qualifier(a)[1])
+    has_suffix_b = bool(_split_core_and_qualifier(b)[1])
     if has_suffix_a != has_suffix_b:
-        # #325: same core, same stability class, but only one side carries a
-        # qualifier suffix at all — the bare version always ranks higher.
+        # #325/#331: same core, same stability class, but only one side carries
+        # a qualifier at all — the bare version always ranks higher.
         return 1 if not has_suffix_a else -1
     tail_diff = _compare_int_lists(_extract_prerelease_numbers(a), _extract_prerelease_numbers(b))
     if tail_diff != 0:

--- a/plugins/maven-mcp/tests/test_version.py
+++ b/plugins/maven-mcp/tests/test_version.py
@@ -204,6 +204,37 @@ class CompareVersionsTest(unittest.TestCase):
         self.assertLess(server.compare_versions("1.0.0-beta", "1.0.0-beta2"), 0)
         self.assertGreater(server.compare_versions("1.0.0-beta2", "1.0.0-beta"), 0)
 
+    def test_bare_release_outranks_dot_delimited_qualifier(self):
+        # #331: .Final / .RELEASE are qualifiers, not numeric core segments.
+        self.assertGreater(server.compare_versions("1.0.0", "1.0.0.Final"), 0)
+        self.assertLess(server.compare_versions("1.0.0.Final", "1.0.0"), 0)
+        self.assertGreater(server.compare_versions("1.0.0", "1.0.0.RELEASE"), 0)
+        self.assertLess(server.compare_versions("1.0.0.RELEASE", "1.0.0"), 0)
+
+    def test_numeric_fourth_segment_still_part_of_core(self):
+        # #331: pure numeric dotted tails remain in the core.
+        self.assertLess(server.compare_versions("1.0.0", "1.0.0.1"), 0)
+        self.assertGreater(server.compare_versions("1.0.0.1", "1.0.0"), 0)
+
+    def test_bare_release_outranks_no_separator_qualifier(self):
+        # #331: glued / underscore free-text tails are qualifiers.
+        self.assertGreater(server.compare_versions("1.0.0", "1.0.0legacy"), 0)
+        self.assertLess(server.compare_versions("1.0.0legacy", "1.0.0"), 0)
+        self.assertGreater(server.compare_versions("1.0.0", "1.0.0_legacy"), 0)
+        self.assertLess(server.compare_versions("1.0.0_legacy", "1.0.0"), 0)
+
+    def test_symmetric_free_text_suffixes_ignore_incidental_digits(self):
+        # #331: free-text digits must not act as ordinal prerelease numbers.
+        # Lexicographic fallback: "0.8.0-0.6.x-compat" < "0.8.0-compat".
+        self.assertGreater(
+            server.compare_versions("0.8.0-compat", "0.8.0-0.6.x-compat"),
+            0,
+        )
+        self.assertLess(
+            server.compare_versions("0.8.0-0.6.x-compat", "0.8.0-compat"),
+            0,
+        )
+
 
 # ---------------------------------------------------------------------------
 # get_upgrade_type


### PR DESCRIPTION
## Summary
- Split numeric core from qualifiers at `.Final`/`.RELEASE`, glued free-text, and `_`/`-`/`+` boundaries so bare releases outrank same-core qualified builds.
- Extract ordinal prerelease digits only from known tokens (`rc`/`beta`/…), so symmetric free-text suffixes no longer misorder on incidental digits.

Fixes #331

## Test plan
- [x] `python3 -m unittest discover -s plugins/maven-mcp/tests -p test_version.py`
- [x] Full `plugins/maven-mcp/tests` suite
- [x] `python3 -m compileall plugins/maven-mcp/plugin/server`
- [ ] CI green


Made with [Cursor](https://cursor.com)