### PR TITLE
Recognize Android variant configs and platform() BOMs

### DIFF
--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -102,14 +102,25 @@ GRADLE_BUILD_FILES = ["build.gradle.kts", "build.gradle"]
 GRADLE_SETTINGS_FILES = ["settings.gradle.kts", "settings.gradle"]
 MAX_MODULE_DEPTH = 5
 
-PRODUCTION_CONFIGURATIONS = {
-    "implementation", "api", "compileOnly", "runtimeOnly",
-}
-NON_PRODUCTION_CONFIGURATIONS = {
-    "testImplementation", "testCompileOnly", "testRuntimeOnly",
-    "kapt", "ksp", "annotationProcessor",
-}
-ALL_CONFIGURATIONS = PRODUCTION_CONFIGURATIONS | NON_PRODUCTION_CONFIGURATIONS
+# Gradle configuration names matched by shape (#346), not a closed allow-list:
+# variant/flavor prefixes (`debugImplementation`, `paidReleaseApi`, …),
+# source-set forms (`androidTestImplementation`, `testFixturesImplementation`),
+# annotation processors (`kapt`/`ksp`/`kaptTest`/…), and common standalone
+# configs (`coreLibraryDesugaring`, `lintChecks`, `detektPlugins`).
+# Test-ness is classified later via `_is_test_configuration`.
+_GRADLE_CONFIGURATION_PATTERN = (
+    r"(?:"
+    # Prefix may be empty (bare `implementation` / `api`) or a variant/flavor/
+    # source-set name (`debugImplementation`, `androidTestApi`, …).
+    r"\w*(?:[Ii]mplementation|[Cc]ompileOnly|[Rr]untimeOnly|"
+    r"[Aa]nnotationProcessor|[Aa]pi)"
+    r"|kapt(?:AndroidTest|Test)?"
+    r"|ksp(?:AndroidTest|Test)?"
+    r"|coreLibraryDesugaring"
+    r"|lintChecks"
+    r"|detektPlugins"
+    r")"
+)
 
 SCOPE_TO_CONFIG = {
     "compile": "implementation",
@@ -1802,13 +1813,16 @@ def _parse_toml_catalog(content: str) -> Dict:
 def _parse_gradle_deps(content: str, source_file: str) -> List[Dict]:
     """Returns list of dep dicts with keys: groupId, artifactId, version, configuration, catalogRef."""
     deps = []
-    config_pattern = "|".join(re.escape(c) for c in sorted(ALL_CONFIGURATIONS, key=len, reverse=True))
+    config_pattern = _GRADLE_CONFIGURATION_PATTERN
 
     # String notation: implementation("group:artifact:version")
+    # Optional platform()/enforcedPlatform() wrapper around the quoted GAV (#346).
     # Version stops at ':' (classifier) or '@' (extension); trailing
     # `:classifier` / `@ext` / `:classifier@ext` are optional and discarded.
     string_re = re.compile(
-        rf'\b({config_pattern})\s*[( ]\s*["\']'
+        rf'\b({config_pattern})\s*[( ]\s*'
+        rf'(?:(?:enforcedPlatform|platform)\s*\(\s*)?'
+        rf'["\']'
         rf'([^"\':\s]+):([^"\':\s]+)'
         rf'(?::([^"\':@]+))?(?::[^"\'@]+)?(?:@[^"\']+)?["\']',
     )

--- a/plugins/maven-mcp/tests/test_parsers.py
+++ b/plugins/maven-mcp/tests/test_parsers.py
@@ -274,6 +274,45 @@ class TestParseGradleDeps(unittest.TestCase):
         versions = [d["version"] for d in deps if d["groupId"] == "com.x"]
         self.assertEqual(versions, ["2.0", "2.0"])
 
+    # #346: Android variant/flavor/source-set configurations + platform()/BOM
+    def test_android_variant_and_platform_bom(self):
+        content = (
+            "dependencies {\n"
+            '  debugImplementation("a:b:1.0")\n'
+            '  androidTestImplementation("e:f:1.0")\n'
+            '  testFixturesImplementation("g:h:1.0")\n'
+            '  implementation(platform("i:j:1.0"))\n'
+            '  implementation(enforcedPlatform("k:l:1.0"))\n'
+            '  paidReleaseApi("m:n:2.0")\n'
+            '  coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")\n'
+            '  lintChecks("com.example:lint:1.0")\n'
+            '  kaptAndroidTest("com.example:kapt-at:1.0")\n'
+            '  debugImplementation(libs.foo.bar)\n'
+            "}"
+        )
+        deps = server._parse_gradle_deps(content, "build.gradle.kts")
+        by_ga = {(d["groupId"], d["artifactId"]): d for d in deps if d["groupId"]}
+        self.assertEqual(by_ga[("a", "b")]["configuration"], "debugImplementation")
+        self.assertEqual(by_ga[("e", "f")]["configuration"], "androidTestImplementation")
+        self.assertEqual(by_ga[("g", "h")]["configuration"], "testFixturesImplementation")
+        self.assertEqual(by_ga[("i", "j")]["version"], "1.0")
+        self.assertEqual(by_ga[("i", "j")]["configuration"], "implementation")
+        self.assertEqual(by_ga[("k", "l")]["configuration"], "implementation")
+        self.assertEqual(by_ga[("m", "n")]["configuration"], "paidReleaseApi")
+        self.assertEqual(
+            by_ga[("com.android.tools", "desugar_jdk_libs")]["configuration"],
+            "coreLibraryDesugaring",
+        )
+        self.assertEqual(by_ga[("com.example", "lint")]["configuration"], "lintChecks")
+        self.assertEqual(
+            by_ga[("com.example", "kapt-at")]["configuration"],
+            "kaptAndroidTest",
+        )
+        catalog = [d for d in deps if d["catalogRef"]]
+        self.assertEqual(len(catalog), 1)
+        self.assertEqual(catalog[0]["configuration"], "debugImplementation")
+        self.assertEqual(catalog[0]["catalogRef"], "libs.foo.bar")
+
 
 # ---------------------------------------------------------------------------
 # _parse_gradle_plugins_block


### PR DESCRIPTION
## Summary
- Match Gradle configurations by shape (variant/flavor/source-set suffixes plus standalone configs) instead of a closed allow-list, so `debugImplementation`, `androidTestImplementation`, `coreLibraryDesugaring`, etc. are no longer dropped.
- Recognize optional `platform(...)` / `enforcedPlatform(...)` wrappers around string-notation GAVs so BOM imports are scanned.
- Add regression coverage for Android variant configs, platform/BOM wrappers, and catalog accessors under variant configs.

Fixes #346

## Test plan
- [x] `python3 -m unittest discover -s plugins/maven-mcp/tests`
- [x] Reproduction snippet from #346 now returns all five deps (plus extras)
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)