### PR TITLE
Close maven-mcp test and release CI gaps (#358)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,34 @@ jobs:
       contents: write
 
     steps:
+      # Full history so we can verify the tag commit is reachable from main
+      # (shallow tag-only checkout would make merge-base checks meaningless).
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag commit is reachable from main
+        working-directory: .
+        run: |
+          set -euo pipefail
+          git fetch origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Tag ${GITHUB_REF_NAME} points at ${GITHUB_SHA}, which is not an ancestor of origin/main. Refuse to release an unreviewed branch commit."
+            exit 1
+          fi
+          echo "Tag ${GITHUB_REF_NAME} (${GITHUB_SHA}) is reachable from origin/main."
 
       - name: Verify all versions match tag
         working-directory: .
         run: bash scripts/validate.sh --check-tag "${GITHUB_REF_NAME#v}"
+
+      # Oldest supported runtime (3.9 per plugins/maven-mcp/AGENTS.md). CI
+      # already matrices 3.9+3.13; the release gate must also pin 3.9 so a
+      # 3.9-only break cannot ship behind a system-python green check (#358).
+      - name: Setup Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
 
       # working-directory: . overrides the job's defaults.run.working-directory
       # (plugins/maven-mcp); without it the -s path would double-resolve to

--- a/plugins/maven-mcp/tests/test_dispatch.py
+++ b/plugins/maven-mcp/tests/test_dispatch.py
@@ -175,5 +175,129 @@ class InvalidParamsTest(unittest.TestCase):
         self.assertEqual(out[0]["id"], 3)
 
 
+class McpProtocolTest(unittest.TestCase):
+    """Real initialize / tools/list / tools/call path through main() (#358)."""
+
+    def test_initialize_returns_server_info(self):
+        out = _run_main(
+            [
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "initialize",
+                        "params": {
+                            "protocolVersion": "2024-11-05",
+                            "capabilities": {},
+                            "clientInfo": {"name": "test", "version": "0"},
+                        },
+                    }
+                )
+            ]
+        )
+        self.assertEqual(len(out), 1)
+        result = out[0]["result"]
+        self.assertEqual(result["protocolVersion"], "2024-11-05")
+        self.assertEqual(result["serverInfo"]["name"], server.SERVER_NAME)
+        self.assertEqual(result["serverInfo"]["version"], server.SERVER_VERSION)
+        self.assertIn("tools", result["capabilities"])
+
+    def test_tools_list_returns_shipped_tools(self):
+        out = _run_main(
+            [json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})]
+        )
+        self.assertEqual(len(out), 1)
+        tools = out[0]["result"]["tools"]
+        self.assertEqual(tools, server.TOOLS)
+        names = [t["name"] for t in tools]
+        self.assertEqual(names, list(server.TOOL_HANDLERS.keys()))
+
+    def test_tools_call_wraps_handler_result_in_text_content(self):
+        # Pin the MCP unwrap contract hooks rely on: .result.content[0].text
+        # is JSON of the handler's return value, correlated by request id.
+        def _fake_handler(arguments):
+            return {"ok": True, "echo": arguments}
+
+        with unittest.mock.patch.dict(
+            server.TOOL_HANDLERS, {"scan_project_dependencies": _fake_handler}
+        ):
+            out = _run_main(
+                [
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": 42,
+                            "method": "tools/call",
+                            "params": {
+                                "name": "scan_project_dependencies",
+                                "arguments": {"projectPath": "/tmp/proj"},
+                            },
+                        }
+                    )
+                ]
+            )
+        self.assertEqual(out[0]["id"], 42)
+        content = out[0]["result"]["content"]
+        self.assertEqual(content[0]["type"], "text")
+        self.assertEqual(
+            json.loads(content[0]["text"]),
+            {"ok": True, "echo": {"projectPath": "/tmp/proj"}},
+        )
+
+    def test_tools_call_unknown_tool_is_method_not_found(self):
+        out = _run_main(
+            [
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 7,
+                        "method": "tools/call",
+                        "params": {"name": "no_such_tool", "arguments": {}},
+                    }
+                )
+            ]
+        )
+        self.assertEqual(out[0]["id"], 7)
+        self.assertEqual(out[0]["error"]["code"], -32601)
+        self.assertIn("Unknown tool", out[0]["error"]["message"])
+
+    def test_initialize_tools_list_tools_call_session_over_stdio(self):
+        # End-to-end stdio session: initialize → tools/list → tools/call.
+        def _fake_handler(_arguments):
+            return {"ping": "pong"}
+
+        with unittest.mock.patch.dict(
+            server.TOOL_HANDLERS, {"search_artifacts": _fake_handler}
+        ):
+            out = _run_main(
+                [
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": 1,
+                            "method": "initialize",
+                            "params": {"protocolVersion": "2024-11-05"},
+                        }
+                    ),
+                    json.dumps({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": 3,
+                            "method": "tools/call",
+                            "params": {
+                                "name": "search_artifacts",
+                                "arguments": {"query": "okhttp"},
+                            },
+                        }
+                    ),
+                ]
+            )
+        self.assertEqual([r["id"] for r in out], [1, 2, 3])
+        self.assertEqual(out[0]["result"]["serverInfo"]["name"], server.SERVER_NAME)
+        self.assertEqual(len(out[1]["result"]["tools"]), len(server.TOOLS))
+        self.assertEqual(json.loads(out[2]["result"]["content"][0]["text"]), {"ping": "pong"})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/maven-mcp/tests/test_hooks_json.py
+++ b/plugins/maven-mcp/tests/test_hooks_json.py
@@ -1,0 +1,118 @@
+"""Pin hooks.json matchers/commands against the shipped hook scripts (#358).
+
+Catches drift where the manifest matcher, script tool gate, or basename filter
+disagree (e.g. PostToolUse missing MultiEdit while PreToolUse includes it).
+"""
+
+import json
+import os
+import re
+import unittest
+
+_TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+_HOOKS_DIR = os.path.normpath(os.path.join(_TESTS_DIR, "..", "plugin", "hooks"))
+_HOOKS_JSON = os.path.join(_HOOKS_DIR, "hooks.json")
+_PRE_EDIT = os.path.join(_HOOKS_DIR, "pre-edit-deps.sh")
+_POST_EDIT = os.path.join(_HOOKS_DIR, "post-edit-deps.sh")
+
+_EXPECTED_MATCHER = "Edit|Write|MultiEdit"
+_TOOL_GATE_RE = re.compile(
+    r'case\s+"\$TOOL_NAME"\s+in\s*\n\s*Edit\|Write\|MultiEdit\)\s*;;',
+    re.MULTILINE,
+)
+
+
+def _load_hooks_json():
+    with open(_HOOKS_JSON, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _command_entries(event_hooks):
+    """Flatten hooks.json event entries into (matcher, command) pairs."""
+    pairs = []
+    for entry in event_hooks:
+        matcher = entry.get("matcher", "")
+        for hook in entry.get("hooks", []):
+            pairs.append((matcher, hook.get("command", "")))
+    return pairs
+
+
+class HooksJsonPinTest(unittest.TestCase):
+    """Manifest ↔ script agreement for PreToolUse and PostToolUse."""
+
+    def test_pre_and_post_matchers_include_multiedit(self):
+        data = _load_hooks_json()
+        hooks = data["hooks"]
+        for event in ("PreToolUse", "PostToolUse"):
+            with self.subTest(event=event):
+                pairs = _command_entries(hooks[event])
+                self.assertTrue(pairs, f"{event} has no command hooks")
+                matchers = [m for m, _ in pairs]
+                self.assertTrue(
+                    any(m == _EXPECTED_MATCHER for m in matchers),
+                    f"{event} matchers {matchers!r} missing {_EXPECTED_MATCHER!r}",
+                )
+
+    def test_commands_point_at_expected_scripts(self):
+        data = _load_hooks_json()
+        hooks = data["hooks"]
+
+        pre_cmds = [c for _, c in _command_entries(hooks["PreToolUse"])]
+        self.assertTrue(
+            any(c.endswith("/hooks/pre-edit-deps.sh") or c.endswith("pre-edit-deps.sh") for c in pre_cmds),
+            f"PreToolUse commands {pre_cmds!r} missing pre-edit-deps.sh",
+        )
+        self.assertTrue(
+            all("${CLAUDE_PLUGIN_ROOT}/hooks/pre-edit-deps.sh" in c for c in pre_cmds),
+            f"PreToolUse commands must use CLAUDE_PLUGIN_ROOT: {pre_cmds!r}",
+        )
+
+        post_cmds = [c for _, c in _command_entries(hooks["PostToolUse"])]
+        self.assertTrue(
+            all("${CLAUDE_PLUGIN_ROOT}/hooks/post-edit-deps.sh" in c for c in post_cmds),
+            f"PostToolUse commands must use CLAUDE_PLUGIN_ROOT: {post_cmds!r}",
+        )
+
+    def test_script_tool_gates_match_manifest_matcher(self):
+        for path in (_PRE_EDIT, _POST_EDIT):
+            with self.subTest(script=os.path.basename(path)):
+                with open(path, encoding="utf-8") as fh:
+                    body = fh.read()
+                self.assertRegex(
+                    body,
+                    _TOOL_GATE_RE,
+                    f"{os.path.basename(path)} tool gate must match {_EXPECTED_MATCHER}",
+                )
+
+    def test_script_basename_gates_cover_build_files(self):
+        # Both scripts must accept the core build-file basenames the matcher
+        # is meant to protect. Pre-edit also accepts *.versions.toml (#359);
+        # post-edit currently pins libs.versions.toml — assert each script's
+        # own documented set so a silent narrowing is caught.
+        required = (
+            "build.gradle",
+            "build.gradle.kts",
+            "settings.gradle",
+            "settings.gradle.kts",
+            "pom.xml",
+        )
+        with open(_PRE_EDIT, encoding="utf-8") as fh:
+            pre = fh.read()
+        with open(_POST_EDIT, encoding="utf-8") as fh:
+            post = fh.read()
+
+        for name in required:
+            self.assertIn(name, pre, f"pre-edit-deps.sh missing basename {name}")
+            self.assertIn(name, post, f"post-edit-deps.sh missing basename {name}")
+
+        self.assertIn("*.versions.toml", pre)
+        self.assertIn("libs.versions.toml", post)
+
+    def test_hook_script_files_exist(self):
+        self.assertTrue(os.path.isfile(_PRE_EDIT), _PRE_EDIT)
+        self.assertTrue(os.path.isfile(_POST_EDIT), _POST_EDIT)
+        self.assertTrue(os.path.isfile(_HOOKS_JSON), _HOOKS_JSON)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/maven-mcp/tests/test_tools_schema.py
+++ b/plugins/maven-mcp/tests/test_tools_schema.py
@@ -1,0 +1,63 @@
+"""Validate TOOLS inputSchema declarations (#358).
+
+Pins well-formedness of every shipped tool's inputSchema and agreement with
+TOOL_HANDLERS — a missing/renamed handler or a malformed schema would otherwise
+only surface at runtime when a client calls tools/list or tools/call.
+"""
+
+import unittest
+
+from _helpers import server
+
+
+class ToolsSchemaTest(unittest.TestCase):
+    """TOOLS entries must be well-formed and match TOOL_HANDLERS 1:1."""
+
+    def test_tools_and_handlers_agree(self):
+        tool_names = [t["name"] for t in server.TOOLS]
+        self.assertEqual(len(tool_names), len(set(tool_names)), "duplicate TOOLS name")
+        self.assertEqual(set(tool_names), set(server.TOOL_HANDLERS.keys()))
+        # Preserve declaration order: handlers dict follows TOOLS order.
+        self.assertEqual(tool_names, list(server.TOOL_HANDLERS.keys()))
+
+    def test_each_tool_has_well_formed_input_schema(self):
+        for tool in server.TOOLS:
+            with self.subTest(tool=tool["name"]):
+                self.assertIsInstance(tool.get("name"), str)
+                self.assertTrue(tool["name"])
+                self.assertIsInstance(tool.get("description"), str)
+                self.assertTrue(tool["description"])
+
+                schema = tool.get("inputSchema")
+                self.assertIsInstance(schema, dict)
+                self.assertEqual(schema.get("type"), "object")
+
+                properties = schema.get("properties", {})
+                self.assertIsInstance(properties, dict)
+                for prop_name, prop_schema in properties.items():
+                    self.assertIsInstance(prop_name, str)
+                    self.assertIsInstance(prop_schema, dict)
+                    self.assertIn(
+                        "type",
+                        prop_schema,
+                        f"{tool['name']}.{prop_name} missing type",
+                    )
+
+                required = schema.get("required", [])
+                self.assertIsInstance(required, list)
+                for req in required:
+                    self.assertIsInstance(req, str)
+                    self.assertIn(
+                        req,
+                        properties,
+                        f"{tool['name']} required {req!r} not in properties",
+                    )
+
+    def test_handlers_are_callable(self):
+        for name, handler in server.TOOL_HANDLERS.items():
+            with self.subTest(tool=name):
+                self.assertTrue(callable(handler), f"{name} handler is not callable")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add real MCP protocol coverage through `main()` (`initialize` → `tools/list` → `tools/call`, including `.result.content[0].text` unwrap + id correlation).
- Pin `TOOLS`/`TOOL_HANDLERS` schema agreement and full `hooks.json` ↔ script matcher/command/basename agreement.
- Pin release gate to Python 3.9 and refuse tags whose commit is not reachable from `main`.

## Already done (not re-implemented)
- Post-edit hook tests + MultiEdit/`hooks.json` PostToolUse matcher: #354 / #371 (`test_post_edit_hook.py`).
- Non-object / batch JSON-RPC dispatcher robustness: #343 / #360 (`test_dispatch.py`).

## Test plan
- [x] `python3 -m unittest discover -s plugins/maven-mcp/tests` (599 tests, 1 skipped)
- [x] `bash scripts/validate.sh`
- [ ] CI green on PR

Fixes #358

Made with [Cursor](https://cursor.com)