### PR TITLE
Add check_version_compatibility for Boot/AGP/Kotlin matrices

### DIFF
--- a/plugins/maven-mcp/AGENTS.md
+++ b/plugins/maven-mcp/AGENTS.md
@@ -42,11 +42,12 @@ python3 -m unittest discover -s plugins/maven-mcp/tests -p test_handlers.py
 - **Metadata & POM** — `fetch_metadata`, `check_version_in_repos`, `fetch_pom`, `_parse_metadata_xml` (regex), `extract_relocation_from_pom` / `check_relocation` (relocation detection, #284 — see *Relocation detection & dead-repository flagging*).
 - **Project scanning** (local collection) — `_detect_build_system` + parsers: `_parse_gradle_deps`, `_parse_gradle_plugins_block`, `_parse_buildscript_classpath`, `_parse_settings_modules`, `_parse_settings_catalogs`, `_parse_maven_deps`, `_parse_maven_modules`, `_parse_toml_catalog`, `_detect_dead_repo_hints` (#284); orchestrated by `scan_project`. `buildSrc/` (kind `buildsrc`) and `build-logic/` subproject convention-plugin scripts (kind `convention-plugin`) are also walked, in addition to settings-listed modules. BOM/platform expansion (#286) is applied later in the scan/audit handlers (network via `fetch_pom`) — see *BOM / platform expansion*.
 - **BOM / platform expansion** — `parse_dependency_management`, `expand_bom`, `apply_bom_managed_versions` (#286).
+- **Version compatibility** — `check_version_compatibility` + shipped `compat-matrices.json` (AGP/KGP/javax→jakarta; Spring Boot via `expand_bom`) (#285).
 - **GitHub & changelog** — `gh_repo_exists` / `gh_fetch_repo` / `gh_fetch_releases` / `gh_fetch_user` / `gh_fetch_issue_stats`, `discover_github_repo` (POM SCM → groupId guess), and `_get_dependency_changes_impl` + `_filter_version_range` (GitHub releases only).
 - **Vulnerabilities** — OSV.dev batch query (`api.osv.dev/v1/querybatch`).
 - **Tool handlers** — `handle_*`, one per MCP tool, plus the stdio JSON-RPC dispatch loop.
 
-**Tools:** `get_latest_version`, `check_version_exists`, `check_multiple_dependencies`, `compare_dependency_versions`, `get_dependency_changes`, `scan_project_dependencies`, `expand_bom`, `get_dependency_vulnerabilities`, `get_dependency_health`, `search_artifacts`, `audit_project_dependencies`, `verify_coordinates` (see *`verify_coordinates`* below).
+**Tools:** `get_latest_version`, `check_version_exists`, `check_multiple_dependencies`, `compare_dependency_versions`, `get_dependency_changes`, `scan_project_dependencies`, `expand_bom`, `check_version_compatibility`, `get_dependency_vulnerabilities`, `get_dependency_health`, `search_artifacts`, `audit_project_dependencies`, `verify_coordinates` (see *`verify_coordinates`* below).
 
 ## Repository resolution
 
@@ -119,6 +120,25 @@ Maven BOMs and Gradle `platform()` / `enforcedPlatform()` declare managed versio
 
 **Apply on scan/audit.** `scan_project` stays local. `handle_scan_project_dependencies` and `handle_audit_project_dependencies` build a `ResolutionContext`, call `apply_bom_managed_versions` (network via `fetch_pom`), then flatten / audit. Versionless non-platform deps gain `effectiveVersion` + `managedBy: {groupId, artifactId, version}` of the BOM/pin that provided the version. Local Maven non-import `dependencyManagement` pins **override** imported managed versions. Explicit dependency versions win over `platform()`; `enforcedPlatform` may override a differing explicit version. Audit uses `effectiveVersion or version` as `currentVersion` for upgrade/vuln paths.
 
+## Version compatibility (`check_version_compatibility`, #285)
+
+Validates a set of versions against known compatibility matrices and returns `{compatible, conflicts[], notes[]}`. Conflicts carry `kind`, `requested`, `expected`, `suggestion`, and `reference`.
+
+**Params:** `springBoot?`, `android?: {agp?, gradle?, kotlin?, jdk?}`, `dependencies?: [{groupId, artifactId, version?}]`, `projectPath?`.
+
+**Checks (v1):**
+1. **Spring Boot BOM** — when `springBoot` is set, expands `org.springframework.boot:spring-boot-dependencies` via `expand_bom` (#286) and flags any `dependencies[]` entry whose version differs from the BOM-managed version (`kind: spring_boot_bom`).
+2. **AGP ↔ Gradle ↔ JDK** — shipped matrix in `plugin/server/compat-matrices.json` (`agpEntries`). AGP line matched by `major.minor`; Gradle must be ≥ `minGradle`; JDK major must be ≥ `minJdk`.
+3. **Kotlin Gradle plugin ↔ Gradle / AGP** — same file (`kotlinGradlePluginEntries`); closed ranges for Gradle and AGP per KGP band.
+4. **javax → jakarta** — when `springBoot ≥ 3.0.0`, flags known `javax.*` EE coordinates (and a few `com.sun.mail` aliases) with the `jakarta.*` replacement from `jakartaMap`.
+
+**Matrix refresh.** Data is **not** scraped at runtime. `_meta.refreshProcedure` in `compat-matrices.json` documents how to update AGP/KGP tables from the official Android / Kotlin docs. Bump `_meta.updated` (and `_meta.version` on shape changes) when refreshing. Stale-but-explicit data with a documented refresh path is intentional — silent drift is the failure mode this fights.
+
+**Known limitations (also echoed in `notes[]`):** AGP coverage is the 7.0–9.2 lines; KGP coverage is 1.9.20–2.4.0 bands; AGP has no published max Gradle (only min enforced); Spring Cloud release-train pairing is not a separate matrix (pass Cloud-managed deps under `dependencies` with `springBoot` set); javax→jakarta is a coordinate heuristic, not a full import/bytecode scanner. Hook integration is advisory `ask` only (never `deny`).
+
+**Hook:** `pre-edit-deps.sh` optionally calls this tool (JSON-RPC id:3) when the edit payload exposes Spring Boot / AGP / Kotlin / Gradle pins (or javax.* coords with a Boot version). Conflicts → `ask` with structured reason text; fail-open if the call is skipped or errors.
+
+
 ## Gradle plugin-marker resolution for vulnerabilities (#290)
 
 Gradle plugin-marker coordinates (`{pluginId}:{pluginId}.gradle.plugin`) are not indexed by OSV directly — OSV indexes the real implementation artifact, not the marker. `resolve_plugin_marker_implementation(group_id, artifact_id, version, ctx)` fetches the marker's POM (via the existing `fetch_pom` / `_repos_for` plugin-scope routing) and extracts its single `<dependency>` block — the implementation GAV — before the coordinate is sent to OSV. `audit_project_dependencies` calls this on every scanned coordinate (deduplicated per-GAV). `get_dependency_vulnerabilities` calls this per input coordinate too, but only builds the `ResolutionContext` (`build_resolution_context` → `discover_repositories`, a filesystem read of the project's build files) when at least one requested coordinate actually has the marker shape — a request with no marker-shaped dependency makes zero filesystem calls and exactly one network call (the OSV POST), preserving the handler's original purity contract; a `ResolutionContext` build failure degrades to "markers unresolved" rather than raising. When a marker is resolved, the result entry keeps the marker's own `groupId`/`artifactId`/`version` identity and gains an additional `resolvedImplementation: {groupId, artifactId, version}` field. Resolution failure (POM fetch failure, missing/incomplete `<dependency>` block, unresolved `${...}` property, missing version) degrades gracefully to no resolution — the coordinate is queried against OSV as-is, which simply yields no CVEs for a marker GA that OSV never indexed; this path never raises.
@@ -184,6 +204,7 @@ Fires before `Edit`/`Write`/`MultiEdit` on build files; extracts coordinates fro
 - `exists` + any `vulnerabilities[].malicious == true` (#322 Layer 1, from `get_dependency_vulnerabilities`) → **`deny`**, set UNCONDITIONALLY (never behind a `[ "$DECISION" = "deny" ] ||`-style guard) — same tier as `absent + likelyHallucination`; MAL- entries carry no CVSS severity, so the CRITICAL/HIGH branch below would never catch this on its own. Unconditional (not just "first-decision-wins") matters: it is what upgrades a prior `ask` (from the CRITICAL/HIGH branch, or from the `typosquatRisk` branch below) to `deny` when both fire for the same coordinate, regardless of which branch runs first in loop order.
 - `exists` + `typosquatRisk.signal == true` (#322 Layer 2, from `verify_coordinates`) → **`ask`**, guarded exactly like the CRITICAL/HIGH branch (`[ "$DECISION" = "deny" ] || DECISION="ask"`) — advisory only (heuristic, false-positive-prone); this guard also prevents a heuristic `ask` on a LATER coordinate in the same batch from downgrading a `deny` already set for an EARLIER coordinate in the same hook invocation (both checks share one per-coordinate loop). Reason text includes `typosquatRisk.reasons` and, when present, `popularMatch.groupId`/`artifactId` — charset-filtered `[A-Za-z0-9._:-]` identically to `suggestions` (same Solr-search-result provenance, same indirect-injection surface into `permissionDecisionReason`).
 - CRITICAL/HIGH CVE on versioned coord → `ask` (advisory prompt; severity comes from OSV `/v1/vulns/{id}` hydration in `query_osv_batch`, #338)
+- Version compatibility conflict from `check_version_compatibility` (#285) → `ask` (advisory; never deny). Triggered only when the edit exposes Spring Boot / AGP / Kotlin / Gradle pins or javax.* with Boot ≥ detection; fail-open if the optional id:3 call is absent/errors.
 - `deny` wins over `ask` when both fire — within one coordinate (malicious-vuln-deny vs. CRITICAL/HIGH-ask or typosquatRisk-ask) AND across two different coordinates in the same batch (an earlier coordinate's deny is never downgraded by a later coordinate's ask)
 
 **Security constraints:**

--- a/plugins/maven-mcp/CLAUDE.md
+++ b/plugins/maven-mcp/CLAUDE.md
@@ -42,11 +42,12 @@ python3 -m unittest discover -s plugins/maven-mcp/tests -p test_handlers.py
 - **Metadata & POM** — `fetch_metadata`, `check_version_in_repos`, `fetch_pom`, `_parse_metadata_xml` (regex), `extract_relocation_from_pom` / `check_relocation` (relocation detection, #284 — see *Relocation detection & dead-repository flagging*).
 - **Project scanning** (local collection) — `_detect_build_system` + parsers: `_parse_gradle_deps`, `_parse_gradle_plugins_block`, `_parse_buildscript_classpath`, `_parse_settings_modules`, `_parse_settings_catalogs`, `_parse_maven_deps`, `_parse_maven_modules`, `_parse_toml_catalog`, `_detect_dead_repo_hints` (#284); orchestrated by `scan_project`. `buildSrc/` (kind `buildsrc`) and `build-logic/` subproject convention-plugin scripts (kind `convention-plugin`) are also walked, in addition to settings-listed modules. BOM/platform expansion (#286) is applied later in the scan/audit handlers (network via `fetch_pom`) — see *BOM / platform expansion*.
 - **BOM / platform expansion** — `parse_dependency_management`, `expand_bom`, `apply_bom_managed_versions` (#286).
+- **Version compatibility** — `check_version_compatibility` + shipped `compat-matrices.json` (AGP/KGP/javax→jakarta; Spring Boot via `expand_bom`) (#285).
 - **GitHub & changelog** — `gh_repo_exists` / `gh_fetch_repo` / `gh_fetch_releases` / `gh_fetch_user` / `gh_fetch_issue_stats`, `discover_github_repo` (POM SCM → groupId guess), and `_get_dependency_changes_impl` + `_filter_version_range` (GitHub releases only).
 - **Vulnerabilities** — OSV.dev batch query (`api.osv.dev/v1/querybatch`).
 - **Tool handlers** — `handle_*`, one per MCP tool, plus the stdio JSON-RPC dispatch loop.
 
-**Tools:** `get_latest_version`, `check_version_exists`, `check_multiple_dependencies`, `compare_dependency_versions`, `get_dependency_changes`, `scan_project_dependencies`, `expand_bom`, `get_dependency_vulnerabilities`, `get_dependency_health`, `search_artifacts`, `audit_project_dependencies`, `verify_coordinates` (see *`verify_coordinates`* below).
+**Tools:** `get_latest_version`, `check_version_exists`, `check_multiple_dependencies`, `compare_dependency_versions`, `get_dependency_changes`, `scan_project_dependencies`, `expand_bom`, `check_version_compatibility`, `get_dependency_vulnerabilities`, `get_dependency_health`, `search_artifacts`, `audit_project_dependencies`, `verify_coordinates` (see *`verify_coordinates`* below).
 
 ## Repository resolution
 
@@ -119,6 +120,25 @@ Maven BOMs and Gradle `platform()` / `enforcedPlatform()` declare managed versio
 
 **Apply on scan/audit.** `scan_project` stays local. `handle_scan_project_dependencies` and `handle_audit_project_dependencies` build a `ResolutionContext`, call `apply_bom_managed_versions` (network via `fetch_pom`), then flatten / audit. Versionless non-platform deps gain `effectiveVersion` + `managedBy: {groupId, artifactId, version}` of the BOM/pin that provided the version. Local Maven non-import `dependencyManagement` pins **override** imported managed versions. Explicit dependency versions win over `platform()`; `enforcedPlatform` may override a differing explicit version. Audit uses `effectiveVersion or version` as `currentVersion` for upgrade/vuln paths.
 
+## Version compatibility (`check_version_compatibility`, #285)
+
+Validates a set of versions against known compatibility matrices and returns `{compatible, conflicts[], notes[]}`. Conflicts carry `kind`, `requested`, `expected`, `suggestion`, and `reference`.
+
+**Params:** `springBoot?`, `android?: {agp?, gradle?, kotlin?, jdk?}`, `dependencies?: [{groupId, artifactId, version?}]`, `projectPath?`.
+
+**Checks (v1):**
+1. **Spring Boot BOM** — when `springBoot` is set, expands `org.springframework.boot:spring-boot-dependencies` via `expand_bom` (#286) and flags any `dependencies[]` entry whose version differs from the BOM-managed version (`kind: spring_boot_bom`).
+2. **AGP ↔ Gradle ↔ JDK** — shipped matrix in `plugin/server/compat-matrices.json` (`agpEntries`). AGP line matched by `major.minor`; Gradle must be ≥ `minGradle`; JDK major must be ≥ `minJdk`.
+3. **Kotlin Gradle plugin ↔ Gradle / AGP** — same file (`kotlinGradlePluginEntries`); closed ranges for Gradle and AGP per KGP band.
+4. **javax → jakarta** — when `springBoot ≥ 3.0.0`, flags known `javax.*` EE coordinates (and a few `com.sun.mail` aliases) with the `jakarta.*` replacement from `jakartaMap`.
+
+**Matrix refresh.** Data is **not** scraped at runtime. `_meta.refreshProcedure` in `compat-matrices.json` documents how to update AGP/KGP tables from the official Android / Kotlin docs. Bump `_meta.updated` (and `_meta.version` on shape changes) when refreshing. Stale-but-explicit data with a documented refresh path is intentional — silent drift is the failure mode this fights.
+
+**Known limitations (also echoed in `notes[]`):** AGP coverage is the 7.0–9.2 lines; KGP coverage is 1.9.20–2.4.0 bands; AGP has no published max Gradle (only min enforced); Spring Cloud release-train pairing is not a separate matrix (pass Cloud-managed deps under `dependencies` with `springBoot` set); javax→jakarta is a coordinate heuristic, not a full import/bytecode scanner. Hook integration is advisory `ask` only (never `deny`).
+
+**Hook:** `pre-edit-deps.sh` optionally calls this tool (JSON-RPC id:3) when the edit payload exposes Spring Boot / AGP / Kotlin / Gradle pins (or javax.* coords with a Boot version). Conflicts → `ask` with structured reason text; fail-open if the call is skipped or errors.
+
+
 ## Gradle plugin-marker resolution for vulnerabilities (#290)
 
 Gradle plugin-marker coordinates (`{pluginId}:{pluginId}.gradle.plugin`) are not indexed by OSV directly — OSV indexes the real implementation artifact, not the marker. `resolve_plugin_marker_implementation(group_id, artifact_id, version, ctx)` fetches the marker's POM (via the existing `fetch_pom` / `_repos_for` plugin-scope routing) and extracts its single `<dependency>` block — the implementation GAV — before the coordinate is sent to OSV. `audit_project_dependencies` calls this on every scanned coordinate (deduplicated per-GAV). `get_dependency_vulnerabilities` calls this per input coordinate too, but only builds the `ResolutionContext` (`build_resolution_context` → `discover_repositories`, a filesystem read of the project's build files) when at least one requested coordinate actually has the marker shape — a request with no marker-shaped dependency makes zero filesystem calls and exactly one network call (the OSV POST), preserving the handler's original purity contract; a `ResolutionContext` build failure degrades to "markers unresolved" rather than raising. When a marker is resolved, the result entry keeps the marker's own `groupId`/`artifactId`/`version` identity and gains an additional `resolvedImplementation: {groupId, artifactId, version}` field. Resolution failure (POM fetch failure, missing/incomplete `<dependency>` block, unresolved `${...}` property, missing version) degrades gracefully to no resolution — the coordinate is queried against OSV as-is, which simply yields no CVEs for a marker GA that OSV never indexed; this path never raises.
@@ -148,7 +168,7 @@ A write-time **anti-slopsquatting** primitive: batch existence check plus a fuzz
 - `gavExists?: bool` — only when `version` was given; membership of `version` in the UNION of versions across all 200-answering repos.
 - `stability?` — `classify_version(latest)`, omitted when no non-empty latest exists (a 200 with an empty `<versions>` list never calls `classify_version` on `None`).
 - `likelyHallucination: bool` — true only when `absent` AND some candidate's raw similarity ≥ `HALLUCINATION_THRESHOLD` (0.8), computed over the full pre-truncation candidate set. **Never** true on `unknown` or `exists`.
-- `suggestions?: [{groupId, artifactId, score, versionCount}]` — only on `absent`. `score` is the raw similarity; ranking down-weights very-low-`versionCount` candidates (sort order only — never folded into the emitted `score` or the flag) so an attacker's brand-new single-version near-miss cannot outrank a popular real coordinate. Framed as **candidates to verify, not endorsements**.
+- `suggestions?: [{groupId, artifactId, score, versionCount}]` — only on `absent`, and **only candidates whose raw similarity ≥ `HALLUCINATION_THRESHOLD`** (same gate as the flag — an empty list means "no close match", not "Solr returned nothing"). `score` is the raw similarity; ranking down-weights very-low-`versionCount` candidates (sort order only — never folded into the emitted `score` or the flag) so an attacker's brand-new single-version near-miss cannot outrank a popular real coordinate. Framed as **candidates to verify, not endorsements**.
 - `typosquatRisk?: {signal, reasons, versionCount, popularMatch?}` — a **SEPARATE, heuristic** field (#322 Layer 2), computed ONLY when `existenceStatus == "exists"` (never present on `absent`/`unknown`). `likelyHallucination`'s semantics are completely unchanged by this field — no shared code path, no shared threshold. Framed as cautiously as `suggestions`: **a candidate to verify, not a verdict** — false-positive-prone by construction (a legitimately new/niche library also has a low version count).
   - `signal: bool` — true when at least one sub-signal below fired.
   - `reasons: [str]` — which of `low_version_count` / `group_mismatch` / `recent_first_publish` fired.
@@ -168,6 +188,8 @@ A write-time **anti-slopsquatting** primitive: batch existence check plus a fuzz
 
 ## Hooks
 
+These hooks ship with the Claude Code plugin bundle (`plugin/hooks/`) and are not Cursor hooks.
+
 ### `pre-edit-deps.sh` (PreToolUse write-time guard)
 
 Fires before `Edit`/`Write`/`MultiEdit` on build files; extracts coordinates from new content and runs `verify_coordinates` + `get_dependency_vulnerabilities` via JSON-RPC 2.0 over stdin/stdout.
@@ -175,13 +197,14 @@ Fires before `Edit`/`Write`/`MultiEdit` on build files; extracts coordinates fro
 **Structural fail-open contract — non-negotiable.** `set -euo pipefail` + `trap 'exit 0' EXIT` are at the top; after `mktemp -d` the trap is replaced with `rm -rf "$TMPDIR_WORK"; exit 0` so the work dir is cleaned without ever hard-blocking. Every external command is guarded so failure produces an empty result and the script continues to exit 0. The script can never reach `exit 2` (hard-block). Any malfunction (jq absent, no `timeout`/`gtimeout`, server crash, network failure) silently allows the edit through.
 
 **Decision policy:**
-- `absent + (likelyHallucination==true OR non-empty suggestions)` → `deny` with candidates framed as "verify before use"
-- `absent + no signal` (bare absent) → `allow`; covers private/non-Central/androidx coords with no similar Central name — **never tighten to deny-on-bare-absent**
+- `absent + likelyHallucination==true` → `deny` with candidates framed as "verify before use" (suggestions, when present, are already threshold-filtered server-side)
+- `absent + no signal` (bare absent, including weak below-threshold Solr hits) → `allow`; covers private/non-Central/androidx coords with no close Central match — **never deny on bare-absent or on non-empty suggestions alone** (#352)
 - `unknown` (401/403/429/5xx/network error from verify_coordinates) → `allow`; unknown ≠ clean but cannot assert absence
 - `exists` (no `malicious` vuln, no `typosquatRisk.signal`) → `allow`
 - `exists` + any `vulnerabilities[].malicious == true` (#322 Layer 1, from `get_dependency_vulnerabilities`) → **`deny`**, set UNCONDITIONALLY (never behind a `[ "$DECISION" = "deny" ] ||`-style guard) — same tier as `absent + likelyHallucination`; MAL- entries carry no CVSS severity, so the CRITICAL/HIGH branch below would never catch this on its own. Unconditional (not just "first-decision-wins") matters: it is what upgrades a prior `ask` (from the CRITICAL/HIGH branch, or from the `typosquatRisk` branch below) to `deny` when both fire for the same coordinate, regardless of which branch runs first in loop order.
 - `exists` + `typosquatRisk.signal == true` (#322 Layer 2, from `verify_coordinates`) → **`ask`**, guarded exactly like the CRITICAL/HIGH branch (`[ "$DECISION" = "deny" ] || DECISION="ask"`) — advisory only (heuristic, false-positive-prone); this guard also prevents a heuristic `ask` on a LATER coordinate in the same batch from downgrading a `deny` already set for an EARLIER coordinate in the same hook invocation (both checks share one per-coordinate loop). Reason text includes `typosquatRisk.reasons` and, when present, `popularMatch.groupId`/`artifactId` — charset-filtered `[A-Za-z0-9._:-]` identically to `suggestions` (same Solr-search-result provenance, same indirect-injection surface into `permissionDecisionReason`).
 - CRITICAL/HIGH CVE on versioned coord → `ask` (advisory prompt; severity comes from OSV `/v1/vulns/{id}` hydration in `query_osv_batch`, #338)
+- Version compatibility conflict from `check_version_compatibility` (#285) → `ask` (advisory; never deny). Triggered only when the edit exposes Spring Boot / AGP / Kotlin / Gradle pins or javax.* with Boot ≥ detection; fail-open if the optional id:3 call is absent/errors.
 - `deny` wins over `ask` when both fire — within one coordinate (malicious-vuln-deny vs. CRITICAL/HIGH-ask or typosquatRisk-ask) AND across two different coordinates in the same batch (an earlier coordinate's deny is never downgraded by a later coordinate's ask)
 
 **Security constraints:**

--- a/plugins/maven-mcp/plugin/hooks/pre-edit-deps.sh
+++ b/plugins/maven-mcp/plugin/hooks/pre-edit-deps.sh
@@ -4,6 +4,7 @@
 # Checks NEW coordinates being added to a build file for:
 #   - Non-existent / likely-hallucinated coords (absent + likelyHallucination)                  → deny
 #   - CRITICAL/HIGH CVEs on a pinned version                                                   → ask
+#   - Version compatibility conflicts (Spring Boot BOM / AGP↔Gradle↔Kotlin↔JDK / javax→jakarta) → ask (#285)
 # Any uncertainty, failure, or network error → fail-open (edit proceeds).
 #
 # IMPORTANT — existence guard scope: the guard is Maven-Central-scoped.
@@ -379,10 +380,127 @@ if [ -n "$DEPS_VULN" ]; then
   fi
 fi
 
+# ── Optional check_version_compatibility (id:3) — richer write-time messages (#285)
+# Fail-open advisory only (ask, never deny). Triggered when NEW_CONTENT exposes
+# a Spring Boot / AGP / Kotlin / Gradle pin, or when extracted coords include
+# javax.* (Boot ≥3 migration). Extraction is best-effort regex on the edit
+# payload; missing signals simply skip this call.
+REQ3=""
+SPRING_BOOT=""
+AGP_VER=""
+GRADLE_VER=""
+KOTLIN_VER=""
+JDK_VER=""
+
+# Spring Boot: plugins DSL or springBootVersion assignment
+SPRING_BOOT=$(printf '%s' "$NEW_CONTENT" | grep -oE \
+  'org\.springframework\.boot["'\'')]*.*version[[:space:]]*["'\''][0-9]+\.[0-9]+(\.[0-9]+)?["'\'']' \
+  2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1) || SPRING_BOOT=""
+if [ -z "$SPRING_BOOT" ]; then
+  SPRING_BOOT=$(printf '%s' "$NEW_CONTENT" | grep -oE \
+    'org\.springframework\.boot:[^"'\''0-9]*[0-9]+\.[0-9]+(\.[0-9]+)?' \
+    2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1) || SPRING_BOOT=""
+fi
+if [ -z "$SPRING_BOOT" ]; then
+  SPRING_BOOT=$(printf '%s' "$NEW_CONTENT" | grep -oE \
+    'springBootVersion[[:space:]]*=[[:space:]]*["'\''][0-9]+\.[0-9]+(\.[0-9]+)?["'\'']' \
+    2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1) || SPRING_BOOT=""
+fi
+
+# AGP: com.android.application / library / tools.build:gradle
+AGP_VER=$(printf '%s' "$NEW_CONTENT" | grep -oE \
+  'com\.android\.(application|library)["'\'')]*.*version[[:space:]]*["'\''][0-9]+\.[0-9]+(\.[0-9]+)?["'\'']' \
+  2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1) || AGP_VER=""
+if [ -z "$AGP_VER" ]; then
+  AGP_VER=$(printf '%s' "$NEW_CONTENT" | grep -oE \
+    'com\.android\.tools\.build:gradle[^0-9]*[0-9]+\.[0-9]+(\.[0-9]+)?' \
+    2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1) || AGP_VER=""
+fi
+if [ -z "$AGP_VER" ]; then
+  AGP_VER=$(printf '%s' "$NEW_CONTENT" | grep -oE \
+    'agp[[:space:]]*=[[:space:]]*["'\''][0-9]+\.[0-9]+(\.[0-9]+)?["'\'']' \
+    2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1) || AGP_VER=""
+fi
+
+# Kotlin plugin version
+KOTLIN_VER=$(printf '%s' "$NEW_CONTENT" | grep -oE \
+  'org\.jetbrains\.kotlin\.[a-zA-Z.]+[^"'\''0-9]*["'\''][0-9]+\.[0-9]+(\.[0-9]+)?["'\'']' \
+  2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1) || KOTLIN_VER=""
+if [ -z "$KOTLIN_VER" ]; then
+  KOTLIN_VER=$(printf '%s' "$NEW_CONTENT" | grep -oE \
+    'kotlin\(["'\''][a-zA-Z-]+["'\'']\)[[:space:]]+version[[:space:]]+["'\''][0-9]+\.[0-9]+(\.[0-9]+)?["'\'']' \
+    2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1) || KOTLIN_VER=""
+fi
+
+# Gradle wrapper distributionUrl
+GRADLE_VER=$(printf '%s' "$NEW_CONTENT" | grep -oE \
+  'gradle-[0-9]+\.[0-9]+(\.[0-9]+)?-' \
+  2>/dev/null | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -n1) || GRADLE_VER=""
+
+# JDK major from JavaVersion.VERSION_17 / jvmToolchain(17) / sourceCompatibility
+JDK_VER=$(printf '%s' "$NEW_CONTENT" | grep -oE \
+  'jvmToolchain[[:space:]]*\([[:space:]]*[0-9]+' \
+  2>/dev/null | grep -oE '[0-9]+' | head -n1) || JDK_VER=""
+if [ -z "$JDK_VER" ]; then
+  JDK_VER=$(printf '%s' "$NEW_CONTENT" | grep -oE \
+    'VERSION_([0-9]+)' \
+    2>/dev/null | grep -oE '[0-9]+' | head -n1) || JDK_VER=""
+fi
+
+HAS_JAVAX=""
+HAS_JAVAX=$(printf '%s\n' "$DEPS_VERIFY" | grep -c '"groupId":"javax\.' 2>/dev/null) || HAS_JAVAX="0"
+
+NEED_COMPAT=""
+[ -n "$SPRING_BOOT" ] && NEED_COMPAT=1
+[ -n "$AGP_VER" ] && NEED_COMPAT=1
+[ -n "$KOTLIN_VER" ] && NEED_COMPAT=1
+[ -n "$GRADLE_VER" ] && NEED_COMPAT=1
+[ "${HAS_JAVAX:-0}" != "0" ] && [ -n "$SPRING_BOOT" ] && NEED_COMPAT=1
+
+if [ -n "$NEED_COMPAT" ]; then
+  COMPAT_ARGS="{}"
+  COMPAT_ARGS=$(jq -c -n \
+    --argjson deps "$DEPS_VERIFY_ARR" \
+    --arg sb "$SPRING_BOOT" \
+    --arg agp "$AGP_VER" \
+    --arg gradle "$GRADLE_VER" \
+    --arg kotlin "$KOTLIN_VER" \
+    --arg jdk "$JDK_VER" \
+    --arg cwd "$CWD" '
+      def nonempty: select(length > 0);
+      {
+        dependencies: $deps
+      }
+      + (if ($sb | length) > 0 then {springBoot: $sb} else {} end)
+      + (
+          if ([($agp|length), ($gradle|length), ($kotlin|length), ($jdk|length)] | max) > 0 then
+            {
+              android: (
+                {}
+                + (if ($agp|length) > 0 then {agp: $agp} else {} end)
+                + (if ($gradle|length) > 0 then {gradle: $gradle} else {} end)
+                + (if ($kotlin|length) > 0 then {kotlin: $kotlin} else {} end)
+                + (if ($jdk|length) > 0 then {jdk: ($jdk|tonumber)} else {} end)
+              )
+            }
+          else {} end
+        )
+      + (if ($cwd|length) > 0 then {projectPath: $cwd} else {} end)
+    ' 2>/dev/null) || COMPAT_ARGS=""
+  if [ -n "$COMPAT_ARGS" ]; then
+    REQ3=$(jq -c -n \
+      --argjson args "$COMPAT_ARGS" \
+      '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"check_version_compatibility","arguments":$args}}' \
+      2>/dev/null) || REQ3=""
+  fi
+fi
+
 # ── Invoke server; scrub GITHUB_TOKEN from spawned env ───────────────────────
 REQUESTS="${REQ1}"
 [ -n "$REQ2" ] && REQUESTS="${REQ1}
 ${REQ2}"
+[ -n "$REQ3" ] && REQUESTS="${REQUESTS}
+${REQ3}"
 
 SERVER_OUTPUT=""
 SERVER_OUTPUT=$(
@@ -612,6 +730,61 @@ if [ -n "$VULN_RESULT" ]; then
     fi
     IDX=$((IDX+1))
   done
+fi
+
+# ── Compatibility conflicts (#285) — advisory ask only ────────────────────────
+RESP3=""
+COMPAT_RESULT=""
+if [ -n "$REQ3" ]; then
+  RESP3=$(printf '%s\n' "$SERVER_OUTPUT" | \
+    jq -c 'select(.id==3)' 2>/dev/null | head -n1) || RESP3=""
+  if [ -n "$RESP3" ]; then
+    COMPAT_RESULT=$(printf '%s' "$RESP3" | \
+      jq -r 'if .error or (.result==null) then empty else .result.content[0].text end' 2>/dev/null | \
+      jq '.' 2>/dev/null) || COMPAT_RESULT=""
+  fi
+fi
+
+if [ -n "$COMPAT_RESULT" ]; then
+  # jq `//` treats false as missing — use explicit == false (boolean).
+  COMPAT_OK=""
+  COMPAT_OK=$(printf '%s' "$COMPAT_RESULT" | jq -r 'if .compatible == false then "false" else "true" end' 2>/dev/null) || COMPAT_OK=""
+  if [ "$COMPAT_OK" = "false" ]; then
+    CCOUNT=0
+    CCOUNT=$(printf '%s' "$COMPAT_RESULT" | jq '.conflicts | length' 2>/dev/null) || CCOUNT=0
+    CIDX=0
+    while [ "$CIDX" -lt "$CCOUNT" ] 2>/dev/null; do
+      CITEM=""
+      CITEM=$(printf '%s' "$COMPAT_RESULT" | jq -c ".conflicts[$CIDX]" 2>/dev/null) || CITEM=""
+      [ -n "$CITEM" ] || { CIDX=$((CIDX+1)); continue; }
+
+      CKIND=""
+      CKIND=$(printf '%s' "$CITEM" | jq -r '.kind // "compatibility"' 2>/dev/null) || CKIND="compatibility"
+      CKIND=$(printf '%s' "$CKIND" | tr -cd 'A-Za-z0-9._-') || CKIND="compatibility"
+
+      CREF=""
+      CREF=$(printf '%s' "$CITEM" | jq -r '.reference // empty' 2>/dev/null) || CREF=""
+      CREF=$(printf '%s' "$CREF" | tr -cd 'A-Za-z0-9._:/=?-') || CREF=""
+
+      SUGGEST=""
+      SUGGEST=$(printf '%s' "$CITEM" | jq -c '.suggestion // empty' 2>/dev/null) || SUGGEST=""
+      SUGGEST=$(printf '%s' "$SUGGEST" | tr -cd 'A-Za-z0-9._:{}," -') || SUGGEST=""
+
+      REASON_LINE=""
+      if [ -n "$SUGGEST" ] && [ "$SUGGEST" != "null" ] && [ -n "$CREF" ]; then
+        REASON_LINE=$(printf 'Version compatibility conflict (%s). Suggested: %s. See %s' \
+          "$CKIND" "$SUGGEST" "$CREF")
+      elif [ -n "$CREF" ]; then
+        REASON_LINE=$(printf 'Version compatibility conflict (%s). See %s' "$CKIND" "$CREF")
+      else
+        REASON_LINE=$(printf 'Version compatibility conflict (%s). Verify versions before use.' "$CKIND")
+      fi
+      printf '%s\n' "$REASON_LINE" >> "$REASONS_FILE" || true
+      CIDX=$((CIDX+1))
+    done
+    # deny wins over ask
+    [ "$DECISION" = "deny" ] || DECISION="ask"
+  fi
 fi
 
 # ── Emit result ───────────────────────────────────────────────────────────────

--- a/plugins/maven-mcp/plugin/hooks/pre-edit-deps.sh
+++ b/plugins/maven-mcp/plugin/hooks/pre-edit-deps.sh
@@ -442,9 +442,10 @@ JDK_VER=$(printf '%s' "$NEW_CONTENT" | grep -oE \
   'jvmToolchain[[:space:]]*\([[:space:]]*[0-9]+' \
   2>/dev/null | grep -oE '[0-9]+' | head -n1) || JDK_VER=""
 if [ -z "$JDK_VER" ]; then
+  # Prefer the last numeric segment so VERSION_1_8 → 8, VERSION_17 → 17.
   JDK_VER=$(printf '%s' "$NEW_CONTENT" | grep -oE \
-    'VERSION_([0-9]+)' \
-    2>/dev/null | grep -oE '[0-9]+' | head -n1) || JDK_VER=""
+    'VERSION_[0-9]+(_[0-9]+)?' \
+    2>/dev/null | head -n1 | grep -oE '[0-9]+$' ) || JDK_VER=""
 fi
 
 HAS_JAVAX=""

--- a/plugins/maven-mcp/plugin/server/compat-matrices.json
+++ b/plugins/maven-mcp/plugin/server/compat-matrices.json
@@ -1,0 +1,167 @@
+{
+  "_meta": {
+    "version": 1,
+    "updated": "2026-07-09",
+    "refreshProcedure": [
+      "1. AGP↔Gradle↔JDK: open https://developer.android.com/build/releases/about-agp (Gradle min table) and the latest AGP release-notes Compatibility tables (JDK). Update agpEntries: for each Plugin major.minor, set minGradle and minJdk; keep referenceUrl pointing at about-agp or the release-notes page used.",
+      "2. Kotlin Gradle plugin↔Gradle/AGP: open https://kotlinlang.org/docs/gradle-configure-project.html (KGP compatibility tables). Replace kotlinGradlePluginEntries ranges (kgpMin/kgpMax, gradleMin/gradleMax, agpMin/agpMax) to match the published tables. Prefer inclusive ranges that cover each documented KGP band.",
+      "3. javax→jakarta: extend jakartaMap only for EE coordinates that Spring Boot 3+ no longer ships under javax.*; keep artifactId mappings 1:1 where the Jakarta EE rename is stable.",
+      "4. Bump _meta.updated (ISO date) and, on breaking shape changes, _meta.version. Run plugins/maven-mcp/tests/test_compat.py.",
+      "5. Do not scrape these pages at runtime — stale-but-explicit data with a documented refresh path is the intended failure mode to avoid."
+    ],
+    "sources": [
+      "https://developer.android.com/build/releases/about-agp",
+      "https://developer.android.com/build/releases/agp-8-7-0-release-notes",
+      "https://kotlinlang.org/docs/gradle-configure-project.html",
+      "https://docs.spring.io/spring-boot/docs/current/reference/html/dependency-versions.html"
+    ],
+    "limitations": [
+      "AGP matrix covers stable 7.0–9.2 lines commonly used in 2024–2026; older 3.x/4.x rows are omitted.",
+      "Kotlin matrix covers KGP 1.9.20–2.4.0 bands from the Kotlin docs; earlier 1.6–1.8 bands are omitted in v1.",
+      "AGP max Gradle is not published as a hard ceiling — only minGradle is enforced for AGP↔Gradle.",
+      "Spring Cloud release-train pairing is not a separate matrix; pass Cloud-managed deps under dependencies with springBoot set so Boot BOM mismatches still surface.",
+      "javax→jakarta is a coordinate heuristic for known EE GAs, not a full bytecode/import scanner."
+    ]
+  },
+  "agpEntries": [
+    {"agp": "9.2", "minGradle": "9.4.1", "minJdk": 17, "referenceUrl": "https://developer.android.com/build/releases/about-agp"},
+    {"agp": "9.1", "minGradle": "9.3.1", "minJdk": 17, "referenceUrl": "https://developer.android.com/build/releases/about-agp"},
+    {"agp": "9.0", "minGradle": "9.1.0", "minJdk": 17, "referenceUrl": "https://developer.android.com/build/releases/about-agp"},
+    {"agp": "8.13", "minGradle": "8.13", "minJdk": 17, "referenceUrl": "https://developer.android.com/build/releases/about-agp"},
+    {"agp": "8.12", "minGradle": "8.13", "minJdk": 17, "referenceUrl": "https://developer.android.com/build/releases/about-agp"},
+    {"agp": "8.11", "minGradle": "8.13", "minJdk": 17, "referenceUrl": "https://developer.android.com/build/releases/about-agp"},
+    {"agp": "8.10", "minGradle": "8.11.1", "minJdk": 17, "referenceUrl": "https://developer.android.com/build/releases/about-agp"},
+    {"agp": "8.9", "minGradle": "8.11.1", "minJdk": 17, "referenceUrl": "https://developer.android.com/build/releases/about-agp"},
+    {"agp": "8.8", "minGradle": "8.10.2", "minJdk": 17, "referenceUrl": "https://developer.android.com/build/releases/about-agp"},
+    {"agp": "8.7", "minGradle": "8.9", "minJdk": 17, "referenceUrl": "https://developer.android.com/build/releases/about-agp"},
+    {"agp": "8.6", "minGradle": "8.7", "minJdk": 17, "referenceUrl": "https://developer.android.com/build/releases/about-agp"},
+    {"agp": "8.5", "minGradle": "8.7", "minJdk": 17, "referenceUrl": "https://developer.android.com/build/releases/about-agp"},
+    {"agp": "8.4", "minGradle": "8.6", "minJdk": 17, "referenceUrl": "https://developer.android.com/build/releases/about-agp"},
+    {"agp": "8.3", "minGradle": "8.4", "minJdk": 17, "referenceUrl": "https://developer.android.com/build/releases/about-agp"},
+    {"agp": "8.2", "minGradle": "8.2", "minJdk": 17, "referenceUrl": "https://developer.android.com/build/releases/about-agp"},
+    {"agp": "8.1", "minGradle": "8.0", "minJdk": 17, "referenceUrl": "https://developer.android.com/build/releases/about-agp"},
+    {"agp": "8.0", "minGradle": "8.0", "minJdk": 17, "referenceUrl": "https://developer.android.com/build/releases/about-agp"},
+    {"agp": "7.4", "minGradle": "7.5", "minJdk": 11, "referenceUrl": "https://developer.android.com/build/releases/about-agp"},
+    {"agp": "7.3", "minGradle": "7.4", "minJdk": 11, "referenceUrl": "https://developer.android.com/build/releases/about-agp"},
+    {"agp": "7.2", "minGradle": "7.3.3", "minJdk": 11, "referenceUrl": "https://developer.android.com/build/releases/about-agp"},
+    {"agp": "7.1", "minGradle": "7.2", "minJdk": 11, "referenceUrl": "https://developer.android.com/build/releases/about-agp"},
+    {"agp": "7.0", "minGradle": "7.0", "minJdk": 11, "referenceUrl": "https://developer.android.com/build/releases/about-agp"}
+  ],
+  "kotlinGradlePluginEntries": [
+    {
+      "kgpMin": "2.4.0",
+      "kgpMax": "2.4.0",
+      "gradleMin": "7.6.3",
+      "gradleMax": "9.5.0",
+      "agpMin": "8.5.2",
+      "agpMax": "9.1.0",
+      "referenceUrl": "https://kotlinlang.org/docs/gradle-configure-project.html"
+    },
+    {
+      "kgpMin": "2.3.20",
+      "kgpMax": "2.3.21",
+      "gradleMin": "7.6.3",
+      "gradleMax": "9.3.0",
+      "agpMin": "8.2.2",
+      "agpMax": "9.0.0",
+      "referenceUrl": "https://kotlinlang.org/docs/gradle-configure-project.html"
+    },
+    {
+      "kgpMin": "2.3.10",
+      "kgpMax": "2.3.10",
+      "gradleMin": "7.6.3",
+      "gradleMax": "9.0.0",
+      "agpMin": "8.2.2",
+      "agpMax": "9.0.0",
+      "referenceUrl": "https://kotlinlang.org/docs/gradle-configure-project.html"
+    },
+    {
+      "kgpMin": "2.3.0",
+      "kgpMax": "2.3.0",
+      "gradleMin": "7.6.3",
+      "gradleMax": "9.0.0",
+      "agpMin": "8.2.2",
+      "agpMax": "8.13.0",
+      "referenceUrl": "https://kotlinlang.org/docs/gradle-configure-project.html"
+    },
+    {
+      "kgpMin": "2.2.20",
+      "kgpMax": "2.2.21",
+      "gradleMin": "7.6.3",
+      "gradleMax": "8.14",
+      "agpMin": "7.3.1",
+      "agpMax": "8.11.1",
+      "referenceUrl": "https://kotlinlang.org/docs/gradle-configure-project.html"
+    },
+    {
+      "kgpMin": "2.2.0",
+      "kgpMax": "2.2.10",
+      "gradleMin": "7.6.3",
+      "gradleMax": "8.14",
+      "agpMin": "7.3.1",
+      "agpMax": "8.10.0",
+      "referenceUrl": "https://kotlinlang.org/docs/gradle-configure-project.html"
+    },
+    {
+      "kgpMin": "2.1.20",
+      "kgpMax": "2.1.21",
+      "gradleMin": "7.6.3",
+      "gradleMax": "8.12.1",
+      "agpMin": "7.3.1",
+      "agpMax": "8.7.2",
+      "referenceUrl": "https://kotlinlang.org/docs/gradle-configure-project.html"
+    },
+    {
+      "kgpMin": "2.1.0",
+      "kgpMax": "2.1.10",
+      "gradleMin": "7.6.3",
+      "gradleMax": "8.10",
+      "agpMin": "7.3.1",
+      "agpMax": "8.7.2",
+      "referenceUrl": "https://kotlinlang.org/docs/gradle-configure-project.html"
+    },
+    {
+      "kgpMin": "2.0.20",
+      "kgpMax": "2.0.21",
+      "gradleMin": "6.8.3",
+      "gradleMax": "8.8",
+      "agpMin": "7.1.3",
+      "agpMax": "8.5",
+      "referenceUrl": "https://kotlinlang.org/docs/gradle-configure-project.html"
+    },
+    {
+      "kgpMin": "2.0.0",
+      "kgpMax": "2.0.0",
+      "gradleMin": "6.8.3",
+      "gradleMax": "8.5",
+      "agpMin": "7.1.3",
+      "agpMax": "8.3.1",
+      "referenceUrl": "https://kotlinlang.org/docs/gradle-configure-project.html"
+    },
+    {
+      "kgpMin": "1.9.20",
+      "kgpMax": "1.9.25",
+      "gradleMin": "6.8.3",
+      "gradleMax": "8.1.1",
+      "agpMin": "4.2.2",
+      "agpMax": "8.1.0",
+      "referenceUrl": "https://kotlinlang.org/docs/gradle-configure-project.html"
+    }
+  ],
+  "jakartaMap": {
+    "javax.persistence:javax.persistence-api": "jakarta.persistence:jakarta.persistence-api",
+    "javax.validation:validation-api": "jakarta.validation:jakarta.validation-api",
+    "javax.servlet:javax.servlet-api": "jakarta.servlet:jakarta.servlet-api",
+    "javax.servlet:servlet-api": "jakarta.servlet:jakarta.servlet-api",
+    "javax.annotation:javax.annotation-api": "jakarta.annotation:jakarta.annotation-api",
+    "javax.inject:javax.inject": "jakarta.inject:jakarta.inject-api",
+    "javax.transaction:javax.transaction-api": "jakarta.transaction:jakarta.transaction-api",
+    "javax.websocket:javax.websocket-api": "jakarta.websocket:jakarta.websocket-api",
+    "javax.ws.rs:javax.ws.rs-api": "jakarta.ws.rs:jakarta.ws.rs-api",
+    "javax.mail:javax.mail-api": "jakarta.mail:jakarta.mail-api",
+    "com.sun.mail:javax.mail": "org.eclipse.angus:jakarta.mail",
+    "javax.xml.bind:jaxb-api": "jakarta.xml.bind:jakarta.xml.bind-api",
+    "javax.activation:javax.activation-api": "jakarta.activation:jakarta.activation-api",
+    "javax.activation:activation": "jakarta.activation:jakarta.activation-api"
+  }
+}

--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -1264,9 +1264,9 @@ def check_android_kotlin_compatibility(android: Dict, matrices: Dict) -> Tuple[L
             suggestion = None
             if nearest_k:
                 suggestion = {
-                    "kotlin": f"{nearest_k['kgpMin']}–{nearest_k['kgpMax']}",
-                    "gradle": f"{nearest_k['gradleMin']}–{nearest_k['gradleMax']}",
-                    "agp": f"{nearest_k['agpMin']}–{nearest_k['agpMax']}",
+                    "kotlin": f"{nearest_k['kgpMin']}-{nearest_k['kgpMax']}",
+                    "gradle": f"{nearest_k['gradleMin']}-{nearest_k['gradleMax']}",
+                    "agp": f"{nearest_k['agpMin']}-{nearest_k['agpMax']}",
                 }
             conflicts.append({
                 "kind": "kotlin_unknown",
@@ -1281,9 +1281,9 @@ def check_android_kotlin_compatibility(android: Dict, matrices: Dict) -> Tuple[L
                 "https://kotlinlang.org/docs/gradle-configure-project.html"
             )
             suggestion = {
-                "kotlin": f"{kgp_entry['kgpMin']}–{kgp_entry['kgpMax']}",
-                "gradle": f"{kgp_entry['gradleMin']}–{kgp_entry['gradleMax']}",
-                "agp": f"{kgp_entry['agpMin']}–{kgp_entry['agpMax']}",
+                "kotlin": f"{kgp_entry['kgpMin']}-{kgp_entry['kgpMax']}",
+                "gradle": f"{kgp_entry['gradleMin']}-{kgp_entry['gradleMax']}",
+                "agp": f"{kgp_entry['agpMin']}-{kgp_entry['agpMax']}",
             }
             if gradle and not _version_in_closed_range(
                 gradle, kgp_entry["gradleMin"], kgp_entry["gradleMax"]
@@ -1391,7 +1391,10 @@ def check_javax_jakarta_migration(
     notes: List[str] = []
     if not spring_boot:
         return conflicts, notes
-    if not _version_gte(spring_boot, "3.0.0"):
+    # Major-version gate: Boot 3 milestones/RCs (3.0.0-M1) compare < 3.0.0
+    # under compare_versions but already require jakarta.*.
+    boot_major = (_parse_segments(spring_boot) or [0])[0]
+    if boot_major < 3:
         return conflicts, notes
     jmap = matrices.get("jakartaMap") or {}
     ref = (

--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -1100,6 +1100,406 @@ def apply_bom_managed_versions(scan: Dict, ctx: "ResolutionContext") -> Dict:
 
 
 # ---------------------------------------------------------------------------
+# Version compatibility matrices (#285)
+# ---------------------------------------------------------------------------
+
+SPRING_BOOT_BOM_GROUP = "org.springframework.boot"
+SPRING_BOOT_BOM_ARTIFACT = "spring-boot-dependencies"
+COMPAT_MATRICES_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "compat-matrices.json")
+MAX_COMPAT_DEPENDENCIES = 100
+
+_COMPAT_MATRICES_CACHE: Optional[Dict] = None
+
+
+def _load_compat_matrices() -> Dict:
+    """Load shipped compat-matrices.json (cached for the process lifetime)."""
+    global _COMPAT_MATRICES_CACHE
+    if _COMPAT_MATRICES_CACHE is not None:
+        return _COMPAT_MATRICES_CACHE
+    with open(COMPAT_MATRICES_PATH, "r", encoding="utf-8") as fh:
+        _COMPAT_MATRICES_CACHE = json.load(fh)
+    return _COMPAT_MATRICES_CACHE
+
+
+def _major_minor_line(version: str) -> str:
+    """Return ``major.minor`` for matrix line matching (e.g. 8.7.3 → 8.7)."""
+    segs = _parse_segments(version)
+    if len(segs) >= 2:
+        return f"{segs[0]}.{segs[1]}"
+    if segs:
+        return str(segs[0])
+    return version
+
+
+def _version_gte(a: str, b: str) -> bool:
+    return compare_versions(a, b) >= 0
+
+
+def _version_lte(a: str, b: str) -> bool:
+    return compare_versions(a, b) <= 0
+
+
+def _version_in_closed_range(version: str, vmin: str, vmax: str) -> bool:
+    return _version_gte(version, vmin) and _version_lte(version, vmax)
+
+
+def _find_agp_entry(agp_version: str, entries: List[Dict]) -> Optional[Dict]:
+    line = _major_minor_line(agp_version)
+    for entry in entries:
+        if entry.get("agp") == line:
+            return entry
+    for entry in entries:
+        if entry.get("agp") == agp_version:
+            return entry
+    return None
+
+
+def _find_kgp_entry(kotlin_version: str, entries: List[Dict]) -> Optional[Dict]:
+    for entry in entries:
+        kmin = entry.get("kgpMin") or ""
+        kmax = entry.get("kgpMax") or ""
+        if kmin and kmax and _version_in_closed_range(kotlin_version, kmin, kmax):
+            return entry
+    return None
+
+
+def _nearest_agp_suggestion(agp_version: str, entries: List[Dict]) -> Optional[Dict]:
+    """Pick the closest AGP matrix row by major.minor distance for suggestions."""
+    if not entries:
+        return None
+    target = _parse_segments(agp_version)
+    best = None
+    best_dist = None
+    for entry in entries:
+        segs = _parse_segments(entry["agp"])
+        # Lexicographic distance on padded major.minor
+        a = (target + [0, 0])[:2]
+        b = (segs + [0, 0])[:2]
+        dist = abs(a[0] - b[0]) * 1000 + abs(a[1] - b[1])
+        if best_dist is None or dist < best_dist:
+            best_dist = dist
+            best = entry
+    return best
+
+
+def check_android_kotlin_compatibility(android: Dict, matrices: Dict) -> Tuple[List[Dict], List[str]]:
+    """Validate AGP/Gradle/Kotlin/JDK against shipped matrices.
+
+    Returns (conflicts, notes).
+    """
+    conflicts: List[Dict] = []
+    notes: List[str] = []
+    agp = (android.get("agp") or "").strip() or None
+    gradle = (android.get("gradle") or "").strip() or None
+    kotlin = (android.get("kotlin") or "").strip() or None
+    jdk_raw = android.get("jdk")
+    jdk: Optional[int] = None
+    if jdk_raw is not None and jdk_raw != "":
+        try:
+            jdk = int(str(jdk_raw).strip())
+        except (TypeError, ValueError):
+            notes.append(f"android.jdk={jdk_raw!r} is not an integer; JDK check skipped.")
+
+    agp_entries = matrices.get("agpEntries") or []
+    kgp_entries = matrices.get("kotlinGradlePluginEntries") or []
+    agp_entry = _find_agp_entry(agp, agp_entries) if agp else None
+
+    if agp and agp_entry is None:
+        nearest = _nearest_agp_suggestion(agp, agp_entries)
+        suggestion = None
+        if nearest:
+            suggestion = {
+                "agp": nearest["agp"],
+                "gradle": nearest["minGradle"],
+                "jdk": nearest["minJdk"],
+            }
+        conflicts.append({
+            "kind": "agp_unknown",
+            "requested": {"agp": agp, "gradle": gradle, "kotlin": kotlin, "jdk": jdk},
+            "expected": None,
+            "suggestion": suggestion,
+            "reference": (nearest or {}).get("referenceUrl")
+            or "https://developer.android.com/build/releases/about-agp",
+        })
+    elif agp_entry is not None:
+        ref = agp_entry.get("referenceUrl") or "https://developer.android.com/build/releases/about-agp"
+        suggestion = {
+            "agp": agp_entry["agp"],
+            "gradle": agp_entry["minGradle"],
+            "jdk": agp_entry["minJdk"],
+        }
+        if gradle and not _version_gte(gradle, agp_entry["minGradle"]):
+            conflicts.append({
+                "kind": "agp_gradle",
+                "requested": {"agp": agp, "gradle": gradle},
+                "expected": {"minGradle": agp_entry["minGradle"]},
+                "suggestion": suggestion,
+                "reference": ref,
+            })
+        if jdk is not None and jdk < int(agp_entry["minJdk"]):
+            conflicts.append({
+                "kind": "agp_jdk",
+                "requested": {"agp": agp, "jdk": jdk},
+                "expected": {"minJdk": agp_entry["minJdk"]},
+                "suggestion": suggestion,
+                "reference": ref,
+            })
+
+    if kotlin:
+        kgp_entry = _find_kgp_entry(kotlin, kgp_entries)
+        if kgp_entry is None:
+            # Suggest the nearest band by kgpMin distance.
+            nearest_k = None
+            best_dist = None
+            for entry in kgp_entries:
+                a = _parse_segments(kotlin)
+                b = _parse_segments(entry["kgpMin"])
+                pad = max(len(a), len(b), 3)
+                a = (a + [0] * pad)[:pad]
+                b = (b + [0] * pad)[:pad]
+                d = sum(abs(x - y) for x, y in zip(a, b))
+                if best_dist is None or d < best_dist:
+                    best_dist = d
+                    nearest_k = entry
+            suggestion = None
+            if nearest_k:
+                suggestion = {
+                    "kotlin": f"{nearest_k['kgpMin']}–{nearest_k['kgpMax']}",
+                    "gradle": f"{nearest_k['gradleMin']}–{nearest_k['gradleMax']}",
+                    "agp": f"{nearest_k['agpMin']}–{nearest_k['agpMax']}",
+                }
+            conflicts.append({
+                "kind": "kotlin_unknown",
+                "requested": {"kotlin": kotlin, "gradle": gradle, "agp": agp},
+                "expected": None,
+                "suggestion": suggestion,
+                "reference": (nearest_k or {}).get("referenceUrl")
+                or "https://kotlinlang.org/docs/gradle-configure-project.html",
+            })
+        else:
+            ref = kgp_entry.get("referenceUrl") or (
+                "https://kotlinlang.org/docs/gradle-configure-project.html"
+            )
+            suggestion = {
+                "kotlin": f"{kgp_entry['kgpMin']}–{kgp_entry['kgpMax']}",
+                "gradle": f"{kgp_entry['gradleMin']}–{kgp_entry['gradleMax']}",
+                "agp": f"{kgp_entry['agpMin']}–{kgp_entry['agpMax']}",
+            }
+            if gradle and not _version_in_closed_range(
+                gradle, kgp_entry["gradleMin"], kgp_entry["gradleMax"]
+            ):
+                conflicts.append({
+                    "kind": "kotlin_gradle",
+                    "requested": {"kotlin": kotlin, "gradle": gradle},
+                    "expected": {
+                        "gradleMin": kgp_entry["gradleMin"],
+                        "gradleMax": kgp_entry["gradleMax"],
+                    },
+                    "suggestion": suggestion,
+                    "reference": ref,
+                })
+            if agp and not _version_in_closed_range(
+                agp, kgp_entry["agpMin"], kgp_entry["agpMax"]
+            ):
+                conflicts.append({
+                    "kind": "kotlin_agp",
+                    "requested": {"kotlin": kotlin, "agp": agp},
+                    "expected": {
+                        "agpMin": kgp_entry["agpMin"],
+                        "agpMax": kgp_entry["agpMax"],
+                    },
+                    "suggestion": suggestion,
+                    "reference": ref,
+                })
+
+    if not agp and not kotlin:
+        notes.append(
+            "android block provided without agp or kotlin; nothing to check against the matrix."
+        )
+    return conflicts, notes
+
+
+def check_spring_boot_bom_compatibility(
+    spring_boot: str,
+    dependencies: List[Dict],
+    ctx: "ResolutionContext",
+) -> Tuple[List[Dict], List[str]]:
+    """Compare requested dependency versions against spring-boot-dependencies BOM."""
+    conflicts: List[Dict] = []
+    notes: List[str] = []
+    managed = expand_bom(
+        SPRING_BOOT_BOM_GROUP, SPRING_BOOT_BOM_ARTIFACT, spring_boot, ctx
+    )
+    if not managed:
+        notes.append(
+            f"Could not expand {SPRING_BOOT_BOM_GROUP}:{SPRING_BOOT_BOM_ARTIFACT}:{spring_boot}; "
+            "Spring Boot BOM checks skipped."
+        )
+        return conflicts, notes
+    managed_map = {
+        (m["groupId"], m["artifactId"]): m["version"] for m in managed
+    }
+    ref = (
+        "https://docs.spring.io/spring-boot/docs/current/reference/html/"
+        "dependency-versions.html"
+    )
+    for dep in dependencies:
+        gid = dep.get("groupId")
+        aid = dep.get("artifactId")
+        requested = dep.get("version")
+        if not gid or not aid or not requested:
+            continue
+        expected = managed_map.get((gid, aid))
+        if expected is None:
+            continue
+        if requested == expected:
+            continue
+        conflicts.append({
+            "kind": "spring_boot_bom",
+            "requested": {
+                "groupId": gid,
+                "artifactId": aid,
+                "version": requested,
+            },
+            "expected": {
+                "groupId": gid,
+                "artifactId": aid,
+                "version": expected,
+                "managedBy": {
+                    "groupId": SPRING_BOOT_BOM_GROUP,
+                    "artifactId": SPRING_BOOT_BOM_ARTIFACT,
+                    "version": spring_boot,
+                },
+            },
+            "suggestion": {
+                "groupId": gid,
+                "artifactId": aid,
+                "version": expected,
+            },
+            "reference": ref,
+        })
+    return conflicts, notes
+
+
+def check_javax_jakarta_migration(
+    spring_boot: Optional[str],
+    dependencies: List[Dict],
+    matrices: Dict,
+) -> Tuple[List[Dict], List[str]]:
+    """Flag javax.* EE coordinates when Spring Boot ≥ 3."""
+    conflicts: List[Dict] = []
+    notes: List[str] = []
+    if not spring_boot:
+        return conflicts, notes
+    if not _version_gte(spring_boot, "3.0.0"):
+        return conflicts, notes
+    jmap = matrices.get("jakartaMap") or {}
+    ref = (
+        "https://github.com/spring-projects/spring-boot/wiki/"
+        "Spring-Boot-3.0-Migration-Guide"
+    )
+    for dep in dependencies:
+        gid = dep.get("groupId") or ""
+        aid = dep.get("artifactId") or ""
+        key = f"{gid}:{aid}"
+        replacement = jmap.get(key)
+        if replacement:
+            jg, ja = replacement.split(":", 1)
+            conflicts.append({
+                "kind": "javax_to_jakarta",
+                "requested": {
+                    "groupId": gid,
+                    "artifactId": aid,
+                    "version": dep.get("version"),
+                },
+                "expected": {"groupId": jg, "artifactId": ja},
+                "suggestion": {"groupId": jg, "artifactId": ja},
+                "reference": ref,
+            })
+            continue
+        # Unmapped javax.* still flagged (no concrete replacement known).
+        if gid.startswith("javax."):
+            conflicts.append({
+                "kind": "javax_to_jakarta",
+                "requested": {
+                    "groupId": gid,
+                    "artifactId": aid,
+                    "version": dep.get("version"),
+                },
+                "expected": None,
+                "suggestion": None,
+                "reference": ref,
+            })
+    return conflicts, notes
+
+
+def check_version_compatibility(
+    *,
+    spring_boot: Optional[str] = None,
+    android: Optional[Dict] = None,
+    dependencies: Optional[List[Dict]] = None,
+    ctx: Optional["ResolutionContext"] = None,
+) -> Dict:
+    """Core compatibility check used by the MCP tool (#285)."""
+    matrices = _load_compat_matrices()
+    conflicts: List[Dict] = []
+    notes: List[str] = list((matrices.get("_meta") or {}).get("limitations") or [])
+    deps = list(dependencies or [])
+    if len(deps) > MAX_COMPAT_DEPENDENCIES:
+        deps = deps[:MAX_COMPAT_DEPENDENCIES]
+        notes.append(
+            f"dependencies truncated to {MAX_COMPAT_DEPENDENCIES} items "
+            "(handler-enforced cap)."
+        )
+
+    if android:
+        c, n = check_android_kotlin_compatibility(android, matrices)
+        conflicts.extend(c)
+        notes.extend(n)
+
+    if spring_boot:
+        if ctx is None:
+            notes.append(
+                "No resolution context; Spring Boot BOM expansion skipped."
+            )
+        else:
+            c, n = check_spring_boot_bom_compatibility(spring_boot, deps, ctx)
+            conflicts.extend(c)
+            notes.extend(n)
+        c, n = check_javax_jakarta_migration(spring_boot, deps, matrices)
+        conflicts.extend(c)
+        notes.extend(n)
+    elif deps and any(
+        (d.get("groupId") or "").startswith("javax.") for d in deps
+    ):
+        notes.append(
+            "javax.* coordinates present but springBoot was not set; "
+            "javax→jakarta migration check skipped (requires Spring Boot ≥ 3)."
+        )
+
+    if not spring_boot and not android and not deps:
+        notes.append(
+            "No springBoot, android, or dependencies provided; nothing to check."
+        )
+
+    # De-dupe identical limitation notes that we always attach — keep order,
+    # but drop exact duplicate strings from the dynamic notes path.
+    seen_notes = set()
+    unique_notes: List[str] = []
+    for note in notes:
+        if note in seen_notes:
+            continue
+        seen_notes.add(note)
+        unique_notes.append(note)
+
+    return {
+        "compatible": len(conflicts) == 0,
+        "conflicts": conflicts,
+        "notes": unique_notes,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Version classification & comparison
 # ---------------------------------------------------------------------------
 
@@ -4192,6 +4592,29 @@ def handle_verify_coordinates(args: Dict) -> Any:
     return {"results": results}
 
 
+
+def handle_check_version_compatibility(args: Dict) -> Any:
+    """Validate Spring Boot BOM / Android-Kotlin-Gradle-JDK / javax→jakarta (#285)."""
+    spring_boot = args.get("springBoot")
+    android = args.get("android")
+    dependencies = args.get("dependencies") or []
+    if not isinstance(dependencies, list):
+        dependencies = []
+    # Cap before any network I/O (BOM expand) — same rationale as verify_coordinates.
+    if len(dependencies) > MAX_COMPAT_DEPENDENCIES:
+        dependencies = dependencies[:MAX_COMPAT_DEPENDENCIES]
+    ctx = None
+    if spring_boot:
+        ctx = build_resolution_context(args)
+    return check_version_compatibility(
+        spring_boot=spring_boot,
+        android=android if isinstance(android, dict) else None,
+        dependencies=dependencies,
+        ctx=ctx,
+    )
+
+
+
 TOOLS = [
     {
         "name": "get_latest_version",
@@ -4310,6 +4733,44 @@ TOOLS = [
         },
     },
     {
+        "name": "check_version_compatibility",
+        "description": "Check whether a set of versions is mutually compatible. Validates (1) dependency versions against the Spring Boot BOM (spring-boot-dependencies) when springBoot is set, (2) AGP↔Gradle↔JDK and Kotlin Gradle plugin↔Gradle/AGP ranges from a shipped matrix file, and (3) javax→jakarta EE coordinate migration when Spring Boot ≥ 3. Returns conflicts with suggested compatible versions and reference URLs. v1 coverage is intentionally bounded — see notes[] / AGENTS.md; matrices are not scraped at runtime and must be refreshed via the documented procedure in compat-matrices.json.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "springBoot": {
+                    "type": "string",
+                    "description": "Spring Boot version. When set, expands org.springframework.boot:spring-boot-dependencies and checks dependencies[] against managed versions; also enables javax→jakarta checks when ≥ 3.0.0.",
+                },
+                "android": {
+                    "type": "object",
+                    "description": "Android / Kotlin toolchain versions to validate against the shipped AGP and KGP matrices.",
+                    "properties": {
+                        "agp": {"type": "string", "description": "Android Gradle Plugin version"},
+                        "gradle": {"type": "string", "description": "Gradle version"},
+                        "kotlin": {"type": "string", "description": "Kotlin Gradle plugin version"},
+                        "jdk": {"type": "integer", "description": "JDK major version used to run the build"},
+                    },
+                },
+                "dependencies": {
+                    "type": "array",
+                    "maxItems": 100,
+                    "description": "Dependencies to check against the Spring Boot BOM and/or javax→jakarta map.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "groupId": {"type": "string"},
+                            "artifactId": {"type": "string"},
+                            "version": {"type": "string"},
+                        },
+                        "required": ["groupId", "artifactId"],
+                    },
+                },
+                "projectPath": {"type": "string", "description": "Project root used to resolve declared repositories for BOM fetch. Defaults to the current working directory."},
+            },
+        },
+    },
+    {
         "name": "get_dependency_vulnerabilities",
         "description": "Check dependencies for known vulnerabilities using the OSV.dev database.",
         "inputSchema": {
@@ -4415,6 +4876,7 @@ TOOL_HANDLERS = {
     "get_dependency_changes": handle_get_dependency_changes,
     "scan_project_dependencies": handle_scan_project_dependencies,
     "expand_bom": handle_expand_bom,
+    "check_version_compatibility": handle_check_version_compatibility,
     "get_dependency_vulnerabilities": handle_get_dependency_vulnerabilities,
     "get_dependency_health": handle_get_dependency_health,
     "search_artifacts": handle_search_artifacts,

--- a/plugins/maven-mcp/tests/test_compat.py
+++ b/plugins/maven-mcp/tests/test_compat.py
@@ -1,6 +1,5 @@
 """Tests for check_version_compatibility (#285)."""
 
-import json
 import os
 import unittest
 import unittest.mock
@@ -140,6 +139,20 @@ class TestJakartaMap(unittest.TestCase):
             server._load_compat_matrices(),
         )
         self.assertEqual(conflicts, [])
+
+    def test_boot3_milestone_still_flags(self):
+        conflicts, _notes = server.check_javax_jakarta_migration(
+            "3.0.0-M1",
+            [
+                {
+                    "groupId": "javax.persistence",
+                    "artifactId": "javax.persistence-api",
+                    "version": "2.2",
+                }
+            ],
+            server._load_compat_matrices(),
+        )
+        self.assertEqual(len(conflicts), 1)
 
 
 class TestSpringBootBomCompat(unittest.TestCase):

--- a/plugins/maven-mcp/tests/test_compat.py
+++ b/plugins/maven-mcp/tests/test_compat.py
@@ -1,0 +1,283 @@
+"""Tests for check_version_compatibility (#285)."""
+
+import json
+import os
+import unittest
+import unittest.mock
+
+from _helpers import empty_ctx, mock_urlopen, server
+
+
+def _bom_pom(managed_xml: str) -> bytes:
+    return (
+        "<project><dependencyManagement><dependencies>"
+        f"{managed_xml}"
+        "</dependencies></dependencyManagement></project>"
+    ).encode()
+
+
+def _managed(group_id: str, artifact_id: str, version: str) -> str:
+    return (
+        "<dependency>"
+        f"<groupId>{group_id}</groupId>"
+        f"<artifactId>{artifact_id}</artifactId>"
+        f"<version>{version}</version>"
+        "</dependency>"
+    )
+
+
+class TestCompatMatricesFile(unittest.TestCase):
+    def test_shipped_file_has_refresh_procedure(self):
+        matrices = server._load_compat_matrices()
+        meta = matrices["_meta"]
+        self.assertIsInstance(meta.get("refreshProcedure"), list)
+        self.assertGreaterEqual(len(meta["refreshProcedure"]), 3)
+        self.assertTrue(matrices.get("agpEntries"))
+        self.assertTrue(matrices.get("kotlinGradlePluginEntries"))
+        self.assertIn(
+            "javax.persistence:javax.persistence-api",
+            matrices["jakartaMap"],
+        )
+        # File lives next to server.py so the plugin bundle ships it.
+        self.assertTrue(os.path.isfile(server.COMPAT_MATRICES_PATH))
+
+
+class TestAndroidMatrix(unittest.TestCase):
+    def test_agp_gradle_jdk_conflict_and_suggestion(self):
+        conflicts, _notes = server.check_android_kotlin_compatibility(
+            {"agp": "8.7.2", "gradle": "8.5", "jdk": 11},
+            server._load_compat_matrices(),
+        )
+        kinds = {c["kind"] for c in conflicts}
+        self.assertIn("agp_gradle", kinds)
+        self.assertIn("agp_jdk", kinds)
+        gradle_c = next(c for c in conflicts if c["kind"] == "agp_gradle")
+        self.assertEqual(gradle_c["expected"]["minGradle"], "8.9")
+        self.assertEqual(gradle_c["suggestion"]["gradle"], "8.9")
+        self.assertIn("developer.android.com", gradle_c["reference"])
+
+    def test_compatible_agp_gradle_jdk(self):
+        conflicts, _notes = server.check_android_kotlin_compatibility(
+            {"agp": "8.7.0", "gradle": "8.9", "jdk": 17},
+            server._load_compat_matrices(),
+        )
+        self.assertEqual(conflicts, [])
+
+    def test_kotlin_gradle_out_of_range(self):
+        conflicts, _notes = server.check_android_kotlin_compatibility(
+            {"kotlin": "2.1.20", "gradle": "9.0.0"},
+            server._load_compat_matrices(),
+        )
+        kinds = {c["kind"] for c in conflicts}
+        self.assertIn("kotlin_gradle", kinds)
+        kc = next(c for c in conflicts if c["kind"] == "kotlin_gradle")
+        self.assertEqual(kc["expected"]["gradleMax"], "8.12.1")
+        self.assertIn("kotlinlang.org", kc["reference"])
+
+    def test_kotlin_agp_out_of_range(self):
+        conflicts, _notes = server.check_android_kotlin_compatibility(
+            {"kotlin": "2.0.0", "agp": "8.7.0"},
+            server._load_compat_matrices(),
+        )
+        kinds = {c["kind"] for c in conflicts}
+        self.assertIn("kotlin_agp", kinds)
+
+    def test_compatible_kotlin_band(self):
+        conflicts, _notes = server.check_android_kotlin_compatibility(
+            {
+                "agp": "8.7.2",
+                "gradle": "8.9",
+                "kotlin": "2.1.20",
+                "jdk": 17,
+            },
+            server._load_compat_matrices(),
+        )
+        self.assertEqual(conflicts, [])
+
+    def test_unknown_agp_suggests_nearest(self):
+        conflicts, _notes = server.check_android_kotlin_compatibility(
+            {"agp": "99.0.0", "gradle": "8.0"},
+            server._load_compat_matrices(),
+        )
+        self.assertTrue(any(c["kind"] == "agp_unknown" for c in conflicts))
+        unk = next(c for c in conflicts if c["kind"] == "agp_unknown")
+        self.assertIsNotNone(unk["suggestion"])
+
+
+class TestJakartaMap(unittest.TestCase):
+    def test_boot3_flags_javax_persistence(self):
+        conflicts, _notes = server.check_javax_jakarta_migration(
+            "3.2.0",
+            [
+                {
+                    "groupId": "javax.persistence",
+                    "artifactId": "javax.persistence-api",
+                    "version": "2.2",
+                }
+            ],
+            server._load_compat_matrices(),
+        )
+        self.assertEqual(len(conflicts), 1)
+        self.assertEqual(conflicts[0]["kind"], "javax_to_jakarta")
+        self.assertEqual(
+            conflicts[0]["suggestion"],
+            {
+                "groupId": "jakarta.persistence",
+                "artifactId": "jakarta.persistence-api",
+            },
+        )
+
+    def test_boot2_does_not_flag(self):
+        conflicts, _notes = server.check_javax_jakarta_migration(
+            "2.7.18",
+            [
+                {
+                    "groupId": "javax.persistence",
+                    "artifactId": "javax.persistence-api",
+                    "version": "2.2",
+                }
+            ],
+            server._load_compat_matrices(),
+        )
+        self.assertEqual(conflicts, [])
+
+
+class TestSpringBootBomCompat(unittest.TestCase):
+    def test_conflicting_managed_version(self):
+        pom = _bom_pom(
+            _managed("org.springframework", "spring-core", "6.1.5")
+            + _managed("com.fasterxml.jackson.core", "jackson-databind", "2.15.4")
+        )
+        with unittest.mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, pom)]),
+        ):
+            conflicts, notes = server.check_spring_boot_bom_compatibility(
+                "3.2.0",
+                [
+                    {
+                        "groupId": "org.springframework",
+                        "artifactId": "spring-core",
+                        "version": "5.3.31",
+                    },
+                    {
+                        "groupId": "com.fasterxml.jackson.core",
+                        "artifactId": "jackson-databind",
+                        "version": "2.15.4",
+                    },
+                    {
+                        "groupId": "com.example",
+                        "artifactId": "unmanaged",
+                        "version": "1.0",
+                    },
+                ],
+                empty_ctx(),
+            )
+        self.assertEqual(notes, [])
+        self.assertEqual(len(conflicts), 1)
+        c = conflicts[0]
+        self.assertEqual(c["kind"], "spring_boot_bom")
+        self.assertEqual(c["requested"]["version"], "5.3.31")
+        self.assertEqual(c["expected"]["version"], "6.1.5")
+        self.assertEqual(c["suggestion"]["version"], "6.1.5")
+
+    def test_missing_bom_notes_and_skips(self):
+        with unittest.mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(404, b"")]),
+        ):
+            conflicts, notes = server.check_spring_boot_bom_compatibility(
+                "3.2.0",
+                [
+                    {
+                        "groupId": "org.springframework",
+                        "artifactId": "spring-core",
+                        "version": "5.3.31",
+                    }
+                ],
+                empty_ctx(),
+            )
+        self.assertEqual(conflicts, [])
+        self.assertTrue(any("Could not expand" in n for n in notes))
+
+
+class TestCheckVersionCompatibilityTool(unittest.TestCase):
+    def test_mixed_compatible_and_incompatible(self):
+        pom = _bom_pom(_managed("org.springframework", "spring-core", "6.1.5"))
+        with unittest.mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, pom)]),
+        ):
+            result = server.handle_check_version_compatibility(
+                {
+                    "springBoot": "3.2.0",
+                    "android": {
+                        "agp": "8.7.2",
+                        "gradle": "8.5",
+                        "kotlin": "2.1.20",
+                        "jdk": 17,
+                    },
+                    "dependencies": [
+                        {
+                            "groupId": "org.springframework",
+                            "artifactId": "spring-core",
+                            "version": "5.3.31",
+                        },
+                        {
+                            "groupId": "javax.servlet",
+                            "artifactId": "javax.servlet-api",
+                            "version": "4.0.1",
+                        },
+                    ],
+                }
+            )
+        self.assertFalse(result["compatible"])
+        kinds = {c["kind"] for c in result["conflicts"]}
+        self.assertIn("spring_boot_bom", kinds)
+        self.assertIn("agp_gradle", kinds)
+        self.assertIn("javax_to_jakarta", kinds)
+        self.assertIsInstance(result["notes"], list)
+        self.assertTrue(result["notes"])  # includes matrix limitations
+
+    def test_all_compatible(self):
+        pom = _bom_pom(_managed("org.springframework", "spring-core", "6.1.5"))
+        with unittest.mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, pom)]),
+        ):
+            result = server.handle_check_version_compatibility(
+                {
+                    "springBoot": "3.2.0",
+                    "android": {
+                        "agp": "8.7.2",
+                        "gradle": "8.9",
+                        "kotlin": "2.1.20",
+                        "jdk": 17,
+                    },
+                    "dependencies": [
+                        {
+                            "groupId": "org.springframework",
+                            "artifactId": "spring-core",
+                            "version": "6.1.5",
+                        },
+                        {
+                            "groupId": "jakarta.persistence",
+                            "artifactId": "jakarta.persistence-api",
+                            "version": "3.1.0",
+                        },
+                    ],
+                }
+            )
+        self.assertTrue(result["compatible"])
+        self.assertEqual(result["conflicts"], [])
+
+    def test_registered_in_tools(self):
+        names = [t["name"] for t in server.TOOLS]
+        self.assertIn("check_version_compatibility", names)
+        self.assertEqual(
+            set(names), set(server.TOOL_HANDLERS.keys())
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/maven-mcp/tests/test_pre_edit_hook.py
+++ b/plugins/maven-mcp/tests/test_pre_edit_hook.py
@@ -1500,5 +1500,126 @@ class ContractDriftGuardTest(unittest.TestCase):
         self.assertIn("results", parsed)
 
 
+@_require_jq_and_timeout()
+class CompatAskTest(unittest.TestCase):
+    """#285: check_version_compatibility conflicts → advisory ask (never deny)."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_agp_gradle_conflict_asks(self):
+        """AGP 8.7 + Gradle 8.5 in edit → id:3 compat call → ask."""
+        _make_fixture(
+            self.tmp,
+            {
+                1: {
+                    "results": [
+                        _verify_entry(
+                            "exists",
+                            "com.android.application",
+                            "com.android.application.gradle.plugin",
+                        )
+                    ]
+                },
+                3: {
+                    "compatible": False,
+                    "conflicts": [
+                        {
+                            "kind": "agp_gradle",
+                            "requested": {"agp": "8.7.2", "gradle": "8.5"},
+                            "expected": {"minGradle": "8.9"},
+                            "suggestion": {
+                                "agp": "8.7",
+                                "gradle": "8.9",
+                                "jdk": 17,
+                            },
+                            "reference": (
+                                "https://developer.android.com/build/releases/about-agp"
+                            ),
+                        }
+                    ],
+                    "notes": [],
+                },
+            },
+        )
+        content = textwrap.dedent(
+            """\
+            plugins {
+              id("com.android.application") version "8.7.2"
+            }
+            // gradle-8.5-bin.zip
+            distributionUrl=https\\://services.gradle.org/distributions/gradle-8.5-bin.zip
+            """
+        )
+        proc = _run_hook(self.tmp, _edit_stdin("build.gradle.kts", content))
+        self.assertEqual(proc.returncode, 0)
+        decision = _parse_decision(proc.stdout)
+        self.assertIsNotNone(decision)
+        ho = decision["hookSpecificOutput"]
+        self.assertEqual(ho["permissionDecision"], "ask")
+        self.assertIn("agp_gradle", ho["permissionDecisionReason"])
+        args = _stub_args(self.tmp)
+        names = {a.get("name") for a in args}
+        self.assertIn("check_version_compatibility", names)
+        compat = next(a for a in args if a.get("name") == "check_version_compatibility")
+        android = compat["arguments"].get("android") or {}
+        self.assertEqual(android.get("agp"), "8.7.2")
+        self.assertEqual(android.get("gradle"), "8.5")
+
+    def test_compat_conflict_does_not_deny(self):
+        """Compatibility arm must use ask, never deny."""
+        _make_fixture(
+            self.tmp,
+            {
+                1: {
+                    "results": [
+                        _verify_entry(
+                            "exists", "javax.persistence", "javax.persistence-api"
+                        )
+                    ]
+                },
+                3: {
+                    "compatible": False,
+                    "conflicts": [
+                        {
+                            "kind": "javax_to_jakarta",
+                            "requested": {
+                                "groupId": "javax.persistence",
+                                "artifactId": "javax.persistence-api",
+                            },
+                            "suggestion": {
+                                "groupId": "jakarta.persistence",
+                                "artifactId": "jakarta.persistence-api",
+                            },
+                            "reference": "https://example.com/boot3",
+                        }
+                    ],
+                    "notes": [],
+                },
+            },
+        )
+        content = textwrap.dedent(
+            """\
+            plugins {
+              id("org.springframework.boot") version "3.2.0"
+            }
+            implementation("javax.persistence:javax.persistence-api:2.2")
+            """
+        )
+        proc = _run_hook(self.tmp, _edit_stdin("build.gradle.kts", content))
+        self.assertEqual(proc.returncode, 0)
+        decision = _parse_decision(proc.stdout)
+        self.assertIsNotNone(decision)
+        self.assertEqual(
+            decision["hookSpecificOutput"]["permissionDecision"], "ask"
+        )
+        self.assertNotEqual(
+            decision["hookSpecificOutput"]["permissionDecision"], "deny"
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add MCP tool `check_version_compatibility` that validates Spring Boot BOM-managed versions (via `expand_bom` from #286), AGP↔Gradle↔JDK and Kotlin Gradle plugin↔Gradle/AGP ranges from a shipped `compat-matrices.json`, and javax→jakarta EE coordinates when Spring Boot ≥ 3.
- Document matrix refresh procedure in `_meta.refreshProcedure` and known v1 limitations in tool description / AGENTS.md / CLAUDE.md.
- Wire an advisory `ask` path into `pre-edit-deps.sh` (JSON-RPC id:3) when edits expose Boot/AGP/Kotlin/Gradle pins.

Fixes #285

## Matrices shipped (v1)
- **Spring Boot BOM** — live expand of `spring-boot-dependencies` for requested deps
- **AGP 7.0–9.2** — min Gradle + min JDK (from Android docs)
- **KGP 1.9.20–2.4.0** — Gradle/AGP closed ranges (from Kotlin docs)
- **javax→jakarta** — known EE coordinate map under Boot ≥ 3

## Known limitations / follow-ups
- No separate Spring Cloud release-train matrix (Cloud-managed deps still surface via Boot BOM when listed)
- AGP has no published max Gradle (only min enforced)
- Older AGP 3.x/4.x and KGP &lt; 1.9.20 omitted
- javax→jakarta is coordinate heuristic, not import/bytecode scan
- Hook integration is advisory `ask` only (never deny)

## Test plan
- [x] `python3 -m unittest discover -s plugins/maven-mcp/tests` (628 OK, 1 skipped)
- [x] `bash scripts/validate.sh`
- [ ] CI green on PR


Made with [Cursor](https://cursor.com)