### PR TITLE
Restore AGP and AndroidX changelog providers

### DIFF
--- a/docs/plans/maven-python-migration/coverage-map.md
+++ b/docs/plans/maven-python-migration/coverage-map.md
@@ -23,7 +23,7 @@ is a **backstop only** — it proves a function executed, never that behavior wa
 **Follow-up divergences** (TS had it, shipped Python does not — all pre-existing #302 gaps):
 - **#1** HTTP retry/backoff (feature gap)
 - **#2** persistent file cache (feature gap)
-- **#3** AGP/AndroidX release-notes changelog providers + html-to-text + github CHANGELOG.md markdown fallback + `changelog/resolver` provider-selection — server.py has no agp/androidx/html parser and `_get_dependency_changes_impl` is GitHub-releases-only (feature gap)
+- **#3** AGP/AndroidX release-notes changelog providers + html-to-text + `changelog/resolver` provider-selection — **resolved by #308** (`test_changelog_providers.py`). Residual: github CHANGELOG.md markdown fallback still not ported.
 - **#4** HTTP/SSE transport — server.py is stdio-only (feature gap)
 
 **Resolved by this PR** (`fix/maven-repo-resolution`) — both former CORRECTNESS regressions are now **ported**:
@@ -61,22 +61,22 @@ is a **backstop only** — it proves a function executed, never that behavior wa
 | `github/tag-matcher.test.ts` | ported | `test_github.py` (TagNormalization + DependencyChangesImpl tag-normalization) |
 | `github/changelog-parser.test.ts` | diverged → #3 | CHANGELOG.md markdown parser (`parseChangelogSections`) has no server.py equivalent; the Python github path uses release bodies only |
 
-### changelog/ (4) — 1 ported, 1 partial, 2 diverged
+### changelog/ (4) — 3 ported, 1 residual via #3/#308
 | TS test file | Bucket | Python |
 |---|---|---|
 | `changelog/github-provider.test.ts` | ported | `test_github.py` (DependencyChangesImpl) + `test_handlers.py` (TestGetDependencyChanges) — github releases path |
-| `changelog/resolver.test.ts` | partial → `test_github.py` + provider-selection diverged → #3 | github branch ported; agp-vs-androidx-vs-github provider selection not in server.py |
-| `changelog/agp-provider.test.ts` | diverged → #3 | no AGP changelog provider in server.py |
-| `changelog/androidx-provider.test.ts` | diverged → #3 | no AndroidX changelog provider in server.py |
+| `changelog/resolver.test.ts` | ported | `test_changelog_providers.py` (ResolveChangelogTest) — AndroidX → AGP → GitHub (#308) |
+| `changelog/agp-provider.test.ts` | ported | `test_changelog_providers.py` (AgpProviderTest + DependencyChangesAgpAndroidXTest) |
+| `changelog/androidx-provider.test.ts` | ported | `test_changelog_providers.py` (AndroidXProviderTest + DependencyChangesAgpAndroidXTest) |
 
-### agp/ + androidx/ + html/ (5) — all diverged → #3
+### agp/ + androidx/ + html/ (5) — ported via #308; CHANGELOG.md residual remains under #3
 | TS test file | Bucket | Python |
 |---|---|---|
-| `agp/release-notes-parser.test.ts` | diverged → #3 | no AGP release-notes parser in server.py |
-| `agp/url.test.ts` | diverged → #3 | no AGP URL mapping in server.py |
-| `androidx/release-notes-parser.test.ts` | diverged → #3 | no AndroidX release-notes parser in server.py |
-| `androidx/url.test.ts` | diverged → #3 | no AndroidX URL mapping in server.py |
-| `html/to-text.test.ts` | diverged → #3 | no htmlToText util in server.py (only used by agp/androidx providers) |
+| `agp/release-notes-parser.test.ts` | ported | `test_changelog_providers.py` (AgpParserTest) |
+| `agp/url.test.ts` | ported | `test_changelog_providers.py` (AgpUrlTest) |
+| `androidx/release-notes-parser.test.ts` | ported | `test_changelog_providers.py` (AndroidXParserTest) |
+| `androidx/url.test.ts` | ported | `test_changelog_providers.py` (AndroidXUrlTest) |
+| `html/to-text.test.ts` | ported | `test_changelog_providers.py` (HtmlToTextTest) |
 
 ### maven/ + search/ + vulnerabilities/ (4) — all ported
 | TS test file | Bucket | Python |

--- a/plugins/maven-mcp/AGENTS.md
+++ b/plugins/maven-mcp/AGENTS.md
@@ -44,7 +44,7 @@ python3 -m unittest discover -s plugins/maven-mcp/tests -p test_handlers.py
 - **BOM / platform expansion** — `parse_dependency_management`, `expand_bom`, `apply_bom_managed_versions` (#286).
 - **deps.dev transitive graphs** — `fetch_depsdev_dependencies`, `get_transitive_graph`, `detect_dependency_conflicts` (#287).
 - **Version compatibility** — `check_version_compatibility` + shipped `compat-matrices.json` (AGP/KGP/javax→jakarta; Spring Boot via `expand_bom`) (#285).
-- **GitHub & changelog** — `gh_repo_exists` / `gh_fetch_repo` / `gh_fetch_releases` / `gh_fetch_user` / `gh_fetch_issue_stats`, `discover_github_repo` (POM SCM → groupId guess), and `_get_dependency_changes_impl` + `_filter_version_range` (GitHub releases only).
+- **GitHub & changelog** — `gh_repo_exists` / `gh_fetch_repo` / `gh_fetch_releases` / `gh_fetch_user` / `gh_fetch_issue_stats`, `discover_github_repo` (POM SCM → groupId guess), and `_get_dependency_changes_impl` + `_filter_version_range` with provider selection (#308): AndroidX docs → AGP docs → GitHub releases. Minimal stdlib `html_to_text` powers the AGP/AndroidX HTML parsers. GitHub CHANGELOG.md markdown fallback is still not ported.
 - **Vulnerabilities** — OSV.dev batch query (`api.osv.dev/v1/querybatch`).
 - **Tool handlers** — `handle_*`, one per MCP tool, plus the stdio JSON-RPC dispatch loop.
 

--- a/plugins/maven-mcp/CLAUDE.md
+++ b/plugins/maven-mcp/CLAUDE.md
@@ -44,7 +44,7 @@ python3 -m unittest discover -s plugins/maven-mcp/tests -p test_handlers.py
 - **BOM / platform expansion** — `parse_dependency_management`, `expand_bom`, `apply_bom_managed_versions` (#286).
 - **deps.dev transitive graphs** — `fetch_depsdev_dependencies`, `get_transitive_graph`, `detect_dependency_conflicts` (#287).
 - **Version compatibility** — `check_version_compatibility` + shipped `compat-matrices.json` (AGP/KGP/javax→jakarta; Spring Boot via `expand_bom`) (#285).
-- **GitHub & changelog** — `gh_repo_exists` / `gh_fetch_repo` / `gh_fetch_releases` / `gh_fetch_user` / `gh_fetch_issue_stats`, `discover_github_repo` (POM SCM → groupId guess), and `_get_dependency_changes_impl` + `_filter_version_range` (GitHub releases only).
+- **GitHub & changelog** — `gh_repo_exists` / `gh_fetch_repo` / `gh_fetch_releases` / `gh_fetch_user` / `gh_fetch_issue_stats`, `discover_github_repo` (POM SCM → groupId guess), and `_get_dependency_changes_impl` + `_filter_version_range` with provider selection (#308): AndroidX docs → AGP docs → GitHub releases. Minimal stdlib `html_to_text` powers the AGP/AndroidX HTML parsers. GitHub CHANGELOG.md markdown fallback is still not ported.
 - **Vulnerabilities** — OSV.dev batch query (`api.osv.dev/v1/querybatch`).
 - **Tool handlers** — `handle_*`, one per MCP tool, plus the stdio JSON-RPC dispatch loop.
 

--- a/plugins/maven-mcp/README.md
+++ b/plugins/maven-mcp/README.md
@@ -16,7 +16,7 @@ The server registers tools that Claude can call during a conversation. It querie
 | `check_version_exists` | Verify if a specific version exists and classify its stability |
 | `check_multiple_dependencies` | Bulk lookup of latest versions for multiple dependencies |
 | `compare_dependency_versions` | Compare current versions against latest (major/minor/patch) |
-| `get_dependency_changes` | Show changes between versions from GitHub releases |
+| `get_dependency_changes` | Show changes between versions (AndroidX/AGP docs or GitHub releases) |
 | `scan_project_dependencies` | Scan Gradle/Maven build files and Gradle version catalogs (`gradle/libs.versions.toml`) for dependencies |
 | `expand_bom` | Expand a Maven BOM into managed dependency versions |
 | `get_transitive_graph` | Resolved transitive dependency graph for a GAV via deps.dev |

--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -3505,8 +3505,118 @@ def discover_github_repo(group_id: str, artifact_id: str, version: str, ctx: "Re
 
 
 # ---------------------------------------------------------------------------
-# GitHub changelog / releases for get_dependency_changes
+# Changelog providers for get_dependency_changes (#308)
+# Order: AndroidX docs → AGP docs → GitHub releases (mirrors retired TS resolver).
 # ---------------------------------------------------------------------------
+
+AGP_GROUP_ID = "com.android.tools.build"
+AGP_RELEASES_BASE = "https://developer.android.com/build/releases"
+ANDROIDX_RELEASES_BASE = "https://developer.android.com/jetpack/androidx/releases"
+# Release-notes HTML pages change infrequently; match the retired TS 7-day TTL.
+TTL_CHANGELOG_HTML = TTL_POM
+
+_AGP_HEADING_RE = re.compile(
+    r'<h3[^>]*\s+data-text="Android Gradle plugin ([\d][^\s"]*)"[^>]*>',
+    re.IGNORECASE,
+)
+_ANDROIDX_VERSION_HEADING_RE = re.compile(
+    r"<h[23][^>]*>\s*Version\s+([\d][^\s<]*)\s*</h[23]>",
+    re.IGNORECASE,
+)
+
+
+def html_to_text(html: str) -> str:
+    """Minimal HTML→text for Android docs release notes (stdlib only, #308).
+
+    Mirrors the retired TS ``html/to-text``: list/br/p formatting, iterative tag
+    strip (handles smuggled nested tags), then a small entity unescape set.
+    """
+    formatted = re.sub(r"<li[^>]*>", "- ", html, flags=re.IGNORECASE)
+    formatted = re.sub(r"</li>", "\n", formatted, flags=re.IGNORECASE)
+    formatted = re.sub(r"<br\s*/?>", "\n", formatted, flags=re.IGNORECASE)
+    formatted = re.sub(r"</p>", "\n\n", formatted, flags=re.IGNORECASE)
+    # Loop so forms like ``<<script>script>`` lose the outer tag first and the
+    # inner tag becomes visible to the next pass (same as the TS stripTags loop).
+    result = formatted
+    while True:
+        prev = result
+        result = re.sub(r"<[^>]*>", "", result)
+        if result == prev:
+            break
+    result = (
+        result.replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", '"')
+        .replace("&#39;", "'")
+        .replace("&amp;", "&")
+    )
+    result = re.sub(r"\n{3,}", "\n\n", result)
+    return result.strip()
+
+
+def is_agp_artifact(group_id: str) -> bool:
+    return group_id == AGP_GROUP_ID
+
+
+def _agp_major_minor(version: str) -> Tuple[str, str]:
+    parts = version.split(".")
+    major = parts[0] if parts else ""
+    minor = parts[1] if len(parts) > 1 else "0"
+    return major, minor
+
+
+def get_agp_releases_url(version: str) -> str:
+    major, minor = _agp_major_minor(version)
+    return f"{AGP_RELEASES_BASE}/agp-{major}-{minor}-0-release-notes"
+
+
+def get_agp_version_url(version: str) -> str:
+    return f"{get_agp_releases_url(version)}#fixed-issues-agp-{version}"
+
+
+def parse_agp_release_notes(html: str) -> Dict[str, str]:
+    """Parse AGP release-notes HTML into version → plain-text body."""
+    headings: List[Tuple[str, int, int]] = []
+    for match in _AGP_HEADING_RE.finditer(html):
+        headings.append((match.group(1), match.start(), match.end()))
+    sections: Dict[str, str] = {}
+    for i, (version, _start, end) in enumerate(headings):
+        content_end = headings[i + 1][1] if i + 1 < len(headings) else len(html)
+        body = html_to_text(html[end:content_end])
+        if body:
+            sections[version] = body
+    return sections
+
+
+def is_androidx_artifact(group_id: str) -> bool:
+    return group_id.startswith("androidx.")
+
+
+def get_androidx_slug(group_id: str) -> str:
+    return group_id[len("androidx.") :].replace(".", "-")
+
+
+def get_androidx_releases_url(group_id: str) -> str:
+    return f"{ANDROIDX_RELEASES_BASE}/{get_androidx_slug(group_id)}"
+
+
+def get_androidx_version_url(group_id: str, version: str) -> str:
+    return f"{get_androidx_releases_url(group_id)}#{version}"
+
+
+def parse_androidx_release_notes(html: str) -> Dict[str, str]:
+    """Parse AndroidX release-notes HTML into version → plain-text body."""
+    headings: List[Tuple[str, int, int]] = []
+    for match in _ANDROIDX_VERSION_HEADING_RE.finditer(html):
+        headings.append((match.group(1), match.start(), match.end()))
+    sections: Dict[str, str] = {}
+    for i, (version, _start, end) in enumerate(headings):
+        content_end = headings[i + 1][1] if i + 1 < len(headings) else len(html)
+        body = html_to_text(html[end:content_end])
+        if body:
+            sections[version] = body
+    return sections
+
 
 def _filter_version_range(versions: List[str], from_v: str, to_v: str) -> List[str]:
     """Return versions between from_v (exclusive) and to_v (inclusive)."""
@@ -3517,6 +3627,105 @@ def _filter_version_range(versions: List[str], from_v: str, to_v: str) -> List[s
         if gt_from and le_to:
             result.append(v)
     return result
+
+
+def _changelog_entries_from_sections(
+    sections: Dict[str, str],
+    version_url_fn: Callable[[str], str],
+) -> Dict[str, Dict]:
+    entries: Dict[str, Dict] = {}
+    for version, body in sections.items():
+        entries[version] = {"body": body, "releaseUrl": version_url_fn(version)}
+    return entries
+
+
+def _fetch_agp_changelog(to_version: str) -> Optional[Dict]:
+    """Fetch/parse AGP developer.android.com release notes. None on failure."""
+    url = get_agp_releases_url(to_version)
+    try:
+        status, body = http_get_cached(url, TTL_CHANGELOG_HTML)
+    except Exception:
+        return None
+    if status != 200:
+        return None
+    try:
+        sections = parse_agp_release_notes(body.decode("utf-8", errors="replace"))
+    except Exception:
+        return None
+    if not sections:
+        return None
+    return {
+        "repositoryUrl": url,
+        "entries": _changelog_entries_from_sections(sections, get_agp_version_url),
+    }
+
+
+def _fetch_androidx_changelog(group_id: str) -> Optional[Dict]:
+    """Fetch/parse AndroidX developer.android.com release notes. None on failure."""
+    url = get_androidx_releases_url(group_id)
+    try:
+        status, body = http_get_cached(url, TTL_CHANGELOG_HTML)
+    except Exception:
+        return None
+    if status != 200:
+        return None
+    try:
+        sections = parse_androidx_release_notes(body.decode("utf-8", errors="replace"))
+    except Exception:
+        return None
+    if not sections:
+        return None
+    return {
+        "repositoryUrl": url,
+        "entries": _changelog_entries_from_sections(
+            sections, lambda v: get_androidx_version_url(group_id, v)
+        ),
+    }
+
+
+def _fetch_github_changelog(
+    group_id: str, artifact_id: str, to_version: str, ctx: "ResolutionContext"
+) -> Optional[Dict]:
+    """GitHub releases path (no CHANGELOG.md fallback — intentional Python MVP)."""
+    gh_repo = discover_github_repo(group_id, artifact_id, to_version, ctx)
+    if not gh_repo:
+        return None
+    owner, repo = gh_repo["owner"], gh_repo["repo"]
+    releases = gh_fetch_releases(owner, repo)
+    entries: Dict[str, Dict] = {}
+    for rel in releases:
+        tag = rel.get("tag_name", "")
+        # Strip leading non-digits (v / release- / artifact- prefixes).
+        candidate = re.sub(r"^[^0-9]*", "", tag)
+        key = candidate if candidate else tag
+        entry: Dict = {}
+        if rel.get("html_url"):
+            entry["releaseUrl"] = rel["html_url"]
+        if rel.get("body"):
+            entry["body"] = rel["body"]
+        # Keep bare version keys even without body so range mapping stays stable.
+        entries[key] = entry
+        if tag != key:
+            entries[tag] = entry
+    return {
+        "repositoryUrl": f"https://github.com/{owner}/{repo}",
+        "entries": entries,
+    }
+
+
+def _resolve_changelog(
+    group_id: str, artifact_id: str, to_version: str, ctx: "ResolutionContext"
+) -> Optional[Dict]:
+    """Provider selection: AndroidX → AGP → GitHub (first non-null wins)."""
+    if is_androidx_artifact(group_id):
+        result = _fetch_androidx_changelog(group_id)
+        if result is not None:
+            return result
+    if is_agp_artifact(group_id):
+        result = _fetch_agp_changelog(to_version)
+        if result is not None:
+            return result
+    return _fetch_github_changelog(group_id, artifact_id, to_version, ctx)
 
 
 def _get_dependency_changes_impl(group_id: str, artifact_id: str, from_version: str, to_version: str, ctx: "ResolutionContext") -> Dict:
@@ -3537,42 +3746,32 @@ def _get_dependency_changes_impl(group_id: str, artifact_id: str, from_version: 
     if not versions_in_range:
         return {**base, "error": f"No versions found between {from_version} and {to_version}"}
 
-    gh_repo = discover_github_repo(group_id, artifact_id, to_version, ctx)
-    if not gh_repo:
+    changelog = _resolve_changelog(group_id, artifact_id, to_version, ctx)
+    if not changelog:
         return {**base, "repositoryNotFound": True}
 
-    owner, repo = gh_repo["owner"], gh_repo["repo"]
-    releases = gh_fetch_releases(owner, repo)
-
-    # Build a map from version string to release info
-    release_map: Dict[str, Dict] = {}
-    for rel in releases:
-        tag = rel.get("tag_name", "")
-        # Try to match tag to version: strip leading 'v' or prefix
-        candidate = re.sub(r"^[^0-9]*", "", tag)
-        if candidate in versions_in_range:
-            release_map[candidate] = rel
-        elif tag in versions_in_range:
-            release_map[tag] = rel
-
+    entries = changelog.get("entries") or {}
     changes = []
     for v in versions_in_range:
-        rel = release_map.get(v)
-        if rel:
+        entry = entries.get(v)
+        if entry:
             change = {"version": v}
-            if rel.get("html_url"):
-                change["releaseUrl"] = rel["html_url"]
-            if rel.get("body"):
-                change["body"] = rel["body"]
+            if entry.get("releaseUrl"):
+                change["releaseUrl"] = entry["releaseUrl"]
+            if entry.get("body"):
+                change["body"] = entry["body"]
             changes.append(change)
         else:
             changes.append({"version": v})
 
-    return {
+    out = {
         **base,
-        "repositoryUrl": f"https://github.com/{owner}/{repo}",
+        "repositoryUrl": changelog["repositoryUrl"],
         "changes": changes,
     }
+    if changelog.get("changelogUrl"):
+        out["changelogUrl"] = changelog["changelogUrl"]
+    return out
 
 
 # ---------------------------------------------------------------------------
@@ -6290,7 +6489,7 @@ TOOLS = [
     },
     {
         "name": "get_dependency_changes",
-        "description": "Get changelog/release notes for a dependency between two versions by fetching GitHub releases.",
+        "description": "Get changelog/release notes between two versions (AndroidX/AGP developer docs when applicable, else GitHub releases).",
         "inputSchema": {
             "type": "object",
             "properties": {

--- a/plugins/maven-mcp/plugin/skills/dependency-changes/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/dependency-changes/SKILL.md
@@ -20,11 +20,13 @@ changelog data.
    - `toVersion` (inclusive)
    - optional `projectPath`
 
-   The server discovers the GitHub repo and fetches releases using `GITHUB_TOKEN`
-   server-side when present — never pass the token in headers yourself.
+   Provider order: AndroidX developer docs (for `androidx.*`), AGP release notes
+   (for `com.android.tools.build`), then GitHub releases. `GITHUB_TOKEN` is used
+   server-side for the GitHub path when present — never pass the token in headers
+   yourself.
 
 3. Present the tool result: versions in range, release notes / bodies, links. If notes are
-   sparse, still show the version list plus GitHub releases / Maven Central URLs from the
+   sparse, still show the version list plus docs / GitHub / Maven Central URLs from the
    response. Collapse the middle when many versions are returned.
 
 ## Context: used after check-deps
@@ -34,7 +36,8 @@ current → latest versions from that table without re-asking.
 
 ## Error handling
 
-- **No GitHub repo / no notes** — say so and provide the Maven Central artifact URL.
+- **No docs page / no GitHub repo / no notes** — say so and provide the Maven Central
+  (or Google Maven) artifact URL.
 - **Rate limited** — note the limit; retry via `get_dependency_changes` (server-side token)
   rather than attaching a token to a client request.
 - **Artifact not found** — suggest checking spelling; do not invent changelog text.

--- a/plugins/maven-mcp/tests/test_changelog_providers.py
+++ b/plugins/maven-mcp/tests/test_changelog_providers.py
@@ -1,0 +1,448 @@
+"""AGP/AndroidX changelog providers + html_to_text (#308).
+
+Mirrors the retired TypeScript suites:
+  - src/html/__tests__/to-text.test.ts
+  - src/agp/__tests__/url.test.ts
+  - src/agp/__tests__/release-notes-parser.test.ts
+  - src/androidx/__tests__/url.test.ts
+  - src/androidx/__tests__/release-notes-parser.test.ts
+  - src/changelog/__tests__/agp-provider.test.ts
+  - src/changelog/__tests__/androidx-provider.test.ts
+  - src/changelog/__tests__/resolver.test.ts (provider selection)
+
+Network is faked via urllib.request.urlopen (same seam as the rest of the suite).
+"""
+
+import json
+import unittest
+import unittest.mock
+
+from _helpers import server, mock_urlopen, http_error, empty_ctx
+
+
+def _metadata_xml(versions):
+    body = "".join(f"<version>{v}</version>" for v in versions)
+    return (
+        f"<metadata><versioning><versions>{body}</versions>"
+        f"</versioning></metadata>"
+    ).encode()
+
+
+AGP_HTML = """
+  <h3 id="fixed-issues-agp-8.5.2" data-text="Android Gradle plugin 8.5.2" tabindex="-1">Android Gradle plugin 8.5.2</h3>
+  <p>Fixed critical build issue.</p>
+  <h3 id="fixed-issues-agp-8.5.1" data-text="Android Gradle plugin 8.5.1" tabindex="-1">Android Gradle plugin 8.5.1</h3>
+  <p>Minor improvements.</p>
+  <h3 id="fixed-issues-agp-8.5.0" data-text="Android Gradle plugin 8.5.0" tabindex="-1">Android Gradle plugin 8.5.0</h3>
+  <p>Initial release.</p>
+"""
+
+ANDROIDX_HTML = """
+  <h3 id="1.17.0">Version 1.17.0</h3>
+  <p>New features in core 1.17.0.</p>
+  <h3 id="1.16.0">Version 1.16.0</h3>
+  <p>Bug fixes in core 1.16.0.</p>
+"""
+
+
+# ---------------------------------------------------------------------------
+# html_to_text — mirrors html/__tests__/to-text.test.ts
+# ---------------------------------------------------------------------------
+class HtmlToTextTest(unittest.TestCase):
+    def test_strips_html_tags(self):
+        self.assertEqual(server.html_to_text("<p>Hello <b>world</b></p>"), "Hello world")
+
+    def test_converts_li_to_bullets(self):
+        self.assertEqual(
+            server.html_to_text("<ul><li>First</li><li>Second</li></ul>"),
+            "- First\n- Second",
+        )
+
+    def test_converts_br_to_newline(self):
+        self.assertEqual(server.html_to_text("Line 1<br/>Line 2"), "Line 1\nLine 2")
+
+    def test_unescapes_entities(self):
+        self.assertEqual(
+            server.html_to_text("&lt;T&gt; &amp; &quot;foo&quot;"),
+            '<T> & "foo"',
+        )
+
+    def test_collapses_multiple_newlines(self):
+        self.assertEqual(server.html_to_text("<p>A</p><p>B</p><p>C</p>"), "A\n\nB\n\nC")
+
+    def test_empty_input(self):
+        self.assertEqual(server.html_to_text(""), "")
+
+    def test_preserves_escaped_angle_brackets(self):
+        self.assertIn("<Fragment>", server.html_to_text("Use &lt;Fragment&gt; here"))
+
+
+# ---------------------------------------------------------------------------
+# AGP URL helpers — mirrors agp/__tests__/url.test.ts
+# ---------------------------------------------------------------------------
+class AgpUrlTest(unittest.TestCase):
+    def test_is_agp_artifact(self):
+        self.assertTrue(server.is_agp_artifact("com.android.tools.build"))
+        self.assertFalse(server.is_agp_artifact("androidx.core"))
+        self.assertFalse(server.is_agp_artifact("com.android.tools"))
+
+    def test_releases_url(self):
+        self.assertEqual(
+            server.get_agp_releases_url("8.5.1"),
+            "https://developer.android.com/build/releases/agp-8-5-0-release-notes",
+        )
+        self.assertEqual(
+            server.get_agp_releases_url("9.1.0-alpha03"),
+            "https://developer.android.com/build/releases/agp-9-1-0-release-notes",
+        )
+        self.assertEqual(
+            server.get_agp_releases_url("8.5.0"),
+            "https://developer.android.com/build/releases/agp-8-5-0-release-notes",
+        )
+
+    def test_version_url_anchor(self):
+        self.assertEqual(
+            server.get_agp_version_url("8.5.2"),
+            "https://developer.android.com/build/releases/"
+            "agp-8-5-0-release-notes#fixed-issues-agp-8.5.2",
+        )
+        self.assertEqual(
+            server.get_agp_version_url("9.1.0-rc01"),
+            "https://developer.android.com/build/releases/"
+            "agp-9-1-0-release-notes#fixed-issues-agp-9.1.0-rc01",
+        )
+
+
+# ---------------------------------------------------------------------------
+# AGP parser — mirrors agp/__tests__/release-notes-parser.test.ts
+# ---------------------------------------------------------------------------
+class AgpParserTest(unittest.TestCase):
+    def test_parses_version_sections(self):
+        html = """
+          <h3 id="fixed-issues-agp-8.5.2" data-text="Android Gradle plugin 8.5.2" tabindex="-1">Android Gradle plugin 8.5.2</h3>
+          <p>Bug fixes for 8.5.2.</p>
+          <h3 id="fixed-issues-agp-8.5.1" data-text="Android Gradle plugin 8.5.1" tabindex="-1">Android Gradle plugin 8.5.1</h3>
+          <p>Bug fixes for 8.5.1.</p>
+        """
+        result = server.parse_agp_release_notes(html)
+        self.assertEqual(set(result), {"8.5.2", "8.5.1"})
+        self.assertIn("Bug fixes for 8.5.2", result["8.5.2"])
+        self.assertIn("Bug fixes for 8.5.1", result["8.5.1"])
+
+    def test_prerelease_versions(self):
+        html = """
+          <h3 id="fixed-issues-agp-9.1.0-rc01" data-text="Android Gradle plugin 9.1.0-rc01" tabindex="-1">Android Gradle plugin 9.1.0-rc01</h3>
+          <p>Release candidate fixes.</p>
+        """
+        result = server.parse_agp_release_notes(html)
+        self.assertIn("9.1.0-rc01", result)
+
+    def test_strips_html_from_body(self):
+        html = """
+          <h3 id="fixed-issues-agp-8.5.0" data-text="Android Gradle plugin 8.5.0" tabindex="-1">Android Gradle plugin 8.5.0</h3>
+          <p><b>Important:</b> New <code>dslOption</code> added.</p>
+          <ul><li>Fixed build issue</li></ul>
+        """
+        body = server.parse_agp_release_notes(html)["8.5.0"]
+        self.assertNotIn("<p>", body)
+        self.assertNotIn("<b>", body)
+        self.assertIn("dslOption", body)
+        self.assertIn("Fixed build issue", body)
+
+    def test_ignores_non_agp_h3(self):
+        html = """
+          <h3 class="devsite-footer-linkbox-heading no-link">More Android</h3>
+          <p>Footer content</p>
+          <h3 id="fixed-issues-agp-8.5.0" data-text="Android Gradle plugin 8.5.0" tabindex="-1">Android Gradle plugin 8.5.0</h3>
+          <p>Real release notes.</p>
+        """
+        result = server.parse_agp_release_notes(html)
+        self.assertEqual(set(result), {"8.5.0"})
+
+    def test_empty_cases(self):
+        self.assertEqual(server.parse_agp_release_notes("<h1>Some Page</h1>"), {})
+        self.assertEqual(server.parse_agp_release_notes(""), {})
+
+    def test_section_boundary(self):
+        html = """
+          <h3 id="fixed-issues-agp-8.5.2" data-text="Android Gradle plugin 8.5.2" tabindex="-1">Android Gradle plugin 8.5.2</h3>
+          <p>Notes for 8.5.2</p>
+          <h3 id="fixed-issues-agp-8.5.1" data-text="Android Gradle plugin 8.5.1" tabindex="-1">Android Gradle plugin 8.5.1</h3>
+          <p>Notes for 8.5.1</p>
+        """
+        result = server.parse_agp_release_notes(html)
+        self.assertNotIn("Notes for 8.5.1", result["8.5.2"])
+        self.assertNotIn("Notes for 8.5.2", result["8.5.1"])
+
+
+# ---------------------------------------------------------------------------
+# AndroidX URL helpers — mirrors androidx/__tests__/url.test.ts
+# ---------------------------------------------------------------------------
+class AndroidXUrlTest(unittest.TestCase):
+    def test_is_androidx_artifact(self):
+        self.assertTrue(server.is_androidx_artifact("androidx.core"))
+        self.assertTrue(server.is_androidx_artifact("androidx.compose.material3"))
+        self.assertFalse(server.is_androidx_artifact("io.ktor"))
+        self.assertFalse(server.is_androidx_artifact("com.google.android.material"))
+
+    def test_releases_url_slug(self):
+        self.assertEqual(
+            server.get_androidx_releases_url("androidx.core"),
+            "https://developer.android.com/jetpack/androidx/releases/core",
+        )
+        self.assertEqual(
+            server.get_androidx_releases_url("androidx.compose.material3"),
+            "https://developer.android.com/jetpack/androidx/releases/compose-material3",
+        )
+        self.assertEqual(
+            server.get_androidx_releases_url("androidx.compose.ui"),
+            "https://developer.android.com/jetpack/androidx/releases/compose-ui",
+        )
+        self.assertEqual(
+            server.get_androidx_releases_url("androidx.lifecycle"),
+            "https://developer.android.com/jetpack/androidx/releases/lifecycle",
+        )
+
+    def test_version_url_anchor(self):
+        self.assertEqual(
+            server.get_androidx_version_url("androidx.core", "1.17.0"),
+            "https://developer.android.com/jetpack/androidx/releases/core#1.17.0",
+        )
+
+
+# ---------------------------------------------------------------------------
+# AndroidX parser — mirrors androidx/__tests__/release-notes-parser.test.ts
+# ---------------------------------------------------------------------------
+class AndroidXParserTest(unittest.TestCase):
+    def test_parses_version_sections(self):
+        html = """
+          <h3 id="1.2.0">Version 1.2.0</h3>
+          <p>January 15, 2025</p>
+          <p>Bug fixes and improvements.</p>
+          <ul><li>Fixed crash on startup</li></ul>
+          <h3 id="1.1.0">Version 1.1.0</h3>
+          <p>December 01, 2024</p>
+          <p>New features added.</p>
+        """
+        result = server.parse_androidx_release_notes(html)
+        self.assertEqual(set(result), {"1.2.0", "1.1.0"})
+        self.assertIn("Bug fixes and improvements", result["1.2.0"])
+        self.assertIn("Fixed crash on startup", result["1.2.0"])
+        self.assertIn("New features added", result["1.1.0"])
+
+    def test_prerelease_and_h2(self):
+        html = """
+          <h3 id="1.0.0-alpha01">Version 1.0.0-alpha01</h3>
+          <p>First alpha release.</p>
+          <h2 id="1.5.0">Version 1.5.0</h2>
+          <p>Release notes content.</p>
+        """
+        result = server.parse_androidx_release_notes(html)
+        self.assertIn("1.0.0-alpha01", result)
+        self.assertIn("1.5.0", result)
+
+    def test_strips_tags_preserves_h4_content(self):
+        html = """
+          <h3 id="2.0.0">Version 2.0.0</h3>
+          <p><code>androidx.core:core:2.0.0</code> is released.</p>
+          <h4>Bug Fixes</h4>
+          <p>Fixed a crash.</p>
+        """
+        body = server.parse_androidx_release_notes(html)["2.0.0"]
+        self.assertNotIn("<p>", body)
+        self.assertNotIn("<code>", body)
+        self.assertIn("androidx.core:core:2.0.0", body)
+        self.assertIn("Bug Fixes", body)
+        self.assertIn("Fixed a crash", body)
+
+    def test_empty_and_boundaries(self):
+        self.assertEqual(server.parse_androidx_release_notes(""), {})
+        html = """
+          <h3 id="2.0.0">Version 2.0.0</h3>
+          <p>Second version notes.</p>
+          <h3 id="1.0.0">Version 1.0.0</h3>
+          <p>First version notes.</p>
+        """
+        result = server.parse_androidx_release_notes(html)
+        self.assertNotIn("First version notes", result["2.0.0"])
+        self.assertNotIn("Second version notes", result["1.0.0"])
+
+
+# ---------------------------------------------------------------------------
+# Provider fetch + resolver selection
+# ---------------------------------------------------------------------------
+class AgpProviderTest(unittest.TestCase):
+    def test_fetches_and_parses(self):
+        with unittest.mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, AGP_HTML.encode())]),
+        ):
+            result = server._fetch_agp_changelog("8.5.1")
+        self.assertIsNotNone(result)
+        self.assertIn("agp-8-5-0-release-notes", result["repositoryUrl"])
+        self.assertEqual(set(result["entries"]), {"8.5.2", "8.5.1", "8.5.0"})
+        self.assertIn("Fixed critical build issue", result["entries"]["8.5.2"]["body"])
+        self.assertIn("#fixed-issues-agp-8.5.2", result["entries"]["8.5.2"]["releaseUrl"])
+
+    def test_null_on_http_error_and_empty(self):
+        with unittest.mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([http_error("https://developer.android.com/x", 500)]),
+        ):
+            self.assertIsNone(server._fetch_agp_changelog("8.5.0"))
+        with unittest.mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([http_error("https://developer.android.com/x", 404)]),
+        ):
+            self.assertIsNone(server._fetch_agp_changelog("99.0.0"))
+        with unittest.mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, b"<h1>Empty</h1>")]),
+        ):
+            self.assertIsNone(server._fetch_agp_changelog("8.5.0"))
+
+
+class AndroidXProviderTest(unittest.TestCase):
+    def test_fetches_and_parses(self):
+        html = """
+          <h3 id="1.2.0">Version 1.2.0</h3>
+          <p>New features.</p>
+          <h3 id="1.1.0">Version 1.1.0</h3>
+          <p>Bug fixes.</p>
+        """
+        with unittest.mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, html.encode())]),
+        ):
+            result = server._fetch_androidx_changelog("androidx.core")
+        self.assertIsNotNone(result)
+        self.assertEqual(
+            result["repositoryUrl"],
+            "https://developer.android.com/jetpack/androidx/releases/core",
+        )
+        self.assertEqual(set(result["entries"]), {"1.2.0", "1.1.0"})
+        self.assertIn("New features", result["entries"]["1.2.0"]["body"])
+        self.assertIn("#1.2.0", result["entries"]["1.2.0"]["releaseUrl"])
+
+    def test_null_on_failure(self):
+        with unittest.mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([http_error("https://developer.android.com/x", 404)]),
+        ):
+            self.assertIsNone(server._fetch_androidx_changelog("androidx.core"))
+        with unittest.mock.patch(
+            "urllib.request.urlopen",
+            side_effect=mock_urlopen([(200, b"<h1>Empty Page</h1>")]),
+        ):
+            self.assertIsNone(server._fetch_androidx_changelog("androidx.core"))
+
+
+class ResolveChangelogTest(unittest.TestCase):
+    def test_androidx_preferred_over_github(self):
+        # AndroidX HTML answers; GitHub must not be consulted.
+        responses = [(200, ANDROIDX_HTML.encode())]
+        with unittest.mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen(responses)
+        ) as m:
+            result = server._resolve_changelog(
+                "androidx.core", "core", "1.17.0", empty_ctx()
+            )
+        self.assertIsNotNone(result)
+        self.assertIn("androidx/releases/core", result["repositoryUrl"])
+        self.assertEqual(len(m.call_args_list), 1)
+
+    def test_agp_preferred_over_github(self):
+        responses = [(200, AGP_HTML.encode())]
+        with unittest.mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen(responses)
+        ) as m:
+            result = server._resolve_changelog(
+                "com.android.tools.build", "gradle", "8.5.2", empty_ctx()
+            )
+        self.assertIsNotNone(result)
+        self.assertIn("agp-8-5-0-release-notes", result["repositoryUrl"])
+        self.assertEqual(len(m.call_args_list), 1)
+
+    def test_androidx_falls_through_to_github_on_docs_miss(self):
+        pom = (
+            '<?xml version="1.0"?><project><scm>'
+            "<url>https://github.com/androidx/androidx</url></scm></project>"
+        )
+        releases = [{
+            "tag_name": "1.17.0",
+            "body": "gh notes",
+            "html_url": "https://github.com/androidx/androidx/releases/tag/1.17.0",
+        }]
+        responses = [
+            http_error("https://developer.android.com/x", 404),  # androidx docs
+            (200, pom.encode()),  # discover_github_repo POM
+            (200, json.dumps(releases).encode()),  # gh releases
+        ]
+        with unittest.mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen(responses)
+        ):
+            result = server._resolve_changelog(
+                "androidx.core", "core", "1.17.0", empty_ctx()
+            )
+        self.assertEqual(result["repositoryUrl"], "https://github.com/androidx/androidx")
+        self.assertEqual(result["entries"]["1.17.0"]["body"], "gh notes")
+
+
+class DependencyChangesAgpAndroidXTest(unittest.TestCase):
+    """End-to-end _get_dependency_changes_impl for AGP/AndroidX (#308)."""
+
+    def test_agp_release_notes(self):
+        # AGP routes Google Maven then Central — fetch_metadata queries both.
+        meta = _metadata_xml(["8.5.0", "8.5.1", "8.5.2"])
+        responses = [
+            (200, meta),
+            (200, meta),
+            (200, AGP_HTML.encode()),
+        ]
+        with unittest.mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen(responses)
+        ):
+            result = server._get_dependency_changes_impl(
+                "com.android.tools.build",
+                "gradle",
+                "8.5.0",
+                "8.5.2",
+                empty_ctx(),
+            )
+        self.assertNotIn("error", result)
+        self.assertNotIn("repositoryNotFound", result)
+        self.assertIn("agp-8-5-0-release-notes", result["repositoryUrl"])
+        by_version = {c["version"]: c for c in result["changes"]}
+        self.assertEqual(set(by_version), {"8.5.1", "8.5.2"})
+        self.assertIn("Minor improvements", by_version["8.5.1"]["body"])
+        self.assertIn("#fixed-issues-agp-8.5.1", by_version["8.5.1"]["releaseUrl"])
+        self.assertIn("Fixed critical build issue", by_version["8.5.2"]["body"])
+
+    def test_androidx_release_notes(self):
+        # androidx.* routes Google Maven then Central — fetch_metadata queries both.
+        meta = _metadata_xml(["1.15.0", "1.16.0", "1.17.0"])
+        responses = [
+            (200, meta),
+            (200, meta),
+            (200, ANDROIDX_HTML.encode()),
+        ]
+        with unittest.mock.patch(
+            "urllib.request.urlopen", side_effect=mock_urlopen(responses)
+        ):
+            result = server._get_dependency_changes_impl(
+                "androidx.core", "core", "1.15.0", "1.17.0", empty_ctx()
+            )
+        self.assertNotIn("error", result)
+        self.assertEqual(
+            result["repositoryUrl"],
+            "https://developer.android.com/jetpack/androidx/releases/core",
+        )
+        by_version = {c["version"]: c for c in result["changes"]}
+        self.assertEqual(set(by_version), {"1.16.0", "1.17.0"})
+        self.assertIn("Bug fixes in core 1.16.0", by_version["1.16.0"]["body"])
+        self.assertIn("#1.16.0", by_version["1.16.0"]["releaseUrl"])
+        self.assertIn("New features in core 1.17.0", by_version["1.17.0"]["body"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/maven-mcp/tests/test_github.py
+++ b/plugins/maven-mcp/tests/test_github.py
@@ -10,12 +10,11 @@ urllib.request.urlopen with the _helpers.mock_urlopen sequence builder; the
 patched mock object records the urllib Request objects so URL + header
 assertions read the exact bytes the server sent.
 
-Divergence guardrail (#3): server.py's changelog path is GitHub-releases-ONLY.
-There is no AGP/AndroidX provider and no provider-selection (the TS
-changelog/resolver + agp/androidx providers do not exist in Python), and the
-GitHub path does NOT fall back to a CHANGELOG.md file when no releases match
-(the TS github-provider does). Those behaviours are intentionally NOT tested
-here — only the github-releases path is exercised.
+Provider selection (AndroidX → AGP → GitHub) and the AGP/AndroidX HTML parsers
+live in ``test_changelog_providers.py`` (#308). This module covers the GitHub
+releases branch only. The GitHub path still does NOT fall back to a
+CHANGELOG.md file when no releases match (the retired TS github-provider did) —
+that residual is intentionally out of scope here.
 """
 
 import json
@@ -321,7 +320,7 @@ class TagNormalizationTest(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
-# _get_dependency_changes_impl — GitHub-releases-only changelog path
+# _get_dependency_changes_impl — GitHub releases branch
 # mirrors changelog/__tests__/github-provider.test.ts (github path only)
 # ---------------------------------------------------------------------------
 class DependencyChangesImplTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Port AGP/AndroidX release-notes providers and minimal stdlib `html_to_text` into `server.py` so `get_dependency_changes` is no longer GitHub-releases-only for Android ecosystem coordinates
- Provider order matches the retired TS resolver: AndroidX docs → AGP docs → GitHub releases (docs HTML cached via existing `http_get_cached`, Wave 0 size/retry hardening preserved)
- Add `test_changelog_providers.py` covering parsers, URL helpers, provider fetch, resolver selection, and end-to-end AGP/AndroidX paths

Fixes #308

## Test plan
- [x] `python3 -m unittest discover -s plugins/maven-mcp/tests` (743 OK, 1 skipped)
- [x] `bash scripts/validate.sh`
- [x] `python3 -m compileall plugins/maven-mcp/plugin/server`
- [ ] CI green on the PR


Made with [Cursor](https://cursor.com)