### PR TITLE
Add catalog_entry for Gradle version catalog edits

### DIFF
--- a/plugins/maven-mcp/AGENTS.md
+++ b/plugins/maven-mcp/AGENTS.md
@@ -46,9 +46,36 @@ python3 -m unittest discover -s plugins/maven-mcp/tests -p test_handlers.py
 - **Version compatibility** — `check_version_compatibility` + shipped `compat-matrices.json` (AGP/KGP/javax→jakarta; Spring Boot via `expand_bom`) (#285).
 - **GitHub & changelog** — `gh_repo_exists` / `gh_fetch_repo` / `gh_fetch_releases` / `gh_fetch_user` / `gh_fetch_issue_stats`, `discover_github_repo` (POM SCM → groupId guess), and `_get_dependency_changes_impl` + `_filter_version_range` with provider selection (#308): AndroidX docs → AGP docs → GitHub releases. Minimal stdlib `html_to_text` powers the AGP/AndroidX HTML parsers. GitHub CHANGELOG.md markdown fallback is still not ported.
 - **Vulnerabilities** — OSV.dev batch query (`api.osv.dev/v1/querybatch`).
+- **Version catalog generate/validate** — `generate_catalog_entry` / `validate_catalog` / `handle_catalog_entry` (#288); reuses `_parse_toml_catalog`.
 - **Tool handlers** — `handle_*`, one per MCP tool, plus the stdio JSON-RPC dispatch loop.
 
-**Tools:** `get_latest_version`, `check_version_exists`, `check_multiple_dependencies`, `compare_dependency_versions`, `get_dependency_changes`, `scan_project_dependencies`, `expand_bom`, `get_transitive_graph`, `detect_dependency_conflicts`, `check_version_compatibility`, `get_dependency_vulnerabilities`, `get_dependency_health`, `get_dependency_license`, `search_artifacts`, `audit_project_dependencies`, `verify_coordinates` (see *`verify_coordinates`* below).
+**Tools:** `get_latest_version`, `check_version_exists`, `check_multiple_dependencies`, `compare_dependency_versions`, `get_dependency_changes`, `scan_project_dependencies`, `expand_bom`, `get_transitive_graph`, `detect_dependency_conflicts`, `check_version_compatibility`, `get_dependency_vulnerabilities`, `get_dependency_health`, `get_dependency_license`, `search_artifacts`, `audit_project_dependencies`, `catalog_entry` (see *Version catalog generate/validate* below), `verify_coordinates` (see *`verify_coordinates`* below).
+
+## Version catalog generate/validate (`catalog_entry`, #288)
+
+Gradle has no native command to update version catalogs; agents editing
+`gradle/libs.versions.toml` by hand routinely break kebab→accessor mapping, reserved
+alias segments, and plugin DSL usage. `catalog_entry` is a pure local tool (no network)
+that generates rule-correct entries and validates existing TOML.
+
+**`catalog_entry({mode, coordinate?, kind?, alias?, catalogToml?, buildContent?, catalogPath?, catalogName?, projectPath?})`.**
+
+- **`mode: "generate"`** — from `{groupId, artifactId, version?}` (+ `kind: library|plugin`)
+  returns `{alias, accessor, entry, suggestedDiff, violations?, notes[]}`. Alias is
+  kebab-case, reserved-segment safe, clash-aware against `catalogToml`. Library accessor
+  is `libs.x.y`; plugin accessor is `alias(libs.plugins.x.y)` (never `id(...)`). When the
+  alias already exists and a version is supplied, `suggestedDiff` is a **minimal**
+  `[versions]` bump (or single-line replace), not a full-file rewrite.
+- **`mode: "validate"`** — parses `catalogToml` (or reads `gradle/libs.versions.toml` under
+  `projectPath`) and optional `buildContent`. Reports `violations[{rule, detail}]` for:
+  invalid alias format, reserved names (`extensions`/`class`/`convention`), reserved first
+  segments (`bundles`/`versions`/`plugins`), accessor clashes (`someAlias` vs `some-alias`),
+  undefined `version.ref`, wrong default catalog path, `id(libs.plugins.x)` misuse, and
+  `libs` accessors inside `subprojects {}` / `buildscript {}`.
+
+Reuses `_parse_toml_catalog` (same parser as `scan_project_dependencies`). Does **not**
+change the pre-edit write guard (`pre-edit-deps.sh` / #359 TOML `[plugins]` extraction).
+`/check-deps` skill routes catalog edits through this tool.
 
 ## License intelligence (`get_dependency_license`, #300)
 

--- a/plugins/maven-mcp/README.md
+++ b/plugins/maven-mcp/README.md
@@ -26,6 +26,7 @@ The server registers tools that Claude can call during a conversation. It querie
 | `get_dependency_health` | Assess adoption-worthiness: version/stability, GitHub activity, issue dynamics, license, owner — raw signals for a verdict |
 | `search_artifacts` | Search Maven Central |
 | `audit_project_dependencies` | Full audit: scan + version compare + vulnerability check |
+| `catalog_entry` | Generate/validate Gradle version-catalog entries (`libs.versions.toml`) with rule-correct aliases and minimal diffs |
 | `verify_coordinates` | Tri-state existence check + did-you-mean for hallucinated coordinates |
 
 ### Skills

--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -4122,7 +4122,534 @@ def _parse_toml_catalog(content: str) -> Dict:
                     version = vinline_m.group(1)
             plugins[alias] = {"id": plugin_id, "version": version}
 
-    return {"libraries": libraries, "plugins": plugins}
+    return {"libraries": libraries, "plugins": plugins, "versions": versions}
+
+
+
+# ---------------------------------------------------------------------------
+# Version catalog generate / validate (#288)
+# ---------------------------------------------------------------------------
+# Gradle version catalogs have strict, error-prone rules (no native update
+# command). Agents editing gradle/libs.versions.toml by hand routinely break
+# kebab→camel accessors, reserved alias segments, and plugin DSL usage.
+# catalog_entry generates rule-correct entries and validates existing TOML.
+
+# Alias shape from Gradle docs: [a-z]([a-zA-Z0-9_.\-])*
+_CATALOG_ALIAS_RE = re.compile(r"^[a-z]([a-zA-Z0-9_.\-]*)$")
+# Fully reserved alias names (any section).
+_CATALOG_RESERVED_NAMES = frozenset({"extensions", "class", "convention"})
+# Cannot be the first subgroup of a library/plugin alias (Gradle docs).
+_CATALOG_RESERVED_FIRST_SEGMENTS = frozenset({"bundles", "versions", "plugins"})
+# Conventional default catalog path (Gradle auto-imports this file).
+_DEFAULT_CATALOG_PATH = "gradle/libs.versions.toml"
+
+
+def _catalog_alias_segments(alias: str) -> List[str]:
+    """Split a catalog alias into accessor segments.
+
+    Dashes, underscores, and dots become segment boundaries. camelCase stays
+    as a single segment (Gradle's way to avoid nested subgroup accessors —
+    ``groovyCore`` → ``libs.groovyCore``, not ``libs.groovy.core``).
+    """
+    parts = re.split(r"[-_.]+", alias)
+    return [p for p in parts if p]
+
+
+def _catalog_normalize_accessor_key(alias: str) -> str:
+    """Normalize alias to the type-safe accessor key (dot form, camelCase kept)."""
+    return ".".join(_catalog_alias_segments(alias))
+
+
+def _catalog_clash_key(alias: str) -> str:
+    """Normalized key used to detect accessor name clashes.
+
+    Gradle treats ``someAlias`` and ``some-alias`` as the same accessor
+    (troubleshooting: accessor name clashes). Clash detection therefore splits
+    camelCase in addition to ``-``/``_``/``.``, then lowercases — unlike the
+    emitted accessor string, which preserves camelCase segments.
+    """
+    segments: List[str] = []
+    for part in _catalog_alias_segments(alias):
+        camel_bits = re.sub(r"([a-z0-9])([A-Z])", r"\1\n\2", part).split("\n")
+        segments.extend(b.lower() for b in camel_bits if b)
+    return ".".join(segments)
+
+
+def _to_kebab_catalog_alias(raw: str) -> str:
+    """Convert an artifactId / plugin-id fragment into a kebab-case alias."""
+    s = raw.strip()
+    # Split dotted plugin ids / group-ish names on dots first.
+    s = s.replace(".", "-")
+    # camelCase / PascalCase → kebab
+    s = re.sub(r"([a-z0-9])([A-Z])", r"\1-\2", s)
+    s = s.replace("_", "-")
+    s = re.sub(r"-{2,}", "-", s)
+    s = s.strip("-").lower()
+    # Alias must start with a letter.
+    s = re.sub(r"^[^a-z]+", "", s)
+    s = re.sub(r"[^a-z0-9_.\-]", "", s)
+    return s
+
+
+def _rewrite_reserved_catalog_alias(value: str) -> str:
+    """Rewrite reserved whole-alias names and reserved first subgroups.
+
+    ``extensions`` / ``class`` / ``convention`` are reserved as full alias names
+    (Gradle docs). ``bundles`` / ``versions`` / ``plugins`` cannot be the first
+    subgroup — ``versions-dependency`` becomes ``versionsDependency``.
+    """
+    if not value:
+        return "lib"
+    segs = _catalog_alias_segments(value)
+    if not segs:
+        return "lib"
+    if value in _CATALOG_RESERVED_NAMES or value.lower() in _CATALOG_RESERVED_NAMES:
+        return f"dep-{value}"
+    if segs[0].lower() in _CATALOG_RESERVED_FIRST_SEGMENTS:
+        if len(segs) == 1:
+            return f"dep-{segs[0]}"
+        rest = "".join(s[:1].upper() + s[1:] for s in segs[1:])
+        return segs[0] + rest
+    return value
+
+
+def _sanitize_catalog_alias(alias: str, existing: Optional[set] = None) -> str:
+    """Ensure alias is valid: format, reserved names/segments, unique."""
+    existing = existing or set()
+    candidate = _rewrite_reserved_catalog_alias(alias or "lib")
+    # Enforce alias regex; fall back to stripped kebab.
+    if not _CATALOG_ALIAS_RE.match(candidate):
+        candidate = _to_kebab_catalog_alias(candidate) or "lib"
+        if not _CATALOG_ALIAS_RE.match(candidate):
+            candidate = "lib"
+        candidate = _rewrite_reserved_catalog_alias(candidate)
+        if not _CATALOG_ALIAS_RE.match(candidate):
+            candidate = "lib"
+    # Uniqueness against existing aliases (clash-key aware).
+    base = candidate
+    n = 2
+    existing_norm = {_catalog_clash_key(a) for a in existing}
+    while candidate in existing or _catalog_clash_key(candidate) in existing_norm:
+        candidate = f"{base}-{n}"
+        n += 1
+    return candidate
+
+
+def _suggest_library_alias(group_id: str, artifact_id: str, existing: Optional[set] = None) -> str:
+    raw = _to_kebab_catalog_alias(artifact_id) or _to_kebab_catalog_alias(group_id.split(".")[-1])
+    return _sanitize_catalog_alias(raw, existing)
+
+
+def _suggest_plugin_alias(plugin_id: str, existing: Optional[set] = None) -> str:
+    parts = [p for p in plugin_id.split(".") if p]
+    if len(parts) >= 2:
+        raw = _to_kebab_catalog_alias("-".join(parts[-2:]))
+    else:
+        raw = _to_kebab_catalog_alias(plugin_id)
+    return _sanitize_catalog_alias(raw, existing)
+
+
+def _library_accessor(alias: str, catalog_name: str = "libs") -> str:
+    return f"{catalog_name}.{_catalog_normalize_accessor_key(alias)}"
+
+
+def _plugin_accessor(alias: str, catalog_name: str = "libs") -> str:
+    # Plugins MUST be applied via alias(...), never id(libs.plugins...).
+    return f"alias({catalog_name}.plugins.{_catalog_normalize_accessor_key(alias)})"
+
+
+def _plugin_id_from_coordinate(group_id: str, artifact_id: str) -> str:
+    """Derive a Gradle plugin id from a Maven-ish coordinate."""
+    if artifact_id.endswith(".gradle.plugin"):
+        # Marker artifact: {id}:{id}.gradle.plugin
+        return group_id
+    if artifact_id == group_id:
+        return group_id
+    # Prefer a dotted artifactId when it looks like a plugin id.
+    if "." in artifact_id and not artifact_id.endswith((".jar", ".pom")):
+        return artifact_id
+    return group_id
+
+
+def _extract_version_refs(content: str) -> List[Dict[str, str]]:
+    """Return raw version.ref usages with section + alias (unresolved)."""
+    refs: List[Dict[str, str]] = []
+    for section in ("libraries", "plugins"):
+        m = re.search(rf"\[{section}\]([\s\S]*?)(?=\n\[|$)", content)
+        if not m:
+            continue
+        for lm in re.finditer(r"^(\S+)\s*=\s*\{([^}]+)\}", m.group(1), re.MULTILINE):
+            alias = lm.group(1)
+            vref = re.search(r'version\.ref\s*=\s*"([^"]+)"', lm.group(2))
+            if vref:
+                refs.append({"section": section, "alias": alias, "versionRef": vref.group(1)})
+    return refs
+
+
+def _validate_alias_name(alias: str, section: str) -> List[Dict[str, str]]:
+    """Validate one catalog alias; return violation dicts."""
+    violations: List[Dict[str, str]] = []
+    if not _CATALOG_ALIAS_RE.match(alias):
+        violations.append({
+            "rule": "invalid_alias_format",
+            "detail": (
+                f"{section} alias {alias!r} does not match "
+                f"[a-z]([a-zA-Z0-9_.-])* required by Gradle version catalogs"
+            ),
+        })
+    if alias in _CATALOG_RESERVED_NAMES or alias.lower() in _CATALOG_RESERVED_NAMES:
+        violations.append({
+            "rule": "reserved_alias",
+            "detail": (
+                f"{section} alias {alias!r} is reserved "
+                f"(extensions/class/convention cannot be used as aliases)"
+            ),
+        })
+    segs = _catalog_alias_segments(alias)
+    if segs and segs[0].lower() in _CATALOG_RESERVED_FIRST_SEGMENTS:
+        violations.append({
+            "rule": "reserved_first_segment",
+            "detail": (
+                f"{section} alias {alias!r} starts with reserved subgroup "
+                f"{segs[0]!r}; bundles/versions/plugins cannot be the first "
+                f"segment (use e.g. versionsDependency or dependency-versions)"
+            ),
+        })
+    return violations
+
+
+def generate_catalog_entry(
+    group_id: str,
+    artifact_id: str,
+    version: Optional[str] = None,
+    kind: str = "library",
+    catalog_toml: Optional[str] = None,
+    catalog_name: str = "libs",
+    alias: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Generate a rule-correct catalog entry + minimal diff suggestion (#288)."""
+    kind = kind if kind in ("library", "plugin") else "library"
+    parsed = _parse_toml_catalog(catalog_toml or "")
+    existing_lib = set(parsed.get("libraries") or {})
+    existing_plugin = set(parsed.get("plugins") or {})
+    existing_versions = set((parsed.get("versions") or {}).keys())
+    existing = existing_plugin if kind == "plugin" else existing_lib
+
+    # Preferred alias before uniqueness suffix — used to detect version bumps
+    # against an existing catalog entry (do not invent alias-2 when bumping).
+    if kind == "plugin":
+        plugin_id = _plugin_id_from_coordinate(group_id, artifact_id)
+        preferred_raw = alias or _to_kebab_catalog_alias(
+            "-".join([p for p in plugin_id.split(".") if p][-2:])
+            if len([p for p in plugin_id.split(".") if p]) >= 2
+            else plugin_id
+        )
+    else:
+        plugin_id = None
+        preferred_raw = alias or (
+            _to_kebab_catalog_alias(artifact_id)
+            or _to_kebab_catalog_alias(group_id.split(".")[-1])
+        )
+    preferred = _sanitize_catalog_alias(preferred_raw, existing=set())
+    bump_existing = bool(catalog_toml and version and preferred in existing)
+    chosen = preferred if bump_existing else _sanitize_catalog_alias(preferred_raw, existing)
+
+    if kind == "plugin":
+        accessor = _plugin_accessor(chosen, catalog_name)
+        version_key = _sanitize_catalog_alias(
+            _to_kebab_catalog_alias(chosen) or chosen, existing_versions
+        )
+        if version:
+            lib_line = f'{chosen} = {{ id = "{plugin_id}", version.ref = "{version_key}" }}'
+            ver_line = f'{version_key} = "{version}"'
+            entry_toml = f"[versions]\n{ver_line}\n\n[plugins]\n{lib_line}\n"
+            suggested = (
+                f"# Minimal addition to {_DEFAULT_CATALOG_PATH}\n"
+                f"[versions]\n{ver_line}\n\n[plugins]\n{lib_line}\n\n"
+                f"# Apply in plugins {{ }} with:\n# {accessor}\n"
+                f"# Do NOT write id({catalog_name}.plugins.{_catalog_normalize_accessor_key(chosen)})\n"
+            )
+        else:
+            lib_line = f'{chosen} = {{ id = "{plugin_id}" }}'
+            ver_line = None
+            entry_toml = f"[plugins]\n{lib_line}\n"
+            suggested = (
+                f"# Minimal addition to {_DEFAULT_CATALOG_PATH}\n"
+                f"[plugins]\n{lib_line}\n\n"
+                f"# Apply in plugins {{ }} with:\n# {accessor}\n"
+            )
+        entry = {
+            "section": "plugins",
+            "alias": chosen,
+            "id": plugin_id,
+            "version": version,
+            "versionRef": version_key if version else None,
+            "tomlLine": lib_line,
+            "versionLine": ver_line,
+        }
+    else:
+        accessor = _library_accessor(chosen, catalog_name)
+        version_key = _sanitize_catalog_alias(
+            _to_kebab_catalog_alias(chosen) or chosen, existing_versions
+        )
+        module = f"{group_id}:{artifact_id}"
+        if version:
+            lib_line = f'{chosen} = {{ module = "{module}", version.ref = "{version_key}" }}'
+            ver_line = f'{version_key} = "{version}"'
+            entry_toml = f"[versions]\n{ver_line}\n\n[libraries]\n{lib_line}\n"
+            suggested = (
+                f"# Minimal addition to {_DEFAULT_CATALOG_PATH}\n"
+                f"[versions]\n{ver_line}\n\n[libraries]\n{lib_line}\n\n"
+                f"# Use in dependencies {{ }}:\n# implementation({accessor})\n"
+            )
+        else:
+            lib_line = f'{chosen} = {{ module = "{module}" }}'
+            ver_line = None
+            entry_toml = f"[libraries]\n{lib_line}\n"
+            suggested = (
+                f"# Minimal addition to {_DEFAULT_CATALOG_PATH}\n"
+                f"[libraries]\n{lib_line}\n\n"
+                f"# Use in dependencies {{ }}:\n# implementation({accessor})\n"
+            )
+        entry = {
+            "section": "libraries",
+            "alias": chosen,
+            "groupId": group_id,
+            "artifactId": artifact_id,
+            "version": version,
+            "versionRef": version_key if version else None,
+            "tomlLine": lib_line,
+            "versionLine": ver_line,
+        }
+
+    # If the alias already exists in the provided catalog, prefer a version-only bump.
+    if bump_existing:
+        bump_lines = []
+        # Prefer bumping version.ref target when present in raw TOML.
+        section = "plugins" if kind == "plugin" else "libraries"
+        raw_refs = [r for r in _extract_version_refs(catalog_toml) if r["alias"] == chosen and r["section"] == section]
+        if raw_refs:
+            vref = raw_refs[0]["versionRef"]
+            bump_lines.append(f'# Update existing [versions] key only\n{vref} = "{version}"')
+            suggested = "\n".join(bump_lines) + "\n"
+            entry["updateKind"] = "version_ref_bump"
+            entry["versionRef"] = vref
+        else:
+            # Inline version in the table/shorthand — replace just the version literal on that alias line.
+            bump_lines.append(f"# Update version on existing [{section}] alias {chosen!r}")
+            bump_lines.append(entry["tomlLine"])
+            suggested = "\n".join(bump_lines) + "\n"
+            entry["updateKind"] = "inline_or_line_replace"
+        entry["tomlSnippet"] = suggested
+    else:
+        entry["updateKind"] = "add"
+        entry["tomlSnippet"] = entry_toml
+
+    # Report when a caller-supplied alias had to be rewritten; chosen alias is
+    # always rule-correct so we do not re-emit validate findings against it.
+    alias_violations: List[Dict[str, str]] = []
+    if alias and alias != chosen:
+        alias_violations.append({
+            "rule": "alias_sanitized",
+            "detail": f"requested alias {alias!r} was adjusted to valid alias {chosen!r}",
+        })
+        alias_violations.extend(_validate_alias_name(alias, entry["section"]))
+
+    return {
+        "alias": chosen,
+        "accessor": accessor,
+        "entry": entry,
+        "suggestedDiff": suggested,
+        "violations": alias_violations,
+        "catalogPath": _DEFAULT_CATALOG_PATH,
+        "notes": [
+            "Gradle has no built-in command to update version catalogs; apply the minimal diff manually.",
+            "Plugin catalog entries must be applied with alias(libs.plugins.*), never id(libs.plugins.*).",
+            "Type-safe catalog accessors are not available inside subprojects {} or buildscript {} blocks.",
+        ],
+    }
+
+
+def validate_catalog(
+    catalog_toml: str,
+    build_content: Optional[str] = None,
+    catalog_path: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Validate catalog TOML (+ optional build script text) against Gradle rules (#288)."""
+    violations: List[Dict[str, str]] = []
+    if catalog_path:
+        norm = catalog_path.replace("\\", "/").lstrip("./")
+        base = os.path.basename(norm)
+        # Default catalog must be exactly gradle/libs.versions.toml; other
+        # *.versions.toml files are valid only when registered in settings.
+        if base == "libs.versions.toml" and norm != _DEFAULT_CATALOG_PATH and not norm.endswith(
+            "/" + _DEFAULT_CATALOG_PATH
+        ):
+            violations.append({
+                "rule": "catalog_path",
+                "detail": (
+                    f"default catalog filename must be {_DEFAULT_CATALOG_PATH!r} "
+                    f"(Gradle auto-imports only that path); got {catalog_path!r}"
+                ),
+            })
+        elif not base.endswith(".versions.toml"):
+            violations.append({
+                "rule": "catalog_path",
+                "detail": (
+                    f"catalog file {catalog_path!r} should use a "
+                    f"*.versions.toml basename (convention: {_DEFAULT_CATALOG_PATH})"
+                ),
+            })
+
+    parsed = _parse_toml_catalog(catalog_toml or "")
+    versions = parsed.get("versions") or {}
+    libraries = parsed.get("libraries") or {}
+    plugins = parsed.get("plugins") or {}
+
+    for alias in libraries:
+        violations.extend(_validate_alias_name(alias, "libraries"))
+    for alias in plugins:
+        violations.extend(_validate_alias_name(alias, "plugins"))
+    for alias in versions:
+        # Version aliases share the same naming rules / reserved words.
+        violations.extend(_validate_alias_name(alias, "versions"))
+
+    # Accessor clashes: someAlias vs some-alias share one clash key.
+    for section_name, table in (("libraries", libraries), ("plugins", plugins), ("versions", versions)):
+        by_key: Dict[str, List[str]] = {}
+        for alias in table:
+            by_key.setdefault(_catalog_clash_key(alias), []).append(alias)
+        for key, aliases in by_key.items():
+            if len(aliases) > 1:
+                violations.append({
+                    "rule": "accessor_clash",
+                    "detail": (
+                        f"{section_name} aliases {aliases!r} normalize to the same "
+                        f"accessor clash key {key!r}"
+                    ),
+                })
+
+    for ref in _extract_version_refs(catalog_toml or ""):
+        if ref["versionRef"] not in versions:
+            violations.append({
+                "rule": "undefined_version_ref",
+                "detail": (
+                    f"{ref['section']} alias {ref['alias']!r} references missing "
+                    f"version {ref['versionRef']!r}"
+                ),
+            })
+
+    if build_content:
+        # id(libs.plugins.x) is invalid — must use alias(libs.plugins.x).
+        for m in re.finditer(
+            r"\bid\s*\(\s*([a-zA-Z_][a-zA-Z0-9_]*)\.plugins\.([a-zA-Z0-9.]+)\s*\)",
+            build_content,
+        ):
+            catalog = m.group(1)
+            plugin_acc = m.group(2)
+            violations.append({
+                "rule": "plugin_id_accessor_misuse",
+                "detail": (
+                    f"found id({catalog}.plugins.{plugin_acc}) — use "
+                    f"alias({catalog}.plugins.{plugin_acc}) instead"
+                ),
+            })
+        # Catalog accessors are not available in subprojects { } / buildscript { }.
+        for block_name in ("subprojects", "buildscript"):
+            found = _find_block(build_content, block_name, 0)
+            # _find_block may only find one; scan all occurrences.
+            pos = 0
+            while True:
+                found = _find_block(build_content, block_name, pos)
+                if not found:
+                    break
+                body, start, end = found
+                if re.search(r"\blibs\.[a-zA-Z_]", body) or re.search(
+                    r"\balias\s*\(\s*libs\.", body
+                ):
+                    violations.append({
+                        "rule": "libs_accessor_unavailable_in_block",
+                        "detail": (
+                            f"type-safe libs accessors are not available inside "
+                            f"{block_name} {{ }}; move catalog usage to the root "
+                            f"project or a regular subproject build script"
+                        ),
+                    })
+                    break
+                pos = end
+
+    return {
+        "violations": violations,
+        "aliasCount": {
+            "versions": len(versions),
+            "libraries": len(libraries),
+            "plugins": len(plugins),
+        },
+        "catalogPath": catalog_path or _DEFAULT_CATALOG_PATH,
+    }
+
+
+def handle_catalog_entry(args: Dict) -> Any:
+    """MCP handler for catalog_entry (#288) — generate or validate catalog edits."""
+    mode = args.get("mode") or "generate"
+    if mode not in ("generate", "validate"):
+        return {
+            "error": f"mode must be 'generate' or 'validate', got {mode!r}",
+            "violations": [{"rule": "invalid_mode", "detail": f"unsupported mode {mode!r}"}],
+        }
+
+    catalog_toml = args.get("catalogToml")
+    if catalog_toml is not None and not isinstance(catalog_toml, str):
+        catalog_toml = str(catalog_toml)
+
+    if mode == "validate":
+        build_content = args.get("buildContent")
+        if build_content is not None and not isinstance(build_content, str):
+            build_content = str(build_content)
+        catalog_path = args.get("catalogPath")
+        if not catalog_toml and args.get("projectPath"):
+            # Convenience: read default catalog from project when TOML omitted.
+            root = args.get("projectPath") or os.getcwd()
+            candidate = os.path.join(root, _DEFAULT_CATALOG_PATH)
+            if os.path.isfile(candidate):
+                with open(candidate, encoding="utf-8") as fh:
+                    catalog_toml = fh.read()
+                catalog_path = catalog_path or _DEFAULT_CATALOG_PATH
+        if catalog_toml is None:
+            return {
+                "error": "validate mode requires catalogToml (or a projectPath with gradle/libs.versions.toml)",
+                "violations": [{
+                    "rule": "missing_catalog",
+                    "detail": "catalogToml is required for validate when the default catalog file is absent",
+                }],
+            }
+        return validate_catalog(catalog_toml, build_content=build_content, catalog_path=catalog_path)
+
+    # generate
+    coord = args.get("coordinate") or {}
+    if not isinstance(coord, dict):
+        return {
+            "error": "coordinate must be an object with groupId and artifactId",
+            "violations": [{"rule": "missing_coordinate", "detail": "coordinate is required for generate"}],
+        }
+    group_id = coord.get("groupId")
+    artifact_id = coord.get("artifactId")
+    version = coord.get("version")
+    if not group_id or not artifact_id:
+        return {
+            "error": "coordinate.groupId and coordinate.artifactId are required for generate",
+            "violations": [{"rule": "missing_coordinate", "detail": "groupId and artifactId are required"}],
+        }
+    kind = args.get("kind") or "library"
+    return generate_catalog_entry(
+        group_id=group_id,
+        artifact_id=artifact_id,
+        version=version,
+        kind=kind if isinstance(kind, str) else "library",
+        catalog_toml=catalog_toml,
+        catalog_name=args.get("catalogName") or "libs",
+        alias=args.get("alias"),
+    )
 
 
 def _parse_gradle_deps(content: str, source_file: str) -> List[Dict]:
@@ -6689,6 +7216,60 @@ TOOLS = [
         },
     },
     {
+        "name": "catalog_entry",
+        "description": "Generate or validate Gradle version-catalog (libs.versions.toml) entries. mode=generate builds a rule-correct [versions]/[libraries]/[plugins] snippet with kebab alias + libs/alias(libs.plugins.*) accessor; mode=validate flags reserved aliases, invalid first subgroups, undefined version.ref, accessor clashes, id(libs.plugins.*) misuse, and libs usage inside subprojects/buildscript. Returns a minimal diff suggestion, not a full file rewrite.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "mode": {
+                    "type": "string",
+                    "enum": ["generate", "validate"],
+                    "description": "generate a catalog entry from a coordinate, or validate catalog TOML (+ optional build script text).",
+                },
+                "coordinate": {
+                    "type": "object",
+                    "description": "Required for generate. Maven GAV or plugin marker coordinate.",
+                    "properties": {
+                        "groupId": {"type": "string"},
+                        "artifactId": {"type": "string"},
+                        "version": {"type": "string"},
+                    },
+                    "required": ["groupId", "artifactId"],
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": ["library", "plugin"],
+                    "description": "Entry kind for generate. Default: library.",
+                },
+                "alias": {
+                    "type": "string",
+                    "description": "Optional preferred alias for generate; sanitized if it violates catalog rules.",
+                },
+                "catalogToml": {
+                    "type": "string",
+                    "description": "Existing libs.versions.toml content. Used by validate; for generate, avoids alias clashes and enables version-only bump suggestions.",
+                },
+                "buildContent": {
+                    "type": "string",
+                    "description": "Optional build script text for validate — detects id(libs.plugins.*) misuse and libs accessors inside subprojects/buildscript.",
+                },
+                "catalogPath": {
+                    "type": "string",
+                    "description": "Optional path of the catalog file for validate path-convention checks (default gradle/libs.versions.toml).",
+                },
+                "catalogName": {
+                    "type": "string",
+                    "description": "Catalog accessor prefix for generate (default libs).",
+                },
+                "projectPath": {
+                    "type": "string",
+                    "description": "Optional project root. In validate mode, reads gradle/libs.versions.toml when catalogToml is omitted.",
+                },
+            },
+            "required": ["mode"],
+        },
+    },
+    {
         "name": "verify_coordinates",
         "description": "Verify whether Maven coordinates exist (tri-state: exists / absent / unknown) and, for absent ones, suggest the closest real coordinates. Detects hallucinated / slopsquat-shaped names an LLM may invent. Existence is NOT a safety guarantee: a published typosquat reports exists and is not flagged. Suggestions are candidates to verify, not endorsements.",
         "inputSchema": {
@@ -6731,6 +7312,7 @@ TOOL_HANDLERS = {
     "get_dependency_license": handle_get_dependency_license,
     "search_artifacts": handle_search_artifacts,
     "audit_project_dependencies": handle_audit_project_dependencies,
+    "catalog_entry": handle_catalog_entry,
     "verify_coordinates": handle_verify_coordinates,
 }
 

--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -4556,14 +4556,12 @@ def validate_catalog(
             })
         # Catalog accessors are not available in subprojects { } / buildscript { }.
         for block_name in ("subprojects", "buildscript"):
-            found = _find_block(build_content, block_name, 0)
-            # _find_block may only find one; scan all occurrences.
             pos = 0
             while True:
                 found = _find_block(build_content, block_name, pos)
                 if not found:
                     break
-                body, start, end = found
+                body, _start, end = found
                 if re.search(r"\blibs\.[a-zA-Z_]", body) or re.search(
                     r"\balias\s*\(\s*libs\.", body
                 ):

--- a/plugins/maven-mcp/plugin/skills/check-deps/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/check-deps/SKILL.md
@@ -71,6 +71,29 @@ Apply only the groups the user confirms. Touch only version values:
 - Module direct / Plugin DSL / Buildscript — inline version string in the build file
 - pom.xml — `<version>` inside the matching `<dependency>`
 
+### Catalog-aware edits (`catalog_entry`, #288)
+
+Gradle has **no** built-in command to update `gradle/libs.versions.toml`. Before adding
+or renaming catalog aliases, call **`catalog_entry`**:
+
+- **Upgrade existing alias** — `mode: "generate"` with the same alias + new `version` and
+  the current `catalogToml`. Prefer the returned `suggestedDiff` (usually a single
+  `[versions]` key bump). Do not rewrite the whole file.
+- **Add a library/plugin** — `mode: "generate"` with `coordinate` + `kind`. Use the
+  returned `alias` / `accessor` / `suggestedDiff` as-is (kebab-case alias, reserved-segment
+  safe, `libs.x` or `alias(libs.plugins.x)`).
+- **Sanity-check before/after** — `mode: "validate"` with `catalogToml` and, when editing
+  build scripts, `buildContent`. Fix any `violations` (reserved aliases, invalid first
+  subgroups, `id(libs.plugins.x)` misuse, `libs` inside `subprojects {}` / `buildscript {}`).
+
+Hard rules when editing catalogs by hand:
+
+- Default catalog path is exactly `gradle/libs.versions.toml`.
+- Plugins: `alias(libs.plugins…)` — never `id(libs.plugins…)`.
+- Do not use reserved aliases (`extensions` / `class` / `convention`) or first segments
+  `bundles` / `versions` / `plugins` (e.g. `versions-foo` is invalid; `versionsFoo` or
+  `foo-versions` is fine).
+
 ## Step 5 — Build verification
 
 After every edit pass:

--- a/plugins/maven-mcp/tests/test_catalog_entry.py
+++ b/plugins/maven-mcp/tests/test_catalog_entry.py
@@ -1,0 +1,279 @@
+"""Tests for catalog_entry generate/validate (#288).
+
+Covers Gradle version-catalog rules: kebab→accessor mapping, reserved alias
+names/first segments, plugin alias() vs id() misuse, and minimal diffs.
+"""
+
+import os
+import tempfile
+import unittest
+
+from _helpers import server
+
+
+class CatalogAliasHelpersTest(unittest.TestCase):
+    def test_kebab_to_accessor_mapping(self):
+        self.assertEqual(
+            server._catalog_normalize_accessor_key("ktor-client-core"),
+            "ktor.client.core",
+        )
+        self.assertEqual(server._library_accessor("ktor-client-core"), "libs.ktor.client.core")
+        self.assertEqual(
+            server._plugin_accessor("kotlin-android"),
+            "alias(libs.plugins.kotlin.android)",
+        )
+
+    def test_camel_case_avoids_subgroup(self):
+        # groovyCore → libs.groovyCore (single segment), not libs.groovy.core
+        self.assertEqual(server._catalog_normalize_accessor_key("groovyCore"), "groovyCore")
+        self.assertEqual(server._library_accessor("groovyCore"), "libs.groovyCore")
+
+    def test_clash_key_merges_camel_and_kebab(self):
+        self.assertEqual(server._catalog_clash_key("someAlias"), "some.alias")
+        self.assertEqual(server._catalog_clash_key("some-alias"), "some.alias")
+
+    def test_sanitize_rewrites_reserved_first_segment(self):
+        # versions-dependency → versionsDependency (docs-approved form)
+        self.assertEqual(
+            server._sanitize_catalog_alias("versions-dependency"),
+            "versionsDependency",
+        )
+        self.assertEqual(server._sanitize_catalog_alias("plugins"), "dep-plugins")
+        self.assertEqual(server._sanitize_catalog_alias("class"), "dep-class")
+
+
+class CatalogGenerateTest(unittest.TestCase):
+    def test_generate_library_kebab_alias_and_accessor(self):
+        result = server.handle_catalog_entry({
+            "mode": "generate",
+            "kind": "library",
+            "coordinate": {
+                "groupId": "io.ktor",
+                "artifactId": "ktor-client-core",
+                "version": "3.1.0",
+            },
+        })
+        self.assertEqual(result["alias"], "ktor-client-core")
+        self.assertEqual(result["accessor"], "libs.ktor.client.core")
+        self.assertEqual(result["entry"]["section"], "libraries")
+        self.assertEqual(result["entry"]["updateKind"], "add")
+        self.assertIn('ktor-client-core = "3.1.0"', result["suggestedDiff"])
+        self.assertIn(
+            'ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor-client-core" }',
+            result["suggestedDiff"],
+        )
+        self.assertIn("implementation(libs.ktor.client.core)", result["suggestedDiff"])
+        # Minimal snippet — not a full-file rewrite of unrelated sections.
+        self.assertNotIn("[bundles]", result["suggestedDiff"])
+
+    def test_generate_plugin_uses_alias_accessor(self):
+        result = server.handle_catalog_entry({
+            "mode": "generate",
+            "kind": "plugin",
+            "coordinate": {
+                "groupId": "org.jetbrains.kotlin.android",
+                "artifactId": "org.jetbrains.kotlin.android.gradle.plugin",
+                "version": "2.0.21",
+            },
+        })
+        self.assertEqual(result["alias"], "kotlin-android")
+        self.assertEqual(result["accessor"], "alias(libs.plugins.kotlin.android)")
+        self.assertEqual(result["entry"]["id"], "org.jetbrains.kotlin.android")
+        self.assertIn("alias(libs.plugins.kotlin.android)", result["suggestedDiff"])
+        self.assertIn("Do NOT write id(libs.plugins.kotlin.android)", result["suggestedDiff"])
+
+    def test_generate_sanitizes_reserved_alias(self):
+        result = server.handle_catalog_entry({
+            "mode": "generate",
+            "kind": "library",
+            "alias": "versions-dependency",
+            "coordinate": {
+                "groupId": "org.sample",
+                "artifactId": "lib",
+                "version": "1.0",
+            },
+        })
+        self.assertEqual(result["alias"], "versionsDependency")
+        self.assertEqual(result["accessor"], "libs.versionsDependency")
+        rules = {v["rule"] for v in result["violations"]}
+        self.assertIn("alias_sanitized", rules)
+        self.assertIn("reserved_first_segment", rules)
+
+    def test_generate_version_ref_bump_is_minimal(self):
+        catalog = (
+            "[versions]\n"
+            'ktor = "3.0.0"\n'
+            "\n"
+            "[libraries]\n"
+            'ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }\n'
+        )
+        result = server.handle_catalog_entry({
+            "mode": "generate",
+            "kind": "library",
+            "alias": "ktor-client-core",
+            "catalogToml": catalog,
+            "coordinate": {
+                "groupId": "io.ktor",
+                "artifactId": "ktor-client-core",
+                "version": "3.1.0",
+            },
+        })
+        self.assertEqual(result["entry"]["updateKind"], "version_ref_bump")
+        self.assertEqual(
+            result["suggestedDiff"].strip(),
+            '# Update existing [versions] key only\nktor = "3.1.0"',
+        )
+        self.assertNotIn("[libraries]", result["suggestedDiff"])
+
+    def test_generate_avoids_existing_alias_clash(self):
+        catalog = (
+            "[libraries]\n"
+            'ktor-client-core = { module = "io.ktor:ktor-client-core", version = "3.0.0" }\n'
+        )
+        result = server.handle_catalog_entry({
+            "mode": "generate",
+            "kind": "library",
+            "catalogToml": catalog,
+            "coordinate": {
+                "groupId": "io.ktor",
+                "artifactId": "ktor-client-core",
+                "version": "3.1.0",
+            },
+        })
+        # Existing alias → version bump path (same alias), not a second clashing alias.
+        self.assertEqual(result["alias"], "ktor-client-core")
+        self.assertEqual(result["entry"]["updateKind"], "inline_or_line_replace")
+
+
+class CatalogValidateTest(unittest.TestCase):
+    def test_validate_flags_reserved_and_first_segment(self):
+        result = server.handle_catalog_entry({
+            "mode": "validate",
+            "catalogToml": (
+                "[libraries]\n"
+                'versions-dependency = { module = "org.sample:lib", version = "1.0" }\n'
+                'class = { module = "org.sample:x", version = "1.0" }\n'
+            ),
+            "catalogPath": "gradle/libs.versions.toml",
+        })
+        rules = {v["rule"] for v in result["violations"]}
+        self.assertIn("reserved_first_segment", rules)
+        self.assertIn("reserved_alias", rules)
+
+    def test_validate_flags_accessor_clash(self):
+        result = server.handle_catalog_entry({
+            "mode": "validate",
+            "catalogToml": (
+                "[libraries]\n"
+                'someAlias = { module = "org.sample:a", version = "1.0" }\n'
+                'some-alias = { module = "org.sample:b", version = "2.0" }\n'
+            ),
+        })
+        rules = {v["rule"] for v in result["violations"]}
+        self.assertIn("accessor_clash", rules)
+
+    def test_validate_flags_undefined_version_ref(self):
+        result = server.handle_catalog_entry({
+            "mode": "validate",
+            "catalogToml": (
+                "[libraries]\n"
+                'lib = { module = "org.sample:lib", version.ref = "missing" }\n'
+            ),
+        })
+        rules = {v["rule"] for v in result["violations"]}
+        self.assertIn("undefined_version_ref", rules)
+
+    def test_validate_flags_plugin_id_misuse(self):
+        result = server.handle_catalog_entry({
+            "mode": "validate",
+            "catalogToml": (
+                "[plugins]\n"
+                'android = { id = "com.android.application", version = "8.7.0" }\n'
+            ),
+            "buildContent": 'plugins {\n    id(libs.plugins.android)\n}\n',
+        })
+        rules = {v["rule"] for v in result["violations"]}
+        self.assertIn("plugin_id_accessor_misuse", rules)
+        detail = next(v["detail"] for v in result["violations"] if v["rule"] == "plugin_id_accessor_misuse")
+        self.assertIn("alias(libs.plugins.android)", detail)
+
+    def test_validate_flags_libs_in_subprojects(self):
+        result = server.handle_catalog_entry({
+            "mode": "validate",
+            "catalogToml": "[libraries]\n",
+            "buildContent": (
+                "subprojects {\n"
+                "    dependencies {\n"
+                "        implementation(libs.foo.bar)\n"
+                "    }\n"
+                "}\n"
+            ),
+        })
+        rules = {v["rule"] for v in result["violations"]}
+        self.assertIn("libs_accessor_unavailable_in_block", rules)
+
+    def test_validate_flags_wrong_default_catalog_path(self):
+        result = server.handle_catalog_entry({
+            "mode": "validate",
+            "catalogToml": "[libraries]\n",
+            "catalogPath": "libs.versions.toml",
+        })
+        rules = {v["rule"] for v in result["violations"]}
+        self.assertIn("catalog_path", rules)
+
+    def test_validate_clean_catalog(self):
+        result = server.handle_catalog_entry({
+            "mode": "validate",
+            "catalogToml": (
+                "[versions]\n"
+                'ktor = "3.1.0"\n'
+                "\n"
+                "[libraries]\n"
+                'ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }\n'
+                "\n"
+                "[plugins]\n"
+                'android-application = { id = "com.android.application", version = "8.7.0" }\n'
+            ),
+            "buildContent": (
+                "plugins {\n"
+                "    alias(libs.plugins.android.application)\n"
+                "}\n"
+                "dependencies {\n"
+                "    implementation(libs.ktor.client.core)\n"
+                "}\n"
+            ),
+            "catalogPath": "gradle/libs.versions.toml",
+        })
+        self.assertEqual(result["violations"], [])
+
+    def test_validate_reads_project_default_catalog(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            gradle_dir = os.path.join(tmp, "gradle")
+            os.makedirs(gradle_dir)
+            with open(os.path.join(gradle_dir, "libs.versions.toml"), "w", encoding="utf-8") as fh:
+                fh.write(
+                    "[libraries]\n"
+                    'class = { module = "org.sample:x", version = "1.0" }\n'
+                )
+            result = server.handle_catalog_entry({
+                "mode": "validate",
+                "projectPath": tmp,
+            })
+            rules = {v["rule"] for v in result["violations"]}
+            self.assertIn("reserved_alias", rules)
+
+
+class CatalogHandlerErrorsTest(unittest.TestCase):
+    def test_invalid_mode(self):
+        result = server.handle_catalog_entry({"mode": "rewrite"})
+        self.assertIn("error", result)
+        self.assertEqual(result["violations"][0]["rule"], "invalid_mode")
+
+    def test_generate_requires_coordinate(self):
+        result = server.handle_catalog_entry({"mode": "generate"})
+        self.assertIn("error", result)
+        self.assertEqual(result["violations"][0]["rule"], "missing_coordinate")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/maven-mcp/tests/test_parsers.py
+++ b/plugins/maven-mcp/tests/test_parsers.py
@@ -986,6 +986,7 @@ class TestParseTomlCatalog(unittest.TestCase):
         result = server._parse_toml_catalog("")
         self.assertEqual(result["libraries"], {})
         self.assertEqual(result["plugins"], {})
+        self.assertEqual(result.get("versions", {}), {})
 
     # Mirrors: toml-parser.test.ts > "parses [plugins] with version.ref"
     def test_plugins_with_version_ref(self):


### PR DESCRIPTION
## Summary
- Add `catalog_entry` MCP tool (`generate` / `validate`) for rule-correct `gradle/libs.versions.toml` edits: kebab aliases, reserved segments, `alias(libs.plugins.*)` accessors, and minimal version bumps.
- Reuse `_parse_toml_catalog`; update `/check-deps` to route catalog edits through the tool. Does not regress the #359 pre-edit TOML `[plugins]` write guard.
- Tests cover generate/validate against the documented Gradle catalog rule set.

Fixes #288

## Test plan
- [x] `python3 -m unittest discover -s plugins/maven-mcp/tests`
- [x] `bash scripts/validate.sh`
- [x] `test_catalog_entry.py` + pre-edit hook suite (no #359 regression)


Made with [Cursor](https://cursor.com)