### PR TITLE
Bump version to 0.24.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.23.0",
+      "version": "0.24.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/maven-mcp/plugin"

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maven-mcp",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Maven dependency intelligence — provides /check-deps, /check-deps-vulnerabilities, /latest-version, /dependency-changes, and /dependency-health skills. Works in Claude cloud and local without any NPM setup.",
   "author": {
     "name": "kirich1409"

--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -31,8 +31,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 # ---------------------------------------------------------------------------
 
 SERVER_NAME = "maven-mcp"
-SERVER_VERSION = "0.23.0"
-USER_AGENT = "maven-mcp/0.23.0"
+SERVER_VERSION = "0.24.0"
+USER_AGENT = "maven-mcp/0.24.0"
 HTTP_TIMEOUT = 15
 # Short timeout for enrichment APIs (OSV / GitHub / deps.dev / android.com).
 # Closed contours must fail fast rather than hang on the full HTTP_TIMEOUT (#296).

--- a/plugins/maven-mcp/tests/test_github.py
+++ b/plugins/maven-mcp/tests/test_github.py
@@ -124,7 +124,7 @@ class GhFetchReleasesTest(unittest.TestCase):
         )
         self.assertEqual(req.get_header("Accept"), "application/vnd.github.v3+json")
         # User-Agent is stored capitalized as "User-agent" by urllib.request.Request.
-        self.assertEqual(req.get_header("User-agent"), "maven-mcp/0.23.0")
+        self.assertEqual(req.get_header("User-agent"), server.USER_AGENT)
 
     def test_returns_empty_list_on_404(self):
         # fetchReleases "returns empty array on non-ok response".


### PR DESCRIPTION
Release 0.24.0. Bumps all three synced version locations (marketplace.json, plugin.json, server.py SERVER_VERSION + USER_AGENT).

## Included since 0.23.0
- #388 — transitive license compliance via deps.dev
- #389 — graceful degradation of external APIs when air-gapped
- #390 — TLS (internal CA) + HTTP proxy support
- #391 — Nexus and Artifactory backends for search_artifacts
- #395 — Gradle-resolved project dependencies (closes epic #392/#393/#394)

## Pre-release checks (local)
- [x] `bash scripts/validate.sh` — green (versions consistent at 0.24.0)
- [x] Test suite — 861 passed, 1 skipped, 0 failures
- [x] Checklist: no non-exec .sh, no .DS_Store, SKILL.md ≤500 / desc ≤1024

After merge: tag `v0.24.0` triggers `.github/workflows/release.yml`.