### PR TITLE
Return tool-execution errors as isError:true; tighten tool schemas

### DIFF
--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -9635,6 +9635,11 @@ TOOL_HANDLERS = {
     "verify_coordinates": handle_verify_coordinates,
 }
 
+# Name -> inputSchema, for the dispatcher's own required-argument pre-check
+# (see _handle_tools_call) — built once from TOOLS rather than re-scanning
+# the list per call.
+TOOL_SCHEMAS = {t["name"]: t["inputSchema"] for t in TOOLS}
+
 
 # ---------------------------------------------------------------------------
 # MCP JSON-RPC 2.0 dispatcher
@@ -9676,20 +9681,36 @@ def _handle_tools_call(msg_id: Any, params: Dict) -> Dict:
             "id": msg_id,
             "error": {"code": -32601, "message": f"Unknown tool: {tool_name}"},
         }
-    try:
-        result = handler(arguments)
-    except KeyError as e:
-        # Missing/malformed required argument is a client (or model) mistake,
-        # not a tool execution failure — Invalid params (#397 audit nit), not
-        # Internal error with a raw KeyError repr.
+    # Validate required top-level arguments BEFORE calling the handler, using
+    # the tool's OWN inputSchema.required — a missing/malformed client argument
+    # (Invalid params, #397) must be detected here, not inferred from catching
+    # KeyError around the handler call: a handler can just as well raise a
+    # KeyError from an INTERNAL lookup with nothing to do with `arguments`
+    # (e.g. handle_get_dependency_health's metadata["versions"],
+    # check_android_kotlin_compatibility's agp_entry["minGradle"]) — catching
+    # KeyError there mislabels an internal bug as a client mistake and hides
+    # it from the isError:true self-correction path below (code review
+    # follow-up on #397).
+    required = (TOOL_SCHEMAS.get(tool_name) or {}).get("required") or []
+    if isinstance(arguments, dict):
+        missing = [name for name in required if name not in arguments]
+    else:
+        missing = list(required)
+    if missing:
         return {
             "jsonrpc": "2.0",
             "id": msg_id,
-            "error": {"code": -32602, "message": f"Invalid params: missing required field {e}"},
+            "error": {
+                "code": -32602,
+                "message": f"Invalid params: missing required field {missing[0]!r}",
+            },
         }
+    try:
+        result = handler(arguments)
     except Exception as e:
         # MCP spec (2024-11-05): a TOOL execution failure (handler raised while
-        # doing its job — resolution failure, ValueError, network error, etc.)
+        # doing its job — resolution failure, ValueError, network error, an
+        # internal KeyError unrelated to the arguments the client sent, etc.)
         # is reported as a successful response with isError:true, not a
         # JSON-RPC protocol error, so the model can see it and self-correct (#397).
         return {

--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -9187,6 +9187,7 @@ TOOLS = [
         "description": "Get the latest version of a Maven artifact from Maven Central, Google Maven, or Gradle Plugin Portal.",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": False,
             "properties": {
                 "groupId": {"type": "string", "description": "Maven group ID"},
                 "artifactId": {"type": "string", "description": "Maven artifact ID"},
@@ -9202,13 +9203,14 @@ TOOLS = [
     },
     {
         "name": "check_version_exists",
-        "description": "Check if a specific version of a Maven artifact exists in any known repository.",
+        "description": "Check if a specific version of a Maven artifact exists in any repository resolved for the project: declared repositories first, then the public Maven Central / Google Maven / Gradle Plugin Portal fallback when the project declares none (see projectPath).",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": False,
             "properties": {
-                "groupId": {"type": "string"},
-                "artifactId": {"type": "string"},
-                "version": {"type": "string"},
+                "groupId": {"type": "string", "description": "Maven group ID"},
+                "artifactId": {"type": "string", "description": "Maven artifact ID"},
+                "version": {"type": "string", "description": "Version to check for existence"},
                 "projectPath": {"type": "string", "description": "Project root used to resolve declared repositories. Defaults to the current working directory."},
             },
             "required": ["groupId", "artifactId", "version"],
@@ -9219,14 +9221,17 @@ TOOLS = [
         "description": "Batch lookup of latest versions for multiple Maven dependencies.",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": False,
             "properties": {
                 "dependencies": {
                     "type": "array",
+                    "description": "Dependencies to look up — no version needed; this tool reports the latest available version for each.",
                     "items": {
                         "type": "object",
+                        "additionalProperties": False,
                         "properties": {
-                            "groupId": {"type": "string"},
-                            "artifactId": {"type": "string"},
+                            "groupId": {"type": "string", "description": "Maven group ID"},
+                            "artifactId": {"type": "string", "description": "Maven artifact ID"},
                         },
                         "required": ["groupId", "artifactId"],
                     },
@@ -9241,15 +9246,18 @@ TOOLS = [
         "description": "Compare current dependency versions against the latest available and determine upgrade types (major/minor/patch).",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": False,
             "properties": {
                 "dependencies": {
                     "type": "array",
+                    "description": "Dependencies with their currently pinned version, compared against the latest available.",
                     "items": {
                         "type": "object",
+                        "additionalProperties": False,
                         "properties": {
-                            "groupId": {"type": "string"},
-                            "artifactId": {"type": "string"},
-                            "currentVersion": {"type": "string"},
+                            "groupId": {"type": "string", "description": "Maven group ID"},
+                            "artifactId": {"type": "string", "description": "Maven artifact ID"},
+                            "currentVersion": {"type": "string", "description": "Currently pinned version to compare against the latest available"},
                         },
                         "required": ["groupId", "artifactId", "currentVersion"],
                     },
@@ -9264,9 +9272,10 @@ TOOLS = [
         "description": "Get changelog/release notes between two versions (AndroidX/AGP developer docs when applicable, else GitHub releases).",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": False,
             "properties": {
-                "groupId": {"type": "string"},
-                "artifactId": {"type": "string"},
+                "groupId": {"type": "string", "description": "Maven group ID"},
+                "artifactId": {"type": "string", "description": "Maven artifact ID"},
                 "fromVersion": {"type": "string", "description": "Starting version (exclusive)"},
                 "toVersion": {"type": "string", "description": "Target version (inclusive)"},
                 "projectPath": {"type": "string", "description": "Project root used to resolve declared repositories. Defaults to the current working directory."},
@@ -9279,6 +9288,7 @@ TOOLS = [
         "description": "Scan a local project directory to extract declared dependencies from build files (Gradle, Maven). Applies BOM/platform managed versions (effectiveVersion/managedBy) via network POM fetch when platforms are declared.",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": False,
             "properties": {
                 "projectPath": {"type": "string", "description": "Path to the project root. Defaults to current working directory."},
             },
@@ -9289,6 +9299,7 @@ TOOLS = [
         "description": "Expand a Maven BOM (Bill of Materials) into its managed dependency versions. Recursively expands import-scope BOMs with first-wins ordering.",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": False,
             "properties": {
                 "groupId": {"type": "string", "description": "BOM group ID"},
                 "artifactId": {"type": "string", "description": "BOM artifact ID"},
@@ -9303,6 +9314,7 @@ TOOLS = [
         "description": "Fetch the resolved transitive dependency graph for a Maven GAV via deps.dev GetDependencies. Returns nodes (g/a/v) and edges (from/to indices). Partial results are flagged when deps.dev is unreachable, returns errors, or the graph is truncated by the node cap.",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": False,
             "properties": {
                 "groupId": {"type": "string", "description": "Maven group ID"},
                 "artifactId": {"type": "string", "description": "Maven artifact ID"},
@@ -9316,6 +9328,7 @@ TOOLS = [
         "description": "Detect version conflicts by unioning deps.dev transitive graphs for each direct project dependency. Flags GAs appearing at ≥2 versions and reports the version Maven nearest-wins or Gradle highest-wins would pick. Approximation of a full project resolve — see notes[] for limitations.",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": False,
             "properties": {
                 "projectPath": {"type": "string", "description": "Path to the project root. Defaults to current working directory."},
                 "buildSystem": {
@@ -9328,9 +9341,10 @@ TOOLS = [
     },
     {
         "name": "check_version_compatibility",
-        "description": "Check whether a set of versions is mutually compatible. Validates (1) dependency versions against the Spring Boot BOM (spring-boot-dependencies) when springBoot is set, (2) AGP↔Gradle↔JDK and Kotlin Gradle plugin↔Gradle/AGP ranges from a shipped matrix file, and (3) javax→jakarta EE coordinate migration when Spring Boot ≥ 3. Returns conflicts with suggested compatible versions and reference URLs. v1 coverage is intentionally bounded — see notes[] / AGENTS.md; matrices are not scraped at runtime and must be refreshed via the documented procedure in compat-matrices.json.",
+        "description": "Check whether a set of versions is mutually compatible. Validates (1) dependency versions against the Spring Boot BOM (spring-boot-dependencies) when springBoot is set, (2) AGP↔Gradle↔JDK and Kotlin Gradle plugin↔Gradle/AGP ranges from a shipped matrix file, and (3) javax→jakarta EE coordinate migration when Spring Boot ≥ 3. Returns conflicts with suggested compatible versions and reference URLs. v1 coverage is intentionally bounded — see notes[] in the response; matrices are not scraped at runtime and must be refreshed via the documented procedure in compat-matrices.json.",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": False,
             "properties": {
                 "springBoot": {
                     "type": "string",
@@ -9338,6 +9352,7 @@ TOOLS = [
                 },
                 "android": {
                     "type": "object",
+                    "additionalProperties": False,
                     "description": "Android / Kotlin toolchain versions to validate against the shipped AGP and KGP matrices.",
                     "properties": {
                         "agp": {"type": "string", "description": "Android Gradle Plugin version"},
@@ -9352,10 +9367,11 @@ TOOLS = [
                     "description": "Dependencies to check against the Spring Boot BOM and/or javax→jakarta map.",
                     "items": {
                         "type": "object",
+                        "additionalProperties": False,
                         "properties": {
-                            "groupId": {"type": "string"},
-                            "artifactId": {"type": "string"},
-                            "version": {"type": "string"},
+                            "groupId": {"type": "string", "description": "Maven group ID"},
+                            "artifactId": {"type": "string", "description": "Maven artifact ID"},
+                            "version": {"type": "string", "description": "Version to compare against the Spring Boot BOM / javax→jakarta map. A dependency without a version is skipped by those checks."},
                         },
                         "required": ["groupId", "artifactId"],
                     },
@@ -9366,19 +9382,22 @@ TOOLS = [
     },
     {
         "name": "get_dependency_vulnerabilities",
-        "description": "Check dependencies for known vulnerabilities using the OSV.dev database.",
+        "description": "Check dependencies for known vulnerabilities using the OSV.dev database. Each dependency requires a pinned version — OSV lookups are version-specific and version-less coordinates are not queried. An empty vulnerabilities list means no known CVE/GHSA advisory was found for that coordinate+version in OSV.dev; it is NOT a safety guarantee (OSV coverage is incomplete and reporting lags real-world disclosure).",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": False,
             "properties": {
                 "dependencies": {
                     "type": "array",
                     "maxItems": 100,
+                    "description": "Dependencies to check, each with a pinned version (required).",
                     "items": {
                         "type": "object",
+                        "additionalProperties": False,
                         "properties": {
-                            "groupId": {"type": "string"},
-                            "artifactId": {"type": "string"},
-                            "version": {"type": "string"},
+                            "groupId": {"type": "string", "description": "Maven group ID"},
+                            "artifactId": {"type": "string", "description": "Maven artifact ID"},
+                            "version": {"type": "string", "description": "Pinned version to check — required; OSV lookups are version-specific"},
                         },
                         "required": ["groupId", "artifactId", "version"],
                     },
@@ -9393,15 +9412,18 @@ TOOLS = [
         "description": "Get health signals for Maven dependencies: version info, GitHub activity, issue stats, license, and maintenance signals.",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": False,
             "properties": {
                 "dependencies": {
                     "type": "array",
+                    "description": "Dependencies to evaluate for maintenance/health signals.",
                     "items": {
                         "type": "object",
+                        "additionalProperties": False,
                         "properties": {
-                            "groupId": {"type": "string"},
-                            "artifactId": {"type": "string"},
-                            "version": {"type": "string"},
+                            "groupId": {"type": "string", "description": "Maven group ID"},
+                            "artifactId": {"type": "string", "description": "Maven artifact ID"},
+                            "version": {"type": "string", "description": "Optional. When omitted, the latest preferred-stable version is evaluated."},
                         },
                         "required": ["groupId", "artifactId"],
                     },
@@ -9416,15 +9438,18 @@ TOOLS = [
         "description": "Resolve license intelligence for Maven dependencies: SPDX id, category (permissive / weak-copyleft / strong-copyleft / network-copyleft / proprietary / unknown), plain-English notes, and source (pom / github / spdx-normalized). Uses POM <licenses> plus optional GitHub license metadata; category mapping is a static lookup (no external license API).",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": False,
             "properties": {
                 "dependencies": {
                     "type": "array",
                     "maxItems": 100,
+                    "description": "Dependencies to resolve license info for.",
                     "items": {
                         "type": "object",
+                        "additionalProperties": False,
                         "properties": {
-                            "groupId": {"type": "string"},
-                            "artifactId": {"type": "string"},
+                            "groupId": {"type": "string", "description": "Maven group ID"},
+                            "artifactId": {"type": "string", "description": "Maven artifact ID"},
                             "version": {"type": "string", "description": "Optional. When omitted, the latest preferred-stable version is used."},
                         },
                         "required": ["groupId", "artifactId"],
@@ -9440,6 +9465,7 @@ TOOLS = [
         "description": "Aggregate SPDX licenses across the transitive closure of one or more Maven GAVs (deps.dev GetDependencies + GetVersion) and flag risky/incompatible licenses against a projectLicense posture or an explicit disallow list (SPDX ids and/or categories). Verdicts: ok / review / violation. Missing license metadata degrades to review, never a false ok. Heuristic policy signal — not legal advice; see notes[].",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": False,
             "properties": {
                 "dependencies": {
                     "type": "array",
@@ -9447,10 +9473,11 @@ TOOLS = [
                     "description": "Root GAVs whose transitive graphs are scanned. Version is required. Capped at MAX_LICENSE_COMPLIANCE_ROOTS.",
                     "items": {
                         "type": "object",
+                        "additionalProperties": False,
                         "properties": {
-                            "groupId": {"type": "string"},
-                            "artifactId": {"type": "string"},
-                            "version": {"type": "string"},
+                            "groupId": {"type": "string", "description": "Maven group ID"},
+                            "artifactId": {"type": "string", "description": "Maven artifact ID"},
+                            "version": {"type": "string", "description": "Required — used to resolve the transitive graph for license aggregation."},
                         },
                         "required": ["groupId", "artifactId", "version"],
                     },
@@ -9473,6 +9500,7 @@ TOOLS = [
         "description": "Search Maven artifacts by keyword. Uses Maven Central Solr by default; in closed/offline mode (or with repositoryType) routes to Nexus 3 REST or Artifactory AQL/GAVC against MAVEN_MCP_REPOSITORY_BASE / mirrors.",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": False,
             "properties": {
                 "query": {"type": "string", "description": "Search query (keyword, or groupId:artifactId for coordinate search)"},
                 "limit": {"type": "integer", "default": 10, "minimum": 1, "maximum": 100, "description": "Maximum number of results. Default 10, clamped to [1, 100]."},
@@ -9491,6 +9519,7 @@ TOOLS = [
         "description": "Orchestrates a full dependency audit: scans project build files, checks for available updates, and optionally queries OSV.dev for vulnerabilities. Optional includeLicenses adds license categorization, summary, and newLicenseCategories (categories unique in the scanned set).",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": False,
             "properties": {
                 "projectPath": {"type": "string", "description": "Project root used to resolve declared repositories. Defaults to the current working directory."},
                 "includeVulnerabilities": {"type": "boolean", "description": "Include OSV vulnerability check (default true)"},
@@ -9504,6 +9533,7 @@ TOOLS = [
         "description": "Generate or validate Gradle version-catalog (libs.versions.toml) entries. mode=generate builds a rule-correct [versions]/[libraries]/[plugins] snippet with kebab alias + libs/alias(libs.plugins.*) accessor; mode=validate flags reserved aliases, invalid first subgroups, undefined version.ref, accessor clashes, id(libs.plugins.*) misuse, and libs usage inside subprojects/buildscript. Returns a minimal diff suggestion, not a full file rewrite.",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": False,
             "properties": {
                 "mode": {
                     "type": "string",
@@ -9512,11 +9542,12 @@ TOOLS = [
                 },
                 "coordinate": {
                     "type": "object",
+                    "additionalProperties": False,
                     "description": "Required for generate. Maven GAV or plugin marker coordinate.",
                     "properties": {
-                        "groupId": {"type": "string"},
-                        "artifactId": {"type": "string"},
-                        "version": {"type": "string"},
+                        "groupId": {"type": "string", "description": "Maven group ID"},
+                        "artifactId": {"type": "string", "description": "Maven artifact ID"},
+                        "version": {"type": "string", "description": "Optional; when omitted, generates a version-less accessor (no [versions] pin)."},
                     },
                     "required": ["groupId", "artifactId"],
                 },
@@ -9558,15 +9589,18 @@ TOOLS = [
         "description": "Verify whether Maven coordinates exist (tri-state: exists / absent / unknown) and, for absent ones, suggest the closest real coordinates. Detects hallucinated / slopsquat-shaped names an LLM may invent. Existence is NOT a safety guarantee: a published typosquat reports exists and is not flagged. Suggestions are candidates to verify, not endorsements.",
         "inputSchema": {
             "type": "object",
+            "additionalProperties": False,
             "properties": {
                 "dependencies": {
                     "type": "array",
                     "maxItems": 100,
+                    "description": "Coordinates to verify for existence; version is optional per item (see items.version).",
                     "items": {
                         "type": "object",
+                        "additionalProperties": False,
                         "properties": {
-                            "groupId": {"type": "string"},
-                            "artifactId": {"type": "string"},
+                            "groupId": {"type": "string", "description": "Maven group ID"},
+                            "artifactId": {"type": "string", "description": "Maven artifact ID"},
                             "version": {"type": "string", "description": "Optional. When given, gavExists reports whether this exact version exists."},
                         },
                         "required": ["groupId", "artifactId"],
@@ -9644,19 +9678,35 @@ def _handle_tools_call(msg_id: Any, params: Dict) -> Dict:
         }
     try:
         result = handler(arguments)
+    except KeyError as e:
+        # Missing/malformed required argument is a client (or model) mistake,
+        # not a tool execution failure — Invalid params (#397 audit nit), not
+        # Internal error with a raw KeyError repr.
+        return {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "error": {"code": -32602, "message": f"Invalid params: missing required field {e}"},
+        }
+    except Exception as e:
+        # MCP spec (2024-11-05): a TOOL execution failure (handler raised while
+        # doing its job — resolution failure, ValueError, network error, etc.)
+        # is reported as a successful response with isError:true, not a
+        # JSON-RPC protocol error, so the model can see it and self-correct (#397).
         return {
             "jsonrpc": "2.0",
             "id": msg_id,
             "result": {
-                "content": [{"type": "text", "text": json.dumps(result)}],
+                "content": [{"type": "text", "text": str(e)}],
+                "isError": True,
             },
         }
-    except Exception as e:
-        return {
-            "jsonrpc": "2.0",
-            "id": msg_id,
-            "error": {"code": -32603, "message": str(e)},
-        }
+    return {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "result": {
+            "content": [{"type": "text", "text": json.dumps(result)}],
+        },
+    }
 
 
 def _handle_ping(msg_id: Any, params: Dict) -> Dict:

--- a/plugins/maven-mcp/tests/test_dispatch.py
+++ b/plugins/maven-mcp/tests/test_dispatch.py
@@ -299,5 +299,94 @@ class McpProtocolTest(unittest.TestCase):
         self.assertEqual(json.loads(out[2]["result"]["content"][0]["text"]), {"ping": "pong"})
 
 
+class ToolExecutionErrorTest(unittest.TestCase):
+    """A tool handler's own failures are MCP tool-execution errors (#397).
+
+    Per the MCP spec (2024-11-05), a failure raised BY a tool handler while
+    doing its job (resolution failure, ValueError, network error, ...) is a
+    "Tool Execution Error": a successful JSON-RPC response whose result is a
+    CallToolResult with isError:true, not a JSON-RPC protocol error — the
+    model must see `result.content`, not `error`, to self-correct. A missing/
+    malformed required argument is a different case (client/model mistake,
+    not the handler failing at its job): Invalid params (-32602), not
+    Internal error with a raw Python KeyError repr.
+    """
+
+    def test_handler_exception_is_isError_content_not_protocol_error(self):
+        def _boom(_arguments):
+            raise ValueError("could not resolve coordinate: no matching repo")
+
+        with unittest.mock.patch.dict(
+            server.TOOL_HANDLERS, {"scan_project_dependencies": _boom}
+        ):
+            out = _run_main(
+                [
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": 50,
+                            "method": "tools/call",
+                            "params": {"name": "scan_project_dependencies", "arguments": {}},
+                        }
+                    )
+                ]
+            )
+        self.assertEqual(len(out), 1)
+        resp = out[0]
+        self.assertEqual(resp["id"], 50)
+        self.assertNotIn("error", resp, "tool execution failure must not be a JSON-RPC error")
+        result = resp["result"]
+        self.assertIs(result["isError"], True)
+        content = result["content"]
+        self.assertEqual(content[0]["type"], "text")
+        self.assertIn("could not resolve coordinate", content[0]["text"])
+
+    def test_handler_keyerror_is_invalid_params_not_internal_error(self):
+        def _needs_group_id(arguments):
+            return arguments["groupId"]  # deliberately raises KeyError when absent
+
+        with unittest.mock.patch.dict(
+            server.TOOL_HANDLERS, {"scan_project_dependencies": _needs_group_id}
+        ):
+            out = _run_main(
+                [
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": 51,
+                            "method": "tools/call",
+                            "params": {"name": "scan_project_dependencies", "arguments": {}},
+                        }
+                    )
+                ]
+            )
+        self.assertEqual(len(out), 1)
+        resp = out[0]
+        self.assertEqual(resp["id"], 51)
+        self.assertNotIn("result", resp)
+        self.assertEqual(resp["error"]["code"], -32602)
+        self.assertIn("groupId", resp["error"]["message"])
+
+    def test_unknown_tool_is_still_a_protocol_error(self):
+        # Unchanged by #397: an unrecognized tool name is detected by the
+        # dispatcher before any handler runs — it is not a handler exception,
+        # so it stays a JSON-RPC protocol error (method not found), not
+        # isError:true.
+        out = _run_main(
+            [
+                json.dumps(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": 52,
+                        "method": "tools/call",
+                        "params": {"name": "no_such_tool", "arguments": {}},
+                    }
+                )
+            ]
+        )
+        self.assertNotIn("result", out[0])
+        self.assertEqual(out[0]["error"]["code"], -32601)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/maven-mcp/tests/test_dispatch.py
+++ b/plugins/maven-mcp/tests/test_dispatch.py
@@ -303,13 +303,19 @@ class ToolExecutionErrorTest(unittest.TestCase):
     """A tool handler's own failures are MCP tool-execution errors (#397).
 
     Per the MCP spec (2024-11-05), a failure raised BY a tool handler while
-    doing its job (resolution failure, ValueError, network error, ...) is a
-    "Tool Execution Error": a successful JSON-RPC response whose result is a
-    CallToolResult with isError:true, not a JSON-RPC protocol error — the
-    model must see `result.content`, not `error`, to self-correct. A missing/
-    malformed required argument is a different case (client/model mistake,
-    not the handler failing at its job): Invalid params (-32602), not
-    Internal error with a raw Python KeyError repr.
+    doing its job (resolution failure, ValueError, network error, an internal
+    KeyError unrelated to the request's arguments, ...) is a "Tool Execution
+    Error": a successful JSON-RPC response whose result is a CallToolResult
+    with isError:true, not a JSON-RPC protocol error — the model must see
+    `result.content`, not `error`, to self-correct.
+
+    A missing/malformed required argument is a different case (client/model
+    mistake, not the handler failing at its job): Invalid params (-32602).
+    This is detected by a dispatcher-level PRE-CHECK against the tool's own
+    `inputSchema.required`, BEFORE the handler ever runs — not by catching
+    KeyError around the handler call, which would also catch (and mislabel)
+    a KeyError the handler raises internally for reasons that have nothing
+    to do with the arguments the client sent (code review follow-up on #397).
     """
 
     def test_handler_exception_is_isError_content_not_protocol_error(self):
@@ -341,12 +347,53 @@ class ToolExecutionErrorTest(unittest.TestCase):
         self.assertEqual(content[0]["type"], "text")
         self.assertIn("could not resolve coordinate", content[0]["text"])
 
-    def test_handler_keyerror_is_invalid_params_not_internal_error(self):
-        def _needs_group_id(arguments):
-            return arguments["groupId"]  # deliberately raises KeyError when absent
+    def test_handler_internal_keyerror_is_isError_not_invalid_params(self):
+        # The exact shape the code review flagged: a KeyError raised INSIDE a
+        # handler's own logic (e.g. handle_get_dependency_health's
+        # metadata["versions"], check_android_kotlin_compatibility's
+        # agp_entry["minGradle"]) has nothing to do with which arguments the
+        # client sent. It must come back as a tool execution failure
+        # (isError:true), never misdiagnosed as -32602 Invalid params just
+        # because the exception type happens to be KeyError.
+        def _internal_lookup_bug(_arguments):
+            internal_state = {"a": 1}
+            return internal_state["b"]  # KeyError unrelated to `arguments`
 
         with unittest.mock.patch.dict(
-            server.TOOL_HANDLERS, {"scan_project_dependencies": _needs_group_id}
+            server.TOOL_HANDLERS, {"scan_project_dependencies": _internal_lookup_bug}
+        ):
+            out = _run_main(
+                [
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": 53,
+                            "method": "tools/call",
+                            "params": {"name": "scan_project_dependencies", "arguments": {}},
+                        }
+                    )
+                ]
+            )
+        self.assertEqual(len(out), 1)
+        resp = out[0]
+        self.assertEqual(resp["id"], 53)
+        self.assertNotIn("error", resp, "internal handler KeyError must not be Invalid params")
+        result = resp["result"]
+        self.assertIs(result["isError"], True)
+        content = result["content"]
+        self.assertEqual(content[0]["type"], "text")
+        self.assertIn("'b'", content[0]["text"])
+
+    def test_missing_required_arg_is_invalid_params_precheck(self):
+        # get_latest_version requires groupId + artifactId (see TOOLS). The
+        # handler is swapped for a spy that fails the test if ever called —
+        # proving the -32602 comes from the dispatcher's pre-check against
+        # inputSchema.required, not from the handler running and raising.
+        def _must_not_be_called(_arguments):
+            raise AssertionError("handler must not run when a required arg is missing")
+
+        with unittest.mock.patch.dict(
+            server.TOOL_HANDLERS, {"get_latest_version": _must_not_be_called}
         ):
             out = _run_main(
                 [
@@ -355,7 +402,10 @@ class ToolExecutionErrorTest(unittest.TestCase):
                             "jsonrpc": "2.0",
                             "id": 51,
                             "method": "tools/call",
-                            "params": {"name": "scan_project_dependencies", "arguments": {}},
+                            "params": {
+                                "name": "get_latest_version",
+                                "arguments": {"artifactId": "guava"},  # groupId missing
+                            },
                         }
                     )
                 ]

--- a/plugins/maven-mcp/tests/test_tools_schema.py
+++ b/plugins/maven-mcp/tests/test_tools_schema.py
@@ -58,6 +58,48 @@ class ToolsSchemaTest(unittest.TestCase):
             with self.subTest(tool=name):
                 self.assertTrue(callable(handler), f"{name} handler is not callable")
 
+    def _assert_object_schemas_closed(self, schema, path):
+        """Recursively assert every ``type: object`` node sets additionalProperties: False.
+
+        The server does not itself run a JSON Schema validator against
+        inputSchema (stdlib-only, no jsonschema dependency) — `maxItems` and
+        friends are advisory client-side metadata (see server.py's own
+        comments on this). additionalProperties: False is the one piece of
+        schema tightening a spec-compliant MCP client (or a well-behaved LLM)
+        DOES enforce client-side, so pinning it here is the correctness gate
+        (#399), not runtime validation.
+        """
+        if not isinstance(schema, dict):
+            return
+        if schema.get("type") == "object":
+            self.assertIs(
+                schema.get("additionalProperties"),
+                False,
+                f"{path}: object schema must set additionalProperties: False",
+            )
+            for prop_name, prop_schema in (schema.get("properties") or {}).items():
+                self._assert_object_schemas_closed(prop_schema, f"{path}.{prop_name}")
+        elif schema.get("type") == "array":
+            items = schema.get("items")
+            if items:
+                self._assert_object_schemas_closed(items, f"{path}[]")
+
+    def test_object_schemas_reject_additional_properties(self):
+        # Every tool's top-level inputSchema, and every nested object schema
+        # (array items, nested option bags), must be closed — an LLM client
+        # should never be invited to guess at unsupported properties (#399).
+        for tool in server.TOOLS:
+            with self.subTest(tool=tool["name"]):
+                self._assert_object_schemas_closed(tool["inputSchema"], tool["name"])
+
+    def test_no_tool_description_references_agents_md(self):
+        # AGENTS.md is a repo file never seen by an MCP client — any guidance
+        # a tool needs must be inline in description or in the response's
+        # notes[] field, not a pointer to a file the model can't read (#399).
+        for tool in server.TOOLS:
+            with self.subTest(tool=tool["name"]):
+                self.assertNotIn("AGENTS.md", tool["description"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #397, closes #399.

**#397** — a tool handler's runtime failure now returns a CallToolResult with `isError: true` (so the model can see and self-correct) instead of JSON-RPC `-32603`. Unknown-tool stays `-32601` (protocol error, per MCP spec); malformed/missing args now map to `-32602` instead of `-32603`. No protocol-revision bump (that is #398).

**#399** — `additionalProperties: false` on all tool input schemas (18 top-level + 9 nested); ~25 missing parameter descriptions added; removed the `AGENTS.md` pointer from a tool description (its content is already surfaced in `notes[]`); clarified `get_dependency_vulnerabilities` (empty result != safe) and `check_version_exists`.

883 tests green (+5, red-green verified via stash isolation). validate.sh green; no version changes.