### PR TITLE
Add skills for the 14 tools with no natural-language entry point

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   "plugins": [
     {
       "name": "maven-mcp",
-      "description": "Maven dependency intelligence \u2014 provides /check-deps, /check-deps-vulnerabilities, /latest-version, /dependency-changes, and /dependency-health skills. Works in Claude cloud and local without any NPM setup.",
+      "description": "Maven dependency intelligence \u2014 dependency updates, vulnerability and license scanning, transitive dependency graphs, version compatibility checks, artifact search, and version-catalog management, exposed as Claude Code skills. Works in Claude cloud and local without any NPM setup.",
       "author": {
         "name": "kirich1409"
       },

--- a/plugins/maven-mcp/README.md
+++ b/plugins/maven-mcp/README.md
@@ -36,10 +36,24 @@ The server registers tools that Claude can call during a conversation. It querie
 | Skill | Description |
 |-------|-------------|
 | `/latest-version <groupId:artifactId>` | Find latest version of a Maven artifact |
+| `/check-version-exists` | Confirm whether one specific, already-known version exists |
+| `/check-multiple-versions` | Batch latest-version lookup for several artifacts being evaluated |
+| `/compare-dependency-versions` | Compare specific current versions against latest and classify the upgrade type |
 | `/check-deps` | Scan project for outdated dependencies and update them |
+| `/scan-project-dependencies` | Raw inventory of a project's declared dependencies (no freshness/CVE check) |
+| `/expand-bom` | Expand a Maven BOM/platform into its managed dependency versions |
+| `/transitive-graph` | Resolved transitive dependency graph for a single GAV |
+| `/dependency-conflicts` | Flag GAs resolved at multiple versions across a project |
+| `/check-version-compatibility` | Validate AGP/Gradle/JDK/Kotlin and Spring Boot BOM/javax→jakarta compatibility |
 | `/check-deps-vulnerabilities` | Scan project dependencies for known CVEs/GHSA via OSV (includes Gradle/Maven submodules) |
+| `/dependency-vulnerabilities` | Check specific named coordinates for known CVEs/GHSA, outside a project scan |
 | `/dependency-changes` | Show release notes/changelog between two versions of a Maven/Gradle dependency |
 | `/dependency-health` | Assess whether a Maven dependency is worth adopting (maintenance, activity, license, owner) |
+| `/dependency-license` | SPDX/category license intelligence for specific dependencies |
+| `/license-compliance` | Aggregate transitive licenses vs a project license policy; flag copyleft/violations |
+| `/search-artifacts` | Search Maven Central (or Nexus/Artifactory in closed mode) by keyword |
+| `/audit-project-dependencies` | One combined report: updates + vulnerabilities + optional license posture |
+| `/catalog-entry` | Generate or validate a Gradle version-catalog (`libs.versions.toml`) entry |
 
 ### Supported build systems
 

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "maven-mcp",
   "version": "0.25.0",
-  "description": "Maven dependency intelligence — provides /check-deps, /check-deps-vulnerabilities, /latest-version, /dependency-changes, and /dependency-health skills. Works in Claude cloud and local without any NPM setup.",
+  "description": "Maven dependency intelligence — dependency updates, vulnerability and license scanning, transitive dependency graphs, version compatibility checks, artifact search, and version-catalog management, exposed as Claude Code skills. Works in Claude cloud and local without any NPM setup.",
   "author": {
     "name": "kirich1409"
   },

--- a/plugins/maven-mcp/plugin/skills/audit-project-dependencies/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/audit-project-dependencies/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: audit-project-dependencies
+description: >-
+  Use when the user asks for "a full dependency audit", "audit my project for outdated,
+  vulnerable, and non-compliant licenses in one report", "comprehensive dependency report",
+  "give me everything on my dependencies at once", or wants one combined report covering
+  version freshness, vulnerabilities, and (optionally) license posture in a single call,
+  rather than three separate checks.
+---
+
+# Audit Project Dependencies
+
+Run one combined dependency audit: scan the project, check for available updates,
+optionally query OSV.dev for vulnerabilities, and optionally add license categorization —
+in a single tool call instead of chaining `/scan-project-dependencies` +
+`/compare-dependency-versions` + `/dependency-vulnerabilities` + `/dependency-license` by
+hand.
+
+## Steps
+
+1. Call **`audit_project_dependencies`** with:
+   - `projectPath` (default: cwd)
+   - `includeVulnerabilities` — default `true`
+   - `productionOnly` — default `true` (excludes test-scope dependencies)
+   - `includeLicenses` — default `false`; set `true` when the user wants license posture
+     in the same report (adds extra POM/GitHub fetches, so it's opt-in)
+
+2. Present the report:
+   - Upgrade table from `dependencies[]` (current → latest, `upgradeType`), grouped by
+     `source.kind` like `/check-deps` does.
+   - Vulnerabilities section for any entry with non-empty `vulnerabilities[]`, sorted by
+     severity; call out `malicious: true` findings first.
+   - When `includeLicenses` was set, a `licenses` section (`summary.byCategory`,
+     `uniqueSpdxIds`, `hasProprietaryOrCopyleft`) plus `newLicenseCategories` — categories
+     that appear exactly once in the scanned set (e.g. one AGPL dependency in an otherwise
+     Apache/MIT tree).
+   - Lead with the `summary` block (`total`, `upgradeable`, `vulnerable`, `major`, `minor`,
+     `patch`) as the headline, details below.
+
+3. Follow the same confirm-before-edit discipline as `/check-deps` if the user wants
+   updates applied — this skill's job is the combined report, not unattended edits.
+
+## Constraints and non-goals
+
+- Not for only checking for updates — `/check-deps` is narrower and offers to apply them.
+- Not for only checking vulnerabilities against a whole project —
+  `/check-deps-vulnerabilities`.
+- Not for a single named dependency outside project context —
+  `/check-multiple-versions`, `/compare-dependency-versions`, `/dependency-vulnerabilities`,
+  or `/dependency-license`.
+
+## Fallback (MCP unavailable only)
+
+Compose the fallbacks of `/scan-project-dependencies`, `/compare-dependency-versions`, and
+`/dependency-vulnerabilities` (plus `/dependency-license` when licenses were requested) by
+hand. State clearly that this loses the single-call dedup (metadata/POM fetches are no
+longer cached across the three checks).

--- a/plugins/maven-mcp/plugin/skills/catalog-entry/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/catalog-entry/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: catalog-entry
+description: >-
+  Use when the user asks to "add this dependency to my version catalog", "generate a
+  libs.versions.toml entry for X", "what alias should I use for this library", "validate my
+  version catalog", "check my libs.versions.toml for mistakes", or wants a new Gradle
+  version-catalog entry generated or an existing catalog validated — Gradle has no built-in
+  command for either.
+---
+
+# Catalog Entry
+
+Generate a rule-correct Gradle version-catalog (`gradle/libs.versions.toml`) entry for a
+new dependency/plugin, or validate an existing catalog for common mistakes. Gradle has no
+native command for either operation.
+
+## Mode: generate (new dependency/plugin)
+
+Call **`catalog_entry`** with:
+- `mode: "generate"`
+- `coordinate: {groupId, artifactId, version?}`
+- `kind`: `"library"` (default) or `"plugin"`
+- optional `alias` — a preferred alias; sanitized if it violates catalog rules
+- optional `catalogToml` — existing catalog content, so the generator avoids alias clashes
+  and can suggest a version-only bump instead of a fresh entry when the alias already
+  exists
+- optional `catalogName` (default `"libs"`)
+
+Present the returned `alias`, `accessor` (`libs.x.y` for a library,
+`alias(libs.plugins.x.y)` — never `id(...)` — for a plugin), and `suggestedDiff`. Apply the
+diff, not a full-file rewrite.
+
+## Mode: validate (existing catalog)
+
+Call **`catalog_entry`** with `mode: "validate"` and either `catalogToml` directly or
+`projectPath` (reads `gradle/libs.versions.toml` under the project when `catalogToml` is
+omitted). Pass `buildContent` too when checking for `id(libs.plugins.x)` misuse or `libs`
+accessors inside `subprojects {}` / `buildscript {}`.
+
+Present `violations[{rule, detail}]` — reserved alias segments
+(`extensions`/`class`/`convention`), reserved first segments
+(`bundles`/`versions`/`plugins`), undefined `version.ref`, accessor clashes, wrong default
+catalog path, plugin DSL misuse.
+
+**No violations:** say so plainly.
+
+## Constraints and non-goals
+
+- Not for bumping the version of an *existing* catalog entry as part of a broader update
+  sweep — that's `/check-deps`, which calls this tool internally (`mode: "generate"` with
+  the same alias) to produce a minimal version bump rather than a full rewrite.
+- Default catalog path is exactly `gradle/libs.versions.toml`.
+
+## Fallback (MCP unavailable only)
+
+Apply the naming rules directly: kebab-case alias, no reserved segment/first-word, library
+accessor `libs.x.y`, plugin accessor `alias(libs.plugins.x.y)` (never `id(...)`). Add a
+single `[versions]` / `[libraries]` / `[plugins]` line rather than rewriting the file.

--- a/plugins/maven-mcp/plugin/skills/check-multiple-versions/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/check-multiple-versions/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: check-multiple-versions
+description: >-
+  Use when the user provides a list of several groupId:artifactId coordinates (with no
+  current version to compare against) and asks "what are the latest versions of these
+  libraries", "look up versions for this list", "batch check these dependencies", "what
+  version should I use for each of these", or is considering adding a handful of new
+  libraries and wants their latest versions before picking one. For updating an existing
+  project's declared dependencies use /check-deps instead.
+---
+
+# Check Multiple Versions
+
+Batch-resolve the latest version for several Maven artifacts at once — for artifacts the
+user is evaluating or about to add, not for auditing an existing project's declared
+dependencies and not for comparing against a *current* version.
+
+## Steps
+
+1. Parse a list of `groupId:artifactId` pairs from the user's message.
+
+2. Call **`check_multiple_dependencies`** with:
+   - `dependencies`: `[{groupId, artifactId}, ...]`
+   - optional `projectPath` when the user is inside a project (uses declared repos)
+
+   Note: unlike `/latest-version`, this tool has no `stabilityFilter` override — it always
+   selects PREFER_STABLE. Call `get_latest_version` per-artifact instead if the user needs
+   `STABLE_ONLY` or `ALL` for one of them.
+
+3. Present a table: artifact → latest version → stability → resolved-from repo. Entries
+   with an `error` (e.g. no version found) are shown separately with the error message —
+   never silently dropped.
+
+## Constraints and non-goals
+
+- Not for a single artifact — use `/latest-version`.
+- Not for comparing against versions already in the project — use
+  `/compare-dependency-versions` or `/check-deps`.
+
+## Fallback (MCP unavailable only)
+
+Fetch `maven-metadata.xml` per artifact from public repos and pick the highest stable
+version from each. Skips project-declared private repos.

--- a/plugins/maven-mcp/plugin/skills/check-version-compatibility/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/check-version-compatibility/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: check-version-compatibility
+description: >-
+  Use when the user asks "is AGP 8.2 compatible with Gradle 8.4", "will this Kotlin version
+  work with my AGP", "what Gradle version does this AGP need", "check Spring Boot BOM
+  compatibility for my dependencies", "do I need to migrate javax to jakarta", or wants to
+  validate a set of Android/Kotlin/Gradle/Spring Boot toolchain versions against each other
+  before upgrading.
+---
+
+# Check Version Compatibility
+
+Validate whether a set of versions is mutually compatible: Android Gradle Plugin ↔ Gradle ↔
+JDK, Kotlin Gradle Plugin ↔ Gradle/AGP, Spring Boot BOM-managed versions, and javax→jakarta
+migration need.
+
+## Steps
+
+1. Gather whichever of these the user is asking about:
+   - `android`: `{agp, gradle, kotlin, jdk}` — any subset
+   - `springBoot`: a version string
+   - `dependencies`: `[{groupId, artifactId, version?}, ...]` (capped at 100 items) —
+     checked against the Spring Boot BOM (when `springBoot` is set) and, when Spring Boot ≥
+     3.0.0, flagged for javax→jakarta coordinate replacements
+
+2. Call **`check_version_compatibility`** with whichever of `android`, `springBoot`,
+   `dependencies`, `projectPath` apply. At least one of `android`/`springBoot`/`dependencies`
+   should be present — an empty call has nothing to validate.
+
+3. Present the result:
+   - `compatible: true` with no `conflicts` → confirm compatibility plainly.
+   - Each conflict: `kind`, `requested`, `expected`, `suggestion`, `reference` (an official
+     doc URL) — always show the suggestion and reference together, never a bare
+     "conflict".
+   - Print any `notes[]` (coverage caveats) alongside the result, not as an afterthought.
+
+## Known limitations
+
+Coverage is intentionally bounded — AGP 7.0–9.2 lines, KGP 1.9.20–2.4.0 bands, no
+published AGP max-Gradle (only min enforced), javax→jakarta is a coordinate heuristic (not
+a bytecode scanner), Spring Cloud release trains are not a separate matrix. State the
+specific gap when a requested version falls outside shipped coverage — never imply
+"compatible" from silence.
+
+## Constraints and non-goals
+
+- Not for applying the suggested version bumps — that's a normal edit; verify with
+  `/check-deps` or a project build afterward.
+
+## Fallback (MCP unavailable only)
+
+Check the official compatibility tables directly: Android Gradle Plugin release notes
+(developer.android.com) for AGP↔Gradle↔JDK, the Kotlin Gradle plugin compatibility guide
+for KGP↔Gradle/AGP, and the Spring Boot release notes / dependency versions page for
+BOM-managed versions. Do not guess a compatibility matrix from memory — this stack changes
+across releases.

--- a/plugins/maven-mcp/plugin/skills/check-version-exists/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/check-version-exists/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: check-version-exists
+description: >-
+  Use when the user asks "does version X exist", "is version 3.2.0 released for okhttp",
+  "check if this version is published", "was this version ever released", "check version
+  exists", or provides a full groupId:artifactId:version and wants to confirm that exact
+  version is available in a Maven repository — not what the latest is (use /latest-version
+  for that).
+---
+
+# Check Version Exists
+
+Confirm whether one specific, already-known version of a Maven artifact exists in any
+resolvable repository.
+
+## Steps
+
+1. Parse `groupId`, `artifactId`, `version` from the user's input (e.g.
+   `com.squareup.okhttp3:okhttp:4.12.0`, or a groupId:artifactId plus a version mentioned in
+   conversation).
+
+2. Call **`check_version_exists`** with:
+   - `groupId`, `artifactId`, `version`
+   - optional `projectPath` when the user is inside a project (uses declared repos)
+
+3. Present the result:
+   - `exists: true` — show `stability` and `repository` (which repo answered), and
+     `relocatedTo` when present (the artifact was relocated via a Maven
+     `<distributionManagement>` POM — tell the user the new coordinates).
+   - `exists: false` — tell the user the version was not found in any resolvable
+     repository. Do not guess a reason; offer `/latest-version` to check what *is*
+     available, or `/search-artifacts` if the artifact name itself may be wrong.
+
+## Error handling
+
+Tool error / not found → report as-is, do not invent a version or existence status from
+memory.
+
+## Constraints and non-goals
+
+- Not for "what's the latest version of X" — use `/latest-version`.
+- Not for "is my current version behind latest" — use `/compare-dependency-versions`.
+- Not for checking many artifacts at once — use `/check-multiple-versions`.
+
+## Fallback (MCP unavailable only)
+
+Fetch `maven-metadata.xml` from public repos (Maven Central → Google Maven → Gradle Plugin
+Portal) and check whether `version` is present in the `<versions>` list. Note that this
+skips project-declared private repos and relocation detection.

--- a/plugins/maven-mcp/plugin/skills/compare-dependency-versions/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/compare-dependency-versions/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: compare-dependency-versions
+description: >-
+  Use when the user gives one or more dependencies together with their CURRENT version and
+  asks "is my version of X behind latest", "how far behind is 3.0.0", "what upgrade type
+  would this be — major, minor, or patch", "classify the version jump from A to B", or wants
+  upgrade-type classification for specific coordinates outside of a full project scan.
+---
+
+# Compare Dependency Versions
+
+Compare one or more Maven dependencies' current version against the latest available and
+classify the upgrade as `major` / `minor` / `patch` / `none`.
+
+## Steps
+
+1. Parse `groupId`, `artifactId`, `currentVersion` for each dependency from the user's
+   message (or from context, e.g. a version noticed in a build file).
+
+2. Call **`compare_dependency_versions`** with:
+   - `dependencies`: `[{groupId, artifactId, currentVersion}, ...]`
+   - optional `projectPath`
+
+3. Present per-dependency: current → latest, `latestStability`, `upgradeType`,
+   `upgradeAvailable`. Use the `summary` block (`total`, `upgradeable`, `major`, `minor`,
+   `patch`) for a one-line rollup when comparing more than a couple of dependencies.
+
+**No upgrade available for any entry:** say so plainly; do not propose edits.
+
+## Constraints and non-goals
+
+- Not for scanning a whole project's build files for outdated dependencies — use
+  `/check-deps` (which also offers to apply the updates).
+- Not for a version with no current baseline to compare against — use `/latest-version` or
+  `/check-multiple-versions`.
+
+## Fallback (MCP unavailable only)
+
+Fetch `maven-metadata.xml` per artifact, pick the highest version reachable from
+`currentVersion` under prefer-stable rules, and classify the semver diff yourself
+(major/minor/patch by first differing segment). Skips project-declared private repos.

--- a/plugins/maven-mcp/plugin/skills/dependency-conflicts/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/dependency-conflicts/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: dependency-conflicts
+description: >-
+  Use when the user asks "do I have conflicting dependency versions", "is there a diamond
+  dependency problem", "which libraries resolve to more than one version", "check for
+  version conflicts across my project", or wants to know whether two paths in the
+  dependency graph pull in incompatible versions of the same library.
+---
+
+# Dependency Conflicts
+
+Detect Maven/Gradle coordinates (`groupId:artifactId`) that appear at more than one version
+across a project's dependency graph, and report which version wins.
+
+## Steps
+
+1. Call **`detect_dependency_conflicts`** with `projectPath` (default: cwd) and optional
+   `buildSystem` (`maven` or `gradle`) to override auto-detection.
+
+   - **Gradle projects** compare versions across Gradle-resolved scan usages
+     (`resolvedBy: "gradle"`) — mediation is `highest-wins`.
+   - **Maven projects** fetch a deps.dev transitive graph per versioned direct dependency
+     and union `groupId:artifactId → {versions seen}` — mediation is `nearest-wins` (BFS
+     depth from each direct root; same-depth ties break to the highest version).
+
+2. Present each conflict: the GA, `versions` seen, `resolvedTo` (what wins), `strategy`,
+   and `risk` (`high`/`medium`/`low`). Sort by risk descending.
+
+**No conflicts found:** say so; do not speculate about hidden ones.
+
+## Known limitations
+
+For Maven, this unions per-root deps.dev graphs resolved **in isolation** — it
+approximates but is not a full project-wide resolve. Project `dependencyManagement`,
+Gradle `ResolutionStrategy` / strict versions / `enforcedPlatform`, exclusions, and
+private/unpublished coordinates are not modeled. Surface `notes[]` / per-root `errors[]` /
+`partial` from the result when present rather than treating the report as exhaustive.
+
+## Fallback (MCP unavailable only)
+
+For Gradle, `./gradlew <module>:dependencies --configuration <name>` already prints
+conflict resolution (`-> x.y.z` annotations) — read that output directly instead of
+reimplementing mediation by hand. For Maven, `mvn dependency:tree -Dverbose` shows omitted
+conflicting versions. Prefer the real build tool's own resolution over a hand-rolled graph
+walk in both cases.

--- a/plugins/maven-mcp/plugin/skills/dependency-license/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/dependency-license/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: dependency-license
+description: >-
+  Use when the user asks "what license does this library use", "is this dependency GPL",
+  "check the license of X before I add it", "what's the SPDX id for this artifact", or
+  wants license intelligence (SPDX id, category, plain-English notes) for one or more
+  specific Maven dependencies — direct lookup, not a transitive-closure scan.
+---
+
+# Dependency License
+
+Resolve license intelligence for one or more Maven dependencies directly: SPDX id, license
+category, plain-English notes, and where the data came from.
+
+## Steps
+
+1. Parse `groupId`, `artifactId`, and optionally `version` for each dependency (when
+   `version` is omitted, the latest preferred-stable version is used).
+
+2. Call **`get_dependency_license`** with `dependencies: [{groupId, artifactId, version?}, ...]`
+   (capped at 100 items) and optional `projectPath`.
+
+3. Present per dependency: `spdxId`, `name`, `category` (`permissive` / `weak-copyleft` /
+   `strong-copyleft` / `network-copyleft` / `proprietary` / `unknown`), `notes`, and
+   `source` (`pom` / `github` / `spdx-normalized`). Call out `unknown` or any
+   copyleft/`proprietary` category explicitly — do not bury it in a table row.
+
+## Constraints and non-goals
+
+- Not for checking the full transitive closure of a dependency against a project's license
+  policy — use `/license-compliance`.
+- Do not issue an adopt/avoid verdict from the category alone — present it as a raw signal
+  and let the user (or their license policy) decide, same convention as
+  `/dependency-health`.
+
+## Fallback (MCP unavailable only)
+
+Fetch the POM and read `<licenses><license><name>/<url>`; optionally check the GitHub
+repo's `license.spdx_id` via the unauthenticated REST API. Category classification
+(permissive vs copyleft) then has to be done by hand against a known SPDX list — state that
+this is a manual judgment call on this path, not the server's static lookup table.

--- a/plugins/maven-mcp/plugin/skills/dependency-vulnerabilities/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/dependency-vulnerabilities/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: dependency-vulnerabilities
+description: >-
+  Use when the user names one or a few specific dependencies (with version) — not a whole
+  project — and asks "does io.ktor:ktor-server-core 3.1.0 have any known vulnerabilities",
+  "check this library for CVEs before I add it", "is this version affected by any GHSA", or
+  wants an OSV.dev vulnerability check for coordinates that may not even be in a build file
+  yet. For scanning an entire Gradle/Maven project's declared dependencies use
+  /check-deps-vulnerabilities instead.
+---
+
+# Dependency Vulnerabilities
+
+Check specific, already-known Maven coordinates (groupId:artifactId:version) for known
+CVE/GHSA advisories via OSV.dev — for artifacts the user names directly, not a project
+scan.
+
+## Steps
+
+1. Parse `groupId`, `artifactId`, `version` for each dependency named by the user.
+
+2. Call **`get_dependency_vulnerabilities`** with:
+   - `dependencies`: `[{groupId, artifactId, version}, ...]` (capped at 100 items)
+   - optional `projectPath` — improves Gradle plugin-marker resolution (a marker
+     coordinate like `{id}:{id}.gradle.plugin` is resolved to its real implementation GAV
+     before querying OSV, since OSV indexes the implementation, not the marker)
+
+3. Present per-dependency findings: `id`, `severity`, `summary`, `fixedVersion`. Sort
+   CRITICAL → HIGH → MEDIUM → LOW → unknown. Link advisories as
+   `https://osv.dev/vulnerability/{id}`.
+
+   **`malicious: true`** on any finding is a distinct, stronger signal than a CVE severity
+   (OSSF Malicious Packages convention) — call it out separately and first; recommend
+   removing the dependency rather than just tracking the CVE.
+
+**No findings:** say so plainly.
+
+**Disclaimer (always mention once):** OSV does not cover shaded/uber JARs — a dependency
+bundled inside a fat JAR may carry CVEs this check will not surface.
+
+## Constraints and non-goals
+
+- Not for "are my project's dependencies vulnerable" with no specific coordinates in hand —
+  use `/check-deps-vulnerabilities`, which resolves the project via `gradlew` first.
+
+## Fallback (MCP unavailable only)
+
+POST the coordinates to `https://api.osv.dev/v1/querybatch`, then **hydrate** each unique
+returned id with `GET https://api.osv.dev/v1/vulns/{id}` before reporting
+severity/summary/fixedVersion — the bare querybatch response (`{id, modified}` only) is not
+enough to report severity. Note that Gradle plugin-marker resolution is skipped on this
+path.

--- a/plugins/maven-mcp/plugin/skills/expand-bom/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/expand-bom/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: expand-bom
+description: >-
+  Use when the user asks to "expand this BOM", "what versions does the Spring Boot BOM
+  manage", "show me the managed versions in this platform", "what does importing
+  io.ktor:ktor-bom pin", or provides a Maven BOM / Gradle platform() coordinate and wants
+  its full set of managed dependency versions.
+---
+
+# Expand BOM
+
+Expand a Maven BOM (Bill of Materials) or Gradle `platform()` coordinate into the full set
+of dependency versions it manages.
+
+## Steps
+
+1. Parse `groupId`, `artifactId`, `version` for the BOM coordinate (for example
+   `org.springframework.boot:spring-boot-dependencies:3.2.5`, `io.ktor:ktor-bom:3.1.3`).
+
+2. Call **`expand_bom`** with `groupId`, `artifactId`, `version`, and optional
+   `projectPath`.
+
+3. Present the `managed` list (`groupId:artifactId → version`). For a long BOM (Spring Boot
+   manages hundreds of entries), let the user filter — ask which group(s) or artifact(s)
+   they care about rather than dumping the entire list unprompted.
+
+Import-scope BOMs referenced by the target BOM are expanded recursively with first-wins
+merge order (an entry already seen is never overwritten by a nested import) — the same
+semantics as Maven's own dependency-management resolution.
+
+## Error handling
+
+- BOM POM not found / not a BOM → say so; do not fabricate managed versions.
+- A managed entry with an unresolved `${...}` property is skipped, not guessed.
+
+## Fallback (MCP unavailable only)
+
+Fetch the BOM's POM directly and parse `<dependencyManagement><dependencies>` (plus parent
+POM properties for `${...}` interpolation) by hand. State that recursive import-BOM
+expansion and property interpolation across parents are error-prone to reproduce manually.

--- a/plugins/maven-mcp/plugin/skills/license-compliance/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/license-compliance/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: license-compliance
+description: >-
+  Use when the user asks "check license compliance across my dependency tree", "are any of
+  my transitive dependencies GPL", "scan for copyleft licenses", "flag license violations
+  against our policy", or wants the FULL transitive closure of one or more root
+  dependencies checked against a project license posture — not just the direct
+  dependency's own license (see /dependency-license for that).
+---
+
+# License Compliance
+
+Aggregate SPDX licenses across the full transitive closure of one or more root Maven GAVs
+and flag risky/incompatible licenses against a project license posture or an explicit
+disallow list.
+
+## Steps
+
+1. Parse root dependencies the user wants scanned — `groupId`, `artifactId`, `version`
+   (version required per entry; capped at 20 roots).
+
+2. Ask (if not already stated) which policy applies:
+   - `projectLicense` — an SPDX id or license name; a **permissive** posture (or omitted
+     `projectLicense`) defaults to disallowing `strong-copyleft`, `network-copyleft`, and
+     `proprietary`.
+   - `disallow` — explicit SPDX ids and/or category names; when set, this **replaces** the
+     default disallow set entirely rather than adding to it.
+
+3. Call **`check_license_compliance`** with `dependencies`, optional `projectLicense`,
+   optional `disallow`.
+
+4. Present per-node verdicts: `ok` / `review` / `violation`, with
+   `groupId:artifactId:version`, `spdxId`/`license`, `category`, `viaTransitive` (direct vs
+   transitive), and `reason`. Group by verdict, `violation` first. Missing/unrecognized
+   license metadata is `review`, never a silent `ok` — present it as needing a human look,
+   not as clean.
+
+## Known limitations
+
+This is a heuristic policy signal, not legal advice — say so when a violation is reported.
+Deps.dev package-metadata SPDX only; per-root graphs are resolved in isolation (same
+caveats as `/transitive-graph` and `/dependency-conflicts`); a compound SPDX expression
+(`A OR B`) or an operator beyond a single known id degrades to `review`.
+
+## Constraints and non-goals
+
+- Not for a single dependency's own license with no transitive scan needed — use
+  `/dependency-license`.
+
+## Fallback (MCP unavailable only)
+
+No practical manual fallback — walking a full transitive graph and fetching per-node
+license metadata by hand does not scale. Tell the user this check is unavailable rather
+than approximating it from the direct dependency's license alone.

--- a/plugins/maven-mcp/plugin/skills/scan-project-dependencies/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/scan-project-dependencies/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: scan-project-dependencies
+description: >-
+  Use when the user asks to "list my project's dependencies", "what dependencies does this
+  project declare", "show me all the libraries in this build file", "extract dependencies
+  from my Gradle/Maven project", or wants a raw inventory of declared coordinates without
+  checking for updates or vulnerabilities. Does not fetch latest versions — see /check-deps
+  for that.
+---
+
+# Scan Project Dependencies
+
+Extract the dependencies a project declares in its build files — Gradle
+(`build.gradle[.kts]`, version catalogs) or Maven (`pom.xml`) — as a raw inventory, with no
+version-freshness or vulnerability checking.
+
+## Steps
+
+1. Call **`scan_project_dependencies`** with `projectPath` (default: cwd).
+
+   For a Gradle project, this resolves production `*RuntimeClasspath` configurations via the
+   project's own `gradlew` and merges build-file provenance (catalog alias, source file,
+   usages) onto the Gradle-resolved coordinates — `resolvedBy: "gradle"` in the result means
+   versions came from actual Gradle resolution (BOM/platform/constraints applied), not
+   regex-guessed. A Maven-only project (no `gradlew`) is parsed from `pom.xml` directly.
+
+2. Present the inventory grouped by `source.kind` (`catalog-library` / `catalog-plugin` /
+   `module-direct` / `plugins-dsl` / `buildscript-classpath` / `gradle-resolved`), each with
+   its declared/resolved version, module, and configuration.
+
+3. Surface `deadRepositoryHints` when present (e.g. a lingering `jcenter()` declaration —
+   read-only since 2021, fully sunset).
+
+## Constraints and non-goals
+
+- Not for checking whether any of these are outdated or vulnerable — use `/check-deps` or
+  `/audit-project-dependencies`, which call this tool internally and add version/CVE data.
+- Not for the resolved transitive closure of a single dependency — use `/transitive-graph`.
+
+## Fallback (MCP unavailable only)
+
+Glob/Read build files (`build.gradle*`, `settings.gradle*`, `pom.xml`,
+`gradle/libs.versions.toml`) and regex-extract coordinates yourself. State that this skips
+Gradle-resolved effective versions (BOM/platform/constraints) and dead-repository hints.

--- a/plugins/maven-mcp/plugin/skills/search-artifacts/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/search-artifacts/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: search-artifacts
+description: >-
+  Use when the user asks to "find a library for X", "search maven central for JSON parsing
+  libraries", "what's the artifact id for Y", "look up an artifact by keyword", or doesn't
+  know the exact groupId:artifactId and wants to search by keyword or partial coordinate.
+---
+
+# Search Artifacts
+
+Search for Maven artifacts by keyword or partial coordinate when the exact
+`groupId:artifactId` isn't known.
+
+## Steps
+
+1. Take the user's search phrase as `query` — a keyword (`"json parsing"`) or partial
+   coordinate (`"okhttp"`, `"com.squareup:okhttp"`).
+
+2. Call **`search_artifacts`** with:
+   - `query`
+   - optional `limit` (default 10, clamped to [1, 100])
+   - optional `repositoryType` (`auto` / `nexus` / `artifactory` / `central`) — leave as
+     `auto` unless the user is on a closed/offline repository manager and wants to force a
+     backend
+   - optional `projectPath` for mirror/closed-mode resolution
+
+3. Present `results` as a table: `groupId:artifactId`, `latestVersion`, `versionCount`. If
+   `searchBackendUnavailable` is present instead of results, say which backend was tried
+   and that the search could not be served (not "no results found").
+
+## Constraints and non-goals
+
+- Not for confirming a coordinate you already believe is correct isn't hallucinated —
+  that's the write-time guard hook's job (`verify_coordinates`), not a conversational
+  search.
+
+## Fallback (MCP unavailable only)
+
+Query the public Solr endpoint directly:
+`https://search.maven.org/solrsearch/select?q={query}&rows={limit}&wt=json`. Note that
+this skips closed-mode Nexus/Artifactory routing and any mirror configuration.

--- a/plugins/maven-mcp/plugin/skills/transitive-graph/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/transitive-graph/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: transitive-graph
+description: >-
+  Use when the user asks to "show me the dependency tree for X", "what does this library
+  pull in transitively", "full transitive graph of Y", "what does adding this dependency
+  bring with it", or wants the resolved dependency graph (nodes and edges) for a single
+  Maven artifact.
+---
+
+# Transitive Graph
+
+Fetch the resolved transitive dependency graph for one Maven GAV via deps.dev.
+
+## Steps
+
+1. Parse `groupId`, `artifactId`, `version` (all required — this tool needs one specific,
+   already-known version; there is no "latest" shortcut).
+
+2. Call **`get_transitive_graph`** with `groupId`, `artifactId`, `version`.
+
+3. Present the result:
+   - `nodes` — every `{groupId, artifactId, version}` in the graph
+   - `edges` — `{from, to}` pairs, indices into `nodes` (render as an indented tree or a
+     `groupId:artifactId:version → groupId:artifactId:version` list, whichever fits the
+     size better)
+   - If `partial: true` (deps.dev unreachable, returned an error, or the graph was
+     truncated by the node cap) — say so explicitly; do not present a partial graph as
+     complete.
+
+## Constraints and non-goals
+
+- Not for finding version conflicts across a whole project's dependencies — use
+  `/dependency-conflicts`, which unions graphs like this one across every direct
+  dependency.
+- Not for a project's own declared (non-transitive) dependencies — use
+  `/scan-project-dependencies`.
+
+## Known limitations
+
+deps.dev resolves in isolation from this one root — project-level `dependencyManagement`,
+Gradle `ResolutionStrategy` / strict versions / exclusions are not modeled. State this when
+the graph is used to make a decision (e.g. "is X actually on the classpath").
+
+## Fallback (MCP unavailable only)
+
+No practical manual fallback — hand-walking a transitive Maven/Gradle resolution from POMs
+is impractical to reproduce correctly. Tell the user the live graph is unavailable rather
+than guessing at transitive contents.


### PR DESCRIPTION
Closes #410.

Only 3 tools had a 1:1 skill; the real skill-less count was 15 (the issue said 6). Adds 14 new skills (one per skill-less user-facing tool) following the existing SKILL.md pattern, each verified against the tool's inputSchema and handler return shape. `verify_coordinates` intentionally skipped — it is the write-time guard hook's anti-slopsquat primitive, not a conversational tool.

Also generalizes plugin.json / marketplace.json descriptions (no longer hard-enumerate skill names → no edit needed per future skill) and updates the plugin README skills table (5→19).

validate.sh green (L7 frontmatter for all 19 skills), validate.sh --check-tag 0.25.0 green (versions untouched), 878 tests pass.