### PR TITLE
Bump version to 0.26.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.25.0",
+      "version": "0.26.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/maven-mcp/plugin"

--- a/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
+++ b/plugins/maven-mcp/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maven-mcp",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "Maven dependency intelligence — dependency updates, vulnerability and license scanning, transitive dependency graphs, version compatibility checks, artifact search, and version-catalog management, exposed as Claude Code skills. Works in Claude cloud and local without any NPM setup.",
   "author": {
     "name": "kirich1409"

--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -35,8 +35,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 # ---------------------------------------------------------------------------
 
 SERVER_NAME = "maven-mcp"
-SERVER_VERSION = "0.25.0"
-USER_AGENT = "maven-mcp/0.25.0"
+SERVER_VERSION = "0.26.0"
+USER_AGENT = "maven-mcp/0.26.0"
 
 # MCP protocol revisions this server negotiates (#398). Every message shape this
 # server emits (tool annotations, outputSchema/structuredContent) is additive-only


### PR DESCRIPTION
Release **0.26.0** — ships the Phase B backlog resolved after the 0.25.0 security release (issues #397–416, across PRs #418–428):

- MCP protocol **2025-11-25** — version negotiation, read-only annotations, outputSchema/structuredContent, tool errors as isError:true
- 2 new tools: `get_vulnerability_paths`, `get_eol_status` (18 → 20 tools)
- OpenSSF Scorecard in health, synthesized safe-upgrade target in vulnerabilities
- Parallelized batch fan-out (ThreadPoolExecutor) + per-tool deadline + audit summary mode
- HTTP gzip (zip-bomb-safe), negative-cache for 404s, search rate-limit signal
- Gradle resolve collapsed to a single `--init-script` invocation
- 14 new discovery skills; ruff + mypy + coverage in CI; docs synced

Python transport only (no npm). ~1004 tests, ruff/mypy/coverage green.