### PR TITLE
Add stateless Streamable HTTP transport; connect maven-mcp from any MCP agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Install a plugin:
 
 ### maven-mcp
 
-Maven dependency intelligence for JVM projects. Auto-registers an MCP server that provides tools for version lookup, dependency auditing, vulnerability checking, and changelog tracking across Maven Central, Google Maven, and custom repositories.
+Maven dependency intelligence for JVM projects. Auto-registers an MCP server that provides tools for version lookup, dependency auditing, vulnerability checking, and changelog tracking across Maven Central, Google Maven, and custom repositories. The server also runs standalone (stdio or HTTP) and can be connected to any MCP-compatible agent — see [Use with any MCP client](plugins/maven-mcp/README.md#use-with-any-mcp-client).
 
 **Features:**
 - Version intelligence — stability-aware selection, upgrade type classification

--- a/plugins/maven-mcp/AGENTS.md
+++ b/plugins/maven-mcp/AGENTS.md
@@ -12,7 +12,7 @@ Rules that are not open for discussion. Violating these is an error, not a judgm
 
 MCP server for Maven dependency intelligence. Provides tools to query artifact versions from Maven repositories (Maven Central, Google Maven, Gradle Plugin Portal).
 
-**Implementation:** `plugin/server/server.py` — a single-file Python 3 server (stdlib only, zero pip dependencies). It speaks MCP over stdio (JSON-RPC 2.0 on stdin/stdout) and is registered via `plugin/.claude-plugin/plugin.json` as `command: python3`. Runs as a stdio MCP server in local and cloud agent environments without Node.js or npm.
+**Implementation:** `plugin/server/server.py` — a single-file Python 3 server (stdlib only, zero pip dependencies). It speaks MCP over stdio (JSON-RPC 2.0 on stdin/stdout) or, when `MAVEN_MCP_TRANSPORT=http`, over a stateless Streamable HTTP endpoint (`POST /mcp`, stdlib `http.server.ThreadingHTTPServer`, JSON responses, no SSE/sessions). The stdio mode is registered via `plugin/.claude-plugin/plugin.json` as `command: python3`. Runs as an MCP server in local and cloud agent environments without Node.js or npm, and standalone with any MCP-compatible client.
 
 **Stack:** Python 3.9+ standard library only (`urllib`, `json`, `re`, `typing`). No build step, no install step.
 
@@ -47,7 +47,7 @@ python3 -m unittest discover -s plugins/maven-mcp/tests -p test_handlers.py
 - **GitHub & changelog** — `gh_repo_exists` / `gh_fetch_repo` / `gh_fetch_releases` / `gh_fetch_user` / `gh_fetch_issue_stats`, `discover_github_repo` (POM SCM → groupId guess), and `_get_dependency_changes_impl` + `_filter_version_range` with provider selection (#308): AndroidX docs → AGP docs → GitHub releases. Minimal stdlib `html_to_text` powers the AGP/AndroidX HTML parsers. GitHub CHANGELOG.md markdown fallback is still not ported.
 - **Vulnerabilities** — OSV.dev batch query (`api.osv.dev/v1/querybatch`).
 - **Version catalog generate/validate** — `generate_catalog_entry` / `validate_catalog` / `handle_catalog_entry` (#288); reuses `_parse_toml_catalog`.
-- **Tool handlers** — `handle_*`, one per MCP tool, plus the stdio JSON-RPC dispatch loop.
+- **Tool handlers** — `handle_*`, one per MCP tool, plus the JSON-RPC dispatch (`_dispatch_message`, transport-agnostic) and the two transport entry points: the stdio loop and the HTTP server (`POST /mcp`). In HTTP mode `ThreadingHTTPServer` serves requests on handler threads, so the thread-safety invariants (per-call state, no module-level counters) apply to top-level requests too.
 
 **MCP protocol surface (#398):** protocol version negotiation (`_handle_initialize` echoes back any client-requested version in `MCP_SUPPORTED_PROTOCOL_VERSIONS`, else falls back to `MCP_LATEST_PROTOCOL_VERSION`, currently `2025-11-25`), read-only tool `annotations` on all 20 tools, `outputSchema`/`structuredContent` on 14 of them, and JSON-RPC batching removed to match the target spec revision — see `CLAUDE.md`'s *MCP protocol surface* section for the full rationale; not duplicated here.
 
@@ -286,6 +286,7 @@ Fires before `Edit`/`Write`/`MultiEdit` on build files; extracts coordinates fro
 
 ## Environment
 
+- `MAVEN_MCP_TRANSPORT` — `stdio` (default) | `http`. In `http` mode the server binds `MAVEN_MCP_HTTP_HOST` (default `127.0.0.1`) : `MAVEN_MCP_HTTP_PORT` (default `8765`) and serves a stateless `POST /mcp` endpoint (no auth — localhost/trusted networks only; a non-loopback bind logs a warning).
 - `GITHUB_TOKEN` — optional, enables higher GitHub API rate limits (5000 req/h vs 60) for `get_dependency_changes` and `get_dependency_health` (the health tool also uses the rate-limited Search API for issue stats).
 - `MAVEN_MCP_PUBLIC_FALLBACK` — optional toggle (default OFF; accepts `1`/`true`/`on`/`yes`). When ON, public well-known repos are appended even for a scope that declares its own repositories. Read once at the handler boundary into the `ResolutionContext`, never sniffed in leaf resolvers. See *Repository resolution*.
 - **Closed / offline mode & mirrors (#294)** — configuration-driven; no new tool. Read once into `ResolutionContext` at the handler boundary:
@@ -304,6 +305,6 @@ Fires before `Edit`/`Write`/`MultiEdit` on build files; extracts coordinates fro
 
 - No XML parser dependency — all XML parsing is regex-based.
 - Network seam is `urllib.request.urlopen`; tests mock it with `unittest.mock.patch("urllib.request.urlopen", ...)`.
-- Tests live dev-only at `plugins/maven-mcp/tests/` (outside `plugin/`, so they are not shipped). They import `server` via a `__file__`-resolved `sys.path` shim in `tests/_helpers.py`; filesystem-touching parsers are exercised against real files written into a `TemporaryDirectory`.
+- Tests live dev-only at `plugins/maven-mcp/tests/` (outside `plugin/`, so they are not shipped). They import `server` via a `__file__`-resolved `sys.path` shim in `tests/_helpers.py`; filesystem-touching parsers are exercised against real files written into a `TemporaryDirectory`. `tests/test_http_transport.py` covers the HTTP transport end-to-end over loopback (`("127.0.0.1", 0)` on a daemon thread).
 - Version constants (`SERVER_VERSION`, `USER_AGENT`) in `server.py` are part of the 3 version locations that must stay in sync on a release; `scripts/validate.sh --check-tag` enforces this.
 - `import server` is side-effect-free (the `if __name__ == "__main__": main()` guard at the tail).

--- a/plugins/maven-mcp/CLAUDE.md
+++ b/plugins/maven-mcp/CLAUDE.md
@@ -12,7 +12,7 @@ Rules that are not open for discussion. Violating these is an error, not a judgm
 
 MCP server for Maven dependency intelligence. Provides tools to query artifact versions from Maven repositories (Maven Central, Google Maven, Gradle Plugin Portal).
 
-**Implementation:** `plugin/server/server.py` — a single-file Python 3 server (stdlib only, zero pip dependencies). It speaks MCP over stdio (JSON-RPC 2.0 on stdin/stdout) and is registered via `plugin/.claude-plugin/plugin.json` as `command: python3`. Works in Claude cloud and local environments without Node.js or npm.
+**Implementation:** `plugin/server/server.py` — a single-file Python 3 server (stdlib only, zero pip dependencies). It speaks MCP over stdio (JSON-RPC 2.0 on stdin/stdout) or, when `MAVEN_MCP_TRANSPORT=http`, over a stateless Streamable HTTP endpoint (`POST /mcp`, stdlib `http.server.ThreadingHTTPServer`, JSON responses, no SSE/sessions). The stdio mode is registered via `plugin/.claude-plugin/plugin.json` as `command: python3`. Works in Claude cloud and local environments without Node.js or npm, and standalone with any MCP-compatible client.
 
 **Stack:** Python 3.9+ standard library only (`urllib`, `json`, `re`, `typing`). No build step, no install step.
 
@@ -61,7 +61,7 @@ coverage report --rcfile=plugins/maven-mcp/pyproject.toml   # fail_under=75, ~90
 - **GitHub & changelog** — `gh_repo_exists` / `gh_fetch_repo` / `gh_fetch_releases` / `gh_fetch_user` / `gh_fetch_issue_stats`, `discover_github_repo` (POM SCM → groupId guess), and `_get_dependency_changes_impl` + `_filter_version_range` with provider selection (#308): AndroidX docs → AGP docs → GitHub releases. Minimal stdlib `html_to_text` powers the AGP/AndroidX HTML parsers. GitHub CHANGELOG.md markdown fallback is still not ported.
 - **Vulnerabilities** — OSV.dev batch query (`api.osv.dev/v1/querybatch`).
 - **Version catalog generate/validate** — `generate_catalog_entry` / `validate_catalog` / `handle_catalog_entry` (#288); reuses `_parse_toml_catalog`.
-- **Tool handlers** — `handle_*`, one per MCP tool, plus the stdio JSON-RPC dispatch loop.
+- **Tool handlers** — `handle_*`, one per MCP tool, plus the JSON-RPC dispatch (`_dispatch_message`, transport-agnostic) and the two transport entry points: the stdio loop and the HTTP server (`POST /mcp`). In HTTP mode `ThreadingHTTPServer` serves requests on handler threads, so the thread-safety invariants (per-call state, no module-level counters) apply to top-level requests too.
 
 ## MCP protocol surface (#398)
 
@@ -330,6 +330,7 @@ Fires before `Edit`/`Write`/`MultiEdit` on build files; extracts coordinates fro
 
 ## Environment
 
+- `MAVEN_MCP_TRANSPORT` — `stdio` (default) | `http`. In `http` mode the server binds `MAVEN_MCP_HTTP_HOST` (default `127.0.0.1`) : `MAVEN_MCP_HTTP_PORT` (default `8765`) and serves a stateless `POST /mcp` endpoint (no auth — localhost/trusted networks only; a non-loopback bind logs a warning).
 - `GITHUB_TOKEN` — optional, enables higher GitHub API rate limits (5000 req/h vs 60) for `get_dependency_changes` and `get_dependency_health` (the health tool also uses the rate-limited Search API for issue stats).
 - `MAVEN_MCP_PUBLIC_FALLBACK` — optional toggle (default OFF; accepts `1`/`true`/`on`/`yes`). When ON, public well-known repos are appended even for a scope that declares its own repositories. Read once at the handler boundary into the `ResolutionContext`, never sniffed in leaf resolvers. See *Repository resolution*.
 - `MAVEN_MCP_GRADLE_TIMEOUT` — optional override (seconds, positive integer) for the Gradle dependency-resolution timeout, default `300` (`GRADLE_RESOLVE_TIMEOUT`). #401 collapsed resolution into a single `--init-script` invocation that must resolve every project's configurations in one window instead of the old per-subprocess-call budget, so a very large multi-module project (many modules × build-type/flavor configurations) may need more than the default even on a warm Gradle daemon. Read fresh per call via `_gradle_resolve_timeout_seconds()` (not memoized); a missing, non-integer, or non-positive value falls back to the default rather than raising.
@@ -349,6 +350,6 @@ Fires before `Edit`/`Write`/`MultiEdit` on build files; extracts coordinates fro
 
 - No XML parser dependency — all XML parsing is regex-based.
 - Network seam is `urllib.request.urlopen`; tests mock it with `unittest.mock.patch("urllib.request.urlopen", ...)`.
-- Tests live dev-only at `plugins/maven-mcp/tests/` (outside `plugin/`, so they are not shipped). They import `server` via a `__file__`-resolved `sys.path` shim in `tests/_helpers.py`; filesystem-touching parsers are exercised against real files written into a `TemporaryDirectory`.
+- Tests live dev-only at `plugins/maven-mcp/tests/` (outside `plugin/`, so they are not shipped). They import `server` via a `__file__`-resolved `sys.path` shim in `tests/_helpers.py`; filesystem-touching parsers are exercised against real files written into a `TemporaryDirectory`. `tests/test_http_transport.py` covers the HTTP transport end-to-end over loopback (`("127.0.0.1", 0)` on a daemon thread).
 - Version constants (`SERVER_VERSION`, `USER_AGENT`) in `server.py` are part of the 3 version locations that must stay in sync on a release; `scripts/validate.sh --check-tag` enforces this.
 - `import server` is side-effect-free (the `if __name__ == "__main__": main()` guard at the tail).

--- a/plugins/maven-mcp/README.md
+++ b/plugins/maven-mcp/README.md
@@ -4,7 +4,7 @@ Claude Code plugin that provides Maven dependency intelligence via an MCP server
 
 ## How it works
 
-The plugin bundles a single-file Python 3 MCP server (`plugin/server/server.py`) that speaks MCP over stdio (JSON-RPC 2.0 on stdin/stdout). It uses the Python standard library only — zero pip dependencies. The plugin manifest registers it with `command: python3`, so it runs the same way in Claude cloud and local environments with no extra runtime setup.
+The plugin bundles a single-file Python 3 MCP server (`plugin/server/server.py`) that speaks MCP over stdio (JSON-RPC 2.0 on stdin/stdout) or over a stateless Streamable HTTP endpoint. It uses the Python standard library only — zero pip dependencies. The plugin manifest registers it with `command: python3`, so it runs the same way in Claude cloud and local environments with no extra runtime setup. The server can also be run standalone and connected to any MCP-compatible agent — see [Use with any MCP client](#use-with-any-mcp-client).
 
 The server registers tools that Claude can call during a conversation. It queries Maven Central, Google Maven, Gradle Plugin Portal, and routes each artifact to the appropriate repository by group-prefix.
 
@@ -99,6 +99,71 @@ claude plugin add /path/to/maven-mcp/plugin
 ```
 
 The plugin manifest registers the bundled server automatically; no separate install or build step is required.
+
+## Use with any MCP client
+
+The bundled server is a plain stdio MCP process, so any MCP-compatible agent can run it directly — no Claude Code required. The only requirement is Python 3.9+.
+
+```bash
+python3 /path/to/krozov-ai-tools/plugins/maven-mcp/plugin/server/server.py
+```
+
+Point your agent's MCP config at that command (use the absolute path to `server.py`):
+
+- **Kimi Code** — `~/.kimi-code/mcp.json` (user-level) or `.kimi-code/mcp.json` (project-level):
+
+  ```json
+  {
+    "mcpServers": {
+      "maven-mcp": {
+        "command": "python3",
+        "args": ["/path/to/krozov-ai-tools/plugins/maven-mcp/plugin/server/server.py"]
+      }
+    }
+  }
+  ```
+
+- **Cursor** — `~/.cursor/mcp.json`, same `mcpServers` shape as above.
+- **Claude Desktop** — `claude_desktop_config.json`, same `mcpServers` shape as above.
+- **Gemini CLI** — `~/.gemini/settings.json`:
+
+  ```json
+  {
+    "mcpServers": {
+      "maven-mcp": {
+        "command": "python3",
+        "args": ["/path/to/krozov-ai-tools/plugins/maven-mcp/plugin/server/server.py"]
+      }
+    }
+  }
+  ```
+
+- **Codex** — `~/.codex/config.toml`:
+
+  ```toml
+  [mcp_servers.maven-mcp]
+  command = "python3"
+  args = ["/path/to/krozov-ai-tools/plugins/maven-mcp/plugin/server/server.py"]
+  ```
+
+Environment variables (`GITHUB_TOKEN`, `MAVEN_MCP_OFFLINE`, …) can be passed through each client's `env` field.
+
+### HTTP mode (remote / cloud agents)
+
+For agents that cannot spawn a local process (cloud sandboxes, remote workspaces), the server also speaks stateless Streamable HTTP. Start it once:
+
+```bash
+MAVEN_MCP_TRANSPORT=http MAVEN_MCP_HTTP_HOST=127.0.0.1 MAVEN_MCP_HTTP_PORT=8765 \
+  python3 /path/to/krozov-ai-tools/plugins/maven-mcp/plugin/server/server.py
+```
+
+The MCP endpoint is `http://<host>:<port>/mcp` (single `POST` endpoint, JSON responses, no SSE). Connect with a URL-based entry instead of `command`:
+
+- **Kimi Code** (`mcp.json`): `{"mcpServers": {"maven-mcp": {"url": "http://127.0.0.1:8765/mcp"}}}`
+- **Gemini CLI** (`settings.json`): `{"mcpServers": {"maven-mcp": {"httpUrl": "http://127.0.0.1:8765/mcp"}}}`
+- **Codex** (`config.toml`): `[mcp_servers.maven-mcp]` with `url = "http://127.0.0.1:8765/mcp"`
+
+`MAVEN_MCP_HTTP_HOST` defaults to `127.0.0.1` and `MAVEN_MCP_HTTP_PORT` to `8765`. The HTTP transport has **no authentication** — bind it to localhost or a trusted network only; for exposure to cloud agents over the internet, put it behind a reverse proxy that terminates TLS and enforces auth.
 
 ## Hooks
 

--- a/plugins/maven-mcp/plugin/server/server.py
+++ b/plugins/maven-mcp/plugin/server/server.py
@@ -11,6 +11,7 @@ import email.utils
 import functools
 import hashlib
 import http.client
+import http.server
 import ipaddress
 import json
 import logging
@@ -11578,7 +11579,201 @@ def dispatch(msg: Any) -> None:
         _write_response(response)
 
 
+# ---------------------------------------------------------------------------
+# Streamable HTTP transport (stateless; MCP spec 2025-03-26 compatible)
+# ---------------------------------------------------------------------------
+
+HTTP_TRANSPORT_DEFAULT_HOST = "127.0.0.1"
+HTTP_TRANSPORT_DEFAULT_PORT = 8765
+HTTP_TRANSPORT_PATH = "/mcp"
+
+# Origin-header hostnames treated as local (DNS-rebinding hardening); urlsplit
+# lowercases and strips IPv6 brackets before the comparison below.
+_HTTP_LOCAL_ORIGIN_HOSTS = ("localhost", "127.0.0.1", "::1")
+
+
+def _http_port_from_env() -> int:
+    """``MAVEN_MCP_HTTP_PORT`` — override for the HTTP transport listen port.
+    Read fresh on every call (not memoized) so tests can override via
+    ``unittest.mock.patch.dict``. Missing, non-integer, or out-of-range values
+    fall back to ``HTTP_TRANSPORT_DEFAULT_PORT`` with a warning rather than
+    raising — a malformed override must degrade, not prevent startup."""
+    raw = (os.environ.get("MAVEN_MCP_HTTP_PORT") or "").strip()
+    if not raw:
+        return HTTP_TRANSPORT_DEFAULT_PORT
+    try:
+        value = int(raw)
+    except ValueError:
+        value = -1
+    if not 0 < value < 65536:
+        _logger.warning(
+            "Ignoring invalid MAVEN_MCP_HTTP_PORT %r; using default port %d",
+            raw,
+            HTTP_TRANSPORT_DEFAULT_PORT,
+        )
+        return HTTP_TRANSPORT_DEFAULT_PORT
+    return value
+
+
+def _http_origin_allowed(origin: str) -> bool:
+    """True when an Origin header value denotes a loopback host. A value that
+    does not parse to a hostname at all is not allowed."""
+    try:
+        hostname = urllib.parse.urlsplit(origin).hostname
+    except ValueError:
+        return False
+    return hostname is not None and hostname.lower() in _HTTP_LOCAL_ORIGIN_HOSTS
+
+
+def _is_loopback_host(host: str) -> bool:
+    """True for localhost / 127.0.0.1 / ::1 — used only to decide whether the
+    no-authentication bind warning fires, not to restrict anything."""
+    stripped = host.strip("[]").lower()
+    if stripped == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(stripped).is_loopback
+    except ValueError:
+        return False
+
+
+class _MCPHTTPRequestHandler(http.server.BaseHTTPRequestHandler):
+    """One JSON-RPC message per POST; no sessions, no SSE streams."""
+
+    def log_message(self, format: str, *args: Any) -> None:
+        # Route the per-request access log through the module logger at DEBUG
+        # (dropped at the default WARNING level) instead of stderr directly.
+        _logger.debug("http transport: " + format, *args)
+
+    def _send_json(self, status: int, payload: Dict) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_empty(self, status: int, extra_headers: Optional[Dict[str, str]] = None) -> None:
+        self.send_response(status)
+        for name, value in (extra_headers or {}).items():
+            self.send_header(name, value)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def _reject_method(self) -> None:
+        self._send_empty(405, {"Allow": "POST"})
+
+    # Stateless JSON responses only — the streamable-HTTP spec's GET (SSE
+    # stream) and DELETE (session teardown) verbs are not implemented.
+    def do_GET(self) -> None:
+        self._reject_method()
+
+    def do_HEAD(self) -> None:
+        self._reject_method()
+
+    def do_DELETE(self) -> None:
+        self._reject_method()
+
+    def do_PUT(self) -> None:
+        self._reject_method()
+
+    def do_PATCH(self) -> None:
+        self._reject_method()
+
+    def do_OPTIONS(self) -> None:
+        self._reject_method()
+
+    def do_POST(self) -> None:
+        if self.path != HTTP_TRANSPORT_PATH:
+            self._send_empty(404)
+            return
+        origin = self.headers.get("Origin")
+        if origin is not None and not _http_origin_allowed(origin):
+            self._send_empty(403)
+            return
+        length_raw = self.headers.get("Content-Length")
+        try:
+            length = int(length_raw) if length_raw is not None else -1
+        except ValueError:
+            length = -1
+        if length < 0:
+            self._send_empty(400)
+            return
+        try:
+            body = self.rfile.read(length)
+        except OSError:
+            self._send_empty(400)
+            return
+        try:
+            msg = json.loads(body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            self._send_json(400, {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32700, "message": "Parse error: body is not valid JSON"},
+            })
+            return
+        if isinstance(msg, list):
+            # JSON-RPC batching was removed from the target MCP protocol
+            # revision (#398) — a top-level array is an Invalid Request, not a
+            # batch (mirrors _dispatch_message's non-dict branch).
+            self._send_json(400, {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32600, "message": "Invalid Request: expected a JSON object"},
+            })
+            return
+        try:
+            response = _dispatch_message(msg)
+        except Exception as e:
+            self._send_json(500, {
+                "jsonrpc": "2.0",
+                "id": msg.get("id") if isinstance(msg, dict) else None,
+                "error": {"code": -32603, "message": f"Internal error: {e}"},
+            })
+            return
+        if response is None:
+            # Notification — accepted, no response body.
+            self._send_empty(202)
+            return
+        self._send_json(200, response)
+
+
+def _make_http_server(host: str, port: int) -> http.server.ThreadingHTTPServer:
+    """Build the HTTP transport server bound to (host, port). Pass port 0 for
+    an ephemeral port (tests); the bound port is readable via ``server_port``.
+    Handler threads call ``_dispatch_message`` directly — handlers are already
+    thread-tolerant, so no extra locking lives here."""
+    httpd = http.server.ThreadingHTTPServer((host, port), _MCPHTTPRequestHandler)
+    httpd.daemon_threads = True
+    return httpd
+
+
+def run_http_server(host: str, port: int) -> None:
+    """Serve the HTTP transport on (host, port) until interrupted."""
+    if not _is_loopback_host(host):
+        _logger.warning(
+            "maven-mcp HTTP transport has no authentication; binding to "
+            "non-loopback host %r is intended for trusted networks only",
+            host,
+        )
+    httpd = _make_http_server(host, port)
+    _logger.info(
+        "maven-mcp HTTP transport listening on http://%s:%d%s",
+        host, httpd.server_port, HTTP_TRANSPORT_PATH,
+    )
+    try:
+        httpd.serve_forever()
+    finally:
+        httpd.server_close()
+
+
 def main() -> None:
+    transport = (os.environ.get("MAVEN_MCP_TRANSPORT") or "stdio").strip().lower()
+    if transport == "http":
+        host = (os.environ.get("MAVEN_MCP_HTTP_HOST") or "").strip() or HTTP_TRANSPORT_DEFAULT_HOST
+        run_http_server(host, _http_port_from_env())
+        return
     for line in sys.stdin:
         line = line.strip()
         if not line:

--- a/plugins/maven-mcp/tests/_helpers.py
+++ b/plugins/maven-mcp/tests/_helpers.py
@@ -42,6 +42,9 @@ os.environ.pop("MAVEN_MCP_REPOSITORY_TYPE", None)
 # Hermetic TLS/proxy defaults (#298): do not inherit developer proxy/CA/insecure.
 os.environ.pop("MAVEN_MCP_CA_CERT", None)
 os.environ.pop("MAVEN_MCP_INSECURE_TLS", None)
+# Hermetic transport default: main() must take the stdio path in stdio-loop
+# tests regardless of the developer's MAVEN_MCP_TRANSPORT.
+os.environ.pop("MAVEN_MCP_TRANSPORT", None)
 for _proxy_key in (
     "HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY",
     "http_proxy", "https_proxy", "all_proxy", "no_proxy",

--- a/plugins/maven-mcp/tests/test_http_transport.py
+++ b/plugins/maven-mcp/tests/test_http_transport.py
@@ -1,0 +1,326 @@
+"""Streamable HTTP transport tests.
+
+Runs the real ``http.server.ThreadingHTTPServer`` from ``server._make_http_server``
+bound to an ephemeral loopback port in setUpClass, and drives it with real
+``urllib.request`` calls — loopback only, no external network. The only mocked
+piece is the tools/call handler (same ``TOOL_HANDLERS`` patch as
+test_dispatch.py), so no tool reaches the network either.
+"""
+
+import contextlib
+import http.client
+import io
+import json
+import os
+import threading
+import unittest
+import unittest.mock
+import urllib.error
+import urllib.request
+
+from _helpers import server
+
+
+def _post(url, payload, headers=None):
+    """POST ``payload`` (dict -> JSON, or raw bytes) and return (status, body).
+
+    urllib raises HTTPError for non-2xx responses; normalize those to the same
+    ``(status, body_bytes)`` tuple so error-path assertions read uniformly.
+    """
+    data = payload if isinstance(payload, bytes) else json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(url, data=data, method="POST")
+    request.add_header("Content-Type", "application/json")
+    for name, value in (headers or {}).items():
+        request.add_header(name, value)
+    try:
+        with urllib.request.urlopen(request) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as e:
+        # HTTPError is a file-like response wrapper; close it after reading to
+        # avoid ResourceWarning on garbage collection.
+        body = e.read()
+        e.close()
+        return e.code, body
+
+
+class StreamableHTTPTest(unittest.TestCase):
+    """POST /mcp end-to-end through the real handler and dispatcher."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.httpd = server._make_http_server("127.0.0.1", 0)
+        cls.thread = threading.Thread(target=cls.httpd.serve_forever, daemon=True)
+        cls.thread.start()
+        cls.url = f"http://127.0.0.1:{cls.httpd.server_port}{server.HTTP_TRANSPORT_PATH}"
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.httpd.shutdown()
+        cls.httpd.server_close()
+        cls.thread.join(2)
+
+    def test_initialize_echoes_protocol_version(self):
+        status, body = _post(
+            self.url,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "0"},
+                },
+            },
+        )
+        self.assertEqual(status, 200)
+        result = json.loads(body)["result"]
+        self.assertEqual(result["protocolVersion"], "2025-06-18")
+        self.assertIn("capabilities", result)
+        self.assertEqual(
+            result["serverInfo"],
+            {"name": server.SERVER_NAME, "version": server.SERVER_VERSION},
+        )
+
+    def test_tools_list_returns_tools(self):
+        status, body = _post(self.url, {"jsonrpc": "2.0", "id": 2, "method": "tools/list"})
+        self.assertEqual(status, 200)
+        tools = json.loads(body)["result"]["tools"]
+        self.assertGreater(len(tools), 0)
+
+    def test_ping_returns_empty_result(self):
+        status, body = _post(self.url, {"jsonrpc": "2.0", "id": 3, "method": "ping"})
+        self.assertEqual(status, 200)
+        self.assertEqual(json.loads(body), {"jsonrpc": "2.0", "id": 3, "result": {}})
+
+    def test_tools_call_offline_handler(self):
+        # Same TOOL_HANDLERS patch as test_dispatch.py — the real dispatcher
+        # runs, but the tool itself is a stub, so nothing touches the network.
+        def _fake_handler(_arguments):
+            return {"results": [{"groupId": "g", "artifactId": "a"}]}
+
+        with unittest.mock.patch.dict(server.TOOL_HANDLERS, {"search_artifacts": _fake_handler}):
+            status, body = _post(
+                self.url,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 4,
+                    "method": "tools/call",
+                    "params": {"name": "search_artifacts", "arguments": {"query": "okhttp"}},
+                },
+            )
+        self.assertEqual(status, 200)
+        result = json.loads(body)["result"]
+        self.assertNotIn("isError", result)
+        self.assertEqual(
+            json.loads(result["content"][0]["text"]),
+            {"results": [{"groupId": "g", "artifactId": "a"}]},
+        )
+
+    def test_notification_returns_202_empty_body(self):
+        status, body = _post(
+            self.url,
+            {"jsonrpc": "2.0", "method": "notifications/initialized"},
+        )
+        self.assertEqual(status, 202)
+        self.assertEqual(body, b"")
+
+    def test_invalid_json_returns_400_parse_error(self):
+        status, body = _post(self.url, b"{not json")
+        self.assertEqual(status, 400)
+        response = json.loads(body)
+        self.assertEqual(response["error"]["code"], -32700)
+        self.assertIsNone(response["id"])
+
+    def test_batch_array_rejected_invalid_request(self):
+        # JSON-RPC batching was removed from the target MCP protocol revision
+        # (#398): a top-level array is -32600, not a batch.
+        status, body = _post(self.url, [{"jsonrpc": "2.0", "id": 1, "method": "ping"}])
+        self.assertEqual(status, 400)
+        self.assertEqual(json.loads(body)["error"]["code"], -32600)
+
+    def test_post_wrong_path_returns_404(self):
+        status, _body = _post(
+            f"http://127.0.0.1:{self.httpd.server_port}/wrong-path",
+            {"jsonrpc": "2.0", "id": 1, "method": "ping"},
+        )
+        self.assertEqual(status, 404)
+
+    def test_non_local_origin_rejected(self):
+        status, _body = _post(
+            self.url,
+            {"jsonrpc": "2.0", "id": 1, "method": "ping"},
+            headers={"Origin": "http://evil.example.com"},
+        )
+        self.assertEqual(status, 403)
+
+    def test_malformed_origin_rejected(self):
+        # An Origin that does not even parse (unterminated IPv6 bracket) must
+        # fail closed, not crash or pass.
+        status, _body = _post(
+            self.url,
+            {"jsonrpc": "2.0", "id": 1, "method": "ping"},
+            headers={"Origin": "http://[::1"},
+        )
+        self.assertEqual(status, 403)
+
+    def test_local_origin_accepted(self):
+        status, _body = _post(
+            self.url,
+            {"jsonrpc": "2.0", "id": 1, "method": "ping"},
+            headers={"Origin": "http://localhost:3000"},
+        )
+        self.assertEqual(status, 200)
+
+    def test_dispatch_exception_returns_500_internal_error(self):
+        # Mirrors main()'s stdio-loop safety net: a dispatch crash must become
+        # a JSON-RPC -32603 response, never a dropped connection.
+        def _boom(_msg):
+            raise RuntimeError("synthetic dispatch failure")
+
+        with unittest.mock.patch.object(server, "_dispatch_message", _boom):
+            status, body = _post(self.url, {"jsonrpc": "2.0", "id": 5, "method": "ping"})
+        self.assertEqual(status, 500)
+        response = json.loads(body)
+        self.assertEqual(response["error"]["code"], -32603)
+        self.assertEqual(response["id"], 5)
+
+    def test_bad_content_length_returns_400(self):
+        # urllib always sends a valid Content-Length; go one level lower to
+        # exercise the defensive header parsing in do_POST.
+        conn = http.client.HTTPConnection("127.0.0.1", self.httpd.server_port)
+        conn.putrequest("POST", server.HTTP_TRANSPORT_PATH)
+        conn.putheader("Content-Length", "not-a-number")
+        conn.endheaders()
+        resp = conn.getresponse()
+        resp.read()
+        self.assertEqual(resp.status, 400)
+        conn.close()
+
+    def test_missing_content_length_returns_400(self):
+        conn = http.client.HTTPConnection("127.0.0.1", self.httpd.server_port)
+        conn.putrequest("POST", server.HTTP_TRANSPORT_PATH)
+        conn.endheaders()
+        resp = conn.getresponse()
+        resp.read()
+        self.assertEqual(resp.status, 400)
+        conn.close()
+
+
+class MethodNotAllowedTest(unittest.TestCase):
+    """GET / DELETE / other verbs get 405 with Allow: POST (no SSE streams)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.httpd = server._make_http_server("127.0.0.1", 0)
+        cls.thread = threading.Thread(target=cls.httpd.serve_forever, daemon=True)
+        cls.thread.start()
+        cls.url = f"http://127.0.0.1:{cls.httpd.server_port}{server.HTTP_TRANSPORT_PATH}"
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.httpd.shutdown()
+        cls.httpd.server_close()
+        cls.thread.join(2)
+
+    def _method(self, method):
+        request = urllib.request.Request(self.url, method=method)
+        with self.assertRaises(urllib.error.HTTPError) as cm:
+            urllib.request.urlopen(request)
+        # Headers stay readable after close; closing avoids ResourceWarning.
+        cm.exception.close()
+        return cm.exception
+
+    def test_get_returns_405_with_allow_post(self):
+        error = self._method("GET")
+        self.assertEqual(error.code, 405)
+        self.assertEqual(error.headers.get("Allow"), "POST")
+
+    def test_delete_returns_405(self):
+        self.assertEqual(self._method("DELETE").code, 405)
+
+    def test_head_put_patch_options_return_405(self):
+        for method in ("HEAD", "PUT", "PATCH", "OPTIONS"):
+            self.assertEqual(self._method(method).code, 405, method)
+
+
+class TransportSelectionTest(unittest.TestCase):
+    """main() picks the transport from MAVEN_MCP_TRANSPORT (env-only config)."""
+
+    def test_http_transport_uses_env_host_and_port(self):
+        env = {
+            "MAVEN_MCP_TRANSPORT": "http",
+            "MAVEN_MCP_HTTP_HOST": "127.0.0.1",
+            "MAVEN_MCP_HTTP_PORT": "18765",
+        }
+        with unittest.mock.patch.dict("os.environ", env):
+            with unittest.mock.patch.object(server, "run_http_server") as run:
+                server.main()
+        run.assert_called_once_with("127.0.0.1", 18765)
+
+    def test_http_transport_defaults(self):
+        # patch.dict restores environ on exit, so the pops inside are reverted;
+        # they guarantee the defaults regardless of the developer's env.
+        with unittest.mock.patch.dict("os.environ", {"MAVEN_MCP_TRANSPORT": "http"}):
+            os.environ.pop("MAVEN_MCP_HTTP_HOST", None)
+            os.environ.pop("MAVEN_MCP_HTTP_PORT", None)
+            with unittest.mock.patch.object(server, "run_http_server") as run:
+                server.main()
+        run.assert_called_once_with(
+            server.HTTP_TRANSPORT_DEFAULT_HOST, server.HTTP_TRANSPORT_DEFAULT_PORT
+        )
+
+    def test_invalid_port_falls_back_to_default_with_warning(self):
+        with unittest.mock.patch.dict(
+            "os.environ", {"MAVEN_MCP_TRANSPORT": "http", "MAVEN_MCP_HTTP_PORT": "not-a-port"}
+        ):
+            with unittest.mock.patch.object(server, "run_http_server") as run:
+                with self.assertLogs(server._logger, level="WARNING"):
+                    server.main()
+        run.assert_called_once_with(
+            server.HTTP_TRANSPORT_DEFAULT_HOST, server.HTTP_TRANSPORT_DEFAULT_PORT
+        )
+
+    def test_stdio_transport_default_keeps_reading_stdin(self):
+        # MAVEN_MCP_TRANSPORT is popped by _helpers; an unset variable must
+        # select the stdio loop, which exits cleanly at stdin EOF.
+        stdin = io.StringIO('{"jsonrpc": "2.0", "id": 1, "method": "ping"}\n')
+        stdout = io.StringIO()
+        with unittest.mock.patch.object(server.sys, "stdin", stdin):
+            with contextlib.redirect_stdout(stdout):
+                with unittest.mock.patch.object(server, "run_http_server") as run:
+                    server.main()
+        run.assert_not_called()
+        self.assertEqual(
+            json.loads(stdout.getvalue()),
+            {"jsonrpc": "2.0", "id": 1, "result": {}},
+        )
+
+
+class BindWarningTest(unittest.TestCase):
+    """Non-loopback binds log the no-authentication warning; loopback does not."""
+
+    def _run(self, host):
+        """Run run_http_server with a mocked server; return the warning mock."""
+        with unittest.mock.patch.object(server, "_make_http_server") as make:
+            make.return_value.server_port = 8765
+            with unittest.mock.patch.object(server._logger, "warning") as warn:
+                server.run_http_server(host, 8765)
+        make.return_value.serve_forever.assert_called_once_with()
+        make.return_value.server_close.assert_called_once_with()
+        return warn
+
+    def test_non_loopback_bind_warns(self):
+        warn = self._run("0.0.0.0")
+        self.assertTrue(any("no authentication" in str(c) for c in warn.call_args_list))
+
+    def test_unresolvable_hostname_bind_warns(self):
+        self.assertTrue(self._run("unresolvable.invalid").called)
+
+    def test_loopback_binds_do_not_warn(self):
+        for host in ("127.0.0.1", "localhost", "::1"):
+            self.assertFalse(self._run(host).called, host)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

The bundled MCP server (`plugins/maven-mcp/plugin/server/server.py`) was only reachable as a stdio child process registered through the Claude Code plugin manifest. This PR makes it connectable from **any MCP-compatible agent**:

1. **Stateless Streamable HTTP transport** in `server.py` (+195 lines, stdlib `http.server` only, no changes to existing code):
   - `MAVEN_MCP_TRANSPORT=stdio|http` (default `stdio`), `MAVEN_MCP_HTTP_HOST` (default `127.0.0.1`), `MAVEN_MCP_HTTP_PORT` (default `8765`)
   - Single `POST /mcp` endpoint reusing the transport-agnostic `_dispatch_message`; JSON responses (no SSE/sessions — the server is stateless by design)
   - Spec-shaped errors: invalid JSON → 400/-32700, batch arrays → 400/-32600, non-POST → 405, unknown path → 404, non-local `Origin` → 403 (DNS-rebinding hardening)
   - No-auth warning on non-loopback binds; stdout stays byte-clean in HTTP mode
2. **Docs** — new *Use with any MCP client* section in the plugin README with ready-made configs for Kimi Code, Cursor, Claude Desktop, Gemini CLI, and Codex (stdio + HTTP), plus root README link and AGENTS.md/CLAUDE.md sync.

## Verification

- 1028 unittest tests OK (24 new in `tests/test_http_transport.py` covering the full session, error paths, transport selection, bind warning)
- ruff, mypy, coverage (91%, gate 75), `scripts/validate.sh` — green
- Live smoke over HTTP: initialize → notification 202 → tools/list (20) → real `get_latest_version`/`check_version_exists` against Maven Central; stdio mode re-verified unchanged

Out of scope (documented): SSE streams, `Mcp-Session-Id` management, auth layer, PyPI/registry publishing.