### PR TITLE
Drop claude-md-management from enabled plugins

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,6 @@
   "enabledPlugins": {
     "skill-creator@claude-plugins-official": true,
     "claude-code-setup@claude-plugins-official": true,
-    "claude-md-management@claude-plugins-official": true,
     "hookify@claude-plugins-official": true
   },
   "extraKnownMarketplaces": {


### PR DESCRIPTION
Ревизия по итогам `/doctor` в `~/.claude`: скан 50 сессий за 21–27.07.2026 по 12 проектам.

`claude-md-management` не использовался — 7 запусков за всё время и ни одного в окне скана. Из user-настроек он уже убран; это включение на project scope было последним, что удерживало плагин установленным, поэтому после правки `claude plugin uninstall` прошёл и плагин снят со всех скоупов.

Остальные три плагина репозитория (`skill-creator`, `claude-code-setup`, `hookify`) не тронуты — они используются.

🤖 Generated with [Claude Code](https://claude.com/claude-code)