### PR TITLE
Make 13 thin maven-mcp skills slash-only to free listing budget

### DIFF
--- a/plugins/maven-mcp/README.md
+++ b/plugins/maven-mcp/README.md
@@ -35,28 +35,43 @@ The server registers tools that Claude can call during a conversation. It querie
 
 ### Skills
 
+Claude Code keeps a listing of every installed skill's name and description in context, on a
+budget of ~1% of the model's context window; when the listing overflows, descriptions get
+dropped. Twenty-one entries from one plugin consume that budget on their own, so only the
+skills whose body adds a workflow beyond a single tool call stay model-routed. The rest are
+manual: the slash command and the underlying MCP tool are unchanged, Claude just no longer
+carries their descriptions in every session.
+
+**Model-routed** — Claude picks these up on its own, and you can also invoke them by name:
+
 | Skill | Description |
 |-------|-------------|
 | `/latest-version <groupId:artifactId>` | Find latest version of a Maven artifact |
+| `/check-deps` | Scan project for outdated dependencies and update them |
+| `/check-deps-vulnerabilities` | Scan project dependencies for known CVEs/GHSA via OSV (includes Gradle/Maven submodules) |
+| `/audit-project-dependencies` | One combined report: updates + vulnerabilities + optional license posture |
+| `/check-version-compatibility` | Validate AGP/Gradle/JDK/Kotlin and Spring Boot BOM/javax→jakarta compatibility |
+| `/dependency-changes` | Show release notes/changelog between two versions of a Maven/Gradle dependency |
+| `/dependency-health` | Assess whether a Maven dependency is worth adopting (maintenance, activity, license, owner) |
+| `/catalog-entry` | Generate or validate a Gradle version-catalog (`libs.versions.toml`) entry |
+
+**Manual only** (`disable-model-invocation: true`) — invoke by name; Claude reaches the same
+capability through the MCP tool above:
+
+| Skill | Description |
+|-------|-------------|
 | `/check-version-exists` | Confirm whether one specific, already-known version exists |
 | `/check-multiple-versions` | Batch latest-version lookup for several artifacts being evaluated |
 | `/compare-dependency-versions` | Compare specific current versions against latest and classify the upgrade type |
-| `/check-deps` | Scan project for outdated dependencies and update them |
 | `/scan-project-dependencies` | Raw inventory of a project's declared dependencies (no freshness/CVE check) |
 | `/expand-bom` | Expand a Maven BOM/platform into its managed dependency versions |
 | `/transitive-graph` | Resolved transitive dependency graph for a single GAV |
 | `/vulnerability-paths` | Trace each transitively vulnerable dependency back to the project root |
 | `/dependency-conflicts` | Flag GAs resolved at multiple versions across a project |
-| `/check-version-compatibility` | Validate AGP/Gradle/JDK/Kotlin and Spring Boot BOM/javax→jakarta compatibility |
-| `/check-deps-vulnerabilities` | Scan project dependencies for known CVEs/GHSA via OSV (includes Gradle/Maven submodules) |
 | `/dependency-vulnerabilities` | Check specific named coordinates for known CVEs/GHSA, outside a project scan |
-| `/dependency-changes` | Show release notes/changelog between two versions of a Maven/Gradle dependency |
-| `/dependency-health` | Assess whether a Maven dependency is worth adopting (maintenance, activity, license, owner) |
 | `/dependency-license` | SPDX/category license intelligence for specific dependencies |
 | `/license-compliance` | Aggregate transitive licenses vs a project license policy; flag copyleft/violations |
 | `/search-artifacts` | Search Maven Central (or Nexus/Artifactory in closed mode) by keyword |
-| `/audit-project-dependencies` | One combined report: updates + vulnerabilities + optional license posture |
-| `/catalog-entry` | Generate or validate a Gradle version-catalog (`libs.versions.toml`) entry |
 | `/eol-status` | Check end-of-life / support status for JDK, Kotlin, Gradle, or Spring Boot |
 
 ### Supported build systems

--- a/plugins/maven-mcp/plugin/skills/check-multiple-versions/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/check-multiple-versions/SKILL.md
@@ -7,6 +7,7 @@ description: >-
   version should I use for each of these", or is considering adding a handful of new
   libraries and wants their latest versions before picking one. For updating an existing
   project's declared dependencies use /check-deps instead.
+disable-model-invocation: true
 ---
 
 # Check Multiple Versions

--- a/plugins/maven-mcp/plugin/skills/check-version-exists/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/check-version-exists/SKILL.md
@@ -6,6 +6,7 @@ description: >-
   exists", or provides a full groupId:artifactId:version and wants to confirm that exact
   version is available in a Maven repository — not what the latest is (use /latest-version
   for that).
+disable-model-invocation: true
 ---
 
 # Check Version Exists

--- a/plugins/maven-mcp/plugin/skills/compare-dependency-versions/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/compare-dependency-versions/SKILL.md
@@ -5,6 +5,7 @@ description: >-
   asks "is my version of X behind latest", "how far behind is 3.0.0", "what upgrade type
   would this be — major, minor, or patch", "classify the version jump from A to B", or wants
   upgrade-type classification for specific coordinates outside of a full project scan.
+disable-model-invocation: true
 ---
 
 # Compare Dependency Versions

--- a/plugins/maven-mcp/plugin/skills/dependency-conflicts/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/dependency-conflicts/SKILL.md
@@ -5,6 +5,7 @@ description: >-
   dependency problem", "which libraries resolve to more than one version", "check for
   version conflicts across my project", or wants to know whether two paths in the
   dependency graph pull in incompatible versions of the same library.
+disable-model-invocation: true
 ---
 
 # Dependency Conflicts

--- a/plugins/maven-mcp/plugin/skills/dependency-license/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/dependency-license/SKILL.md
@@ -5,6 +5,7 @@ description: >-
   "check the license of X before I add it", "what's the SPDX id for this artifact", or
   wants license intelligence (SPDX id, category, plain-English notes) for one or more
   specific Maven dependencies — direct lookup, not a transitive-closure scan.
+disable-model-invocation: true
 ---
 
 # Dependency License

--- a/plugins/maven-mcp/plugin/skills/dependency-vulnerabilities/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/dependency-vulnerabilities/SKILL.md
@@ -7,6 +7,7 @@ description: >-
   wants an OSV.dev vulnerability check for coordinates that may not even be in a build file
   yet. For scanning an entire Gradle/Maven project's declared dependencies use
   /check-deps-vulnerabilities instead.
+disable-model-invocation: true
 ---
 
 # Dependency Vulnerabilities

--- a/plugins/maven-mcp/plugin/skills/eol-status/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/eol-status/SKILL.md
@@ -5,6 +5,7 @@ description: >-
   life", "is this Spring Boot version EOL", "is JDK 17 still maintained", "check end-of-life
   status", "when do I need to upgrade", or wants the support/end-of-life status of a JDK,
   Kotlin, Gradle, or Spring Boot version via endoflife.date.
+disable-model-invocation: true
 ---
 
 # EOL Status

--- a/plugins/maven-mcp/plugin/skills/expand-bom/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/expand-bom/SKILL.md
@@ -5,6 +5,7 @@ description: >-
   manage", "show me the managed versions in this platform", "what does importing
   io.ktor:ktor-bom pin", or provides a Maven BOM / Gradle platform() coordinate and wants
   its full set of managed dependency versions.
+disable-model-invocation: true
 ---
 
 # Expand BOM

--- a/plugins/maven-mcp/plugin/skills/license-compliance/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/license-compliance/SKILL.md
@@ -6,6 +6,7 @@ description: >-
   against our policy", or wants the FULL transitive closure of one or more root
   dependencies checked against a project license posture — not just the direct
   dependency's own license (see /dependency-license for that).
+disable-model-invocation: true
 ---
 
 # License Compliance

--- a/plugins/maven-mcp/plugin/skills/scan-project-dependencies/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/scan-project-dependencies/SKILL.md
@@ -6,6 +6,7 @@ description: >-
   from my Gradle/Maven project", or wants a raw inventory of declared coordinates without
   checking for updates or vulnerabilities. Does not fetch latest versions — see /check-deps
   for that.
+disable-model-invocation: true
 ---
 
 # Scan Project Dependencies

--- a/plugins/maven-mcp/plugin/skills/search-artifacts/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/search-artifacts/SKILL.md
@@ -4,6 +4,7 @@ description: >-
   Use when the user asks to "find a library for X", "search maven central for JSON parsing
   libraries", "what's the artifact id for Y", "look up an artifact by keyword", or doesn't
   know the exact groupId:artifactId and wants to search by keyword or partial coordinate.
+disable-model-invocation: true
 ---
 
 # Search Artifacts

--- a/plugins/maven-mcp/plugin/skills/transitive-graph/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/transitive-graph/SKILL.md
@@ -5,6 +5,7 @@ description: >-
   pull in transitively", "full transitive graph of Y", "what does adding this dependency
   bring with it", or wants the resolved dependency graph (nodes and edges) for a single
   Maven artifact.
+disable-model-invocation: true
 ---
 
 # Transitive Graph

--- a/plugins/maven-mcp/plugin/skills/vulnerability-paths/SKILL.md
+++ b/plugins/maven-mcp/plugin/skills/vulnerability-paths/SKILL.md
@@ -6,6 +6,7 @@ description: >-
   dependency chain", "where does this vulnerability come from", or wants the dependency chain
   from a project root artifact down to each transitively vulnerable node — not just a flat
   list of CVEs.
+disable-model-invocation: true
 ---
 
 # Vulnerability Paths


### PR DESCRIPTION
Closes #432.

## Что показал замер

Issue #432 ставил вопрос: платить ли дизайном плагина за ~2 029 резидентных токенов (21 скилл), или дешевле отключать плагин целиком. Оказалось, что вопрос уже не гипотетический — **перерасход бюджета листинга наблюдаем**.

Claude Code держит имя + описание каждого установленного скилла в контексте с бюджетом ~1% окна модели и **отбрасывает описания при переполнении** (`code.claude.com/docs/en/skills.md`, раздел *Skill descriptions are cut short*). В сессии с этим плагином включённым:

- `maven-mcp:license-compliance`, `search-artifacts`, `transitive-graph` перечислены **без описания вовсе**;
- то же произошло со скиллами других установленных плагинов (`plugin-dev:command-development`, `hook-development`, `context-mode:ctx-*`), у которых описания в исходном `SKILL.md` есть.

То есть 21 запись одного плагина не просто дорога — она вытесняет описания чужих скиллов, ломая их маршрутизацию.

## Почему не слияние скиллов

Постановка issue рассматривала слияние близких скиллов и честно оговаривала цену: развилка между `check-deps` / `check-multiple-versions` / `latest-version` не исчезает, а переезжает внутрь скилла, где решать её будет модель по параметрам, а не маршрутизатор по описанию.

Третий рычаг оказался лучше и дешевле: `disable-model-invocation: true`. По официальной таблице frontmatter — «You can invoke: Yes, Claude can invoke: No, Description **not in context**, full skill loads when you invoke». Развилка никуда не переезжает, потому что 17 из 21 скилла — обёртки 1:1 над MCP-инструментом, у которого уже есть собственное описание в списке инструментов. Скилл дублировал маршрутизацию по полной резидентной цене.

`skillOverrides` как альтернатива не подходит: документация прямо исключает плагинные скиллы («Does not apply to plugin skills, which are managed through `/plugin`»).

## Что изменено

`disable-model-invocation: true` на 13 скиллах, чьё тело не добавляет ничего сверх одного вызова инструмента. Слэш-команда и MCP-инструмент не меняются — уходит только описание, видимое модели.

**Остаются model-routed (8):** `check-deps` (5 инструментов), `check-deps-vulnerabilities` (3), `audit-project-dependencies`, `catalog-entry`, `check-version-compatibility`, `dependency-changes`, `dependency-health`, `latest-version`.

**Становятся manual-only (13):** `check-version-exists`, `check-multiple-versions`, `compare-dependency-versions`, `scan-project-dependencies`, `expand-bom`, `transitive-graph`, `vulnerability-paths`, `dependency-conflicts`, `dependency-vulnerabilities`, `dependency-license`, `license-compliance`, `search-artifacts`, `eol-status`.

Восемь оставшихся выбраны так, чтобы не порвать внешние ссылки: `~/.claude/agents/source-researcher.md` адресует `maven-mcp:latest-version`, `check-deps-vulnerabilities`, `dependency-changes` и dependency health — все четыре сохранены.

Экономия: 13 из 21 записи, ≈1 250 est. резидентных токенов в каждой сессии с включённым плагином.

## Проверка

Эмпирически, а не по документации:

1. **Механизм на изолированном плагине** — скилл с `disable-model-invocation: true` отсутствует в листинге модели; `/plugin:skill` его по-прежнему запускает и тело грузится.
2. **На реальном плагине** (`claude -p --plugin-dir plugins/maven-mcp/plugin`) — модель перечисляет ровно 8 сохранённых скиллов, ни одного из 13 скрытых.
3. **Слэш-вызов скрытого** — `/maven-mcp:expand-bom` грузится и отрабатывает.
4. `bash scripts/validate.sh` — all checks passed.
5. `python3 -m unittest discover -s plugins/maven-mcp/tests` — 1028 tests, OK (skipped=1).

## Что осталось за рамками

Замечание из #432 в силе: за окно скана 50 сессий плагин не вызывался ни разу. Этот PR снижает его резидентную цену, но не отвечает на вопрос, нужен ли он включённым глобально — это отдельное решение на стороне `~/.claude`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013R6KuFqQ6kswwxCVJv2e73