### PR TITLE
Document plugin isolation as a repo-level principle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ plugins/
 
 See the plugin's own `CLAUDE.md` for plugin-specific instructions.
 
+**Plugins are isolated.** This is a shared home for multiple independent plugins, not a monolith with unified internals. A convention, pattern, or design decision that fits one plugin (module layout, error-handling style, a specific caching or retry strategy, dependency choices) is scoped to that plugin — do not migrate it into another plugin just because both live in this repo. Evaluate each plugin's own requirements on their own terms; cross-plugin consistency is not a goal here.
+
 ## Plugin Standards
 
 All plugins must comply with [`docs/PLUGIN-STANDARDS.md`](docs/PLUGIN-STANDARDS.md). Before every release:


### PR DESCRIPTION
## What changed
Adds a note to root `CLAUDE.md`'s Project section: this repo hosts multiple independent plugins, and conventions/patterns from one plugin should not be migrated into another just because they share a repo.

## Why
User feedback: avoid cross-pollinating plugin-specific approaches during cross-plugin work (e.g. don't carry maven-mcp conventions into youtube-transcript, or vice versa) just because both live in this monorepo.