### PR TITLE
Decouple plugin versions and reset youtube-transcript to 0.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,7 +23,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.27.0",
+      "version": "0.1.0",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/youtube-transcript/plugin"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,10 @@ jobs:
         working-directory: .
         run: python3 -m unittest discover -s plugins/maven-mcp/tests
 
-      # Unified versioning releases every plugin in marketplace.json together
-      # under one tag, so the gate must run every plugin's suite, not just
-      # maven-mcp's. working-directory: . overrides the job's
+      # The release gate runs every plugin's suite, not just maven-mcp's: the
+      # tag ships one commit of the whole repo, so a break in any plugin is a
+      # break in what the release publishes, released plugin or not.
+      # working-directory: . overrides the job's
       # defaults.run.working-directory (plugins/maven-mcp) for the same reason
       # as the step above: without it, the -s path would resolve relative to
       # plugins/maven-mcp instead of the repo root.
@@ -86,15 +87,25 @@ jobs:
           # Claude Code resolves plugin dependencies through tags of the form
           # {plugin-name}--v{version}. Push each tag independently so a failure
           # on one plugin does not abort the rest, and every outcome is logged.
+          #
+          # Plugin versions are independent: tag ${TAG} releases only the
+          # plugins standing on ${VERSION}. Everything else is skipped with a
+          # log line -- stamping a per-plugin tag on an unchanged plugin would
+          # claim a release that never happened (that is how tags for long
+          # deleted plugins ended up in the tag history).
           rc=0
-          while IFS= read -r plugin; do
+          while IFS=$'\t' read -r plugin plugin_version; do
+            if [ "${plugin_version}" != "${VERSION}" ]; then
+              echo "Skipping ${plugin}: not part of this release (version ${plugin_version}, tag ${VERSION})."
+              continue
+            fi
             per_plugin_tag="${plugin}--${TAG}"
             if git rev-parse -q --verify "refs/tags/${per_plugin_tag}" >/dev/null; then
               echo "Tag ${per_plugin_tag} already exists locally — skipping."
               continue
             fi
             echo "Creating ${per_plugin_tag}..."
-            if ! git tag -a "${per_plugin_tag}" -m "Release ${plugin} ${VERSION} (unified release ${TAG})"; then
+            if ! git tag -a "${per_plugin_tag}" -m "Release ${plugin} ${VERSION}"; then
               echo "::error::Failed to create ${per_plugin_tag}" >&2
               rc=1
               continue
@@ -106,5 +117,5 @@ jobs:
               echo "::error::Failed to push ${per_plugin_tag}" >&2
               rc=1
             fi
-          done < <(jq -r '.plugins[].name' .claude-plugin/marketplace.json)
+          done < <(jq -r '.plugins[] | [.name, .version] | @tsv' .claude-plugin/marketplace.json)
           exit "$rc"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Instructions for AI coding agents (Cursor Agent and others) working in this repo
 Rules that are not open for discussion. Violating these is an error, not a judgment call.
 
 - **Never run `npm publish` locally.** Publishing is exclusively via GitHub Actions — prevents partial releases and version skew.
-- **All 3 version locations must stay in sync.** A version bump touches `plugin.json`, `marketplace.json`, and the bundled server `server.py` (`SERVER_VERSION` + `USER_AGENT`) simultaneously — see Publishing for the list.
+- **All 3 version locations of a plugin must stay in sync.** Each plugin carries its version in three places, and a bump touches all three of *that plugin* simultaneously — the other plugin is not touched. See Publishing for the per-plugin list.
 - **Critical or Major violations of PLUGIN-STANDARDS.md block the release.** Fix first, release later.
 - **All extension content is written in English.** Skills (`SKILL.md`, references, evals), agents (`agents/*.md`), hooks, MCP servers, plugin manifests (`plugin.json`, `marketplace.json`), and any prompt/instruction text shipped inside `plugins/` must be in English. User-facing chat in any language is fine; the shipped extension content itself targets an international audience and must not contain non-English prose. Code identifiers and external API field names keep their original form regardless of language. **Excluded:** repository documentation under `docs/` and top-level `README.md` — these are maintainer-facing and may be in any language. Do not "fix" them to English.
 
@@ -46,16 +46,22 @@ Always work on changes in a separate branch using a worktree (`.worktrees/`). Cr
 
 ## Publishing
 
-All plugins use **unified versioning** — every release bumps all plugins to the same version.
+**Plugin versions are independent.** Each plugin moves on its own version line; a release does not drag the others along.
 
-To release a new version:
-1. Bump the version in all three of these locations to the new version:
-   - `plugins/maven-mcp/plugin/.claude-plugin/plugin.json` (`version`)
-   - `.claude-plugin/marketplace.json` (`version`)
-   - `plugins/maven-mcp/plugin/server/server.py` (`SERVER_VERSION` and `USER_AGENT`)
+Each plugin's version lives in three places:
+
+| Plugin | Locations |
+|--------|-----------|
+| maven-mcp | `plugins/maven-mcp/plugin/.claude-plugin/plugin.json` (`version`), `.claude-plugin/marketplace.json` (its entry's `version`), `plugins/maven-mcp/plugin/server/server.py` (`SERVER_VERSION`, `USER_AGENT` derives from it) |
+| youtube-transcript | `plugins/youtube-transcript/plugin/.claude-plugin/plugin.json` (`version`), `.claude-plugin/marketplace.json` (its entry's `version`), `plugins/youtube-transcript/plugin/server/server.py` (`SERVER_VERSION`, `USER_AGENT` derives from it) |
+
+To release:
+1. Bump all three locations of the plugin(s) you are releasing to the new version. Plugins that are not being released keep their current version.
 2. Merge to `main`.
-3. Push a git tag matching the version: `git tag v0.9.0 && git push origin v0.9.0`.
-4. GitHub Actions (`.github/workflows/release.yml`) triggers on `v*` tags: verifies all versions match the tag (`validate.sh --check-tag`), runs the Python test suite, **then creates one per-plugin tag `{plugin-name}--v{version}` for each plugin in `marketplace.json`**. These per-plugin tags are what Claude Code uses to resolve `dependencies` semver ranges.
+3. Push a git tag matching that version: `git tag v0.9.0 && git push origin v0.9.0`.
+4. GitHub Actions (`.github/workflows/release.yml`) triggers on `v*` tags. **Tag `vX.Y.Z` releases exactly the plugins whose version is `X.Y.Z`**: `validate.sh --check-tag` verifies those plugins' three locations and logs a `SKIP:` line for every plugin on another version (a tag matching no plugin at all is an error), the Python suites of all plugins run, and a per-plugin tag `{plugin-name}--v{version}` is created **only for the released plugins**. Those per-plugin tags are what Claude Code uses to resolve `dependencies` semver ranges.
+
+Consequence: two plugins can only be released under the same tag when they happen to stand on the same version. Making the per-plugin tag (`youtube-transcript--v0.1.0`) the release trigger itself is the next step; it is deferred until the `workflow_dispatch` dry-run exists, because that path cannot be tested before a tag is pushed.
 
 ## Worktrees
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Rules that are not open for discussion. Violating these is an error, not a judgment call.
 
 - **Never run `npm publish` locally.** Publishing is exclusively via GitHub Actions — prevents partial releases and version skew.
-- **All 3 version locations must stay in sync.** A version bump touches `plugin.json`, `marketplace.json`, and the bundled server `server.py` (`SERVER_VERSION` + `USER_AGENT`) simultaneously — see Publishing for the list.
+- **All 3 version locations of a plugin must stay in sync.** Each plugin carries its version in three places, and a bump touches all three of *that plugin* simultaneously — the other plugin is not touched. See Publishing for the per-plugin list.
 - **Critical or Major violations of PLUGIN-STANDARDS.md block the release.** Fix first, release later.
 - **All extension content is written in English.** Skills (`SKILL.md`, references, evals), agents (`agents/*.md`), hooks, MCP servers, plugin manifests (`plugin.json`, `marketplace.json`), and any prompt/instruction text shipped inside `plugins/` must be in English. User-facing chat in any language is fine; the shipped extension content itself targets an international audience and must not contain non-English prose. Code identifiers and external API field names keep their original form regardless of language. **Excluded:** repository documentation under `docs/` and top-level `README.md` — these are maintainer-facing and may be in any language. Do not "fix" them to English.
 
@@ -48,16 +48,22 @@ Always work on changes in a separate branch using a worktree (`.worktrees/`). Cr
 
 ## Publishing
 
-All plugins use **unified versioning** — every release bumps all plugins to the same version.
+**Plugin versions are independent.** Each plugin moves on its own version line; a release does not drag the others along.
 
-To release a new version:
-1. Bump the version in all three of these locations to the new version:
-   - `plugins/maven-mcp/plugin/.claude-plugin/plugin.json` (`version`)
-   - `.claude-plugin/marketplace.json` (`version`)
-   - `plugins/maven-mcp/plugin/server/server.py` (`SERVER_VERSION` and `USER_AGENT`)
+Each plugin's version lives in three places:
+
+| Plugin | Locations |
+|--------|-----------|
+| maven-mcp | `plugins/maven-mcp/plugin/.claude-plugin/plugin.json` (`version`), `.claude-plugin/marketplace.json` (its entry's `version`), `plugins/maven-mcp/plugin/server/server.py` (`SERVER_VERSION`, `USER_AGENT` derives from it) |
+| youtube-transcript | `plugins/youtube-transcript/plugin/.claude-plugin/plugin.json` (`version`), `.claude-plugin/marketplace.json` (its entry's `version`), `plugins/youtube-transcript/plugin/server/server.py` (`SERVER_VERSION`, `USER_AGENT` derives from it) |
+
+To release:
+1. Bump all three locations of the plugin(s) you are releasing to the new version. Plugins that are not being released keep their current version.
 2. Merge to `main`.
-3. Push a git tag matching the version: `git tag v0.9.0 && git push origin v0.9.0`.
-4. GitHub Actions (`.github/workflows/release.yml`) triggers on `v*` tags: verifies all versions match the tag (`validate.sh --check-tag`), runs the Python test suite, **then creates one per-plugin tag `{plugin-name}--v{version}` for each plugin in `marketplace.json`**. These per-plugin tags are what Claude Code uses to resolve `dependencies` semver ranges.
+3. Push a git tag matching that version: `git tag v0.9.0 && git push origin v0.9.0`.
+4. GitHub Actions (`.github/workflows/release.yml`) triggers on `v*` tags. **Tag `vX.Y.Z` releases exactly the plugins whose version is `X.Y.Z`**: `validate.sh --check-tag` verifies those plugins' three locations and logs a `SKIP:` line for every plugin on another version (a tag matching no plugin at all is an error), the Python suites of all plugins run, and a per-plugin tag `{plugin-name}--v{version}` is created **only for the released plugins**. Those per-plugin tags are what Claude Code uses to resolve `dependencies` semver ranges.
+
+Consequence: two plugins can only be released under the same tag when they happen to stand on the same version. Making the per-plugin tag (`youtube-transcript--v0.1.0`) the release trigger itself is the next step; it is deferred until the `workflow_dispatch` dry-run exists, because that path cannot be tested before a tag is pushed.
 
 ## Worktrees
 

--- a/docs/PLUGIN-STANDARDS.md
+++ b/docs/PLUGIN-STANDARDS.md
@@ -25,7 +25,7 @@ Plugins with no plugin-specific invariants beyond the project root `CLAUDE.md` a
 Обязательное:
 
 - `name` — kebab-case, уникальный в пределах `marketplace.json`
-- `version` — валидный semver (`0.9.0`, `1.0.0`). В монорепо все плагины релизятся одной версией (unified versioning).
+- `version` — валидный semver (`0.9.0`, `1.0.0`). У каждого плагина своя версия: релиз одного плагина не двигает версии остальных.
 
 Обязательно рекомендуется (для самодостаточности плагина без опоры на marketplace):
 
@@ -112,20 +112,21 @@ Frontmatter:
 - Semver ranges: `^`, `~`, exact (`=`), range (`>=1.4.0`)
 - Для resolution нужны **git-теги формата `{plugin-name}--v{version}`** в release workflow
 - Cross-marketplace deps требуют allowlist в корневом `marketplace.json`
-- При unified versioning в монорепо — рекомендуется `^X.Y.0` (совместимость в рамках одной major-minor серии)
+- Версии плагинов независимы, поэтому range берётся от реальной версии плагина-зависимости, а не от версии репо; `^X.Y.0` — разумный дефолт
 
 ## 8. Marketplace (`marketplace.json`)
 
 - Один `marketplace.json` на репо (в `.claude-plugin/`)
 - Для каждого плагина entry: `name`, `source`, `description`, `version`, `author`, опционально `homepage`, `category`, `keywords`
-- `version` в marketplace entry **должна совпадать** с `version` в `plugin.json` (unified versioning)
+- `version` в marketplace entry **должна совпадать** с `version` в `plugin.json` того же плагина
 - `source: "./plugins/<name>"` — относительный path от корня репо
 
 ## 9. Versioning
 
-- **Unified versioning**: все плагины в репо релизятся одной версией при каждом релизе
+- **Независимые версии**: у каждого плагина своя версия, релиз одного не бампает остальные
 - Bump правила: MAJOR — breaking, MINOR — features/additions, PATCH — fixes
 - Tag format: корневой `vX.Y.Z` + per-plugin `{plugin-name}--vX.Y.Z` (для semver resolution в `dependencies`)
+- Тег `vX.Y.Z` выпускает те плагины, чья версия равна `X.Y.Z`; per-plugin теги создаются только им. Тег, не совпавший ни с одним плагином, — ошибка
 - `CHANGELOG.md` на уровне репо (если нужно — per-plugin)
 
 ## 10. Pre-release checklist
@@ -134,7 +135,8 @@ Frontmatter:
 
 - [ ] `bash validate.sh` — зелёный
 - [ ] `plugin-dev:plugin-validator` agent на каждом плагине — PASS или только Minor
-- [ ] Версии в `plugin.json` каждого плагина и в `marketplace.json` — синхронизированы
+- [ ] У каждого плагина три его места версии (`plugin.json`, entry в `marketplace.json`, `SERVER_VERSION` в bundled server) — синхронизированы между собой; версии разных плагинов совпадать не обязаны
+- [ ] Версия выпускаемого плагина равна версии тега; плагины на других версиях этим релизом не выпускаются — `validate.sh --check-tag X.Y.Z` печатает по ним `SKIP:`
 - [ ] Нет `.DS_Store`, `*-workspace/` runtime-папок в коммитах
 - [ ] Все shell-скрипты executable (`find plugins -name "*.sh" ! -executable`)
 - [ ] Описания skills (`description` frontmatter) ≤ 1024 символа

--- a/plugins/youtube-transcript/plugin/.claude-plugin/plugin.json
+++ b/plugins/youtube-transcript/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-transcript",
-  "version": "0.27.0",
+  "version": "0.1.0",
   "description": "Fetches existing YouTube subtitles (manual or auto-generated) via the InnerTube API and returns them as plain text, SRT, or VTT. Does not perform speech-to-text or video/audio download — only retrieves captions YouTube already publishes.",
   "author": {
     "name": "kirich1409"

--- a/plugins/youtube-transcript/plugin/server/server.py
+++ b/plugins/youtube-transcript/plugin/server/server.py
@@ -35,7 +35,7 @@ from protocol.schemas import TOOL_SCHEMAS
 # `User-Agent` header sent to YouTube's InnerTube API, T-10 -- a completely
 # separate string this module has no `ALLOWED_EDGES` route to and no reason to
 # reference).
-SERVER_VERSION = "0.27.0"
+SERVER_VERSION = "0.1.0"
 USER_AGENT = f"youtube-transcript/{SERVER_VERSION}"
 
 _SCHEMAS_BY_NAME: Dict[str, Dict[str, Any]] = {schema["name"]: schema for schema in TOOL_SCHEMAS}

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -3,7 +3,9 @@
 #
 # Usage:
 #   bash scripts/validate.sh                    # full validation
-#   bash scripts/validate.sh --check-tag 1.2.3  # + verify all versions match tag
+#   bash scripts/validate.sh --check-tag 1.2.3  # + verify the plugins released by
+#                                               #   tag v1.2.3 (those standing on
+#                                               #   that version) are consistent
 #
 # Exit code: 0 if all checks pass, 1 if any error found.
 set -uo pipefail
@@ -109,7 +111,7 @@ check_name_consistency() {
   done < <(jq -r '.plugins[] | [.name, .source] | @tsv' "$MARKETPLACE")
 }
 
-# ---------- L4: Unified versioning ----------
+# ---------- L4: Versioning ----------
 
 check_version_consistency() {
   echo "--- L4: Versions consistent (marketplace.json ↔ plugin.json) ---"
@@ -145,16 +147,36 @@ check_semver() {
   done < <(jq -r '.plugins[] | [.name, .version, .source] | @tsv' "$MARKETPLACE")
 }
 
+# Plugin versions are independent: a tag vX.Y.Z releases exactly those plugins
+# whose marketplace.json version equals X.Y.Z. Plugins on another version are
+# not part of this release and are skipped -- loudly, because a silent skip is
+# indistinguishable from a forgotten version bump. A tag matching no plugin at
+# all releases nothing and is treated as a typo in the tag.
 check_tag_versions() {
   local version="$1"
-  echo "--- L4: All versions match tag v${version} ---"
+  echo "--- L4: Plugins released by tag v${version} ---"
   SEMVER='^[0-9]+\.[0-9]+\.[0-9]+$'
   if ! echo "$version" | grep -qE "$SEMVER"; then
     fail "Tag version is not semver: $version"
     return
   fi
 
-  # All plugin.json files — data-driven from marketplace.json
+  local matched=0
+  while IFS=$'\t' read -r name mkt_version; do
+    if [ "$mkt_version" != "$version" ]; then
+      echo "SKIP: '$name' not part of this release (version $mkt_version)"
+      continue
+    fi
+    matched=$((matched + 1))
+    ok "marketplace.json '$name' version $mkt_version"
+  done < <(jq -r '.plugins[] | [.name, .version] | @tsv' "$MARKETPLACE")
+
+  if [ "$matched" -eq 0 ]; then
+    fail "tag v${version} matches no plugin in $MARKETPLACE — it would release nothing"
+    return
+  fi
+
+  # plugin.json of the released plugins — data-driven from marketplace.json
   while IFS=$'\t' read -r name source; do
     plugin_json="${source}/.claude-plugin/plugin.json"
     if [ ! -f "$plugin_json" ]; then
@@ -167,16 +189,7 @@ check_tag_versions() {
     else
       ok "'$name' plugin.json version $plugin_version"
     fi
-  done < <(jq -r '.plugins[] | [.name, .source] | @tsv' "$MARKETPLACE")
-
-  # marketplace.json plugin versions
-  while IFS=$'\t' read -r name mkt_version; do
-    if [ "$mkt_version" != "$version" ]; then
-      fail "marketplace.json plugin '$name' version \"$mkt_version\" does not match tag v${version}"
-    else
-      ok "marketplace.json '$name' version $mkt_version"
-    fi
-  done < <(jq -r '.plugins[] | [.name, .version] | @tsv' "$MARKETPLACE")
+  done < <(jq -r --arg v "$version" '.plugins[] | select(.version == $v) | [.name, .source] | @tsv' "$MARKETPLACE")
 
   # Bundled MCP server scripts — version constants must track the tag.
   # The script path is derived from each plugin.json mcpServers entry
@@ -209,7 +222,7 @@ check_tag_versions() {
       | select(.value.command | test("^python"))
       | .value.args[]? | select(test("\\.py$"))
     ' "$plugin_json")
-  done < <(jq -r '.plugins[] | [.name, .source] | @tsv' "$MARKETPLACE")
+  done < <(jq -r --arg v "$version" '.plugins[] | select(.version == $v) | [.name, .source] | @tsv' "$MARKETPLACE")
 }
 
 # ---------- L5: plugin.json component paths ----------


### PR DESCRIPTION
`youtube-transcript` sat at `0.27.0` — a number it never earned. It landed two days ago and has never been released (`git tag -l 'youtube-transcript--v*'` returns nothing); the version came entirely from `maven-mcp`'s 26 releases, by way of the repo's unified-versioning rule.

That rule contradicts this repo's own stated principle — plugins are independent and conventions do not migrate between them — in the one place where the two plugins were still welded together. This is the last moment the number can be corrected for free: after a first release it is fixed forever.

## What changes

**Versions become independent.** `youtube-transcript` resets to `0.1.0` across its three locations; `maven-mcp` stays at `0.27.0`, untouched.

**A release tag no longer speaks for every plugin.** `scripts/validate.sh --check-tag X.Y.Z` now validates the plugins whose version *is* `X.Y.Z` and reports the others as not part of that release. A tag matching no plugin is an error — it would release nothing, which only happens through a typo.

**`release.yml` stops stamping bystanders.** The per-plugin tag loop previously created `{plugin}--v{version}` for every plugin in `marketplace.json` regardless of whether it changed. Those tags are what Claude Code resolves `dependencies` ranges through, so a range could resolve to a tag containing no changes to that plugin at all — the tag history shows seven plugin names accumulated this way, including ones long since removed. The loop now skips plugins whose version does not match the release, and logs each skip.

**The workflow trigger is deliberately unchanged.** Moving to per-plugin release tags as the trigger touches a path that cannot be exercised before a tag is pushed; that is deferred to the MCPB bundle's Stage 2, which builds a `workflow_dispatch` dry-run so the path becomes falsifiable first. Three review cycles have already shown what blind edits there cost.

**Docs follow.** The non-negotiable read "all 3 version locations" — with two plugins there are six. It now says three *per plugin* and lists both. The Publishing section describes what actually happens instead of unified bumps. `AGENTS.md` mirrors the edited sections of `CLAUDE.md` verbatim, as it already did.

## Verification

- `validate.sh` green; `--check-tag 0.27.0` passes with `youtube-transcript` reported as outside the release, `--check-tag 0.1.0` mirrors it, `--check-tag 9.9.9` fails with "matches no plugin — it would release nothing".
- The `release.yml` tag loop was extracted and run against the real `marketplace.json` with `git tag`/`git push` replaced by echo: only `maven-mcp` is tagged for `v0.27.0`, `youtube-transcript` is skipped with a logged reason. No real tags were created.
- Plugin test suite green; `shellcheck scripts/validate.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZjtfbch3SmN3tfyppBQbt