### PR TITLE
Force the tag fetch in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,8 +82,18 @@ jobs:
           # so sibling per-plugin tags from previous releases won't be known
           # locally. Fetch all tags so the rev-parse existence check below
           # matches the remote state.
+          #
+          # `--force` is load-bearing, not defensive. actions/checkout leaves a
+          # *lightweight* local tag at the checked-out commit, so when the
+          # release tag is *annotated* the remote ref names a different object
+          # and a plain fetch refuses it ("would clobber existing tag"),
+          # failing the step under `bash -e` before a single per-plugin tag is
+          # created. Observed on v0.1.0, the first annotated release tag; every
+          # earlier release happened to use a lightweight tag and never hit it.
+          # Overwriting local tags is exactly what this fetch is for -- it
+          # exists only so the existence check below sees remote state.
           echo "Fetching remote tags..."
-          git fetch --tags origin
+          git fetch --tags --force origin
           # Claude Code resolves plugin dependencies through tags of the form
           # {plugin-name}--v{version}. Push each tag independently so a failure
           # on one plugin does not abort the rest, and every outcome is logged.


### PR DESCRIPTION
The `v0.1.0` release run failed at its last step and lost the per-plugin tag Claude Code resolves `dependencies` ranges through.

**Root cause.** The step fetches remote tags so its existence check reflects remote state. `actions/checkout` leaves a *lightweight* local tag at the checked-out commit; an **annotated** release tag names a different object remotely, so a plain `git fetch --tags` is rejected with "would clobber existing tag" and the step dies under `bash -e` before creating a single per-plugin tag.

Every earlier release happened to use a lightweight tag, which is why a latent fragility only surfaced now. Overwriting local tags is precisely what this fetch exists to do, so `--force` is the fix rather than a workaround.

**Reproduced** on a throwaway repository: a lightweight local tag against an annotated remote one is rejected identically; with `--force` the tag updates to the annotated object.

**Blast radius of the incident.** Version validation, both test suites and the GitHub Release all succeeded — only `youtube-transcript--v0.1.0` was missing. It has been created by hand so the release is complete; this change makes the next one unattended.

**Still unproven in production:** the release-side half of version decoupling. The step died on the fetch, before the loop that skips plugins outside the release ever ran. It is verified locally against the real `marketplace.json`, not in a real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZjtfbch3SmN3tfyppBQbt
