### PR TITLE
Declare workflow_dispatch on the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,32 @@
 name: Release
 
+# `workflow_dispatch` is declared here ahead of the release-wiring restructure
+# and does nothing on its own. GitHub only offers manual dispatch for a
+# workflow whose *default-branch* copy declares the trigger, so a restructured
+# copy on a feature branch cannot be dry-run until this declaration is on
+# `main` -- which is the whole point of landing it separately and early.
+#
+# It is inert by construction: the only job is gated on `github.event_name ==
+# 'push'`, so a dispatch produces a run whose job is skipped. There is
+# deliberately no `dry_run` input: a manual run must never be able to publish,
+# because the ancestry check below is skipped on non-tag events and a
+# publishing dispatch would therefore release unreviewed code.
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      plugin:
+        description: "Plugin whose release path to dry-run (used after the restructure lands)"
+        type: choice
+        required: true
+        options:
+          - youtube-transcript
+          - maven-mcp
 
 jobs:
   publish:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     defaults:


### PR DESCRIPTION
Preparatory step for the Stage 2 release-wiring restructure. It changes no release behaviour.

GitHub offers manual dispatch only for a workflow whose **default-branch** copy declares the trigger. The restructured `release.yml` on a feature branch therefore cannot be dry-run at all until this declaration is on `main` — which is exactly what turns the dry run into a pre-merge gate instead of a post-merge hope. That gate is the reason Stage 2 was split off from Stage 1 in the first place, and the failed `v0.1.0` run earlier today is what it exists to catch.

**Inert by construction.** The only job is gated on `github.event_name == 'push'`, so a dispatch produces a run whose job is skipped: no release, no tag, no attestation.

**No `dry_run` input, deliberately.** A review of the Stage 2 plan found that a dispatch able to publish would be an ungated release path from any branch: the ancestry check that refuses to release an unreviewed commit is skipped on non-tag events, so a publishing dispatch would defeat the very guard it sits next to. Manual runs are always dry runs; publishing happens only on a tag push.

## Verification

- YAML parses; `actionlint` clean.
- All eight existing steps intact and unmodified.
- Trigger list is `push` + `workflow_dispatch`; the job's condition is `github.event_name == 'push'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZjtfbch3SmN3tfyppBQbt
