### PR TITLE
Bump youtube-transcript to 0.1.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,7 +23,7 @@
       "author": {
         "name": "kirich1409"
       },
-      "version": "0.1.0",
+      "version": "0.1.1",
       "category": "development",
       "homepage": "https://github.com/kirich1409/krozov-ai-tools",
       "source": "./plugins/youtube-transcript/plugin"

--- a/plugins/youtube-transcript/plugin/.claude-plugin/plugin.json
+++ b/plugins/youtube-transcript/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "youtube-transcript",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Fetches existing YouTube subtitles (manual or auto-generated) via the InnerTube API and returns them as plain text, SRT, or VTT. Does not perform speech-to-text or video/audio download — only retrieves captions YouTube already publishes.",
   "author": {
     "name": "kirich1409"

--- a/plugins/youtube-transcript/plugin/server/server.py
+++ b/plugins/youtube-transcript/plugin/server/server.py
@@ -35,7 +35,7 @@ from protocol.schemas import TOOL_SCHEMAS
 # `User-Agent` header sent to YouTube's InnerTube API, T-10 -- a completely
 # separate string this module has no `ALLOWED_EDGES` route to and no reason to
 # reference).
-SERVER_VERSION = "0.1.0"
+SERVER_VERSION = "0.1.1"
 USER_AGENT = f"youtube-transcript/{SERVER_VERSION}"
 
 _SCHEMAS_BY_NAME: Dict[str, Dict[str, Any]] = {schema["name"]: schema for schema in TOOL_SCHEMAS}


### PR DESCRIPTION
Prepares the first release that actually carries the `.mcpb` bundle.

The plugin's own code is unchanged since `0.1.0` — everything merged since then was build and release wiring. A patch bump is the honest label: behaviour did not change, delivery did.

`0.1.0`'s release predates the wiring and has no assets attached. There is no way to add one retroactively without moving a published tag, and the tag ruleset now forbids exactly that, so a new version is the correct route rather than a workaround.

`maven-mcp` stays at `0.27.0` — a per-plugin tag releases only the plugin it names.

## Verification

- The diff is exactly three lines, one per version location. An earlier attempt round-tripped `marketplace.json` through a JSON writer and silently un-escaped a Unicode character in `maven-mcp`'s description; that was reverted and the version edited surgically instead, so nothing outside `youtube-transcript` is touched.
- `validate.sh` green; `--check-tag youtube-transcript--v0.1.1` passes and `--check-tag youtube-transcript--v0.1.0` now correctly fails.
- Plugin test suite green.

## What happens on the tag

Pushing `youtube-transcript--v0.1.1` after this merges runs the restructured release workflow for the first time end to end. `gate` and `pack` have been exercised by dispatch dry runs; `attest` and `publish` are unreachable from a dispatch by construction and therefore execute for the first time on this tag. That run is supervised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YZjtfbch3SmN3tfyppBQbt
